### PR TITLE
Optimize mobile transcript virtualization

### DIFF
--- a/apps/ios/Comet/App/DemoDataset.swift
+++ b/apps/ios/Comet/App/DemoDataset.swift
@@ -276,7 +276,7 @@ final class DemoDataset {
         let reply = """
         Here's how the streamed reply renders on this device:
 
-        - Markdown re-parses **only the tail** — the last two top-level blocks
+        - Only mounted rows parse Markdown — off-screen history stays as raw text
         - New text fades in through the paint-only veil
         - The transcript stays glued to the bottom until you scroll up
 

--- a/apps/ios/Comet/Markdown/MarkdownModel.swift
+++ b/apps/ios/Comet/Markdown/MarkdownModel.swift
@@ -1,15 +1,15 @@
 // Markdown block model — a port of crates/ui/src/markdown/parser.rs.
 //
-// The transcript renders one row per *top-level block*, so the model is
-// block-first: a parsed document is a flat list of `TopBlock`s whose content
-// hash doubles as the row-version key for the virtualizer. Inline content is a
-// run model (adjacent same-style runs merged) rather than an AST, which keeps
-// rendering a single pass over styled spans.
+// Mounted transcript rows parse into a flat list of `TopBlock`s. The
+// virtualizer itself holds raw Markdown source and calculates height without
+// constructing this model; off-screen history therefore never reaches this
+// parser. Inline content is a run model (adjacent same-style runs merged)
+// rather than an AST, which keeps rendering a single pass over styled spans.
 
 import Foundation
 import Markdown
 
-struct InlineStyle: Hashable {
+struct InlineStyle: Hashable, Sendable {
     var bold = false
     var italic = false
     var code = false
@@ -19,22 +19,22 @@ struct InlineStyle: Hashable {
     static let plain = InlineStyle()
 }
 
-struct InlineRun: Hashable {
+struct InlineRun: Hashable, Sendable {
     var text: String
     var style: InlineStyle
 }
 
-enum MDAlign: Hashable {
+enum MDAlign: Hashable, Sendable {
     case left, center, right, none
 }
 
-struct MDListItem: Hashable {
+struct MDListItem: Hashable, Sendable {
     /// Task-list checkbox state; nil for plain items.
     var checked: Bool?
     var children: [MDBlock]
 }
 
-indirect enum MDBlock: Hashable {
+indirect enum MDBlock: Hashable, Sendable {
     case paragraph([InlineRun])
     case heading(level: Int, [InlineRun])
     case codeBlock(language: String?, code: String)
@@ -46,7 +46,7 @@ indirect enum MDBlock: Hashable {
 
 /// A top-level block plus the 1-based source line it starts on (the stable
 /// re-parse anchor) and a content hash used as the row diff key.
-struct TopBlock: Hashable {
+struct TopBlock: Hashable, Sendable {
     var startLine: Int
     var block: MDBlock
 
@@ -189,15 +189,17 @@ enum MarkdownParser {
 
 /// Re-parses only the streaming tail: on append, parsing restarts from the
 /// start of the *second-to-last* top-level block (covers continuation merges),
-/// so per-append cost is O(delta + tail), never O(document). Link-reference
-/// definitions (`[label]: url`) break the locality assumption and force full
-/// re-parses.
-final class IncrementalMarkdownParser {
+/// so per-append cost is O(delta + tail), never O(document). Plain prose takes
+/// a stricter O(delta) path that appends directly to the last inline run.
+/// Link-reference definitions (`[label]: url`) break the locality assumption
+/// and force full re-parses.
+struct IncrementalMarkdownParser: Sendable {
     private(set) var source: String = ""
     private(set) var blocks: [TopBlock] = []
     private var fullOnly = false
+    private var plainTailEligible = false
 
-    func setText(_ text: String) {
+    mutating func setText(_ text: String) {
         if text == source { return }
         if !fullOnly, text.hasPrefix(source), !source.isEmpty {
             append(text)
@@ -206,22 +208,29 @@ final class IncrementalMarkdownParser {
         }
     }
 
-    private func reset(_ text: String) {
+    private mutating func reset(_ text: String) {
         source = text
         fullOnly = Self.hasLinkDefs(text)
         blocks = MarkdownParser.parse(text)
+        plainTailEligible = Self.hasPlainTail(source: text, blocks: blocks)
     }
 
-    private func append(_ text: String) {
+    private mutating func append(_ text: String) {
         let delta = String(text.dropFirst(source.count))
+        if appendPlainDelta(delta) {
+            source = text
+            return
+        }
         source = text
         if Self.hasLinkDefs(delta) {
             fullOnly = true
             blocks = MarkdownParser.parse(text)
+            plainTailEligible = false
             return
         }
         guard blocks.count >= 2 else {
             blocks = MarkdownParser.parse(text)
+            plainTailEligible = Self.hasPlainTail(source: text, blocks: blocks)
             return
         }
         // Stable boundary: the start line of the second-to-last block.
@@ -232,6 +241,47 @@ final class IncrementalMarkdownParser {
             TopBlock(startLine: top.startLine + boundaryLine - 1, block: top.block)
         }
         blocks = stable + tailBlocks
+        plainTailEligible = Self.hasPlainTail(source: text, blocks: blocks)
+    }
+
+    /// Most streamed tokens are ordinary paragraph text. If the current tail
+    /// has never contained Markdown control syntax, appending such a token
+    /// cannot alter block or inline structure, so bypass swift-markdown.
+    private mutating func appendPlainDelta(_ delta: String) -> Bool {
+        guard plainTailEligible, !delta.isEmpty,
+              !delta.contains(where: Self.isMarkdownControl),
+              let lastIndex = blocks.indices.last,
+              case .paragraph(var runs) = blocks[lastIndex].block,
+              !runs.isEmpty,
+              runs.allSatisfy({ $0.style == .plain }) else {
+            return false
+        }
+        runs[runs.count - 1].text += delta
+        blocks[lastIndex].block = .paragraph(runs)
+        return true
+    }
+
+    private static func hasPlainTail(source: String, blocks: [TopBlock]) -> Bool {
+        guard let top = blocks.last,
+              case .paragraph(let runs) = top.block,
+              !runs.isEmpty,
+              runs.allSatisfy({ $0.style == .plain }) else {
+            return false
+        }
+        let tail = suffix(of: source, fromLine: top.startLine)
+        return !tail.isEmpty && !tail.contains(where: isMarkdownControl)
+    }
+
+    /// Characters that may open/close inline syntax or introduce a new block
+    /// after a newline. Falling back is conservative; correctness wins for the
+    /// uncommon formatted token while normal prose remains allocation-light.
+    private static func isMarkdownControl(_ character: Character) -> Bool {
+        switch character {
+        case "\n", "\r", "\\", "*", "_", "~", "`", "[", "<", "&":
+            return true
+        default:
+            return false
+        }
     }
 
     /// The substring starting at the given 1-based line.

--- a/apps/ios/Comet/Sync/SessionStore.swift
+++ b/apps/ios/Comet/Sync/SessionStore.swift
@@ -15,6 +15,9 @@ final class SessionStore {
     /// The chat's host device — nudge target for cold-host command drains.
     var hostDeviceId: String?
     private(set) var entries: [MessageEntry] = []
+    /// Monotonic input key for transcript row derivation. Scroll-only view
+    /// updates can return the already-built row array in O(1).
+    private(set) var transcriptRevision: UInt64 = 0
     private(set) var connected = false
     /// Client-minted ids of sends the host hasn't materialized yet.
     private(set) var pendingSends: [(messageId: String, text: String, at: Int64)] = []
@@ -38,6 +41,7 @@ final class SessionStore {
     /// Demo-mode injection point (also used by previews).
     func setEntries(_ new: [MessageEntry]) {
         entries = new
+        transcriptRevision &+= 1
     }
 
     @ObservationIgnored private var saver: DocSaver?
@@ -107,6 +111,7 @@ final class SessionStore {
         // Drop echoes the host has materialized.
         let ids = Set(entries.map(\.id))
         pendingSends.removeAll { ids.contains($0.messageId) }
+        transcriptRevision &+= 1
     }
 
     private static func entryFrom(_ value: LoroValue) -> MessageEntry? {
@@ -217,6 +222,7 @@ final class SessionStore {
             "messageId": messageId,
         ])
         pendingSends.append((messageId, prompt, nowMs()))
+        transcriptRevision &+= 1
     }
 
     func sendSteer(prompt: String) {
@@ -231,6 +237,7 @@ final class SessionStore {
             "messageId": messageId,
         ])
         pendingSends.append((messageId, prompt, nowMs()))
+        transcriptRevision &+= 1
     }
 
     func sendInterrupt() {

--- a/apps/ios/Comet/Transcript/TranscriptHeightCache.swift
+++ b/apps/ios/Comet/Transcript/TranscriptHeightCache.swift
@@ -1,0 +1,340 @@
+// Font-driven row heights for the mobile transcript virtualizer.
+//
+// LazyVStack is only cheap when it can establish off-screen geometry without
+// constructing every SwiftUI text tree. Heights here use the same Geist fonts,
+// line heights, paddings and block metrics as the row views. Mounted rows still
+// render normally; the prepared minimum gives the lazy stack its scroll model,
+// and a larger mounted measurement is cached as the authoritative correction.
+
+import SwiftUI
+import UIKit
+
+final class TranscriptHeightCache {
+    private struct Key: Hashable {
+        var id: String
+        var version: UInt64
+        var widthPixels: Int
+        var expanded: Bool
+    }
+
+    private struct WidthKey: Hashable {
+        var fontName: String
+        var pointSize: CGFloat
+        var text: String
+    }
+
+    private var values: [Key: CGFloat] = [:]
+    /// Canvas-style shaping cache: once a token has been measured in a font,
+    /// every row can reuse its width and line wrapping becomes pure arithmetic.
+    private var tokenWidths: [WidthKey: CGFloat] = [:]
+
+    func clear() {
+        values.removeAll(keepingCapacity: true)
+    }
+
+    func height(for row: TranscriptRow, width: CGFloat, expanded: Bool = false) -> CGFloat {
+        let key = key(for: row, width: width, expanded: expanded)
+        if let cached = values[key] { return cached }
+        let measured = ceil(contentHeight(for: row.kind, width: max(1, width), expanded: expanded))
+        values[key] = measured
+        if values.count > 20_000 {
+            // Width/version keys naturally repopulate; a wholesale trim is
+            // cheaper than maintaining an LRU during a scroll gesture.
+            values = [key: measured]
+        }
+        return measured
+    }
+
+    func storeMeasuredHeight(_ height: CGFloat, for row: TranscriptRow,
+                             width: CGFloat, expanded: Bool) {
+        guard height > 0 else { return }
+        values[key(for: row, width: width, expanded: expanded)] = ceil(height)
+    }
+
+    private func key(for row: TranscriptRow, width: CGFloat, expanded: Bool) -> Key {
+        let scale = UIScreen.main.scale
+        return Key(
+            id: row.id,
+            version: row.version,
+            widthPixels: Int((width * scale).rounded()),
+            expanded: expanded
+        )
+    }
+
+    private func contentHeight(for kind: RowKind, width: CGFloat, expanded: Bool) -> CGFloat {
+        switch kind {
+        case .user(let text):
+            let bubbleWidth = max(1, min(width, TranscriptView.maxContentWidth * 0.8) - 32)
+            return measure(text: text, font: Theme.sansUI(MD.textSize),
+                           lineHeight: MD.lineHeight, width: bubbleWidth) + 20
+
+        case .markdown(let source, _):
+            return markdownSourceHeight(source, width: width)
+
+        case .toolGroup(let tools, _):
+            return 26 + (expanded ? 2 + CGFloat(tools.count) * 38 : 0)
+
+        case .inputChip, .errorChip:
+            return 34
+        }
+    }
+
+    /// Fast source-only Markdown layout. This deliberately does not construct
+    /// a swift-markdown Document: it recognizes height-affecting block syntax,
+    /// measures prose with the resolved fonts, and uses analytic metrics for
+    /// code/tables/rules. The full AST is deferred until the row mounts.
+    private func markdownSourceHeight(_ source: String, width: CGFloat) -> CGFloat {
+        let lines = source.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var blockHeights: [CGFloat] = []
+        var index = 0
+
+        while index < lines.count {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty {
+                index += 1
+                continue
+            }
+
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                let marker = String(trimmed.prefix(3))
+                let language = String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+                var codeLines = 0
+                index += 1
+                while index < lines.count {
+                    if lines[index].trimmingCharacters(in: .whitespaces).hasPrefix(marker) {
+                        index += 1
+                        break
+                    }
+                    codeLines += 1
+                    index += 1
+                }
+                let header: CGFloat = language.isEmpty ? 0 : 24
+                blockHeights.append(
+                    header + CGFloat(max(1, codeLines)) * MD.codeLineHeight + 2 * MD.codePaddingY
+                )
+                continue
+            }
+
+            if let heading = headingSource(trimmed) {
+                let metrics = MD.headingMetrics(heading.level)
+                blockHeights.append(
+                    measure(text: heading.text,
+                            font: Theme.sansUI(metrics.size, weight: .semibold),
+                            lineHeight: metrics.line,
+                            width: width)
+                )
+                index += 1
+                continue
+            }
+
+            if isRule(trimmed) {
+                blockHeights.append(1)
+                index += 1
+                continue
+            }
+
+            if isTableStart(lines, at: index) {
+                var rowCount = 1 // header
+                index += 2       // header + delimiter
+                while index < lines.count, lines[index].contains("|"),
+                      !lines[index].trimmingCharacters(in: .whitespaces).isEmpty {
+                    rowCount += 1
+                    index += 1
+                }
+                blockHeights.append(
+                    CGFloat(rowCount) * (MD.lineHeight + 24) + CGFloat(max(0, rowCount - 1))
+                )
+                continue
+            }
+
+            if isListLine(trimmed) {
+                var height: CGFloat = 0
+                var count = 0
+                while index < lines.count {
+                    let item = lines[index].trimmingCharacters(in: .whitespaces)
+                    guard isListLine(item) else { break }
+                    let text = stripListMarker(item)
+                    height += max(
+                        MD.lineHeight,
+                        measure(text: text, font: Theme.sansUI(MD.textSize),
+                                lineHeight: MD.lineHeight, width: max(1, width - 26))
+                    )
+                    count += 1
+                    index += 1
+                }
+                blockHeights.append(height + CGFloat(max(0, count - 1)) * 4)
+                continue
+            }
+
+            var paragraph: [String] = []
+            var quote = false
+            while index < lines.count {
+                let candidate = lines[index].trimmingCharacters(in: .whitespaces)
+                if candidate.isEmpty || candidate.hasPrefix("```") || candidate.hasPrefix("~~~")
+                    || headingSource(candidate) != nil || isRule(candidate)
+                    || isTableStart(lines, at: index) || isListLine(candidate) {
+                    break
+                }
+                if candidate.hasPrefix(">") {
+                    quote = true
+                    paragraph.append(
+                        String(candidate.dropFirst()).trimmingCharacters(in: .whitespaces)
+                    )
+                } else {
+                    paragraph.append(candidate)
+                }
+                index += 1
+            }
+            if paragraph.isEmpty {
+                // Unknown syntax must still make progress.
+                paragraph.append(trimmed)
+                index += 1
+            }
+            let inset: CGFloat = quote ? 22 : 0
+            let prose = paragraph.joined(separator: " ")
+            let measured = measure(
+                text: prose,
+                font: Theme.sansUI(MD.textSize),
+                lineHeight: MD.lineHeight,
+                width: max(1, width - inset)
+            )
+            blockHeights.append(measured + (quote ? 12 : 0))
+        }
+
+        return blockHeights.reduce(0, +)
+            + CGFloat(max(0, blockHeights.count - 1)) * MD.blockGap
+    }
+
+    private func headingSource(_ line: String) -> (level: Int, text: String)? {
+        let hashes = line.prefix { $0 == "#" }.count
+        guard (1...6).contains(hashes) else { return nil }
+        let remainder = String(line.dropFirst(hashes))
+        guard remainder.first?.isWhitespace == true else { return nil }
+        return (hashes, remainder.trimmingCharacters(in: .whitespaces))
+    }
+
+    private func isRule(_ line: String) -> Bool {
+        let compact = line.filter { !$0.isWhitespace }
+        guard compact.count >= 3, let first = compact.first,
+              first == "-" || first == "*" || first == "_" else { return false }
+        return compact.allSatisfy { $0 == first }
+    }
+
+    private func isTableStart(_ lines: [String], at index: Int) -> Bool {
+        guard index + 1 < lines.count, lines[index].contains("|") else { return false }
+        let delimiter = lines[index + 1]
+            .filter { !$0.isWhitespace && $0 != "|" && $0 != ":" }
+        return delimiter.count >= 3 && delimiter.allSatisfy { $0 == "-" }
+    }
+
+    private func isListLine(_ line: String) -> Bool {
+        if line.hasPrefix("- ") || line.hasPrefix("* ") || line.hasPrefix("+ ") { return true }
+        guard let dot = line.firstIndex(of: ".") else { return false }
+        return !line[..<dot].isEmpty
+            && line[..<dot].allSatisfy { $0.isNumber }
+            && line[line.index(after: dot)...].first?.isWhitespace == true
+    }
+
+    private func stripListMarker(_ line: String) -> String {
+        if line.hasPrefix("- ") || line.hasPrefix("* ") || line.hasPrefix("+ ") {
+            return String(line.dropFirst(2))
+        }
+        guard let dot = line.firstIndex(of: ".") else { return line }
+        return String(line[line.index(after: dot)...]).trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Mugen-style measurement: shape each distinct token once, cache its
+    /// width, then calculate wrapping with additions and comparisons. This
+    /// avoids allocating attributed strings and running TextKit layout for
+    /// every paragraph in a large session.
+    private func measure(text: String, font: UIFont, lineHeight: CGFloat,
+                         width: CGFloat) -> CGFloat {
+        guard !text.isEmpty else { return 0 }
+        let available = max(1, width)
+        var lineCount = 1
+        var lineWidth: CGFloat = 0
+        var pendingWhitespace: CGFloat = 0
+
+        func placeWord(_ word: String) {
+            let wordWidth = measuredWidth(word, font: font)
+            if lineWidth > 0, lineWidth + pendingWhitespace + wordWidth <= available + 0.5 {
+                lineWidth += pendingWhitespace + wordWidth
+                pendingWhitespace = 0
+                return
+            }
+            if lineWidth > 0 {
+                lineCount += 1
+                lineWidth = 0
+                pendingWhitespace = 0
+            }
+            if wordWidth <= available + 0.5 {
+                lineWidth = wordWidth
+                return
+            }
+
+            // UIKit falls back to grapheme wrapping for an unbroken token that
+            // is wider than the line. This path is rare (long URLs/code), and
+            // individual grapheme widths share the same cache.
+            for character in word {
+                let characterWidth = measuredWidth(String(character), font: font)
+                if lineWidth > 0, lineWidth + characterWidth > available + 0.5 {
+                    lineCount += 1
+                    lineWidth = 0
+                }
+                lineWidth += characterWidth
+            }
+        }
+
+        func placeWhitespace(_ whitespace: String) {
+            guard lineWidth > 0 else { return }
+            pendingWhitespace += measuredWidth(whitespace, font: font)
+        }
+
+        var token = ""
+        var tokenIsWhitespace: Bool?
+
+        func flushToken() {
+            guard !token.isEmpty, let whitespace = tokenIsWhitespace else { return }
+            if whitespace {
+                placeWhitespace(token)
+            } else {
+                placeWord(token)
+            }
+            token.removeAll(keepingCapacity: true)
+            tokenIsWhitespace = nil
+        }
+
+        for character in text {
+            if character.isNewline {
+                flushToken()
+                lineCount += 1
+                lineWidth = 0
+                pendingWhitespace = 0
+                continue
+            }
+            let whitespace = character.isWhitespace
+            if let currentKind = tokenIsWhitespace, currentKind != whitespace {
+                flushToken()
+            }
+            tokenIsWhitespace = whitespace
+            token.append(character)
+        }
+        flushToken()
+
+        return CGFloat(lineCount) * lineHeight
+    }
+
+    private func measuredWidth(_ text: String, font: UIFont) -> CGFloat {
+        let key = WidthKey(fontName: font.fontName, pointSize: font.pointSize, text: text)
+        if let cached = tokenWidths[key] { return cached }
+        let width = (text as NSString).size(withAttributes: [.font: font]).width
+        tokenWidths[key] = width
+        if tokenWidths.count > 30_000 {
+            // Token widths are cheap to repopulate and independent of row
+            // identity. Bound retained source strings on unusually varied logs.
+            tokenWidths = [key: width]
+        }
+        return width
+    }
+}

--- a/apps/ios/Comet/Transcript/TranscriptRows.swift
+++ b/apps/ios/Comet/Transcript/TranscriptRows.swift
@@ -1,17 +1,18 @@
-// Transcript row model — a port of crates/ui/src/shell/transcript.rs
-// rows_for_entry. One row = one markdown top-level block / tool group / chip,
-// never one message: streamed tokens re-render one row, and SwiftUI's lazy
-// stack only re-measures what changed.
+// Transcript row model. One row = one raw text part / tool group / chip.
+// Markdown parts stay as source until their virtual row mounts, so opening a
+// long session never parses off-screen history.
 //
-// Stable ids: markdown rows are "{entryId}#{partId}.{blockIx}", tool groups
-// "{entryId}#g{groupIx}", chips "{entryId}#{partId}". Live and completed parts
-// split identically, so the live→complete handoff never changes row identity.
+// Stable ids: markdown rows are "{entryId}#{partId}", tool groups
+// "{entryId}#g{groupIx}", chips "{entryId}#{partId}".
 
 import Foundation
 
 enum RowKind {
     case user(text: String)
-    case markdown(block: MDBlock, streaming: Bool)
+    /// Raw source stays unparsed until this row mounts. This is the
+    /// virtualization boundary: opening a long session never constructs
+    /// Markdown ASTs for off-screen history.
+    case markdown(source: String, streaming: Bool)
     case toolGroup(tools: [ToolItem], autoOpen: Bool)
     case inputChip(header: String, resolved: Bool)
     case errorChip(message: String)
@@ -35,21 +36,20 @@ struct TranscriptRow: Identifiable {
 }
 
 enum TranscriptRowBuilder {
-    /// Split entries into rows. `parsers` caches one incremental parser per
-    /// "{entryId}#{partId}" so the streaming tail re-parses O(delta + tail).
+    /// Convert entries to cheap part-level rows without parsing Markdown.
+    /// Text parts become one virtual row and are parsed only after mounting.
     static func rows(entries: [MessageEntry],
-                     pendingSends: [(messageId: String, text: String, at: Int64)],
-                     parsers: inout [String: IncrementalMarkdownParser]) -> [TranscriptRow] {
+                     pendingSends: [(messageId: String, text: String, at: Int64)]) -> [TranscriptRow] {
         var rows: [TranscriptRow] = []
         for entry in entries {
-            rowsForEntry(entry, into: &rows, parsers: &parsers)
+            rowsForEntry(entry, into: &rows)
         }
         // Optimistic echo: pending sends share their client-minted id, so the
         // host's real entry replaces them without a flicker.
         let ids = Set(entries.map(\.id))
         for pending in pendingSends where !ids.contains(pending.messageId) {
             rows.append(TranscriptRow(id: pending.messageId,
-                                      version: fnv1a(pending.text) | 1,
+                                      version: textLengthVersion(pending.text) | 1,
                                       turnStart: true,
                                       kind: .user(text: pending.text),
                                       entryId: pending.messageId,
@@ -59,8 +59,7 @@ enum TranscriptRowBuilder {
     }
 
     private static func rowsForEntry(_ entry: MessageEntry,
-                                     into rows: inout [TranscriptRow],
-                                     parsers: inout [String: IncrementalMarkdownParser]) {
+                                     into rows: inout [TranscriptRow]) {
         let streaming = entry.status == .streaming
         let settled = entry.status != nil && !streaming
 
@@ -71,7 +70,7 @@ enum TranscriptRowBuilder {
                 return nil
             }.joined(separator: "\n")
             guard !text.isEmpty else { return }
-            rows.append(TranscriptRow(id: entry.id, version: fnv1a(text),
+            rows.append(TranscriptRow(id: entry.id, version: textLengthVersion(text),
                                       turnStart: true, kind: .user(text: text),
                                       entryId: entry.id, timestamp: entry.createdAt))
             return
@@ -107,21 +106,19 @@ enum TranscriptRowBuilder {
                 guard !text.isEmpty else { continue }
                 let key = "\(entry.id)#\(partId)"
                 let isLiveTail = streaming && ix == lastPartIx
-                let blocks = parse(text: text, key: key, streaming: isLiveTail, parsers: &parsers)
-                for (blockIx, top) in blocks.enumerated() {
-                    var version = (top.fingerprint << 1) | (isLiveTail && blockIx == blocks.count - 1 ? 1 : 0)
-                    if settled, ix == lastPartIx, blockIx == blocks.count - 1 {
-                        version ^= 1 << 62  // timestamp attach keeps the diff key honest
-                    }
-                    rows.append(TranscriptRow(
-                        id: "\(key).\(blockIx)", version: version, turnStart: first,
-                        kind: .markdown(block: top.block,
-                                        streaming: isLiveTail && blockIx == blocks.count - 1),
-                        entryId: entry.id,
-                        timestamp: settled && ix == lastPartIx && blockIx == blocks.count - 1
-                            ? entry.createdAt : nil))
-                    first = false
+                var version = textLengthVersion(text) | (isLiveTail ? 1 : 0)
+                if settled, ix == lastPartIx {
+                    version ^= 1 << 62
                 }
+                rows.append(TranscriptRow(
+                    id: key,
+                    version: version,
+                    turnStart: first,
+                    kind: .markdown(source: text, streaming: isLiveTail),
+                    entryId: entry.id,
+                    timestamp: settled && ix == lastPartIx ? entry.createdAt : nil
+                ))
+                first = false
 
             case .input(let partId, _, let questions, let resolved):
                 flushTools(lastIx: ix - 1)
@@ -143,22 +140,6 @@ enum TranscriptRowBuilder {
             }
         }
         flushTools(lastIx: lastPartIx)
-    }
-
-    private static func parse(text: String, key: String, streaming: Bool,
-                              parsers: inout [String: IncrementalMarkdownParser]) -> [TopBlock] {
-        if streaming {
-            let parser = parsers[key] ?? IncrementalMarkdownParser()
-            parser.setText(text)
-            parsers[key] = parser
-            return parser.blocks
-        }
-        // Completed: adopt the live parser's tree when the flip happens
-        // (handoff), else parse fresh; drop the live parser either way.
-        if let live = parsers.removeValue(forKey: key), live.source == text {
-            return live.blocks
-        }
-        return MarkdownParser.parse(text)
     }
 
     private static func toolFingerprint(_ tools: [ToolItem]) -> UInt64 {
@@ -187,6 +168,13 @@ enum TranscriptRowBuilder {
             hash = hash &* 0x100000001b3
         }
         return hash << 1
+    }
+
+    /// Session text is append-only/immutable after settling, so byte length is
+    /// the same cheap version key used by desktop. This avoids hashing all
+    /// historical text whenever the streaming tail advances.
+    private static func textLengthVersion(_ text: String) -> UInt64 {
+        UInt64(text.utf8.count) << 1
     }
 }
 

--- a/apps/ios/Comet/Transcript/TranscriptView.swift
+++ b/apps/ios/Comet/Transcript/TranscriptView.swift
@@ -1,4 +1,5 @@
-// Transcript — virtualized block-granularity rows with stick-to-bottom.
+// Transcript — virtualized part rows with source-only height preparation and
+// mounted-only Markdown parsing.
 //
 // Desktop parity (transcript.rs): GAP_TURN 14 / GAP_BLOCK 8 / MD_BLOCK_GAP 12,
 // content column max 736, re-engage band 70, jump-button threshold 320,
@@ -26,14 +27,43 @@ struct TranscriptView: View {
     @State private var distanceFromBottom: CGFloat = 0
     @State private var userScrolling = false
     @State private var scrollPosition = ScrollPosition(edge: .bottom)
+    @State private var viewportWidth = UIScreen.main.bounds.width
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        let rows = builder.rows(entries: store.entries, pendingSends: store.pendingSends)
+        let rows = builder.rows(
+            chatId: chatId,
+            revision: store.transcriptRevision,
+            entries: store.entries,
+            pendingSends: store.pendingSends
+        )
+        let contentWidth = max(1, min(viewportWidth, Self.maxContentWidth) - 32)
+        let preparedHeights = builder.prepareHeights(
+            revision: store.transcriptRevision,
+            rows: rows,
+            width: contentWidth,
+            folds: folds
+        )
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(Array(rows.enumerated()), id: \.element.id) { ix, row in
-                    rowView(row, previous: ix > 0 ? rows[ix - 1] : nil, isFirst: ix == 0)
+                    let gap = rowGap(row, isFirst: ix == 0)
+                    let expanded = builder.isExpanded(row, folds: folds)
+                    rowView(row, isFirst: ix == 0)
+                        .frame(
+                            minHeight: gap + preparedHeights[ix],
+                            alignment: .top
+                        )
+                        .onGeometryChange(for: CGFloat.self) { geo in
+                            geo.size.height
+                        } action: { _, actualHeight in
+                            builder.recordMeasuredHeight(
+                                max(0, actualHeight - gap),
+                                for: row,
+                                width: contentWidth,
+                                expanded: expanded
+                            )
+                        }
                         .id(row.id)
                 }
                 Color.clear.frame(height: 44)  // bottom pad clears the fade + floating status strip
@@ -50,6 +80,11 @@ struct TranscriptView: View {
             // anchor — snap once the first pass settles.
             try? await Task.sleep(nanoseconds: 80_000_000)
             scrollPosition.scrollTo(edge: .bottom)
+        }
+        .onGeometryChange(for: CGFloat.self) { geo in
+            geo.size.width
+        } action: { _, newWidth in
+            if newWidth > 0 { viewportWidth = newWidth }
         }
         .onScrollPhaseChange { _, newPhase in
             // Desktop rule: the pin breaks only on USER input (wheel-up/drag),
@@ -142,20 +177,20 @@ struct TranscriptView: View {
     // MARK: Row rendering
 
     @ViewBuilder
-    private func rowView(_ row: TranscriptRow, previous: TranscriptRow?, isFirst: Bool) -> some View {
-        let gap: CGFloat = isFirst
-            ? Self.gapTurn + 10
-            : row.turnStart ? Self.gapTurn
-            : sameMarkdownPart(row, previous) ? MD.blockGap
-            : Self.gapBlock
-
+    private func rowView(_ row: TranscriptRow, isFirst: Bool) -> some View {
         Group {
             switch row.kind {
             case .user(let text):
                 UserBubble(text: text, pending: row.timestamp == nil)
 
-            case .markdown(let block, let streaming):
-                MarkdownRowView(row: row, block: block, streaming: streaming, veils: veils)
+            case .markdown(let source, let streaming):
+                LazyMarkdownRowView(
+                    row: row,
+                    source: source,
+                    streaming: streaming,
+                    veils: veils,
+                    cache: builder.markdownCache
+                )
 
             case .toolGroup(let tools, let autoOpen):
                 ToolGroupView(tools: tools,
@@ -173,27 +208,93 @@ struct TranscriptView: View {
                 ErrorChipView(message: message)
             }
         }
-        .padding(.top, gap)
+        .padding(.top, rowGap(row, isFirst: isFirst))
         .padding(.horizontal, 16)
     }
 
-    private func sameMarkdownPart(_ row: TranscriptRow, _ previous: TranscriptRow?) -> Bool {
-        guard let previous, case .markdown = row.kind, case .markdown = previous.kind else { return false }
-        // Ids are "{entry}#{part}.{ix}" — same prefix ⇒ same part.
-        return row.id.split(separator: ".").dropLast().joined() ==
-            previous.id.split(separator: ".").dropLast().joined()
+    private func rowGap(_ row: TranscriptRow, isFirst: Bool) -> CGFloat {
+        isFirst
+            ? Self.gapTurn + 10
+            : row.turnStart ? Self.gapTurn
+            : Self.gapBlock
     }
+
 }
 
-/// Row-build cache: one incremental parser per streaming part, reused across
-/// body evaluations (a reference type, so building rows never mutates state
-/// mid-render).
+/// Prepared transcript state retained across body evaluations: cheap part rows,
+/// arithmetic heights, and parsed trees only for rows that have mounted.
 final class TranscriptBuilderCache {
-    private var parsers: [String: IncrementalMarkdownParser] = [:]
+    private let heights = TranscriptHeightCache()
+    let markdownCache = MarkdownRenderCache()
+    private var lastChatId: String?
+    private var lastRevision: UInt64?
+    private var lastRows: [TranscriptRow] = []
+    private var preparedRevision: UInt64?
+    private var preparedWidthPixels: Int?
+    private var preparedFoldFingerprint: Int?
+    private var preparedHeights: [CGFloat] = []
 
-    func rows(entries: [MessageEntry],
+    func rows(chatId: String,
+              revision: UInt64,
+              entries: [MessageEntry],
               pendingSends: [(messageId: String, text: String, at: Int64)]) -> [TranscriptRow] {
-        TranscriptRowBuilder.rows(entries: entries, pendingSends: pendingSends, parsers: &parsers)
+        if lastChatId == chatId, lastRevision == revision { return lastRows }
+        if lastChatId != chatId {
+            lastRows.removeAll(keepingCapacity: true)
+            preparedHeights.removeAll(keepingCapacity: true)
+            preparedRevision = nil
+            heights.clear()
+            markdownCache.clear()
+        }
+        let rows = TranscriptRowBuilder.rows(
+            entries: entries,
+            pendingSends: pendingSends
+        )
+        lastChatId = chatId
+        lastRevision = revision
+        lastRows = rows
+        return rows
+    }
+
+    func prepareHeights(revision: UInt64, rows: [TranscriptRow], width: CGFloat,
+                        folds: [String: Bool]) -> [CGFloat] {
+        let widthPixels = Int((width * UIScreen.main.scale).rounded())
+        var foldHasher = Hasher()
+        for (key, value) in folds.sorted(by: { $0.key < $1.key }) {
+            key.hash(into: &foldHasher)
+            value.hash(into: &foldHasher)
+        }
+        let foldFingerprint = foldHasher.finalize()
+        if preparedRevision == revision,
+           preparedWidthPixels == widthPixels,
+           preparedFoldFingerprint == foldFingerprint,
+           preparedHeights.count == rows.count {
+            return preparedHeights
+        }
+        let result = rows.map { row in
+            let expanded = isExpanded(row, folds: folds)
+            return heights.height(for: row, width: width, expanded: expanded)
+        }
+        preparedRevision = revision
+        preparedWidthPixels = widthPixels
+        preparedFoldFingerprint = foldFingerprint
+        preparedHeights = result
+        return result
+    }
+
+    func isExpanded(_ row: TranscriptRow, folds: [String: Bool]) -> Bool {
+        guard case .toolGroup(_, let autoOpen) = row.kind else { return false }
+        return folds[row.id] ?? autoOpen
+    }
+
+    func recordMeasuredHeight(_ height: CGFloat, for row: TranscriptRow,
+                              width: CGFloat, expanded: Bool) {
+        heights.storeMeasuredHeight(height, for: row, width: width, expanded: expanded)
+        if let index = lastRows.firstIndex(where: { $0.id == row.id }),
+           index < preparedHeights.count,
+           height > preparedHeights[index] {
+            preparedHeights[index] = ceil(height)
+        }
     }
 }
 
@@ -241,6 +342,110 @@ struct UserBubble: View {
                 }
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+}
+
+// MARK: - Lazy Markdown parsing
+
+/// Parsed trees for rows that have actually mounted. Stable row versions make
+/// scroll-back a cache hit without parsing the off-screen transcript on open.
+final class MarkdownRenderCache {
+    private struct Entry {
+        var version: UInt64
+        var parser: IncrementalMarkdownParser
+    }
+
+    private var entries: [String: Entry] = [:]
+    private var insertionOrder: [String] = []
+
+    func clear() {
+        entries.removeAll(keepingCapacity: true)
+        insertionOrder.removeAll(keepingCapacity: true)
+    }
+
+    func blocks(for rowId: String, version: UInt64) -> [TopBlock]? {
+        guard let entry = entries[rowId], entry.version == version else { return nil }
+        return entry.parser.blocks
+    }
+
+    /// Return a value snapshot so parsing can mutate it off the main thread
+    /// without racing cache reads. A streaming row therefore resumes from its
+    /// previous stable block prefix instead of parsing the whole message.
+    func parser(for rowId: String) -> IncrementalMarkdownParser {
+        entries[rowId]?.parser ?? IncrementalMarkdownParser()
+    }
+
+    func store(_ parser: IncrementalMarkdownParser, for rowId: String, version: UInt64) {
+        if entries[rowId] == nil {
+            insertionOrder.append(rowId)
+        }
+        entries[rowId] = Entry(version: version, parser: parser)
+        if insertionOrder.count > 2_048 {
+            let evicted = insertionOrder.prefix(512)
+            for key in evicted {
+                entries.removeValue(forKey: key)
+            }
+            insertionOrder.removeFirst(min(512, insertionOrder.count))
+        }
+    }
+}
+
+/// The virtual row exists from raw source + arithmetic height immediately.
+/// Only a mounted row pays for swift-markdown, and parsing runs after the
+/// navigation frame rather than blocking the session press. Streaming rows
+/// retain their incremental parser: plain tokens append directly, while
+/// structural Markdown reparses only the unstable tail.
+struct LazyMarkdownRowView: View {
+    let row: TranscriptRow
+    let source: String
+    let streaming: Bool
+    let veils: VeilStore
+    let cache: MarkdownRenderCache
+
+    @State private var blocks: [TopBlock] = []
+
+    var body: some View {
+        Group {
+            if blocks.isEmpty {
+                Color.clear
+            } else {
+                VStack(alignment: .leading, spacing: MD.blockGap) {
+                    ForEach(Array(blocks.enumerated()), id: \.offset) { ix, top in
+                        if streaming, ix == blocks.count - 1 {
+                            MarkdownRowView(
+                                row: row,
+                                block: top.block,
+                                streaming: true,
+                                veils: veils
+                            )
+                        } else {
+                            MarkdownBlockView(
+                                block: top.block,
+                                cacheKey: "\(row.id).\(ix)"
+                            )
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .task(id: row.version) {
+            if let cached = cache.blocks(for: row.id, version: row.version) {
+                blocks = cached
+                return
+            }
+            let text = source
+            let version = row.version
+            let parserSnapshot = cache.parser(for: row.id)
+            let updatedParser = await Task.detached(priority: .userInitiated) {
+                var updated = parserSnapshot
+                updated.setText(text)
+                return updated
+            }.value
+            guard !Task.isCancelled, version == row.version else { return }
+            cache.store(updatedParser, for: row.id, version: version)
+            blocks = updatedParser.blocks
+        }
     }
 }
 

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -48,20 +48,24 @@ Sync/
   SessionStore.swift    session doc mirror: entries/parts (continuations
                         joined), command ledger appends (rule 1), host nudge
 Markdown/
-  MarkdownModel.swift   block model + incremental tail re-parser (re-parse
-                        from the 2nd-to-last top-level block; link-defs force
-                        full parses) — parser.rs port
+  MarkdownModel.swift   block model + incremental tail parser used only after
+                        a transcript row mounts; stable blocks are reused while
+                        streaming and off-screen history remains raw source
   Highlight.swift       line tokenizer with carry state, paint-only
   MarkdownBlockView.swift  desktop metrics: body 14/22, headings 19/27…14/22,
                         code 12.5/18 (analytic line rows), violet inline code,
                         accent blockquotes, hairline tables
 Transcript/
-  TranscriptRows.swift  rows_for_entry port: block-granularity rows, stable
-                        ids ({msg}#{part}.{block}, {msg}#g{n}), fingerprint
-                        versions, consecutive-tool grouping
-  TranscriptView.swift  lazy stack + stick-to-bottom (pin breaks only on user
-                        scroll, 70pt re-engage band, 320pt jump button),
-                        tool-group folds, error/input chips
+  TranscriptRows.swift  cheap part rows with stable ids ({msg}#{part},
+                        {msg}#g{n}), fingerprint versions, tool grouping; no
+                        Markdown parsing on the session-open path
+  TranscriptHeightCache.swift cached token widths + arithmetic line wrapping
+                        for the complete virtualizer offset model; mounted
+                        sizes correct cache
+  TranscriptView.swift  lazy mounted-only Markdown with per-row parser cache +
+                        stick-to-bottom (pin breaks only on user scroll, 70pt
+                        re-engage band, 320pt jump button), tool folds,
+                        error/input chips
   Veil.swift            paint-only streaming fade (EMA-tracked duration,
                         1−(1−p)^1.6 curve)
 Composer/               glass pill, Send→Steer→Stop morph, QuestionPanel


### PR DESCRIPTION
## What changed

- Keep historical Markdown rows as raw source until they mount.
- Precompute virtual row heights from cached font token widths and arithmetic wrapping.
- Retain per-row incremental Markdown parser state for streaming updates.
- Cache measured geometry and avoid rebuilding transcript rows during scroll-only renders.
- Preserve the newer preload bottom-anchor and tool-group interaction changes from `main`.

## Why

Long mobile sessions performed Markdown parsing and expensive text layout across too much history during navigation. The new path calculates off-screen geometry cheaply, parses only mounted content, and reuses stable parser and measurement state.

## Impact

Opening and scrolling long sessions should do substantially less main-thread work. Desktop code is unchanged.

## Validation

- `git diff --check`
- Remote branch verified as one commit and exactly seven iOS files against `main`
- iOS build not run because this environment does not include Xcode

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet-native/pr/1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787538481&installation_model_id=425430&pr_number=1&repository=zeronsh%2Fcomet-native&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet-native%2Fpull%2F1&signature=6199f294cb1595bec4b42b26fe8b72859815b40f9027bd221cf3581eae432a47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->