### PR TITLE
Use native word-editing shortcuts on every platform

### DIFF
--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -666,9 +666,7 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("shift-cmd-right", SelectEnd, ctx),
         KeyBinding::new("shift-cmd-up", SelectDocStart, ctx),
         KeyBinding::new("shift-cmd-down", SelectDocEnd, ctx),
-        // Deletion by word / to the line edge (Opt+Delete, Cmd+Delete).
-        KeyBinding::new("alt-backspace", DeleteWordLeft, ctx),
-        KeyBinding::new("alt-delete", DeleteWordRight, ctx),
+        // Line-edge deletion (Cmd+Delete on macOS).
         KeyBinding::new("cmd-backspace", DeleteToLineStart, ctx),
         KeyBinding::new("cmd-delete", DeleteToLineEnd, ctx),
     ];
@@ -676,22 +674,42 @@ pub fn init(cx: &mut App) {
         bindings.push(KeyBinding::new(&format!("{prefix}-z"), Undo, ctx));
         bindings.push(KeyBinding::new(&format!("shift-{prefix}-z"), Redo, ctx));
     }
-    // Word navigation and clipboard: bind both modifier conventions so the same
-    // map works across platforms.
-    for prefix in ["ctrl", "alt"] {
-        bindings.push(KeyBinding::new(&format!("{prefix}-left"), WordLeft, ctx));
-        bindings.push(KeyBinding::new(&format!("{prefix}-right"), WordRight, ctx));
-        bindings.push(KeyBinding::new(
-            &format!("shift-{prefix}-left"),
-            SelectWordLeft,
-            ctx,
-        ));
-        bindings.push(KeyBinding::new(
-            &format!("shift-{prefix}-right"),
-            SelectWordRight,
-            ctx,
-        ));
-    }
+    // Word-level editing: Option on macOS, Ctrl on Windows/Linux.
+    let word_edit_prefix = if cfg!(target_os = "macos") {
+        "alt"
+    } else {
+        "ctrl"
+    };
+    bindings.push(KeyBinding::new(
+        &format!("{word_edit_prefix}-backspace"),
+        DeleteWordLeft,
+        ctx,
+    ));
+    bindings.push(KeyBinding::new(
+        &format!("{word_edit_prefix}-delete"),
+        DeleteWordRight,
+        ctx,
+    ));
+    bindings.push(KeyBinding::new(
+        &format!("{word_edit_prefix}-left"),
+        WordLeft,
+        ctx,
+    ));
+    bindings.push(KeyBinding::new(
+        &format!("{word_edit_prefix}-right"),
+        WordRight,
+        ctx,
+    ));
+    bindings.push(KeyBinding::new(
+        &format!("shift-{word_edit_prefix}-left"),
+        SelectWordLeft,
+        ctx,
+    ));
+    bindings.push(KeyBinding::new(
+        &format!("shift-{word_edit_prefix}-right"),
+        SelectWordRight,
+        ctx,
+    ));
     for prefix in ["cmd", "ctrl"] {
         bindings.push(KeyBinding::new(&format!("{prefix}-a"), SelectAll, ctx));
         bindings.push(KeyBinding::new(&format!("{prefix}-c"), Copy, ctx));
@@ -717,31 +735,38 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("cmd-right", End, palette),
         KeyBinding::new("shift-cmd-left", SelectHome, palette),
         KeyBinding::new("shift-cmd-right", SelectEnd, palette),
-        KeyBinding::new("alt-backspace", DeleteWordLeft, palette),
         KeyBinding::new("cmd-backspace", DeleteToLineStart, palette),
     ];
-    for prefix in ["ctrl", "alt"] {
-        palette_bindings.push(KeyBinding::new(
-            &format!("{prefix}-left"),
-            WordLeft,
-            palette,
-        ));
-        palette_bindings.push(KeyBinding::new(
-            &format!("{prefix}-right"),
-            WordRight,
-            palette,
-        ));
-        palette_bindings.push(KeyBinding::new(
-            &format!("shift-{prefix}-left"),
-            SelectWordLeft,
-            palette,
-        ));
-        palette_bindings.push(KeyBinding::new(
-            &format!("shift-{prefix}-right"),
-            SelectWordRight,
-            palette,
-        ));
-    }
+    palette_bindings.push(KeyBinding::new(
+        &format!("{word_edit_prefix}-backspace"),
+        DeleteWordLeft,
+        palette,
+    ));
+    palette_bindings.push(KeyBinding::new(
+        &format!("{word_edit_prefix}-delete"),
+        DeleteWordRight,
+        palette,
+    ));
+    palette_bindings.push(KeyBinding::new(
+        &format!("{word_edit_prefix}-left"),
+        WordLeft,
+        palette,
+    ));
+    palette_bindings.push(KeyBinding::new(
+        &format!("{word_edit_prefix}-right"),
+        WordRight,
+        palette,
+    ));
+    palette_bindings.push(KeyBinding::new(
+        &format!("shift-{word_edit_prefix}-left"),
+        SelectWordLeft,
+        palette,
+    ));
+    palette_bindings.push(KeyBinding::new(
+        &format!("shift-{word_edit_prefix}-right"),
+        SelectWordRight,
+        palette,
+    ));
     for prefix in ["cmd", "ctrl"] {
         palette_bindings.push(KeyBinding::new(&format!("{prefix}-a"), SelectAll, palette));
         palette_bindings.push(KeyBinding::new(&format!("{prefix}-c"), Copy, palette));


### PR DESCRIPTION
## Problem

The composer uses the same word-editing modifiers on every platform: both `Ctrl` and `Alt` move or select by word, while word deletion is hardcoded to `Alt`. That does not match the native convention on Windows and Linux, where users expect `Ctrl+Backspace` and `Ctrl+Delete` alongside `Ctrl+Left` and `Ctrl+Right`.

The command palette also binds only backward word deletion, leaving no modifier-qualified shortcut for deleting the next word.

## What this changes

| Platform | Keys | Behavior |
|---|---|---|
| macOS | `Option+Left/Right` | move by word |
| macOS | `Shift+Option+Left/Right` | select by word |
| macOS | `Option+Backspace/Delete` | delete the previous/next word |
| Windows/Linux | `Ctrl+Left/Right` | move by word |
| Windows/Linux | `Shift+Ctrl+Left/Right` | select by word |
| Windows/Linux | `Ctrl+Backspace/Delete` | delete the previous/next word |

These bindings apply to both the main composer and the command palette. The previous non-native aliases are removed, while clipboard shortcuts and macOS `Cmd+Backspace/Delete` line-edge deletion remain unchanged.

## Implementation

The keymap chooses a single `word_edit_prefix` at compile time: `alt` on macOS and `ctrl` everywhere else. The same prefix is then used for word movement, selection, and deletion in both the `Composer` and `PaletteSearch` contexts, keeping the two input surfaces in sync.

This reuses the existing `WordLeft`, `WordRight`, `SelectWordLeft`, `SelectWordRight`, `DeleteWordLeft`, and `DeleteWordRight` actions, so no text-boundary behavior changes.

## Testing

- `cargo test -p comet-ui` — 313 passed, 0 failed
- `cargo fmt --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788264766&installation_model_id=425430&pr_number=8&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F8&signature=bbe06635fcdb059ee0dde14ecd71e72829ee1e31503a7300461b2d8e1b3de42f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->