### PR TITLE
Add light mode

### DIFF
--- a/crates/ui/src/app_menus.rs
+++ b/crates/ui/src/app_menus.rs
@@ -14,6 +14,7 @@
 
 use gpui::{App, KeyBinding, Menu, MenuItem, OsAction, SystemMenuType, Window, actions};
 
+use crate::appearance::{self, AppearanceMode};
 use crate::composer;
 
 actions!(
@@ -27,6 +28,9 @@ actions!(
         Minimize,
         Zoom,
         CloseWindow,
+        AppearanceSystem,
+        AppearanceLight,
+        AppearanceDark,
     ]
 );
 
@@ -46,6 +50,11 @@ pub fn init(cx: &mut App) {
     cx.on_action(|_: &Minimize, cx| with_active_window(cx, |window| window.minimize_window()));
     cx.on_action(|_: &Zoom, cx| with_active_window(cx, |window| window.zoom_window()));
     cx.on_action(|_: &CloseWindow, cx| with_active_window(cx, |window| window.remove_window()));
+    // Appearance. Each verb persists and repaints every window; see
+    // `appearance::set_mode`.
+    cx.on_action(|_: &AppearanceSystem, cx| appearance::set_mode(AppearanceMode::System, cx));
+    cx.on_action(|_: &AppearanceLight, cx| appearance::set_mode(AppearanceMode::Light, cx));
+    cx.on_action(|_: &AppearanceDark, cx| appearance::set_mode(AppearanceMode::Dark, cx));
 }
 
 fn with_active_window(cx: &mut App, f: impl FnOnce(&mut Window)) {
@@ -130,6 +139,13 @@ pub fn app_menus() -> Vec<Menu> {
             MenuItem::os_action("Select All", composer::SelectAll, OsAction::SelectAll),
         ]),
     ];
+    // Appearance lives under View on every platform — it is the only View verb
+    // today, but "Appearance" as a top-level menu would read oddly next to Edit.
+    menus.push(Menu::new("View").items([
+        MenuItem::action("Appearance: System", AppearanceSystem),
+        MenuItem::action("Appearance: Light", AppearanceLight),
+        MenuItem::action("Appearance: Dark", AppearanceDark),
+    ]));
     if macos {
         // Standard Window menu; macOS appends the open-window list itself.
         menus.push(Menu::new("Window").items([
@@ -210,6 +226,23 @@ mod tests {
             assert_eq!(got_name, want_name);
             assert!(got_os == want_os, "OsAction mismatch for {want_name}");
         }
+    }
+
+    #[test]
+    fn view_menu_offers_all_three_appearance_modes() {
+        let menus = app_menus();
+        let view = menus
+            .iter()
+            .find(|m| m.name.as_ref() == "View")
+            .expect("View menu present");
+        assert_eq!(
+            action_names(view),
+            vec![
+                AppearanceSystem.name(),
+                AppearanceLight.name(),
+                AppearanceDark.name()
+            ]
+        );
     }
 
     #[test]

--- a/crates/ui/src/appearance.rs
+++ b/crates/ui/src/appearance.rs
@@ -1,0 +1,253 @@
+//! Light/dark switching: what the user asked for, what the OS reports, and the
+//! plumbing that turns a change in either into a repaint.
+//!
+//! Three pieces, following the pattern zed uses (`crates/theme/src/theme.rs`
+//! `SystemAppearance` + `reload_theme` + `cx.refresh_windows`):
+//!
+//! 1. [`AppearanceMode`] — the persisted user choice: follow the OS, or pin one.
+//! 2. [`AppearanceState`] — a gpui global holding that choice alongside the last
+//!    appearance the OS reported, so [`resolve`] can combine them.
+//! 3. [`observe_window`] — subscribes to the platform's appearance notification
+//!    (macOS `viewDidChangeEffectiveAppearance`) and re-applies.
+//!
+//! # Why `refresh_windows` and not `notify`
+//!
+//! Colors are read *imperatively* (`Theme::of(cx).text`) at paint time, not
+//! through a reactive binding, so no view knows its colors went stale — a
+//! `notify()` on some entity would repaint that entity and nothing else.
+//! [`App::refresh_windows`] marks every window dirty *and* disables gpui's
+//! per-view prepaint cache for the frame, which is the only thing that forces
+//! already-laid-out elements to re-run their paint with the new palette.
+
+use std::path::{Path, PathBuf};
+
+use gpui::{App, Global, Subscription, Window};
+use serde::{Deserialize, Serialize};
+
+use crate::settings::UiSettings;
+use crate::theme::{Appearance, Theme};
+
+/// The user's appearance preference. Persisted in `ui-settings.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AppearanceMode {
+    /// Follow the OS. The default — matches every other native app on the
+    /// machine, including when the user has macOS set to switch at sunset.
+    #[default]
+    System,
+    Light,
+    Dark,
+}
+
+impl AppearanceMode {
+    /// Menu/label text.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::System => "System",
+            Self::Light => "Light",
+            Self::Dark => "Dark",
+        }
+    }
+
+    pub const ALL: [Self; 3] = [Self::System, Self::Light, Self::Dark];
+}
+
+/// Global state behind the current theme: what the user chose, and what the OS
+/// last said. Kept separate from [`Theme`] itself so that flipping the OS
+/// appearance while the user has pinned Light still records the new system value
+/// (and takes effect the moment they switch back to `System`).
+pub struct AppearanceState {
+    pub mode: AppearanceMode,
+    pub system: Appearance,
+    /// Where `ui-settings.json` lives, so a menu action can persist the choice
+    /// without routing through the shell entity that normally owns settings.
+    pub data_dir: PathBuf,
+}
+
+impl Global for AppearanceState {}
+
+/// Combine the user's choice with the OS state.
+pub fn resolve(mode: AppearanceMode, system: Appearance) -> Appearance {
+    match mode {
+        AppearanceMode::System => system,
+        AppearanceMode::Light => Appearance::Light,
+        AppearanceMode::Dark => Appearance::Dark,
+    }
+}
+
+/// Install the appearance globals and the matching theme. Call once at boot,
+/// before any window opens, so the first frame is already the right palette
+/// (installing later produces a visible dark-to-light flash).
+pub fn init(mode: AppearanceMode, data_dir: impl Into<PathBuf>, cx: &mut App) {
+    let system = Appearance::from_window(cx.window_appearance());
+    tracing::debug!(?mode, ?system, "appearance: initial");
+    cx.set_global(AppearanceState {
+        mode,
+        system,
+        data_dir: data_dir.into(),
+    });
+    Theme::install(resolve(mode, system), cx);
+}
+
+/// The mode currently in effect (defaults to `System` before [`init`]).
+pub fn mode(cx: &App) -> AppearanceMode {
+    cx.try_global::<AppearanceState>()
+        .map(|s| s.mode)
+        .unwrap_or_default()
+}
+
+/// Change the user's preference, repaint if that changed the palette, and write
+/// the choice to disk.
+pub fn set_mode(mode: AppearanceMode, cx: &mut App) {
+    if !cx.has_global::<AppearanceState>() {
+        return;
+    }
+    let state = cx.global_mut::<AppearanceState>();
+    if state.mode == mode {
+        return;
+    }
+    state.mode = mode;
+    let data_dir = state.data_dir.clone();
+    apply(cx);
+    persist(mode, &data_dir);
+}
+
+/// Read-modify-write `ui-settings.json` for just the appearance key.
+///
+/// Deliberately a fresh load rather than a write of some cached struct: the
+/// shell holds its own `UiSettings` and saves it debounced, so writing a stale
+/// snapshot from here would silently roll back a pane resize the user made
+/// seconds earlier. Reloading keeps this to the one field we own.
+fn persist(mode: AppearanceMode, data_dir: &Path) {
+    let mut settings = UiSettings::load(data_dir);
+    settings.appearance = mode;
+    if let Err(err) = settings.save(data_dir) {
+        tracing::warn!(error = %err, "could not persist appearance");
+    }
+}
+
+/// Subscribe a window to OS appearance changes. The returned [`Subscription`]
+/// must outlive the window — callers typically `.detach()` it.
+///
+/// The notification is *per window*, but the appearance it reports is a system
+/// setting, so any one window is enough to learn about the change; re-applying
+/// is idempotent when several fire.
+pub fn observe_window(window: &mut Window, cx: &mut App) -> Subscription {
+    // Reconcile against the *window's* appearance before subscribing.
+    //
+    // [`init`] runs before any window exists and can only ask the platform
+    // (`App::window_appearance`), which on macOS reads `NSApp.effectiveAppearance`
+    // — and that is not reliably populated that early in launch. When it guesses
+    // wrong the app paints the wrong palette until some unrelated event happens to
+    // fire the appearance notification, which reads as "it booted dark and fixed
+    // itself when I clicked something". The window knows for certain, so ask it.
+    sync(Appearance::from_window(window.appearance()), cx);
+    window.observe_window_appearance(|window, cx| {
+        sync(Appearance::from_window(window.appearance()), cx);
+    })
+}
+
+/// Record the OS appearance and re-apply if it moved.
+fn sync(system: Appearance, cx: &mut App) {
+    if !cx.has_global::<AppearanceState>() {
+        return;
+    }
+    let state = cx.global_mut::<AppearanceState>();
+    if state.system == system {
+        return;
+    }
+    tracing::debug!(?system, "appearance: system changed");
+    state.system = system;
+    apply(cx);
+}
+
+/// Re-resolve the palette and, if it moved, swap the theme and force a full
+/// repaint. A no-op when the resolved appearance is unchanged — the OS fires the
+/// notification for vibrancy and accent-color changes too, and repainting every
+/// window for those would be a visible hitch for nothing.
+pub fn apply(cx: &mut App) {
+    let Some(state) = cx.try_global::<AppearanceState>() else {
+        return;
+    };
+    let wanted = resolve(state.mode, state.system);
+    let changed = !cx
+        .try_global::<Theme>()
+        .is_some_and(|t| t.appearance == wanted);
+    if changed {
+        tracing::debug!(?wanted, "appearance: installing palette");
+        Theme::install(wanted, cx);
+        cx.refresh_windows();
+    }
+    // Unconditional, even when the palette did not move: this is the only thing
+    // that keeps macOS vibrancy alive. gpui's macOS backend removes the
+    // `NSVisualEffectView` from the window the moment the background appearance
+    // is anything but `Blurred`, and nothing puts it back on its own — so a
+    // single missed re-apply leaves the sidebar and tab strip permanently
+    // opaque, which is exactly how the frost died. zed runs the same loop on
+    // every settings change (`crates/zed/src/main.rs`).
+    reapply_window_background(cx);
+}
+
+/// Push the theme's window background appearance onto every open window.
+pub fn reapply_window_background(cx: &mut App) {
+    let Some(wanted) = cx
+        .try_global::<Theme>()
+        .map(|theme| theme.window_background_appearance())
+    else {
+        return;
+    };
+    for window in cx.windows() {
+        window
+            .update(cx, |_, window, _| {
+                window.set_background_appearance(wanted);
+            })
+            .ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_mode_follows_the_os() {
+        assert_eq!(
+            resolve(AppearanceMode::System, Appearance::Light),
+            Appearance::Light
+        );
+        assert_eq!(
+            resolve(AppearanceMode::System, Appearance::Dark),
+            Appearance::Dark
+        );
+    }
+
+    #[test]
+    fn pinned_modes_ignore_the_os() {
+        for system in [Appearance::Light, Appearance::Dark] {
+            assert_eq!(resolve(AppearanceMode::Light, system), Appearance::Light);
+            assert_eq!(resolve(AppearanceMode::Dark, system), Appearance::Dark);
+        }
+    }
+
+    #[test]
+    fn default_mode_is_system() {
+        assert_eq!(AppearanceMode::default(), AppearanceMode::System);
+    }
+
+    /// The setting round-trips through the settings file as a lowercase string.
+    #[test]
+    fn mode_serialises_stably() {
+        for (mode, json) in [
+            (AppearanceMode::System, "\"system\""),
+            (AppearanceMode::Light, "\"light\""),
+            (AppearanceMode::Dark, "\"dark\""),
+        ] {
+            assert_eq!(serde_json::to_string(&mode).unwrap(), json);
+            assert_eq!(
+                serde_json::from_str::<AppearanceMode>(json).unwrap(),
+                mode,
+                "{json} should parse back"
+            );
+        }
+    }
+}

--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -24,7 +24,7 @@ use gpui::{
 };
 
 use crate::state::EngineHandle;
-use crate::theme::white_alpha;
+use crate::theme::ink;
 use comet_rpc::methods;
 
 /// use-attachments.ts `MAX_ATTACHMENT_BYTES`.
@@ -561,7 +561,7 @@ pub fn lightbox(
                     .occlude()
                     .w(viewport.width)
                     .h(viewport.height)
-                    .bg(gpui::hsla(0.0, 0.0, 0.0, 0.7))
+                    .bg(crate::popover::scrim_alpha(0.7))
                     .flex()
                     .flex_col()
                     .items_center()
@@ -582,7 +582,7 @@ pub fn lightbox(
                             .max_w(max_w)
                             .overflow_hidden()
                             .text_size(px(11.0))
-                            .text_color(white_alpha(0.45))
+                            .text_color(ink(0.45))
                             .child(preview.name.clone()),
                     ),
             ),

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -31,7 +31,7 @@ use crate::markdown::highlight::{Lang, LineCarry, Token, lang_for_tag, tokenize_
 use crate::markdown::render;
 use crate::motion::{self, AnimationExt as _, CHEVRON, COLLAPSE};
 use crate::state::{AppState, EngineHandle};
-use crate::theme::{Theme, oklch};
+use crate::theme::Theme;
 
 // ---------------------------------------------------------------------------
 // Layout numbers (analytic — they drive the fold tween)
@@ -808,7 +808,7 @@ impl Changes {
             .flex()
             .flex_col()
             .border_b_1()
-            .border_color(crate::theme::white_alpha(0.04))
+            .border_color(crate::theme::hairline(0.04))
             .child(header)
             .child(body)
             .into_any_element()
@@ -864,9 +864,9 @@ impl Changes {
             .items_center()
             .gap(px(8.0))
             .px(px(Theme::SPACE_MD))
-            .bg(crate::theme::white_alpha(0.025))
+            .bg(crate::theme::ink(0.025))
             .cursor_pointer()
-            .hover(|s| s.bg(crate::theme::white_alpha(0.05)))
+            .hover(|s| s.bg(crate::theme::ink(0.05)))
             .on_click(cx.listener(move |this, _, _, cx| {
                 this.toggle_fold(&path, expanded_height);
                 cx.notify();
@@ -879,7 +879,7 @@ impl Changes {
                     .truncate()
                     .font_family(theme.font_mono.clone())
                     .text_size(px(12.0))
-                    .text_color(crate::theme::grey(0x98))
+                    .text_color(theme.text_dim)
                     .child(SharedString::from(file.path.clone())),
             )
             .when(file.binary, |el| {
@@ -897,7 +897,7 @@ impl Changes {
                         .flex_none()
                         .font_family(theme.font_mono.clone())
                         .text_size(px(11.0))
-                        .text_color(add_color())
+                        .text_color(add_color(theme))
                         .child(SharedString::from(format!("+{adds}"))),
                 )
             })
@@ -907,7 +907,7 @@ impl Changes {
                         .flex_none()
                         .font_family(theme.font_mono.clone())
                         .text_size(px(11.0))
-                        .text_color(del_color())
+                        .text_color(del_color(theme))
                         .child(SharedString::from(format!("−{dels}"))),
                 )
             })
@@ -926,7 +926,7 @@ impl Changes {
                 .gap(px(10.0))
                 .px(px(Theme::SPACE_LG))
                 .border_b_1()
-                .border_color(crate::theme::white_alpha(0.06))
+                .border_color(crate::theme::hairline(0.06))
                 .child(
                     div()
                         .text_size(px(12.0))
@@ -937,14 +937,14 @@ impl Changes {
                     div()
                         .font_family(theme.font_mono.clone())
                         .text_size(px(11.0))
-                        .text_color(add_color())
+                        .text_color(add_color(theme))
                         .child(SharedString::from(format!("+{}", parsed.additions))),
                 )
                 .child(
                     div()
                         .font_family(theme.font_mono.clone())
                         .text_size(px(11.0))
-                        .text_color(del_color())
+                        .text_color(del_color(theme))
                         .child(SharedString::from(format!("−{}", parsed.deletions))),
                 )
                 .child(div().flex_1())
@@ -967,13 +967,13 @@ impl Changes {
 }
 
 /// Green for additions — sampled from the reference diff (soft emerald).
-fn add_color() -> gpui::Hsla {
-    oklch(0.765, 0.177, 163.223) // emerald-400
+fn add_color(theme: &Theme) -> gpui::Hsla {
+    theme.diff_add // emerald-400
 }
 
 /// Red for deletions — softer than the theme danger, per the reference diff.
-fn del_color() -> gpui::Hsla {
-    oklch(0.704, 0.191, 22.216) // red-400
+fn del_color(theme: &Theme) -> gpui::Hsla {
+    theme.diff_del // red-400
 }
 
 /// Diff syntax palette — since round 9 the transcript's code blocks share the
@@ -1010,12 +1010,12 @@ fn render_file_body(
     }
 
     // Row tints sampled from the reference: ~5–6% washes over the pane tone.
-    let mut add_bg = add_color();
+    let mut add_bg = add_color(theme);
     add_bg.a = 0.055;
-    let mut del_bg = del_color();
+    let mut del_bg = del_color(theme);
     del_bg.a = 0.055;
     // Bluish-grey hunk-header wash.
-    let hunk_bg = gpui::hsla(0.6, 0.35, 0.6, 0.05);
+    let hunk_bg = theme.diff_hunk_bg;
 
     for hunk in &file.hunks {
         children.push(
@@ -1063,17 +1063,17 @@ fn render_file_body(
             let (marker, marker_color, row_bg, accent, number_color) = match line.kind {
                 LineKind::Add => (
                     "+",
-                    add_color(),
+                    add_color(theme),
                     Some(add_bg),
-                    Some(add_color().opacity(0.55)),
-                    add_color().opacity(0.9),
+                    Some(add_color(theme).opacity(0.55)),
+                    add_color(theme).opacity(0.9),
                 ),
                 LineKind::Del => (
                     "−",
-                    del_color(),
+                    del_color(theme),
                     Some(del_bg),
-                    Some(del_color().opacity(0.55)),
-                    del_color().opacity(0.9),
+                    Some(del_color(theme).opacity(0.55)),
+                    del_color(theme).opacity(0.9),
                 ),
                 _ => (
                     "·",

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -1883,7 +1883,8 @@ impl gpui::Element for ComposerTextElement {
         let input = self.input.read(cx);
         let scroll = px(input.scroll_top);
         let origin = point(bounds.left(), bounds.top() - scroll);
-        let selection_color = gpui::hsla(0.66, 0.6, 0.55, 0.35);
+        let selection_color = Theme::of(cx).selection;
+        let caret_color = Theme::of(cx).caret;
 
         let mut selection_quads = Vec::new();
         let mut cursor = None;
@@ -1894,12 +1895,12 @@ impl gpui::Element for ComposerTextElement {
                         point(origin.x + p.x, origin.y + p.y),
                         size(px(2.0), input.line_height),
                     ),
-                    gpui::hsla(0.66, 0.7, 0.7, 1.0),
+                    caret_color,
                 ));
             } else if input.display_is_placeholder {
                 cursor = Some(fill(
                     Bounds::new(origin, size(px(2.0), input.line_height)),
-                    gpui::hsla(0.66, 0.7, 0.7, 1.0),
+                    caret_color,
                 ));
             }
         } else if let (Some(start), Some(end)) = (
@@ -2334,7 +2335,7 @@ impl Composer {
                             .rounded(px(8.0))
                             .overflow_hidden()
                             .border_1()
-                            .border_color(crate::theme::white_alpha(0.10))
+                            .border_color(crate::theme::hairline(0.10))
                             .cursor_pointer()
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.preview = Some(preview.clone());
@@ -3051,18 +3052,18 @@ impl Composer {
                 .rounded(px(12.0))
                 .border_1()
                 .border_color(if picked {
-                    crate::theme::white_alpha(0.16)
+                    crate::theme::ink(0.16)
                 } else {
                     gpui::transparent_black()
                 })
                 // comet question-panel.tsx option rows: `transition-colors`.
                 .bg(if picked {
-                    crate::theme::white_alpha(0.09)
+                    crate::theme::ink(0.09)
                 } else {
                     motion::hover_blend(
                         &format!("wizard-option-{ix}"),
-                        crate::theme::white_alpha(0.025),
-                        crate::theme::white_alpha(0.06),
+                        crate::theme::ink(0.025),
+                        crate::theme::ink(0.06),
                     )
                 })
                 .on_hover(motion::hover_listener(format!("wizard-option-{ix}")))
@@ -3092,9 +3093,9 @@ impl Composer {
                             .justify_center()
                             .rounded(px(6.0))
                             .bg(if picked {
-                                crate::theme::white_alpha(0.16)
+                                crate::theme::ink(0.16)
                             } else {
-                                crate::theme::white_alpha(0.05)
+                                crate::theme::ink(0.05)
                             })
                             .text_size(px(11.0))
                             .text_color(if picked {
@@ -3116,7 +3117,7 @@ impl Composer {
             .rounded(px(26.0))
             .border_1()
             .border_color(theme.border)
-            .bg(crate::theme::white_alpha(0.03))
+            .bg(theme.input_bg)
             .shadow_lg()
             .flex()
             .flex_col()
@@ -3150,7 +3151,7 @@ impl Composer {
                                         .flex()
                                         .items_center()
                                         .rounded(px(6.0))
-                                        .bg(crate::theme::white_alpha(0.06))
+                                        .bg(crate::theme::ink(0.06))
                                         .text_size(px(10.0))
                                         .font_weight(gpui::FontWeight::MEDIUM)
                                         .text_color(theme.text_muted.opacity(0.6))
@@ -3190,7 +3191,7 @@ impl Composer {
                         div()
                             .mt(px(12.0))
                             .border_t_1()
-                            .border_color(crate::theme::white_alpha(0.06))
+                            .border_color(crate::theme::hairline(0.06))
                             .pt(px(12.0))
                             .pb(px(4.0))
                             .px(px(4.0))
@@ -3404,7 +3405,7 @@ impl Render for Composer {
                 let offline = message.as_ref() == "Engine not connected";
                 let (border_c, wash, text_c) = if offline {
                     let amber = theme.warning; // amber-400
-                    let amber_200 = crate::theme::oklch(0.924, 0.12, 95.746);
+                    let amber_200 = theme.warning_muted;
                     (
                         amber.opacity(0.16),
                         amber.opacity(0.05),
@@ -3412,7 +3413,7 @@ impl Render for Composer {
                     )
                 } else {
                     let danger = theme.danger; // red-400
-                    let red_300 = crate::theme::oklch(0.808, 0.114, 19.571);
+                    let red_300 = theme.danger_muted;
                     (
                         danger.opacity(0.16),
                         danger.opacity(0.05),
@@ -3508,7 +3509,7 @@ impl Render for Composer {
             .bg(motion::hover_blend(
                 "composer-attach",
                 gpui::transparent_black(),
-                crate::theme::white_alpha(0.10),
+                crate::theme::ink(0.10),
             ))
             .on_hover(motion::hover_listener("composer-attach"))
             .on_click(cx.listener(|this, _, _, cx| this.open_file_picker(cx)))
@@ -3525,7 +3526,7 @@ impl Render for Composer {
         // border-white/[0.08] bg-white/[0.03] shadow-xl` — a floating pill with
         // a hairline over a faint wash, never a solid grey box. Picker chips,
         // attach, and the send circle all live INSIDE the pill.
-        let pill_bg = crate::theme::white_alpha(0.03);
+        let pill_bg = theme.input_bg;
         let pill = div()
             .rounded(px(26.0))
             .bg(pill_bg)

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`loaders`] — comet pulse loader, gradient spinner, boot splash.
 
 pub mod app_menus;
+pub mod appearance;
 pub mod attachments;
 pub mod changes;
 pub mod composer;
@@ -135,7 +136,15 @@ pub fn run_app(config: UiConfig) {
         // NB: pinned-rev API — `gpui_tokio::init(cx)` free function (not `Tokio::init`).
         gpui_tokio::init(cx);
         register_fonts(cx);
-        cx.set_global(theme::Theme::dark());
+        // Appearance before anything paints: the theme global has to be the
+        // final one on the very first frame, or the window flashes the wrong
+        // palette while settings load.
+        let data_dir = config.boot().data_dir.clone();
+        appearance::init(
+            settings::UiSettings::load(&data_dir).appearance,
+            data_dir,
+            cx,
+        );
         composer::init(cx);
         terminal::panel::init(cx);
         app_menus::init(cx);
@@ -215,15 +224,24 @@ fn open_main_window(state: gpui::Entity<state::AppState>, boot: EngineBootConfig
             // shell paints its frost surface translucent so the sidebar reads
             // as glass (shell.rs root). Elsewhere blur support is compositor
             // roulette — stay opaque.
-            window_background: if cfg!(target_os = "macos") {
-                gpui::WindowBackgroundAppearance::Blurred
-            } else {
-                gpui::WindowBackgroundAppearance::Opaque
-            },
+            // One source of truth with the re-apply loop in `appearance::apply`
+            // — if these two ever disagree, vibrancy dies on the first theme
+            // change and never comes back.
+            window_background: theme::Theme::of(cx).window_background_appearance(),
             app_id: Some("comet".into()),
             ..Default::default()
         },
-        move |_, cx| cx.new(|cx| shell::Shell::new(state, boot, cx)),
+        move |window, cx| {
+            // React to the user flipping macOS between light and dark. Detached:
+            // the subscription lives as long as the window does, and the window
+            // owns nothing that would drop it early.
+            appearance::observe_window(window, cx).detach();
+            cx.new(|cx| shell::Shell::new(state, boot, cx))
+        },
     )
     .expect("failed to open window");
+    // Belt and braces: assert the blur once the window actually exists. The
+    // `WindowOptions` value is applied during creation, before the view is
+    // attached; re-pushing it here means a window is never left opaque.
+    appearance::reapply_window_background(cx);
 }

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -463,7 +463,12 @@ fn render_table(
                 TableAlign::Right => cell.text_right(),
             };
             if let Some(flat) = cell_flat {
-                cell = cell.child(flat_text_element(flat, table_cell_ix(ix, r, c), opts, theme));
+                cell = cell.child(flat_text_element(
+                    flat,
+                    table_cell_ix(ix, r, c),
+                    opts,
+                    theme,
+                ));
             }
             row_el = row_el.child(cell);
         }
@@ -633,7 +638,12 @@ fn flatten_cached(
 }
 
 /// Veiled, clickable text for a flattened block (no sizing wrapper).
-fn flat_text_element(flat: &FlatText, ix: usize, opts: &RenderOptions, theme: &Theme) -> AnyElement {
+fn flat_text_element(
+    flat: &FlatText,
+    ix: usize,
+    opts: &RenderOptions,
+    theme: &Theme,
+) -> AnyElement {
     // Streaming veil: opacity-only recolor of the runs covering newly appended
     // chunks. Same text, same fonts, same lengths — layout is untouched.
     // Settled elements return no spans and reuse the cached runs unsplit.
@@ -1114,7 +1124,7 @@ pub fn token_color(class: TokenClass, theme: &Theme) -> Hsla {
     match class {
         TokenClass::Keyword => theme.syntax_keyword, // soft rose
         TokenClass::StringLit => theme.syntax_string, // soft green
-        TokenClass::Number => theme.syntax_number,    // soft amber
+        TokenClass::Number => theme.syntax_number,   // soft amber
         TokenClass::Comment => theme.text_faint,
     }
 }

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -58,7 +58,7 @@ pub const TABLE_MIN_COLUMN_CONTENT: f32 = 48.0;
 pub const TABLE_MIN_COLUMN_WIDTH: f32 = 96.0;
 /// Hairline tone (comet md theme `table.borderColor`: rgba(255,255,255,0.1)).
 pub fn table_hairline() -> Hsla {
-    crate::theme::white_alpha(0.10)
+    crate::theme::hairline(0.10)
 }
 
 /// Options for one rendered tree (a transcript row or a whole live message).
@@ -114,10 +114,16 @@ impl RenderOptions {
 /// below that boundary is byte-identical and its flatten result (and, via
 /// gpui's line-layout cache keyed on identical text+runs, its shaping) can be
 /// reused as-is. `SharedString`/`Rc` make the reuse O(1) per block.
+/// Cached runs carry a resolved [`gpui::Hsla`] per span, so an entry is only
+/// valid for the palette that produced it — content-only keys silently serve
+/// dark-mode text onto a light background after an appearance switch.
+/// [`RenderCache::sync_palette`] drops everything when the palette moves.
 #[derive(Default)]
 pub struct RenderCache {
     flats: HashMap<(SharedString, usize, usize), Rc<FlatText>>,
     code: HashMap<(SharedString, usize, usize), Rc<CachedCode>>,
+    /// The [`crate::theme::theme_generation`] these entries were shaped under.
+    generation: u32,
 }
 
 /// Cached per-line code runs (validity: code length + highlight identity).
@@ -138,6 +144,16 @@ impl RenderCache {
     pub fn clear(&mut self) {
         self.flats.clear();
         self.code.clear();
+    }
+
+    /// Drop every entry if the palette changed since they were shaped. Cheap
+    /// enough (one relaxed atomic load) to call on every cache access.
+    fn sync_palette(&mut self) {
+        let generation = crate::theme::theme_generation();
+        if self.generation != generation {
+            self.clear();
+            self.generation = generation;
+        }
     }
 }
 
@@ -447,7 +463,7 @@ fn render_table(
                 TableAlign::Right => cell.text_right(),
             };
             if let Some(flat) = cell_flat {
-                cell = cell.child(flat_text_element(flat, table_cell_ix(ix, r, c), opts));
+                cell = cell.child(flat_text_element(flat, table_cell_ix(ix, r, c), opts, theme));
             }
             row_el = row_el.child(cell);
         }
@@ -479,11 +495,11 @@ pub struct FlatText {
 /// Inline-code tint (round 9): the original is neutral (chat-view.tsx mdTheme
 /// `inlineCode: #f0f0f0 on white/8%`), but the user asked for "a nice purple"
 /// — violet-300 text over a violet-400 wash, readable on the #060606 panel.
-pub fn inline_code_text() -> Hsla {
-    crate::theme::oklch(0.811, 0.111, 293.571) // violet-300
+pub fn inline_code_text(theme: &Theme) -> Hsla {
+    theme.code_text // violet-300
 }
-pub fn inline_code_wash() -> Hsla {
-    crate::theme::oklch(0.702, 0.183, 293.541).opacity(0.12) // violet-400/12
+pub fn inline_code_wash(theme: &Theme) -> Hsla {
+    theme.code_wash // violet-400/12
 }
 /// Rounded-wash geometry: small radius on a slightly inset box (paint-only —
 /// x extends 2px past the glyphs, y insets 2px from the 22px line box).
@@ -539,7 +555,7 @@ fn flatten_runs_weighted(runs: &[InlineRun], theme: &Theme, base_weight: FontWei
         // Inline code reads violet (see `inline_code_text`); everything else
         // stays the monochrome foreground.
         let color = if run.style.code {
-            inline_code_text()
+            inline_code_text(theme)
         } else {
             theme.text
         };
@@ -603,18 +619,21 @@ fn flatten_cached(
     theme: &Theme,
 ) -> Rc<FlatText> {
     match &opts.cache {
-        Some(cache) => cache
-            .borrow_mut()
-            .flats
-            .entry((opts.row_key.clone(), top_ix, ix))
-            .or_insert_with(|| Rc::new(flatten_runs_weighted(runs, theme, base_weight)))
-            .clone(),
+        Some(cache) => {
+            let mut cache = cache.borrow_mut();
+            cache.sync_palette();
+            cache
+                .flats
+                .entry((opts.row_key.clone(), top_ix, ix))
+                .or_insert_with(|| Rc::new(flatten_runs_weighted(runs, theme, base_weight)))
+                .clone()
+        }
         None => Rc::new(flatten_runs_weighted(runs, theme, base_weight)),
     }
 }
 
 /// Veiled, clickable text for a flattened block (no sizing wrapper).
-fn flat_text_element(flat: &FlatText, ix: usize, opts: &RenderOptions) -> AnyElement {
+fn flat_text_element(flat: &FlatText, ix: usize, opts: &RenderOptions, theme: &Theme) -> AnyElement {
     // Streaming veil: opacity-only recolor of the runs covering newly appended
     // chunks. Same text, same fonts, same lengths — layout is untouched.
     // Settled elements return no spans and reuse the cached runs unsplit.
@@ -648,10 +667,11 @@ fn flat_text_element(flat: &FlatText, ix: usize, opts: &RenderOptions) -> AnyEle
     let sel_key: std::sync::Arc<str> = format!("{}:{ix}", opts.row_key).into();
     let code_ranges = flat.code_ranges.clone();
     let flat_text = flat.text.clone();
+    let wash = inline_code_wash(theme);
+    let sel_wash = selection_wash(theme);
     let underlay = canvas(
         |_, _, _| (),
         move |_, _, window, _| {
-            let wash = inline_code_wash();
             for range in &code_ranges {
                 for rect in range_rects(&layout, range, INLINE_CODE_PAD_X, INLINE_CODE_INSET_Y) {
                     window.paint_quad(quad(
@@ -669,7 +689,7 @@ fn flat_text_element(flat: &FlatText, ix: usize, opts: &RenderOptions) -> AnyEle
                     window.paint_quad(quad(
                         rect,
                         px(0.0),
-                        selection_wash(),
+                        sel_wash,
                         px(0.0),
                         gpui::transparent_black(),
                         BorderStyle::default(),
@@ -699,8 +719,8 @@ fn flat_text_element(flat: &FlatText, ix: usize, opts: &RenderOptions) -> AnyEle
 }
 
 /// Selection tint: the accent hue under the glyphs, dark-panel strength.
-fn selection_wash() -> Hsla {
-    crate::theme::oklch(0.673, 0.182, 276.935).opacity(0.35) // indigo-400
+fn selection_wash(theme: &Theme) -> Hsla {
+    theme.accent.opacity(0.35) // indigo-400
 }
 
 /// One painted text element, registered per frame in document order — the
@@ -923,7 +943,7 @@ fn text_element(
         FontWeight::NORMAL
     };
     let flat = flatten_cached(runs, weight, top_ix, ix, opts, theme);
-    let inner = flat_text_element(&flat, ix, opts);
+    let inner = flat_text_element(&flat, ix, opts, theme);
     div()
         .text_size(px(size))
         .line_height(px(line_height))
@@ -969,6 +989,7 @@ fn render_code_block(
     let cached: Rc<CachedCode> = match &opts.cache {
         Some(cache) => {
             let mut cache = cache.borrow_mut();
+            cache.sync_palette();
             let entry = cache
                 .code
                 .entry((opts.row_key.clone(), top_ix, ix))
@@ -1015,7 +1036,7 @@ fn render_code_block(
             .bg(crate::motion::hover_blend(
                 &fade_key,
                 gpui::transparent_black(),
-                crate::theme::white_alpha(0.08),
+                crate::theme::ink(0.08),
             ))
             .on_hover(crate::motion::hover_listener(fade_key))
             .text_size(px(10.5))
@@ -1036,7 +1057,7 @@ fn render_code_block(
         .rounded(px(10.0))
         // Faint white wash over the near-black panel ≈ #101010 (comet's code
         // surface), with the hairline border.
-        .bg(crate::theme::white_alpha(0.035))
+        .bg(crate::theme::ink(0.035))
         .border_1()
         .border_color(theme.border)
         .overflow_hidden()
@@ -1049,7 +1070,7 @@ fn render_code_block(
                     .border_b_1()
                     .border_color(theme.border)
                     // A whisper of tone separation between header and body.
-                    .bg(crate::theme::white_alpha(0.02))
+                    .bg(crate::theme::ink(0.02))
                     .text_size(px(11.0))
                     .text_color(theme.text_muted)
                     .child(SharedString::from(lang.to_string())),
@@ -1091,9 +1112,9 @@ fn render_code_block(
 /// asked for color; these are the diff pane's hues, now shared by both).
 pub fn token_color(class: TokenClass, theme: &Theme) -> Hsla {
     match class {
-        TokenClass::Keyword => crate::theme::oklch(0.709, 0.129, 20.0), // soft rose
-        TokenClass::StringLit => crate::theme::oklch(0.77, 0.11, 168.0), // soft green
-        TokenClass::Number => crate::theme::oklch(0.78, 0.12, 80.0),    // soft amber
+        TokenClass::Keyword => theme.syntax_keyword, // soft rose
+        TokenClass::StringLit => theme.syntax_string, // soft green
+        TokenClass::Number => theme.syntax_number,    // soft amber
         TokenClass::Comment => theme.text_faint,
     }
 }
@@ -1207,7 +1228,7 @@ mod tests {
         assert_eq!(flat.code_ranges, vec![4..9, 14..17]);
         // Code text is the violet tint; the square run background is gone
         // (the rounded wash is painted by the canvas underlay instead).
-        assert_eq!(flat.runs[1].color, inline_code_text());
+        assert_eq!(flat.runs[1].color, inline_code_text(&theme));
         assert_eq!(flat.runs[1].background_color, None);
         assert_eq!(flat.runs[0].color, theme.text);
     }

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -811,7 +811,7 @@ mod tests {
 
         // Transparent → wash: alpha ramps, hue stays the wash's (premultiplied
         // — never a darkened grey mid-fade).
-        let wash = crate::theme::white_alpha(0.06);
+        let wash = crate::theme::ink(0.06);
         let half = mix(gpui::transparent_black(), wash, 0.5);
         assert!((half.a - 0.03).abs() < 1e-4, "alpha midpoint {}", half.a);
         let half_rgba = Rgba::from(half);

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -810,7 +810,10 @@ mod tests {
         assert!(mid.l > rest.l && mid.l < hover.l, "mid lightness {}", mid.l);
 
         // Transparent → wash: alpha ramps, hue stays the wash's (premultiplied
-        // — never a darkened grey mid-fade).
+        // — never a darkened grey mid-fade). `ink` reads the process-wide
+        // appearance, which theme's tests flip — hold the lock so this test
+        // never observes a mid-flip Light palette.
+        let _guard = crate::theme::lock_appearance();
         let wash = crate::theme::ink(0.06);
         let half = mix(gpui::transparent_black(), wash, 0.5);
         assert!((half.a - 0.03).abs() < 1e-4, "alpha midpoint {}", half.a);

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -1930,8 +1930,7 @@ impl Pickers {
                             })
                             .when(is_disabled, |el| el.opacity(0.35))
                             .when(!is_disabled, |el| {
-                                el.cursor_pointer()
-                                    .hover(|s| s.bg(crate::theme::ink(0.06)))
+                                el.cursor_pointer().hover(|s| s.bg(crate::theme::ink(0.06)))
                             })
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.pick_harness(harness, cx);

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -1369,7 +1369,7 @@ impl Pickers {
                 } else {
                     theme.text_muted
                 },
-                Theme::dark().text,
+                theme.text,
             ))
             .bg(if open {
                 theme.element_hover
@@ -1931,7 +1931,7 @@ impl Pickers {
                             .when(is_disabled, |el| el.opacity(0.35))
                             .when(!is_disabled, |el| {
                                 el.cursor_pointer()
-                                    .hover(|s| s.bg(crate::theme::white_alpha(0.06)))
+                                    .hover(|s| s.bg(crate::theme::ink(0.06)))
                             })
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.pick_harness(harness, cx);
@@ -2059,7 +2059,7 @@ impl Pickers {
                             .w(px(148.0))
                             .flex_none()
                             .border_r_1()
-                            .border_color(crate::theme::white_alpha(0.06))
+                            .border_color(crate::theme::hairline(0.06))
                             .child(rail),
                     )
                     .child(
@@ -2104,7 +2104,7 @@ impl Pickers {
                                     .max_h(px(190.0))
                                     .overflow_y_scroll()
                                     .border_t_1()
-                                    .border_color(crate::theme::white_alpha(0.06))
+                                    .border_color(crate::theme::hairline(0.06))
                                     .p(px(4.0))
                                     .child(traits),
                             ),
@@ -2116,7 +2116,7 @@ impl Pickers {
                     .flex_none()
                     .bg(popover::band())
                     .border_t_1()
-                    .border_color(crate::theme::white_alpha(0.06))
+                    .border_color(crate::theme::hairline(0.06))
                     .px(px(12.0))
                     .py(px(8.0))
                     .flex()
@@ -2254,7 +2254,7 @@ fn trait_chip(theme: &Theme, active: bool) -> gpui::Div {
                 .text_color(theme.text)
         })
         .when(!active, |el| {
-            el.bg(crate::theme::white_alpha(0.04))
+            el.bg(crate::theme::ink(0.04))
                 .text_color(theme.text_muted.opacity(0.7))
                 .hover(|s| s.bg(theme.element_hover))
         })
@@ -2290,7 +2290,7 @@ fn toggle_switch(theme: &Theme, on: bool) -> gpui::Div {
         .bg(if on {
             theme.text
         } else {
-            crate::theme::white_alpha(0.15)
+            crate::theme::ink(0.15)
         })
         .relative()
         .child(
@@ -2301,9 +2301,9 @@ fn toggle_switch(theme: &Theme, on: bool) -> gpui::Div {
                 .size(px(14.0))
                 .rounded_full()
                 .bg(if on {
-                    crate::theme::grey(0x0e)
+                    theme.on_solid
                 } else {
-                    crate::theme::white_alpha(0.7)
+                    crate::theme::ink(0.7)
                 }),
         )
 }

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -16,7 +16,7 @@ use gpui::{
 };
 
 use crate::motion::{self, AnimationExt as _, COMET_PULSE};
-use crate::theme::{Theme, grey, white_alpha};
+use crate::theme::{Theme, hairline, ink};
 
 // ---------------------------------------------------------------------------
 // Loadable — async slot state shared by pickers/settings pages
@@ -146,7 +146,7 @@ pub fn classify_key(key: &str, cmd: bool, ctrl: bool) -> MenuKey {
 pub fn popover_card(theme: &Theme) -> gpui::Div {
     let card = div()
         .border_1()
-        .border_color(white_alpha(0.10))
+        .border_color(hairline(0.10))
         .rounded(px(12.0))
         .shadow_lg()
         .p(px(4.0))
@@ -156,9 +156,9 @@ pub fn popover_card(theme: &Theme) -> gpui::Div {
     if Theme::GLASS_ALPHA < 1.0 {
         // Translucent tint — the backdrop blur beneath it comes from the
         // [`crate::frost::frosted`] wrapper at the mount helpers below.
-        card.bg(grey(0x16).opacity(0.65))
+        card.bg(theme.surface_overlay.opacity(0.65))
     } else {
-        card.bg(grey(0x16))
+        card.bg(theme.surface_overlay)
     }
 }
 
@@ -271,6 +271,18 @@ pub fn menu_at(
     .into_any_element()
 }
 
+/// Modal/overlay scrim at the *current* appearance, quoted in dark-mode terms
+/// like [`ink`]/[`hairline`] — for callers (`modal`, the attachment lightbox)
+/// that paint from a `deferred`/`anchored` layer with no `Theme`/`cx` in
+/// scope. Mirrors [`Theme::scrim`], which is pinned at `X = 0.6` dark /
+/// `0.32` light; other dark-mode alphas scale the light side by the same
+/// ratio so the *dark* result is always exactly `alpha_dark` (never routed
+/// through [`Hsla::opacity`], whose `0..=1` clamp would clip a
+/// larger-than-0.6 alpha before it could scale the light side).
+pub(crate) fn scrim_alpha(alpha_dark: f32) -> gpui::Hsla {
+    crate::theme::scrim(alpha_dark)
+}
+
 /// Full-window modal: dim scrim + centered card with the `dialog-in` entrance.
 /// The scrim swallows clicks; the caller wires its own dismiss/confirm.
 /// `viewport` is the window size (an `anchored` layer sizes to its children,
@@ -289,7 +301,7 @@ pub fn modal(
                     .occlude()
                     .w(viewport.width)
                     .h(viewport.height)
-                    .bg(gpui::hsla(0.0, 0.0, 0.0, 0.6))
+                    .bg(scrim_alpha(0.6))
                     .flex()
                     .items_center()
                     .justify_center()
@@ -322,11 +334,7 @@ pub fn menu_row(theme: &Theme, active: bool, fade_key: impl Into<SharedString>) 
     } else {
         let fade_key = fade_key.into();
         let mut row = row
-            .text_color(motion::hover_blend(
-                &fade_key,
-                theme.text.opacity(0.9),
-                Theme::dark().text,
-            ))
+            .text_color(motion::hover_blend(&fade_key, theme.text.opacity(0.9), theme.text))
             .bg(motion::hover_blend(
                 &fade_key,
                 crate::theme::wash(0.0),
@@ -397,7 +405,7 @@ pub fn menu_separator() -> gpui::Div {
         .h(px(1.0))
         .mx(px(-4.0))
         .my(px(4.0))
-        .bg(white_alpha(0.07))
+        .bg(hairline(0.07))
 }
 
 /// The trailing check on the selected row (comet `MenuCheck`): 14px,
@@ -411,8 +419,12 @@ pub fn menu_check(theme: &Theme) -> impl IntoElement {
 /// The recessed band tone for a palette/picker header or footer strip — a
 /// translucent black so the glass still reads through (the add-space palette
 /// converged on this; measured subtler tones vanish against the dim scrim).
+/// Free function (like [`ink`]/[`hairline`]/[`wash`]), mirroring
+/// [`Theme::band`], for the several callers with no `Theme`/`cx` in scope
+/// (some outside this crate's `ui` module tree — threading a `&Theme` param
+/// would ripple past this task's file scope).
 pub fn band() -> gpui::Hsla {
-    gpui::hsla(0.0, 0.0, 0.0, 0.16)
+    crate::theme::band()
 }
 
 /// One footer key-cap (22px, rounded-5, `white/[0.05]`) holding arbitrary
@@ -428,7 +440,7 @@ pub fn key_cap(_theme: &Theme) -> gpui::Div {
         .items_center()
         .justify_center()
         .gap(px(4.0))
-        .bg(white_alpha(0.05))
+        .bg(ink(0.05))
 }
 
 /// The tiny verb after a key-cap.
@@ -477,7 +489,7 @@ pub fn key_hint_pair(
                         .size(px(12.5))
                         .text_color(theme.text_muted.opacity(0.7)),
                 )
-                .child(div().w(px(1.0)).h(px(11.0)).bg(white_alpha(0.10)))
+                .child(div().w(px(1.0)).h(px(11.0)).bg(hairline(0.10)))
                 .child(
                     crate::icons::icon(second)
                         .size(px(12.5))
@@ -494,9 +506,9 @@ pub fn kbd_hint(theme: &Theme, label: &str) -> gpui::Div {
         .px(px(5.0))
         .py(px(1.0))
         .rounded(px(5.0))
-        .bg(white_alpha(0.05))
+        .bg(ink(0.05))
         .text_size(px(10.0))
-        .font_family(Theme::dark().font_mono.clone())
+        .font_family(theme.font_mono.clone())
         .text_color(theme.text_muted.opacity(0.6))
         .child(SharedString::from(label.to_string()))
 }
@@ -511,7 +523,7 @@ pub fn search_input_frame(_theme: &Theme, input: AnyElement) -> gpui::Div {
         .px(px(10.0))
         .py(px(6.0))
         .rounded(px(8.0))
-        .bg(white_alpha(0.04))
+        .bg(ink(0.04))
         .text_size(px(13.0))
         .child(input)
 }
@@ -525,7 +537,7 @@ pub fn menu_section() -> gpui::Div {
         .mt(px(4.0))
         .pt(px(4.0))
         .border_t_1()
-        .border_color(white_alpha(0.06))
+        .border_color(hairline(0.06))
         .flex()
         .flex_col()
         .gap(px(2.0))
@@ -542,9 +554,9 @@ pub fn dialog_card(theme: &Theme) -> gpui::Div {
         .w(px(360.0))
         .p(px(20.0))
         .rounded(px(16.0))
-        .bg(grey(0x10))
+        .bg(theme.surface_dialog)
         .border_1()
-        .border_color(white_alpha(0.10))
+        .border_color(hairline(0.10))
         .shadow_lg()
         .flex()
         .flex_col()
@@ -578,8 +590,8 @@ pub fn dialog_field(input: AnyElement) -> gpui::Div {
         .py(px(8.0))
         .rounded(px(8.0))
         .border_1()
-        .border_color(white_alpha(0.08))
-        .bg(white_alpha(0.04))
+        .border_color(hairline(0.08))
+        .bg(ink(0.04))
         .text_size(px(14.0))
         .child(input)
 }
@@ -594,15 +606,11 @@ pub fn btn_ghost(theme: &Theme, label: &str, fade_key: impl Into<SharedString>) 
         .py(px(6.0))
         .rounded(px(8.0))
         .text_size(px(13.0))
-        .text_color(motion::hover_blend(
-            &fade_key,
-            theme.text_muted,
-            Theme::dark().text,
-        ))
+        .text_color(motion::hover_blend(&fade_key, theme.text_muted, theme.text))
         .bg(motion::hover_blend(
             &fade_key,
             crate::theme::wash(0.0),
-            white_alpha(0.06),
+            ink(0.06),
         ))
         .cursor_pointer()
         .child(SharedString::from(label.to_string()));
@@ -620,19 +628,19 @@ pub fn btn_primary(theme: &Theme, label: &str) -> gpui::Div {
         .bg(theme.text)
         .text_size(px(13.0))
         .font_weight(gpui::FontWeight::MEDIUM)
-        .text_color(grey(0x0e))
+        .text_color(theme.on_solid)
         .cursor_pointer()
         .hover(|s| s.opacity(0.9))
         .child(SharedString::from(label.to_string()))
 }
 
 /// Destructive button (`btnDestructive`): the muted red fill.
-pub fn btn_danger(_theme: &Theme, label: &str) -> gpui::Div {
+pub fn btn_danger(theme: &Theme, label: &str) -> gpui::Div {
     div()
         .px(px(12.0))
         .py(px(6.0))
         .rounded(px(8.0))
-        .bg(crate::theme::oklch(0.58, 0.16, 25.0))
+        .bg(theme.danger_strong)
         .text_size(px(13.0))
         .font_weight(gpui::FontWeight::MEDIUM)
         .text_color(gpui::white())
@@ -644,7 +652,7 @@ pub fn btn_danger(_theme: &Theme, label: &str) -> gpui::Div {
 /// Pulsing skeleton rows shown while a list loads (comet:
 /// `h-7 animate-pulse rounded-md bg-white/[0.04]`).
 pub fn skeleton_rows(id: &'static str, _theme: &Theme, count: usize) -> AnyElement {
-    let wash = white_alpha(0.04);
+    let wash = ink(0.04);
     div()
         .flex()
         .flex_col()

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -334,7 +334,11 @@ pub fn menu_row(theme: &Theme, active: bool, fade_key: impl Into<SharedString>) 
     } else {
         let fade_key = fade_key.into();
         let mut row = row
-            .text_color(motion::hover_blend(&fade_key, theme.text.opacity(0.9), theme.text))
+            .text_color(motion::hover_blend(
+                &fade_key,
+                theme.text.opacity(0.9),
+                theme.text,
+            ))
             .bg(motion::hover_blend(
                 &fade_key,
                 crate::theme::wash(0.0),
@@ -401,11 +405,7 @@ pub fn tracked_upper(label: &str) -> String {
 pub fn menu_separator() -> gpui::Div {
     // Full-bleed: negative margins cancel the card's p-1 inset so the hairline
     // runs border to border (user request).
-    div()
-        .h(px(1.0))
-        .mx(px(-4.0))
-        .my(px(4.0))
-        .bg(hairline(0.07))
+    div().h(px(1.0)).mx(px(-4.0)).my(px(4.0)).bg(hairline(0.07))
 }
 
 /// The trailing check on the selected row (comet `MenuCheck`): 14px,

--- a/crates/ui/src/rail.rs
+++ b/crates/ui/src/rail.rs
@@ -475,7 +475,7 @@ impl Transcript {
                 let bar_color = if is_active || is_hovered {
                     theme.text.opacity(0.8)
                 } else {
-                    crate::theme::white_alpha(0.16)
+                    crate::theme::ink(0.16)
                 };
                 let prompt = truncate_preview(&tick.prompt, PREVIEW_PROMPT_CHARS);
                 let reply = tick

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 pub mod accounts;
+pub mod appearance;
 pub mod archived;
 pub mod composer;
 pub mod devices;
@@ -72,6 +73,8 @@ pub struct UiSettings {
     pub terminal_open: bool,
     /// Customizable shortcut combos (feature-inventory §1.4).
     pub keymap: KeymapConfig,
+    /// Light/dark preference. Defaults to following the OS.
+    pub appearance: crate::appearance::AppearanceMode,
 }
 
 impl Default for UiSettings {
@@ -89,6 +92,7 @@ impl Default for UiSettings {
             terminal_height: TERMINAL_DEFAULT_HEIGHT,
             terminal_open: false,
             keymap: KeymapConfig::default(),
+            appearance: crate::appearance::AppearanceMode::default(),
         }
     }
 }
@@ -347,9 +351,30 @@ mod tests {
                 toggle_sidebar: "mod-shift-s".into(),
                 ..KeymapConfig::default()
             },
+            appearance: crate::appearance::AppearanceMode::Light,
         };
         settings.save(dir.path()).unwrap();
         assert_eq!(UiSettings::load(dir.path()), settings);
+    }
+
+    /// A settings file written before light mode existed has no `appearance`
+    /// key; it must load as "follow the OS" rather than failing the whole parse
+    /// and resetting every other preference to defaults.
+    #[test]
+    fn settings_without_appearance_default_to_system() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            UiSettings::path(dir.path()),
+            r#"{"sidebarWidth": 300, "soundEnabled": false}"#,
+        )
+        .unwrap();
+        let loaded = UiSettings::load(dir.path());
+        assert_eq!(
+            loaded.appearance,
+            crate::appearance::AppearanceMode::System
+        );
+        assert_eq!(loaded.sidebar_width, 300.0);
+        assert!(!loaded.sound_enabled, "other keys still parse");
     }
 
     #[test]

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -369,10 +369,7 @@ mod tests {
         )
         .unwrap();
         let loaded = UiSettings::load(dir.path());
-        assert_eq!(
-            loaded.appearance,
-            crate::appearance::AppearanceMode::System
-        );
+        assert_eq!(loaded.appearance, crate::appearance::AppearanceMode::System);
         assert_eq!(loaded.sidebar_width, 300.0);
         assert!(!loaded.sound_enabled, "other keys still parse");
     }

--- a/crates/ui/src/settings/accounts.rs
+++ b/crates/ui/src/settings/accounts.rs
@@ -310,9 +310,7 @@ impl AccountsPage {
                 } else {
                     gpui::transparent_black()
                 })
-                .when(!open, |el| {
-                    el.hover(|s| s.bg(crate::theme::ink(0.04)))
-                })
+                .when(!open, |el| el.hover(|s| s.bg(crate::theme::ink(0.04))))
                 .on_click(cx.listener(|this, _, _, cx| {
                     let just_dismissed = this
                         .device_menu_dismissed_at
@@ -801,10 +799,7 @@ impl AccountsPage {
                         .text_color(theme.text_muted)
                         .cursor_pointer()
                         .when(is_busy, |el| el.opacity(0.5))
-                        .hover(|s| {
-                            s.bg(crate::theme::ink(0.06))
-                                .text_color(theme.text)
-                        })
+                        .hover(|s| s.bg(crate::theme::ink(0.06)).text_color(theme.text))
                         .on_click(cx.listener(move |this, _, _, cx| {
                             this.account_action(methods::FORGET_AGENT_ACCOUNT, &forget_account, cx);
                         }))
@@ -1348,9 +1343,11 @@ impl Render for AccountsPage {
                                             .child(SharedString::from("Add account")),
                                     ),
                             )
-                            .children(warnings.into_iter().map(|warning| {
-                                widgets::warning_strip(&theme, warning)
-                            }))
+                            .children(
+                                warnings
+                                    .into_iter()
+                                    .map(|warning| widgets::warning_strip(&theme, warning)),
+                            )
                             .child(card)
                             .into_any_element()
                     })

--- a/crates/ui/src/settings/accounts.rs
+++ b/crates/ui/src/settings/accounts.rs
@@ -290,7 +290,7 @@ impl AccountsPage {
             .as_ref()
             .map(|d| d.name.clone().into())
             .unwrap_or_else(|| SharedString::from("This device"));
-        let emerald = crate::theme::oklch(0.765, 0.177, 163.223);
+        let emerald = theme.success;
         let open = self.device_menu_open;
 
         let mut trigger =
@@ -306,12 +306,12 @@ impl AccountsPage {
                 .gap(px(6.0))
                 .cursor_pointer()
                 .bg(if open {
-                    crate::theme::white_alpha(0.06)
+                    crate::theme::ink(0.06)
                 } else {
                     gpui::transparent_black()
                 })
                 .when(!open, |el| {
-                    el.hover(|s| s.bg(crate::theme::white_alpha(0.04)))
+                    el.hover(|s| s.bg(crate::theme::ink(0.04)))
                 })
                 .on_click(cx.listener(|this, _, _, cx| {
                     let just_dismissed = this
@@ -340,7 +340,7 @@ impl AccountsPage {
                     if effective == local_id {
                         emerald
                     } else {
-                        crate::theme::white_alpha(0.2)
+                        crate::theme::ink(0.2)
                     },
                 ))
                 .child(
@@ -401,7 +401,7 @@ impl AccountsPage {
                                 .bg(if is_local {
                                     emerald
                                 } else {
-                                    crate::theme::white_alpha(0.2)
+                                    crate::theme::ink(0.2)
                                 }),
                         )
                 }))
@@ -707,7 +707,7 @@ impl AccountsPage {
                     .h(px(5.0))
                     .rounded_full()
                     .overflow_hidden()
-                    .bg(crate::theme::white_alpha(0.07))
+                    .bg(crate::theme::ink(0.07))
                     .when(fraction > 0.0, |el| {
                         el.child(
                             div()
@@ -777,7 +777,7 @@ impl AccountsPage {
             .items_center()
             .gap(px(6.0))
             .when(account.active, |el| {
-                el.child(widgets::badge_active("Active"))
+                el.child(widgets::badge_active(theme, "Active"))
             })
             .when_some(account.plan_label.clone(), |el, plan| {
                 el.child(widgets::badge(theme, plan))
@@ -802,8 +802,8 @@ impl AccountsPage {
                         .cursor_pointer()
                         .when(is_busy, |el| el.opacity(0.5))
                         .hover(|s| {
-                            s.bg(crate::theme::white_alpha(0.06))
-                                .text_color(Theme::dark().text)
+                            s.bg(crate::theme::ink(0.06))
+                                .text_color(theme.text)
                         })
                         .on_click(cx.listener(move |this, _, _, cx| {
                             this.account_action(methods::FORGET_AGENT_ACCOUNT, &forget_account, cx);
@@ -854,7 +854,7 @@ impl AccountsPage {
                     .rounded_full()
                     .border_1()
                     .border_color(theme.border)
-                    .bg(crate::theme::white_alpha(0.03))
+                    .bg(crate::theme::ink(0.03))
                     .flex()
                     .items_center()
                     .justify_center()
@@ -918,7 +918,7 @@ impl AccountsPage {
         cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
         let theme = Theme::of(cx).clone();
-        let red_text = crate::theme::oklch(0.81, 0.108, 19.6).opacity(0.9); // red-300
+        let red_text = theme.danger_muted.opacity(0.9); // red-300
         let login = self.login.as_ref()?;
         let title = login.title();
         let url_link =
@@ -933,7 +933,7 @@ impl AccountsPage {
                     .text_color(theme.text_muted.opacity(0.6))
                     .truncate()
                     .cursor_pointer()
-                    .hover(|s| s.text_color(Theme::dark().text))
+                    .hover(|s| s.text_color(theme.text))
                     .on_click(cx.listener(move |_, _, _, cx| {
                         cx.open_url(&open_url);
                     }))
@@ -1104,7 +1104,7 @@ impl AccountsPage {
                         el.rounded(px(4.0))
                     }
                 })
-                .bg(crate::theme::white_alpha(0.05))
+                .bg(crate::theme::ink(0.05))
         };
         let meters = div()
             .mt(px(8.0))
@@ -1125,7 +1125,7 @@ impl AccountsPage {
                             .max_w(px(230.0))
                             .h(px(5.0))
                             .rounded_full()
-                            .bg(crate::theme::white_alpha(0.04)),
+                            .bg(crate::theme::ink(0.04)),
                     )
                     .child(ghost(px(64.0).into(), 9.0, false))
             }));
@@ -1140,7 +1140,7 @@ impl AccountsPage {
                     .self_center()
                     .size(px(32.0))
                     .rounded_full()
-                    .bg(crate::theme::white_alpha(0.05)),
+                    .bg(crate::theme::ink(0.05)),
             )
             .child(
                 div()
@@ -1259,7 +1259,7 @@ impl Render for AccountsPage {
             Loadable::Error(message) => {
                 let message = message.clone();
                 vec![
-                    widgets::error_strip(message)
+                    widgets::error_strip(&theme, message)
                         .id("accounts-load-error")
                         .cursor_pointer()
                         .on_click(cx.listener(|this, _, _, cx| {
@@ -1270,7 +1270,7 @@ impl Render for AccountsPage {
                             div()
                                 .mt(px(4.0))
                                 .text_size(px(11.5))
-                                .text_color(Theme::dark().text_muted)
+                                .text_color(theme.text_muted)
                                 .child(SharedString::from("Click to retry")),
                         )
                         .into_any_element(),
@@ -1336,7 +1336,7 @@ impl Render for AccountsPage {
                                     .child(
                                         widgets::ghost_action(&theme)
                                             .id(add_id)
-                                            .hover(widgets::ghost_hover)
+                                            .hover(|s| widgets::ghost_hover(&theme, s))
                                             .on_click(cx.listener(move |this, _, _, cx| {
                                                 this.start_login(harness, cx);
                                             }))
@@ -1348,11 +1348,9 @@ impl Render for AccountsPage {
                                             .child(SharedString::from("Add account")),
                                     ),
                             )
-                            .children(
-                                warnings
-                                    .into_iter()
-                                    .map(|warning| widgets::warning_strip(warning)),
-                            )
+                            .children(warnings.into_iter().map(|warning| {
+                                widgets::warning_strip(&theme, warning)
+                            }))
                             .child(card)
                             .into_any_element()
                     })
@@ -1382,7 +1380,7 @@ impl Render for AccountsPage {
                                     .id("accounts-refresh")
                                     .flex_none()
                                     .text_size(px(12.5))
-                                    .hover(widgets::ghost_hover)
+                                    .hover(|s| widgets::ghost_hover(&theme, s))
                                     .when(refreshing, |el| el.opacity(0.5))
                                     .on_click(cx.listener(|this, _, _, cx| {
                                         this.load(force_usage_for(LoadTrigger::Refresh), cx)
@@ -1404,7 +1402,7 @@ impl Render for AccountsPage {
                     ))
                     .when_some(self.error.clone(), |el, message| {
                         el.child(
-                            widgets::error_strip(message)
+                            widgets::error_strip(&theme, message)
                                 .id("accounts-action-error")
                                 .cursor_pointer()
                                 .on_click(cx.listener(|this, _, _, cx| {

--- a/crates/ui/src/settings/appearance.rs
+++ b/crates/ui/src/settings/appearance.rs
@@ -1,0 +1,254 @@
+//! Settings → Appearance: pick between following the system and pinning light or
+//! dark.
+//!
+//! Uses [`widgets::option_card_row`] — a preview-card picker, because the choice
+//! is a *look*, and a miniature of the result says more than a sentence about it.
+//! The control itself is theme-agnostic; only the previews below know what a
+//! theme is.
+//!
+//! Stateless. The choice lives in the [`crate::appearance`] globals, and
+//! `set_mode` repaints every window, so this page has nothing of its own to hold.
+
+use gpui::{AnyElement, Context, Hsla, IntoElement, Render, SharedString, Window, div, prelude::*, px};
+
+use crate::appearance::{self, AppearanceMode};
+use crate::settings::widgets;
+use crate::theme::{Appearance, Theme};
+
+pub struct AppearancePage;
+
+impl AppearancePage {
+    pub fn new(_cx: &mut Context<Self>) -> Self {
+        Self
+    }
+}
+
+/// One placeholder bar in the miniature.
+fn bar(width: f32, tone: Hsla) -> gpui::Div {
+    div().h(px(5.0)).w(px(width)).rounded(px(3.0)).bg(tone)
+}
+
+/// Which corners a miniature rounds — the split card needs each half to round
+/// only its outer side so the two meet flush down the middle.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Corners {
+    All,
+    Left,
+    Right,
+}
+
+/// A miniature of the app in `theme`: sidebar strip, inset content card, a few
+/// placeholder lines. Built from the theme's own tokens rather than fixed
+/// swatches, so the previews stay honest if the palette is retuned.
+///
+/// Rounds itself: the card frame cannot do it for us (see
+/// [`widgets::OPTION_CARD_RADIUS`]). Only this root paints a background that
+/// reaches the corners — the sidebar strip is transparent and the content card is
+/// inset — so rounding here is enough.
+fn miniature(theme: &Theme, corners: Corners) -> AnyElement {
+    let line = theme.text.opacity(0.22);
+    let strong = theme.text.opacity(0.34);
+    let r = px(widgets::OPTION_CARD_RADIUS);
+    let root = div()
+        .size_full()
+        .flex()
+        .flex_row()
+        .bg(theme.surface);
+    let root = match corners {
+        Corners::All => root.rounded(r),
+        Corners::Left => root.rounded_tl(r).rounded_bl(r),
+        Corners::Right => root.rounded_tr(r).rounded_br(r),
+    };
+    root
+        .child(
+            // Sidebar strip.
+            div()
+                .w(px(44.0))
+                .h_full()
+                .flex_none()
+                .flex()
+                .flex_col()
+                .gap(px(7.0))
+                .px(px(8.0))
+                .pt(px(14.0))
+                .child(bar(20.0, strong))
+                .child(bar(28.0, line))
+                .child(bar(24.0, line))
+                .child(bar(28.0, line)),
+        )
+        .child(
+            // Inset content card — the same rounded plate the real shell floats.
+            div()
+                .flex_1()
+                .min_w_0()
+                .my(px(8.0))
+                .mr(px(8.0))
+                .rounded(px(6.0))
+                .border_1()
+                .border_color(theme.border)
+                .bg(theme.bg)
+                .flex()
+                .flex_col()
+                .gap(px(7.0))
+                .p(px(10.0))
+                .child(bar(52.0, strong))
+                .child(bar(70.0, line))
+                .child(bar(62.0, line))
+                .child(bar(44.0, line)),
+        )
+        .into_any_element()
+}
+
+/// The System card: light on the left, dark on the right. Each half is a
+/// complete miniature clipped to its side, which is what makes the card read as
+/// "whichever one the system is on".
+fn miniature_split() -> AnyElement {
+    div()
+        .size_full()
+        .flex()
+        .flex_row()
+        .child(
+            div()
+                .w_1_2()
+                .h_full()
+                .overflow_hidden()
+                .child(miniature(&Theme::light(), Corners::Left)),
+        )
+        .child(
+            div()
+                .w_1_2()
+                .h_full()
+                .overflow_hidden()
+                .child(miniature(&Theme::dark(), Corners::Right)),
+        )
+        .into_any_element()
+}
+
+/// The preview graphic for a mode.
+///
+/// The one place `Theme::light()`/`Theme::dark()` are legitimately built outside
+/// the installed global: a preview has to show the palette you are *not* using.
+fn preview(mode: AppearanceMode) -> AnyElement {
+    match mode {
+        AppearanceMode::System => miniature_split(),
+        AppearanceMode::Light => miniature(&Theme::light(), Corners::All),
+        AppearanceMode::Dark => miniature(&Theme::dark(), Corners::All),
+    }
+}
+
+/// Helper copy under the picker.
+fn helper(mode: AppearanceMode, system: Appearance) -> SharedString {
+    match mode {
+        // Naming the resolved appearance makes "System" concrete — otherwise the
+        // card says nothing about what you actually get right now.
+        AppearanceMode::System => {
+            let resolved = if system.is_dark() { "dark" } else { "light" };
+            format!(
+                "Following the system appearance — currently {resolved}. Comet switches with \
+                 macOS, including scheduled changes."
+            )
+            .into()
+        }
+        AppearanceMode::Light => "Always light, whatever the system is set to.".into(),
+        AppearanceMode::Dark => "Always dark, whatever the system is set to.".into(),
+    }
+}
+
+impl Render for AppearancePage {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = Theme::of(cx).clone();
+        let current = appearance::mode(cx);
+        let system = cx
+            .try_global::<appearance::AppearanceState>()
+            .map(|state| state.system)
+            .unwrap_or_default();
+
+        let cards = AppearanceMode::ALL.into_iter().map(|mode| {
+            widgets::option_card(&theme, mode.label(), mode == current, preview(mode))
+                .id(SharedString::from(format!("appearance-{}", mode.label())))
+                .on_click(cx.listener(move |_, _, _, cx| {
+                    appearance::set_mode(mode, cx);
+                    cx.notify();
+                }))
+        });
+
+        div()
+            .id("appearance-page")
+            .size_full()
+            .overflow_y_scroll()
+            .child(
+                widgets::page_column()
+                    .child(widgets::page_header(&theme, "Appearance", None))
+                    .child(
+                        widgets::page_subtitle(
+                            &theme,
+                            "How comet picks between light and dark. This setting stays on this \
+                             device.",
+                        )
+                        .max_w(px(512.0))
+                        .line_height(px(20.0)),
+                    )
+                    .child(
+                        div()
+                            .mt(px(32.0))
+                            .flex()
+                            .flex_col()
+                            .gap(px(12.0))
+                            .child(widgets::field_label(&theme, "Theme"))
+                            .child(widgets::option_card_row().children(cards)),
+                    )
+                    .child(
+                        div()
+                            .mt(px(16.0))
+                            .text_size(px(12.0))
+                            .text_color(theme.text_muted)
+                            .line_height(px(18.0))
+                            .child(helper(current, system)),
+                    ),
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_mode_gets_a_card() {
+        assert_eq!(AppearanceMode::ALL.len(), 3);
+        for mode in AppearanceMode::ALL {
+            assert!(!mode.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn system_helper_names_the_resolved_appearance() {
+        let dark = helper(AppearanceMode::System, Appearance::Dark);
+        let light = helper(AppearanceMode::System, Appearance::Light);
+        assert!(dark.contains("currently dark"), "got {dark}");
+        assert!(light.contains("currently light"), "got {light}");
+    }
+
+    /// The pinned modes must not claim to follow anything — that copy is the only
+    /// thing telling the user the system setting is being ignored.
+    #[test]
+    fn pinned_helpers_do_not_mention_following() {
+        for mode in [AppearanceMode::Light, AppearanceMode::Dark] {
+            for system in [Appearance::Light, Appearance::Dark] {
+                let copy = helper(mode, system).to_lowercase();
+                assert!(!copy.contains("following"), "{mode:?}: {copy}");
+                assert!(copy.contains("whatever the system"), "{mode:?}: {copy}");
+            }
+        }
+    }
+
+    /// The previews must differ from each other, or the picker is decoration.
+    /// Comparing the tones they are built from is the closest we can get without
+    /// a renderer.
+    #[test]
+    fn light_and_dark_previews_draw_from_different_palettes() {
+        let (l, d) = (Theme::light(), Theme::dark());
+        assert_ne!(l.surface.l, d.surface.l);
+        assert_ne!(l.bg.l, d.bg.l);
+    }
+}

--- a/crates/ui/src/settings/appearance.rs
+++ b/crates/ui/src/settings/appearance.rs
@@ -23,9 +23,18 @@ impl AppearancePage {
     }
 }
 
-/// One placeholder bar in the miniature.
-fn bar(width: f32, tone: Hsla) -> gpui::Div {
-    div().h(px(5.0)).w(px(width)).rounded(px(3.0)).bg(tone)
+/// One placeholder bar in the miniature, width given as a fraction of its
+/// container.
+///
+/// Relative rather than fixed px because the System card renders this same
+/// miniature into *half* a card. Fixed widths were wider than the squeezed
+/// content pane and spilled out over the card edge.
+fn bar(fraction: f32, tone: Hsla) -> gpui::Div {
+    div()
+        .h(px(5.0))
+        .w(gpui::relative(fraction))
+        .rounded(px(3.0))
+        .bg(tone)
 }
 
 /// Which corners a miniature rounds — the split card needs each half to round
@@ -66,15 +75,16 @@ fn miniature(theme: &Theme, corners: Corners) -> AnyElement {
                 .w(px(44.0))
                 .h_full()
                 .flex_none()
+                .overflow_hidden()
                 .flex()
                 .flex_col()
                 .gap(px(7.0))
                 .px(px(8.0))
                 .pt(px(14.0))
-                .child(bar(20.0, strong))
-                .child(bar(28.0, line))
-                .child(bar(24.0, line))
-                .child(bar(28.0, line)),
+                .child(bar(0.70, strong))
+                .child(bar(1.0, line))
+                .child(bar(0.85, line))
+                .child(bar(1.0, line)),
         )
         .child(
             // Inset content card — the same rounded plate the real shell floats.
@@ -87,14 +97,15 @@ fn miniature(theme: &Theme, corners: Corners) -> AnyElement {
                 .border_1()
                 .border_color(theme.border)
                 .bg(theme.bg)
+                .overflow_hidden()
                 .flex()
                 .flex_col()
                 .gap(px(7.0))
                 .p(px(10.0))
-                .child(bar(52.0, strong))
-                .child(bar(70.0, line))
-                .child(bar(62.0, line))
-                .child(bar(44.0, line)),
+                .child(bar(0.62, strong))
+                .child(bar(0.88, line))
+                .child(bar(0.76, line))
+                .child(bar(0.52, line)),
         )
         .into_any_element()
 }

--- a/crates/ui/src/settings/appearance.rs
+++ b/crates/ui/src/settings/appearance.rs
@@ -9,7 +9,9 @@
 //! Stateless. The choice lives in the [`crate::appearance`] globals, and
 //! `set_mode` repaints every window, so this page has nothing of its own to hold.
 
-use gpui::{AnyElement, Context, Hsla, IntoElement, Render, SharedString, Window, div, prelude::*, px};
+use gpui::{
+    AnyElement, Context, Hsla, IntoElement, Render, SharedString, Window, div, prelude::*, px,
+};
 
 use crate::appearance::{self, AppearanceMode};
 use crate::settings::widgets;
@@ -58,56 +60,51 @@ fn miniature(theme: &Theme, corners: Corners) -> AnyElement {
     let line = theme.text.opacity(0.22);
     let strong = theme.text.opacity(0.34);
     let r = px(widgets::OPTION_CARD_RADIUS);
-    let root = div()
-        .size_full()
-        .flex()
-        .flex_row()
-        .bg(theme.surface);
+    let root = div().size_full().flex().flex_row().bg(theme.surface);
     let root = match corners {
         Corners::All => root.rounded(r),
         Corners::Left => root.rounded_tl(r).rounded_bl(r),
         Corners::Right => root.rounded_tr(r).rounded_br(r),
     };
-    root
-        .child(
-            // Sidebar strip.
-            div()
-                .w(px(44.0))
-                .h_full()
-                .flex_none()
-                .overflow_hidden()
-                .flex()
-                .flex_col()
-                .gap(px(7.0))
-                .px(px(8.0))
-                .pt(px(14.0))
-                .child(bar(0.70, strong))
-                .child(bar(1.0, line))
-                .child(bar(0.85, line))
-                .child(bar(1.0, line)),
-        )
-        .child(
-            // Inset content card — the same rounded plate the real shell floats.
-            div()
-                .flex_1()
-                .min_w_0()
-                .my(px(8.0))
-                .mr(px(8.0))
-                .rounded(px(6.0))
-                .border_1()
-                .border_color(theme.border)
-                .bg(theme.bg)
-                .overflow_hidden()
-                .flex()
-                .flex_col()
-                .gap(px(7.0))
-                .p(px(10.0))
-                .child(bar(0.62, strong))
-                .child(bar(0.88, line))
-                .child(bar(0.76, line))
-                .child(bar(0.52, line)),
-        )
-        .into_any_element()
+    root.child(
+        // Sidebar strip.
+        div()
+            .w(px(44.0))
+            .h_full()
+            .flex_none()
+            .overflow_hidden()
+            .flex()
+            .flex_col()
+            .gap(px(7.0))
+            .px(px(8.0))
+            .pt(px(14.0))
+            .child(bar(0.70, strong))
+            .child(bar(1.0, line))
+            .child(bar(0.85, line))
+            .child(bar(1.0, line)),
+    )
+    .child(
+        // Inset content card — the same rounded plate the real shell floats.
+        div()
+            .flex_1()
+            .min_w_0()
+            .my(px(8.0))
+            .mr(px(8.0))
+            .rounded(px(6.0))
+            .border_1()
+            .border_color(theme.border)
+            .bg(theme.bg)
+            .overflow_hidden()
+            .flex()
+            .flex_col()
+            .gap(px(7.0))
+            .p(px(10.0))
+            .child(bar(0.62, strong))
+            .child(bar(0.88, line))
+            .child(bar(0.76, line))
+            .child(bar(0.52, line)),
+    )
+    .into_any_element()
 }
 
 /// The System card: light on the left, dark on the right. Each half is a

--- a/crates/ui/src/settings/archived.rs
+++ b/crates/ui/src/settings/archived.rs
@@ -119,7 +119,7 @@ impl Render for ArchivedPage {
                     .rounded(px(8.0))
                     .px(px(12.0))
                     .py(px(8.0))
-                    .hover(|s| s.bg(crate::theme::white_alpha(0.03)))
+                    .hover(|s| s.bg(crate::theme::ink(0.03)))
                     .on_hover(cx.listener(move |this, hovered: &bool, _, cx| {
                         if *hovered {
                             this.hovered = Some(ix);
@@ -220,8 +220,8 @@ impl Render for ArchivedPage {
                             .when(is_busy, |el| el.opacity(0.4))
                             .cursor_pointer()
                             .hover(|s| {
-                                s.bg(crate::theme::oklch(0.235, 0.0, 0.0))
-                                    .text_color(Theme::dark().text)
+                                s.bg(theme.surface_raised)
+                                    .text_color(theme.text)
                             })
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.unarchive(chat_id.clone(), cx);
@@ -300,7 +300,7 @@ impl Render for ArchivedPage {
                     ))
                     .when_some(self.error.clone(), |el, message| {
                         el.child(
-                            widgets::error_strip(message)
+                            widgets::error_strip(&theme, message)
                                 .id("archived-error")
                                 .cursor_pointer()
                                 .on_click(cx.listener(|this, _, _, cx| {

--- a/crates/ui/src/settings/archived.rs
+++ b/crates/ui/src/settings/archived.rs
@@ -219,10 +219,7 @@ impl Render for ArchivedPage {
                             .opacity(if row_hovered || is_busy { 1.0 } else { 0.0 })
                             .when(is_busy, |el| el.opacity(0.4))
                             .cursor_pointer()
-                            .hover(|s| {
-                                s.bg(theme.surface_raised)
-                                    .text_color(theme.text)
-                            })
+                            .hover(|s| s.bg(theme.surface_raised).text_color(theme.text))
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.unarchive(chat_id.clone(), cx);
                             }))

--- a/crates/ui/src/settings/devices.rs
+++ b/crates/ui/src/settings/devices.rs
@@ -210,7 +210,7 @@ impl Render for DevicesPage {
         };
         let copied = self.copied.clone();
         let dialog = self.render_rename_dialog(window.viewport_size(), cx);
-        let emerald = crate::theme::oklch(0.765, 0.177, 163.223); // emerald-400
+        let emerald = theme.success; // emerald-400
         let count = devices.len();
 
         let rows: Vec<AnyElement> = devices
@@ -252,7 +252,7 @@ impl Render for DevicesPage {
                                 inset: false,
                             }])
                         })
-                        .when(!online, |el| el.bg(crate::theme::white_alpha(0.22))),
+                        .when(!online, |el| el.bg(crate::theme::ink(0.22))),
                 );
                 // One quiet meta line: platform · version · (offline: last
                 // seen) · id chip.
@@ -297,12 +297,12 @@ impl Render for DevicesPage {
                         .font_family(theme.font_mono.clone())
                         .text_size(px(10.5))
                         .text_color(if id_copied {
-                            crate::theme::oklch(0.845, 0.143, 164.978).opacity(0.9)
+                            theme.success_muted.opacity(0.9)
                         } else {
                             theme.text_muted.opacity(0.5)
                         })
                         .cursor_pointer()
-                        .hover(|s| s.text_color(Theme::dark().text_muted))
+                        .hover(|s| s.text_color(theme.text_muted))
                         .on_click(cx.listener(move |this, _, _, cx| {
                             this.copy_id(copy_id.clone(), cx);
                         }))
@@ -337,8 +337,8 @@ impl Render for DevicesPage {
                             .opacity(0.7)
                             .hover(|s| {
                                 s.opacity(1.0)
-                                    .bg(crate::theme::white_alpha(0.06))
-                                    .text_color(Theme::dark().text)
+                                    .bg(crate::theme::ink(0.06))
+                                    .text_color(theme.text)
                             })
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.open_rename(rename_id.clone(), rename_name.clone(), cx);
@@ -386,7 +386,7 @@ impl Render for DevicesPage {
                     ))
                     .when_some(self.error.clone(), |el, message| {
                         el.child(
-                            widgets::error_strip(message)
+                            widgets::error_strip(&theme, message)
                                 .id("devices-error")
                                 .cursor_pointer()
                                 .on_click(cx.listener(|this, _, _, cx| {

--- a/crates/ui/src/settings/shortcuts.rs
+++ b/crates/ui/src/settings/shortcuts.rs
@@ -185,7 +185,7 @@ impl Render for ShortcutsPage {
                             .text_size(px(11.0))
                             .text_color(theme.text_muted.opacity(0.7))
                             .cursor_pointer()
-                            .hover(|s| s.text_color(Theme::dark().text))
+                            .hover(|s| s.text_color(theme.text))
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.keymap.reset(id);
                                 this.recording = None;
@@ -211,7 +211,7 @@ impl Render for ShortcutsPage {
                             if is_recording {
                                 el.border_color(theme.text.opacity(0.3))
                                     .bg(theme.text)
-                                    .text_color(crate::theme::grey(0x0e))
+                                    .text_color(theme.on_solid)
                             } else {
                                 el.border_color(theme.border)
                                     .bg(theme.bg)
@@ -220,7 +220,7 @@ impl Render for ShortcutsPage {
                                         // `hover:border-foreground/20` — the
                                         // neutral foreground, not pure white.
                                         s.border_color(theme.text.opacity(0.2))
-                                            .bg(crate::theme::white_alpha(0.03))
+                                            .bg(crate::theme::ink(0.03))
                                     })
                             }
                         })
@@ -287,8 +287,8 @@ impl Render for ShortcutsPage {
                                     .when(disabled, |el| el.opacity(0.35))
                                     .when(!disabled, |el| {
                                         el.hover(|s| {
-                                            s.bg(crate::theme::white_alpha(0.04))
-                                                .text_color(Theme::dark().text)
+                                            s.bg(crate::theme::ink(0.04))
+                                                .text_color(theme.text)
                                         })
                                         .on_click(
                                             cx.listener(|this, _, _, cx| {

--- a/crates/ui/src/settings/shortcuts.rs
+++ b/crates/ui/src/settings/shortcuts.rs
@@ -287,8 +287,7 @@ impl Render for ShortcutsPage {
                                     .when(disabled, |el| el.opacity(0.35))
                                     .when(!disabled, |el| {
                                         el.hover(|s| {
-                                            s.bg(crate::theme::ink(0.04))
-                                                .text_color(theme.text)
+                                            s.bg(crate::theme::ink(0.04)).text_color(theme.text)
                                         })
                                         .on_click(
                                             cx.listener(|this, _, _, cx| {

--- a/crates/ui/src/settings/widgets.rs
+++ b/crates/ui/src/settings/widgets.rs
@@ -71,12 +71,7 @@ pub fn field_label(theme: &Theme, label: impl Into<SharedString>) -> gpui::Div {
 /// control works for a density picker, a layout picker or anything else where
 /// the choice is easier to show than to describe. Pair with [`option_card`].
 pub fn option_card_row() -> gpui::Div {
-    div()
-        .flex()
-        .flex_row()
-        .items_start()
-        .gap(px(16.0))
-        .w_full()
+    div().flex().flex_row().items_start().gap(px(16.0)).w_full()
 }
 
 /// Default height of an [`option_card`] preview frame.
@@ -148,7 +143,11 @@ pub fn option_card(
         .child(
             div()
                 .text_size(px(13.0))
-                .text_color(if selected { theme.text } else { theme.text_muted })
+                .text_color(if selected {
+                    theme.text
+                } else {
+                    theme.text_muted
+                })
                 .child(label.into()),
         )
 }

--- a/crates/ui/src/settings/widgets.rs
+++ b/crates/ui/src/settings/widgets.rs
@@ -5,7 +5,7 @@
 
 use gpui::{AnyElement, SharedString, div, prelude::*, px};
 
-use crate::theme::{Theme, white_alpha};
+use crate::theme::{Theme, ink};
 
 /// Centered page column: `mx-auto w-full max-w-3xl px-6 pb-16 pt-8`.
 pub fn page_column() -> gpui::Div {
@@ -54,6 +54,105 @@ pub fn page_subtitle(theme: &Theme, copy: impl Into<SharedString>) -> gpui::Div 
         .child(copy.into())
 }
 
+/// Small label above a group of controls (`text-[13px] font-medium`) — the
+/// "Theme" caption over a picker, not a page headline.
+pub fn field_label(theme: &Theme, label: impl Into<SharedString>) -> gpui::Div {
+    div()
+        .text_size(px(13.0))
+        .font_weight(gpui::FontWeight::MEDIUM)
+        .text_color(theme.text)
+        .child(label.into())
+}
+
+/// A row of equally-sized preview cards for picking one of N *visual* options.
+///
+/// Deliberately knows nothing about themes: the caller supplies each preview as
+/// an arbitrary element and picks however many cards it wants, so the same
+/// control works for a density picker, a layout picker or anything else where
+/// the choice is easier to show than to describe. Pair with [`option_card`].
+pub fn option_card_row() -> gpui::Div {
+    div()
+        .flex()
+        .flex_row()
+        .items_start()
+        .gap(px(16.0))
+        .w_full()
+}
+
+/// Default height of an [`option_card`] preview frame.
+pub const OPTION_CARD_HEIGHT: f32 = 148.0;
+/// Corner radius of the preview frame.
+///
+/// Public because the preview has to round *itself* to this. gpui content masks
+/// are axis-aligned rectangles, so `overflow_hidden` on the frame clips to its
+/// bounding box and not to its corner radius — a preview that paints its own
+/// background will square off the corners and cover the frame's border with it.
+pub const OPTION_CARD_RADIUS: f32 = 10.0;
+/// Clear space between the frame and the selection ring.
+const RING_GAP: f32 = 2.0;
+/// Thickness of the selection ring.
+const RING_WIDTH: f32 = 2.0;
+
+/// One card in an [`option_card_row`]: a fixed-height preview frame that carries
+/// the selection ring, with a caption underneath.
+///
+/// `preview` fills the frame and **must round its own corners** to
+/// [`OPTION_CARD_RADIUS`] if it paints a background — see that constant.
+///
+/// Returns a plain `Div` like the rest of this module — the caller adds `.id(..)`
+/// and `.on_click(..)`, so selection behaviour stays with the page that owns the
+/// state.
+pub fn option_card(
+    theme: &Theme,
+    label: impl Into<SharedString>,
+    selected: bool,
+    preview: AnyElement,
+) -> gpui::Div {
+    let frame = div()
+        .h(px(OPTION_CARD_HEIGHT))
+        .w_full()
+        .rounded(px(OPTION_CARD_RADIUS))
+        .overflow_hidden()
+        .border_1()
+        .border_color(theme.border)
+        .child(preview);
+
+    // The ring is a *wrapper border*, not a spread shadow. A shadow's spread
+    // grows the rectangle without growing its corner radius, so the halo's
+    // corners tighten relative to the frame's and the two visibly drift apart by
+    // a pixel at each rounded corner. Concentric borders can't do that: each
+    // element rounds itself, and the outer radius is the inner one plus the gap
+    // it sits behind. Always present, transparent when unselected, so selecting a
+    // card never reflows the row.
+    div()
+        .flex_1()
+        .min_w_0()
+        .flex()
+        .flex_col()
+        .items_center()
+        .gap(px(8.0))
+        .cursor_pointer()
+        .child(
+            div()
+                .w_full()
+                .rounded(px(OPTION_CARD_RADIUS + RING_GAP + RING_WIDTH))
+                .p(px(RING_GAP))
+                .border_2()
+                .border_color(if selected {
+                    theme.accent
+                } else {
+                    gpui::transparent_black()
+                })
+                .child(frame),
+        )
+        .child(
+            div()
+                .text_size(px(13.0))
+                .text_color(if selected { theme.text } else { theme.text_muted })
+                .child(label.into()),
+        )
+}
+
 /// Section card: `mt-6 overflow-hidden rounded-xl border border-border bg-card`
 /// — the opaque raised-card tone (comet `--card`), not a translucent wash.
 pub fn section_card(theme: &Theme) -> gpui::Div {
@@ -75,7 +174,7 @@ pub fn card_row(theme: &Theme, first: bool) -> gpui::Div {
         .px(px(20.0))
         .py(px(14.0))
         .when(!first, |el| el.border_t_1().border_color(theme.border))
-        .hover(|s| s.bg(white_alpha(0.015)))
+        .hover(|s| s.bg(ink(0.015)))
         .flex()
         .flex_row()
         .items_center()
@@ -91,7 +190,7 @@ pub fn row_tile(theme: &Theme, icon_path: &'static str) -> gpui::Div {
         .rounded(px(10.0))
         .border_1()
         .border_color(theme.border)
-        .bg(white_alpha(0.03))
+        .bg(ink(0.03))
         .flex()
         .items_center()
         .justify_center()
@@ -157,9 +256,9 @@ pub fn badge(theme: &Theme, label: impl Into<SharedString>) -> gpui::Div {
 
 /// Emerald status pill (the Accounts "Active" badge:
 /// `bg-emerald-400/[0.12] text-emerald-300/90`).
-pub fn badge_active(label: impl Into<SharedString>) -> gpui::Div {
-    let emerald = crate::theme::oklch(0.765, 0.177, 163.223);
-    let emerald_text = crate::theme::oklch(0.845, 0.143, 164.978); // emerald-300
+pub fn badge_active(theme: &Theme, label: impl Into<SharedString>) -> gpui::Div {
+    let emerald = theme.success;
+    let emerald_text = theme.success_muted; // emerald-300
     div()
         .flex_none()
         .px(px(8.0))
@@ -191,16 +290,16 @@ pub fn ghost_action(theme: &Theme) -> gpui::Div {
 
 /// The default ghost-action hover wash (`hover:bg-white/[0.06]
 /// hover:text-foreground`).
-pub fn ghost_hover(s: gpui::StyleRefinement) -> gpui::StyleRefinement {
-    s.bg(white_alpha(0.06)).text_color(Theme::dark().text)
+pub fn ghost_hover(theme: &Theme, s: gpui::StyleRefinement) -> gpui::StyleRefinement {
+    s.bg(ink(0.06)).text_color(theme.text)
 }
 
 /// The dismissible red error strip (`flex items-start gap-2 rounded-xl border
 /// border-red-400/20 bg-red-400/[0.06] text-red-300/90` with a leading
 /// `DangerTriangle mt-0.5 size-4`).
-pub fn error_strip(message: impl Into<SharedString>) -> gpui::Div {
-    let red = crate::theme::oklch(0.704, 0.191, 22.216); // red-400
-    let red_text = crate::theme::oklch(0.81, 0.108, 19.6); // red-300
+pub fn error_strip(theme: &Theme, message: impl Into<SharedString>) -> gpui::Div {
+    let red = theme.danger; // red-400
+    let red_text = theme.danger_muted; // red-300
     div()
         .mt(px(16.0))
         .px(px(16.0))
@@ -228,9 +327,9 @@ pub fn error_strip(message: impl Into<SharedString>) -> gpui::Div {
 /// The amber warning strip (`flex items-start gap-2 border-amber-400/20
 /// bg-amber-400/[0.06] text-amber-200/90` with a leading `DangerTriangle
 /// mt-0.5 size-3.5`).
-pub fn warning_strip(message: impl Into<SharedString>) -> gpui::Div {
-    let amber = crate::theme::oklch(0.828, 0.189, 84.429); // amber-400
-    let amber_text = crate::theme::oklch(0.924, 0.12, 95.746); // amber-200
+pub fn warning_strip(theme: &Theme, message: impl Into<SharedString>) -> gpui::Div {
+    let amber = theme.warning; // amber-400
+    let amber_text = theme.warning_muted; // amber-200
     div()
         .mt(px(8.0))
         .px(px(16.0))

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -32,9 +32,9 @@ use crate::motion::{self, AnimationExt as _, MotionSpec, RESIZE, SPLASH_OUT};
 use crate::popover::{self, Loadable};
 use crate::rail;
 use crate::settings::accounts::AccountsPage;
+use crate::settings::appearance::AppearancePage;
 use crate::settings::archived::ArchivedPage;
 use crate::settings::devices::DevicesPage;
-use crate::settings::appearance::AppearancePage;
 use crate::settings::shortcuts::{ShortcutsEvent, ShortcutsPage};
 use crate::settings::{
     KeymapConfig, RIGHT_PANE_DEFAULT, RIGHT_PANE_MAX, RIGHT_PANE_MIN, SAVE_DEBOUNCE_MS,
@@ -1702,10 +1702,7 @@ impl Shell {
                                     theme.text_muted
                                 })
                                 .cursor_pointer()
-                                .hover(|s| {
-                                    s.bg(crate::theme::wash(0.11))
-                                        .text_color(theme.text)
-                                })
+                                .hover(|s| s.bg(crate::theme::wash(0.11)).text_color(theme.text))
                                 .on_click(
                                     cx.listener(move |this, _, _, cx| this.open_settings(item, cx)),
                                 )
@@ -1733,10 +1730,7 @@ impl Shell {
                         .text_size(px(13.0))
                         .text_color(theme.text_muted)
                         .cursor_pointer()
-                        .hover(|s| {
-                            s.bg(crate::theme::wash(0.11))
-                                .text_color(theme.text)
-                        })
+                        .hover(|s| s.bg(crate::theme::wash(0.11)).text_color(theme.text))
                         .on_click(cx.listener(|this, _, _, cx| this.close_settings(cx)))
                         .child(
                             // AltArrowLeft chevron (comet settings-sidebar.tsx),

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -34,6 +34,7 @@ use crate::rail;
 use crate::settings::accounts::AccountsPage;
 use crate::settings::archived::ArchivedPage;
 use crate::settings::devices::DevicesPage;
+use crate::settings::appearance::AppearancePage;
 use crate::settings::shortcuts::{ShortcutsEvent, ShortcutsPage};
 use crate::settings::{
     KeymapConfig, RIGHT_PANE_DEFAULT, RIGHT_PANE_MAX, RIGHT_PANE_MIN, SAVE_DEBOUNCE_MS,
@@ -142,14 +143,16 @@ pub fn apply_keymap(cx: &mut App, keymap: &KeymapConfig) {
 pub enum SettingsSection {
     Devices,
     Agents,
+    Appearance,
     Shortcuts,
     Archived,
 }
 
 impl SettingsSection {
-    pub const ALL: [SettingsSection; 4] = [
+    pub const ALL: [SettingsSection; 5] = [
         SettingsSection::Devices,
         SettingsSection::Agents,
+        SettingsSection::Appearance,
         SettingsSection::Shortcuts,
         SettingsSection::Archived,
     ];
@@ -160,6 +163,7 @@ impl SettingsSection {
         match self {
             SettingsSection::Devices => "Devices",
             SettingsSection::Agents => "Accounts",
+            SettingsSection::Appearance => "Appearance",
             SettingsSection::Shortcuts => "Shortcuts",
             SettingsSection::Archived => "Archived sessions",
         }
@@ -429,6 +433,7 @@ pub struct Shell {
     nav: NavHistory,
     devices_page: Option<Entity<DevicesPage>>,
     archived_page: Option<Entity<ArchivedPage>>,
+    appearance_page: Option<Entity<AppearancePage>>,
     shortcuts_page: Option<Entity<ShortcutsPage>>,
     accounts_page: Option<Entity<AccountsPage>>,
     shortcuts_sub: Option<Subscription>,
@@ -595,6 +600,7 @@ impl Shell {
                 Route::Settings(SettingsSection::Devices)
             }
             Some("settings/agents") => Route::Settings(SettingsSection::Agents),
+            Some("settings/appearance") => Route::Settings(SettingsSection::Appearance),
             Some("settings/shortcuts") => Route::Settings(SettingsSection::Shortcuts),
             Some("settings/archived") => Route::Settings(SettingsSection::Archived),
             // `new` pins the new-chat canvas (suppresses boot auto-select).
@@ -633,6 +639,7 @@ impl Shell {
             nav,
             devices_page: None,
             archived_page: None,
+            appearance_page: None,
             shortcuts_page: None,
             accounts_page: None,
             shortcuts_sub: None,
@@ -1037,7 +1044,15 @@ impl Shell {
             cx.background_executor()
                 .timer(Duration::from_millis(SAVE_DEBOUNCE_MS))
                 .await;
-            let Ok(snapshot) = this.update(cx, |shell, _| shell.settings.clone()) else {
+            // Re-stamp the appearance from the global before writing. The View
+            // menu changes it through `appearance::set_mode`, which never touches
+            // this shell's in-memory copy — without this, the next pane resize
+            // would quietly write the boot-time appearance back over the user's
+            // choice.
+            let Ok(snapshot) = this.update(cx, |shell, cx| {
+                shell.settings.appearance = crate::appearance::mode(cx);
+                shell.settings.clone()
+            }) else {
                 return;
             };
             cx.background_executor()
@@ -1124,6 +1139,15 @@ impl Shell {
                     self.accounts_page = Some(cx.new(|cx| AccountsPage::new(state, cx)));
                 }
                 match &self.accounts_page {
+                    Some(page) => page.clone().into_any_element(),
+                    None => Empty.into_any_element(),
+                }
+            }
+            SettingsSection::Appearance => {
+                if self.appearance_page.is_none() {
+                    self.appearance_page = Some(cx.new(AppearancePage::new));
+                }
+                match &self.appearance_page {
                     Some(page) => page.clone().into_any_element(),
                     None => Empty.into_any_element(),
                 }
@@ -1626,6 +1650,7 @@ impl Shell {
         let section_icon = |item: SettingsSection| match item {
             SettingsSection::Devices => icons::MONITOR,
             SettingsSection::Agents => icons::KEY_MINIMALISTIC,
+            SettingsSection::Appearance => icons::TUNING,
             SettingsSection::Shortcuts => icons::KEYBOARD,
             SettingsSection::Archived => icons::ARCHIVE_MINIMALISTIC,
         };
@@ -1679,7 +1704,7 @@ impl Shell {
                                 .cursor_pointer()
                                 .hover(|s| {
                                     s.bg(crate::theme::wash(0.11))
-                                        .text_color(Theme::dark().text)
+                                        .text_color(theme.text)
                                 })
                                 .on_click(
                                     cx.listener(move |this, _, _, cx| this.open_settings(item, cx)),
@@ -1710,7 +1735,7 @@ impl Shell {
                         .cursor_pointer()
                         .hover(|s| {
                             s.bg(crate::theme::wash(0.11))
-                                .text_color(Theme::dark().text)
+                                .text_color(theme.text)
                         })
                         .on_click(cx.listener(|this, _, _, cx| this.close_settings(cx)))
                         .child(
@@ -2771,7 +2796,7 @@ impl Shell {
                     div()
                         .absolute()
                         .inset_0()
-                        .bg(gpui::hsla(0.0, 0.0, 0.0, 0.4))
+                        .bg(theme.scrim().opacity(0.4 / 0.6))
                         .flex()
                         .items_center()
                         .justify_center()
@@ -2825,7 +2850,7 @@ impl Shell {
                         .bg(motion::hover_blend(
                             "jump-pill",
                             theme.surface_raised,
-                            crate::theme::neutral(0.29),
+                            theme.surface_raised_hover,
                         ))
                         .on_hover(motion::hover_listener("jump-pill"))
                         .on_click(cx.listener(|this, _, _, cx| {
@@ -3076,7 +3101,7 @@ impl Shell {
                         .text_size(px(13.0))
                         .text_color(theme.text)
                         .cursor_pointer()
-                        .hover(|s| s.bg(Theme::dark().element_hover))
+                        .hover(|s| s.bg(theme.element_hover))
                         .on_click(cx.listener(|this, _, _, cx| this.retry_engine(cx)))
                         .child(SharedString::from("Retry")),
                 )
@@ -3090,7 +3115,7 @@ impl Shell {
                 .rounded(px(12.0))
                 .border_1()
                 .border_color(theme.border)
-                .bg(crate::theme::grey(0x0e))
+                .bg(theme.surface_card)
                 .shadow_lg()
                 .flex()
                 .flex_col()
@@ -3133,7 +3158,7 @@ impl Shell {
                         .bg(theme.text)
                         .text_size(px(14.0))
                         .font_weight(gpui::FontWeight::MEDIUM)
-                        .text_color(crate::theme::grey(0x0e))
+                        .text_color(theme.on_solid)
                         .cursor_pointer()
                         .hover(|s| s.opacity(0.9))
                         .on_click(cx.listener(|this, _, _, cx| this.start_sign_in(cx)))
@@ -3271,7 +3296,7 @@ impl Shell {
             .rounded(px(12.0))
             .border_1()
             .border_color(theme.border)
-            .bg(crate::theme::grey(0x0e))
+            .bg(theme.surface_card)
             .shadow_lg()
             .flex()
             .flex_col()
@@ -3329,7 +3354,7 @@ impl Shell {
                             .bg(theme.text)
                             .text_size(px(14.0))
                             .font_weight(gpui::FontWeight::MEDIUM)
-                            .text_color(crate::theme::grey(0x0e))
+                            .text_color(theme.on_solid)
                             .when(submitting, |el| el.opacity(0.5))
                             .cursor_pointer()
                             .hover(|s| s.opacity(0.9))
@@ -3348,7 +3373,7 @@ impl Shell {
                         .mt(px(16.0))
                         .text_size(px(12.0))
                         .line_height(px(17.0))
-                        .text_color(crate::theme::oklch(0.81, 0.108, 19.6).opacity(0.9)) // red-300
+                        .text_color(theme.danger_muted.opacity(0.9)) // red-300
                         .child(message),
                 )
             })
@@ -3359,7 +3384,7 @@ impl Shell {
                         .text_size(px(12.0))
                         .text_color(theme.text_muted.opacity(0.6))
                         .cursor_pointer()
-                        .hover(|s| s.text_color(Theme::dark().text))
+                        .hover(|s| s.text_color(theme.text))
                         .on_click(cx.listener(|this, _, _, cx| this.sign_out(cx)))
                         .child(SharedString::from("Use a different account")),
                 ),
@@ -3387,7 +3412,7 @@ impl Shell {
 /// 44px hairlines at white 3.5%, with the radial mask approximated by edge
 /// gradients back into the page background (gpui has no mask-image).
 fn grid_backdrop(theme: &Theme) -> AnyElement {
-    let line = crate::theme::white_alpha(0.035);
+    let line = crate::theme::hairline(0.035);
     let bg = theme.bg;
     const STEP: f32 = 44.0;
     const SPAN: f32 = 2640.0;
@@ -3495,7 +3520,7 @@ fn window_control_button(
         .bg(motion::hover_blend(
             &fade_key,
             crate::theme::wash(0.0),
-            Theme::dark().element_hover,
+            theme.element_hover,
         ))
         .on_hover(motion::hover_listener(fade_key))
         // Buttons in/over a titlebar drag strip must be EXCLUDED from the

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -115,7 +115,7 @@ pub(super) fn status_dot_color(status: ChatIndicator, theme: &Theme) -> gpui::Hs
         // Pink, not amber — the harsh yellow read as a warning; running is
         // routine (user request).
         ChatIndicator::Working => {
-            crate::theme::oklch(0.718, 0.202, 349.761).opacity(0.85) // pink-400
+            theme.busy.opacity(0.85) // pink-400
         }
         // Blue: "asking you a question" must read differently from "busy
         // working" at a glance.
@@ -123,9 +123,9 @@ pub(super) fn status_dot_color(status: ChatIndicator, theme: &Theme) -> gpui::Hs
         ChatIndicator::Errored => theme.danger,
         // Green: finished-but-unseen reads as "ready for you".
         ChatIndicator::Completed => {
-            crate::theme::oklch(0.765, 0.177, 163.223).opacity(0.9) // emerald-400
+            theme.success.opacity(0.9) // emerald-400
         }
-        ChatIndicator::Idle => crate::theme::white_alpha(0.14),
+        ChatIndicator::Idle => crate::theme::ink(0.14),
     }
 }
 
@@ -308,12 +308,12 @@ impl Shell {
                     .text_color(motion::hover_blend(
                         "add-space-ghost",
                         theme.text_muted,
-                        Theme::dark().text,
+                        theme.text,
                     ))
                     .bg(motion::hover_blend(
                         "add-space-ghost",
                         crate::theme::wash(0.0),
-                        Theme::dark().element_hover,
+                        theme.element_hover,
                     ))
                     .on_hover(motion::hover_listener("add-space-ghost"))
                     .cursor_pointer()
@@ -526,7 +526,7 @@ impl Shell {
             .child(
                 div().size(px(6.0)).rounded_full().flex_none().bg(attention
                     .map(|status| status_dot_color(status, theme))
-                    .unwrap_or_else(|| crate::theme::white_alpha(0.14))),
+                    .unwrap_or_else(|| crate::theme::ink(0.14))),
             )
             .child(
                 icon(icons::FOLDER)
@@ -1018,7 +1018,7 @@ impl Shell {
         let devices = self.state.read(cx).devices.clone();
         let rows = self.add_space_filtered(cx);
         let query_empty = search.read(cx).is_empty();
-        let hairline = crate::theme::white_alpha(0.06);
+        let hairline = crate::theme::hairline(0.06);
         let now = Utc::now();
         // (browsed device name, online) per rail row — presence is the same
         // signal the sidebar space rows use.
@@ -1046,7 +1046,7 @@ impl Shell {
                 .flex_row()
                 .items_center()
                 .gap(px(2.0))
-                .bg(crate::theme::white_alpha(0.05))
+                .bg(crate::theme::ink(0.05))
                 .text_size(px(11.0))
                 .font_family(theme.font_mono.clone())
                 .text_color(theme.text_muted.opacity(0.7))
@@ -1075,7 +1075,7 @@ impl Shell {
                 el.child(
                     icon(icons::COMMAND)
                         .size(px(11.0))
-                        .text_color(crate::theme::grey(0x0e).opacity(0.8)),
+                        .text_color(theme.on_solid.opacity(0.8)),
                 )
                 .child(SharedString::from("Enter"))
             })
@@ -1117,7 +1117,7 @@ impl Shell {
                 key_chip(&theme)
                     .id("add-space-esc")
                     .cursor_pointer()
-                    .hover(|s| s.bg(crate::theme::white_alpha(0.09)))
+                    .hover(|s| s.bg(crate::theme::ink(0.09)))
                     .on_click(cx.listener(|this, _, _, cx| {
                         this.add_space = None;
                         cx.notify();
@@ -1168,7 +1168,7 @@ impl Shell {
                             crumb
                                 .text_color(theme.text_muted.opacity(0.55))
                                 .cursor_pointer()
-                                .hover(|s| s.text_color(Theme::dark().text))
+                                .hover(|s| s.text_color(theme.text))
                                 .on_click(cx.listener(|this, _, _, cx| {
                                     if let Some(flow) = this.add_space.as_mut() {
                                         flow.browser_repo = false;
@@ -1206,7 +1206,7 @@ impl Shell {
                                     } else {
                                         crumb
                                             .cursor_pointer()
-                                            .hover(|s| s.text_color(Theme::dark().text))
+                                            .hover(|s| s.text_color(theme.text))
                                             .on_click(cx.listener(move |this, _, _, cx| {
                                                 if let Some(flow) = this.add_space.as_mut() {
                                                     flow.browser_repo = false;
@@ -1405,7 +1405,7 @@ impl Shell {
                             .when(online, |el| {
                                 // The Devices-page presence emerald, soft glow
                                 // included.
-                                let emerald = crate::theme::oklch(0.765, 0.177, 163.223);
+                                let emerald = theme.success;
                                 el.bg(emerald.opacity(0.9)).shadow(vec![gpui::BoxShadow {
                                     color: emerald.opacity(0.55),
                                     offset: gpui::point(px(0.0), px(0.0)),
@@ -1414,7 +1414,7 @@ impl Shell {
                                     inset: false,
                                 }])
                             })
-                            .when(!online, |el| el.bg(crate::theme::white_alpha(0.22))),
+                            .when(!online, |el| el.bg(crate::theme::ink(0.22))),
                     )
             }))
             .child(div().h(px(1.0)).mx(px(2.0)).my(px(6.0)).bg(hairline))
@@ -1496,14 +1496,14 @@ impl Shell {
                 .w(px(680.0))
                 .rounded(px(14.0))
                 .border_1()
-                .border_color(crate::theme::white_alpha(0.10))
+                .border_color(crate::theme::hairline(0.10))
                 // The popover_card glass recipe: a translucent tint over the
                 // frosted backdrop blur (`popover::modal` wraps in `frosted`) —
                 // an opaque fill here killed the vibrancy every other float has.
                 .bg(if Theme::GLASS_ALPHA < 1.0 {
-                    crate::theme::grey(0x16).opacity(0.65)
+                    theme.surface_overlay.opacity(0.65)
                 } else {
-                    crate::theme::grey(0x16)
+                    theme.surface_overlay
                 })
                 .shadow_lg()
                 .overflow_hidden()

--- a/crates/ui/src/terminal/panel.rs
+++ b/crates/ui/src/terminal/panel.rs
@@ -860,7 +860,7 @@ impl TerminalPanel {
             .pl(px(8.0))
             .pr(px(6.0))
             .border_b_1()
-            .border_color(crate::theme::white_alpha(0.07))
+            .border_color(crate::theme::hairline(0.07))
             .on_drag_move::<TabDragPayload>(cx.listener(
                 move |this, event: &gpui::DragMoveEvent<TabDragPayload>, _, cx| {
                     let payload = event.drag(cx);
@@ -895,7 +895,7 @@ impl TerminalPanel {
                         // Comet tab: `h-7 rounded-lg pl-2 pr-1 gap-1.5 text-xs`,
                         // terminal glyph + label + close; active = white/8 wash.
                         let (text_color, bg, glyph_alpha) = if selected {
-                            (theme.text, crate::theme::white_alpha(0.08), 0.8)
+                            (theme.text, crate::theme::ink(0.08), 0.8)
                         } else {
                             (
                                 theme.text_muted.opacity(0.6),
@@ -913,7 +913,7 @@ impl TerminalPanel {
                             .rounded(px(6.0))
                             .when(!selected, |el| el.invisible())
                             .cursor_pointer()
-                            .hover(|s| s.bg(crate::theme::white_alpha(0.09)))
+                            .hover(|s| s.bg(crate::theme::ink(0.09)))
                             .on_click(cx.listener(move |this, _, window, cx| {
                                 cx.stop_propagation();
                                 this.close_tab(&chat_close2, key, window, cx);
@@ -1017,7 +1017,7 @@ impl TerminalPanel {
                     .bg(motion::hover_blend(
                         "term-new-tab",
                         gpui::transparent_black(),
-                        crate::theme::white_alpha(0.05),
+                        crate::theme::ink(0.05),
                     ))
                     .on_hover(motion::hover_listener("term-new-tab"))
                     .on_click(cx.listener(|this, _, _, cx| {
@@ -1046,7 +1046,7 @@ impl TerminalPanel {
                     .bg(motion::hover_blend(
                         "term-collapse",
                         gpui::transparent_black(),
-                        crate::theme::white_alpha(0.05),
+                        crate::theme::ink(0.05),
                     ))
                     .on_hover(motion::hover_listener("term-collapse"))
                     .on_click(|_, window, cx| {

--- a/crates/ui/src/terminal/view.rs
+++ b/crates/ui/src/terminal/view.rs
@@ -408,13 +408,9 @@ impl gpui::Element for TerminalElement {
             );
             if self.focused {
                 // Translucent block: the glyph underneath stays legible.
-                fill(cursor_bounds, gpui::hsla(0.0, 0.0, 1.0, 0.35))
+                fill(cursor_bounds, theme.cursor)
             } else {
-                outline(
-                    cursor_bounds,
-                    gpui::hsla(0.0, 0.0, 1.0, 0.35),
-                    gpui::BorderStyle::Solid,
-                )
+                outline(cursor_bounds, theme.cursor, gpui::BorderStyle::Solid)
             }
         });
 

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -96,6 +96,17 @@ pub fn theme_generation() -> u32 {
     THEME_GENERATION.load(Ordering::Relaxed)
 }
 
+/// [`CURRENT_APPEARANCE`] is process-wide, so under the parallel test runner
+/// any test that flips it — or asserts on the output of a helper that reads it
+/// ([`ink`], [`hairline`], [`wash`], …) — must hold this lock. Crate-visible
+/// because such tests exist outside this module too (see `motion::tests`).
+/// Tests that flip the appearance restore Dark before releasing the guard.
+#[cfg(test)]
+pub(crate) fn lock_appearance() -> std::sync::MutexGuard<'static, ()> {
+    static APPEARANCE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    APPEARANCE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// Point the context-free paint helpers at an appearance. Called by
 /// [`Theme::install`]; exposed for tests that build a theme without an `App`.
 pub fn set_current_appearance(appearance: Appearance) {
@@ -382,17 +393,17 @@ impl Theme {
             text_muted: neutral(0.708), // ~neutral-400
             text_faint: neutral(0.556), // ~neutral-500
             text_dim: grey(0x98),
-            solid: neutral(0.922),      // near-white plate
-            on_solid: grey(0x0e),       // near-black label
-            accent: oklch(0.673, 0.182, 276.935), // indigo-400
+            solid: neutral(0.922),                       // near-white plate
+            on_solid: grey(0x0e),                        // near-black label
+            accent: oklch(0.673, 0.182, 276.935),        // indigo-400
             accent_strong: oklch(0.585, 0.233, 277.117), // indigo-500
             on_accent: neutral(0.985),
-            danger: oklch(0.704, 0.191, 22.216), // red-400
+            danger: oklch(0.704, 0.191, 22.216),       // red-400
             danger_muted: oklch(0.808, 0.114, 19.571), // red-300
-            warning: oklch(0.828, 0.189, 84.429), // amber-400
+            warning: oklch(0.828, 0.189, 84.429),      // amber-400
             warning_muted: oklch(0.924, 0.12, 95.746), // amber-200
-            success: oklch(0.765, 0.177, 163.223), // emerald-400
-            busy: oklch(0.718, 0.202, 349.761),  // pink-400
+            success: oklch(0.765, 0.177, 163.223),     // emerald-400
+            busy: oklch(0.718, 0.202, 349.761),        // pink-400
             success_muted: oklch(0.845, 0.143, 164.978), // emerald-300
             surface_raised_hover: neutral(0.29),
             band: band_for(Appearance::Dark),
@@ -405,9 +416,9 @@ impl Theme {
             code_wash: oklch(0.702, 0.183, 293.541).opacity(0.12), // violet-400/12
             syntax_keyword: oklch(0.709, 0.129, 20.0), // soft rose
             syntax_string: oklch(0.77, 0.11, 168.0), // soft green
-            syntax_number: oklch(0.78, 0.12, 80.0), // soft amber
-            diff_add: oklch(0.765, 0.177, 163.223), // emerald-400
-            diff_del: oklch(0.704, 0.191, 22.216), // red-400
+            syntax_number: oklch(0.78, 0.12, 80.0),  // soft amber
+            diff_add: oklch(0.765, 0.177, 163.223),  // emerald-400
+            diff_del: oklch(0.704, 0.191, 22.216),   // red-400
             diff_hunk_bg: hsla(0.6, 0.35, 0.6, 0.05),
             font_sans: "Geist".into(),
             font_mono: "Geist Mono".into(),
@@ -427,7 +438,7 @@ impl Theme {
     pub fn light() -> Self {
         Self {
             appearance: Appearance::Light,
-            bg: grey(0xff),           // main panel — clean white
+            bg: grey(0xff), // main panel — clean white
             // Deeper than ~neutral-100 looks on paper: the content card is pure
             // white and sits *inside* this surface, so too small a step leaves the
             // whole window one flat sheet with a hairline drawn on it.
@@ -456,17 +467,17 @@ impl Theme {
             // too, not just on the white content plane.
             text_faint: neutral(0.535),
             text_dim: neutral(0.50),
-            solid: neutral(0.205),      // near-black plate, deeper than body text
-            on_solid: neutral(0.985),   // near-white label
+            solid: neutral(0.205),    // near-black plate, deeper than body text
+            on_solid: neutral(0.985), // near-white label
             accent: oklch(0.511, 0.262, 276.966), // indigo-600
             accent_strong: oklch(0.511, 0.262, 276.966), // indigo-600 fill
             on_accent: neutral(0.985),
-            danger: oklch(0.577, 0.245, 27.325), // red-600
-            danger_muted: oklch(0.505, 0.213, 27.518), // red-700
-            warning: oklch(0.555, 0.163, 48.998), // amber-700 — carries 12px text
+            danger: oklch(0.577, 0.245, 27.325),        // red-600
+            danger_muted: oklch(0.505, 0.213, 27.518),  // red-700
+            warning: oklch(0.555, 0.163, 48.998),       // amber-700 — carries 12px text
             warning_muted: oklch(0.473, 0.137, 46.201), // amber-800
-            success: oklch(0.596, 0.145, 163.225), // emerald-600
-            busy: oklch(0.592, 0.249, 0.584),    // pink-600
+            success: oklch(0.596, 0.145, 163.225),      // emerald-600
+            busy: oklch(0.592, 0.249, 0.584),           // pink-600
             success_muted: oklch(0.508, 0.118, 165.612), // emerald-700
             // Opaque pills darken on hover here rather than brighten — same
             // "brighten the plate, don't wash it out" rule, read the other way.
@@ -485,7 +496,7 @@ impl Theme {
             syntax_string: oklch(0.46, 0.11, 168.0),
             syntax_number: oklch(0.52, 0.13, 70.0),
             diff_add: oklch(0.596, 0.145, 163.225), // emerald-600
-            diff_del: oklch(0.577, 0.245, 27.325), // red-600
+            diff_del: oklch(0.577, 0.245, 27.325),  // red-600
             diff_hunk_bg: hsla(0.6, 0.35, 0.35, 0.07),
             font_sans: "Geist".into(),
             font_mono: "Geist Mono".into(),
@@ -827,15 +838,6 @@ pub fn mix(a: Hsla, b: Hsla, t: f32) -> Hsla {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// [`CURRENT_APPEARANCE`] is process-wide, so the tests that flip it would
-    /// race each other under the default parallel test runner. They take this
-    /// lock and restore Dark on the way out.
-    static APPEARANCE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn lock_appearance() -> std::sync::MutexGuard<'static, ()> {
-        APPEARANCE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
 
     fn srgb_u8(c: [f32; 3]) -> [u8; 3] {
         [

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -1,52 +1,268 @@
-//! Always-dark monochrome theme — concrete values, no indirection.
+//! The app theme — two concrete appearances, one token set.
 //!
 //! Colors are precomputed from an oklch-derived neutral scale (perceptually even
 //! lightness steps; the same scale comet's Tailwind theme used) into gpui [`Hsla`].
-//! Hairlines are white at low alpha so they read on any surface. **Numbers drive
-//! layout, colors are paint**: layout constants live here as plain numbers and never
-//! depend on which color is painted.
+//! **Numbers drive layout, colors are paint**: layout constants live here as plain
+//! numbers and never depend on which color is painted.
 //!
-//! Installed as a gpui [`Global`] at boot (`cx.set_global(Theme::dark())`); read with
-//! [`Theme::of`].
+//! # Light is designed, not inverted
+//!
+//! Mirroring lightness produces the classic "washed-out inverted" look, for three
+//! reasons this module handles explicitly:
+//!
+//! 1. **Surface order flips meaning.** In dark, the main content panel is the
+//!    *darkest* plane and raised surfaces get *lighter*. In light, the content
+//!    panel is *white* and the shell/sidebar goes *grey* — chrome recedes by
+//!    getting darker, not lighter. Popovers stay white and earn separation from a
+//!    border and shadow rather than from lightness.
+//! 2. **Elevation reverses.** On dark, a faint *white* wash means "raised". Its
+//!    literal translation — a faint *black* wash on white — means "recessed", so
+//!    the composer read as a dent instead of a plate. Light lifts with white plus
+//!    a border and shadow ([`Theme::input_bg`], the elevation ladder). Fill
+//!    *alphas* carry over unchanged ([`INK_FILL_SCALE`]); only hairlines scale, so
+//!    a 1px edge survives a bright surround ([`INK_HAIRLINE_SCALE`]).
+//! 3. **Accents must move down the scale.** The dark palette's 400-level accents
+//!    (indigo/red/amber) are chosen for contrast against near-black; on white they
+//!    fall to 2–4:1 and fail WCAG AA. Light mode uses the 600-level siblings at the
+//!    same hue, which restores the *contrast ratio* the dark token had.
+//!
+//! Text tones are chosen so each light token lands within ~0.5 of its dark
+//! counterpart's contrast ratio against its own background — the pairing is
+//! verified in [`tests::text_contrast_is_paired_across_appearances`], not eyeballed.
+//!
+//! Installed as a gpui [`Global`] at boot; read with [`Theme::of`].
+
+use std::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 
 use gpui::{App, Global, Hsla, SharedString, hsla};
 
-/// The app theme. One concrete instance — comet is always-dark by design.
+/// Which appearance the app is painting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Appearance {
+    #[default]
+    Dark,
+    Light,
+}
+
+impl Appearance {
+    pub fn is_dark(self) -> bool {
+        matches!(self, Self::Dark)
+    }
+
+    pub fn is_light(self) -> bool {
+        matches!(self, Self::Light)
+    }
+
+    /// Map a gpui window appearance onto ours (both vibrant variants are just
+    /// the blurred flavour of the same tone).
+    pub fn from_window(appearance: gpui::WindowAppearance) -> Self {
+        use gpui::WindowAppearance::*;
+        match appearance {
+            Light | VibrantLight => Self::Light,
+            Dark | VibrantDark => Self::Dark,
+        }
+    }
+}
+
+/// Process-wide mirror of the installed theme's appearance.
+///
+/// The paint helpers ([`ink`], [`hairline`], [`wash`], …) are free functions
+/// called from deep inside element builders that have no `cx` in scope, so they
+/// read the appearance from here instead of the gpui global. Appearance is
+/// genuinely process-wide — one setting for every window — so a single mirror is
+/// sound; [`Theme::install`] is the only writer outside tests.
+static CURRENT_APPEARANCE: AtomicU8 = AtomicU8::new(0);
+
+/// Bumped every time the appearance actually changes.
+///
+/// Anything that caches *resolved colors* — most importantly the markdown
+/// renderer's cross-frame `TextRun` cache, which bakes an `Hsla` into every run —
+/// is only valid for the palette that produced it. Those caches were written when
+/// the theme was a compile-time constant, so their validity keys cover content
+/// only. Rather than thread the palette through every key, they compare this
+/// counter and drop everything when it moves.
+static THEME_GENERATION: AtomicU32 = AtomicU32::new(0);
+
+/// The appearance the context-free paint helpers are painting for.
+pub fn current_appearance() -> Appearance {
+    match CURRENT_APPEARANCE.load(Ordering::Relaxed) {
+        1 => Appearance::Light,
+        _ => Appearance::Dark,
+    }
+}
+
+/// Monotonic id of the current palette — see [`THEME_GENERATION`].
+pub fn theme_generation() -> u32 {
+    THEME_GENERATION.load(Ordering::Relaxed)
+}
+
+/// Point the context-free paint helpers at an appearance. Called by
+/// [`Theme::install`]; exposed for tests that build a theme without an `App`.
+pub fn set_current_appearance(appearance: Appearance) {
+    let encoded = match appearance {
+        Appearance::Dark => 0,
+        Appearance::Light => 1,
+    };
+    if CURRENT_APPEARANCE.swap(encoded, Ordering::Relaxed) != encoded {
+        THEME_GENERATION.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Light-mode alpha multiplier for **fills** (hover/active washes, chip and pill
+/// backgrounds).
+///
+/// This was 0.5 on the theory that dark ink on a bright field reads heavier and
+/// should be scaled back. That theory is right for a *large* wash and badly wrong
+/// for everything else: this palette leans on very low alphas for its subtle
+/// fills — the composer plate is `ink(0.03)`, key caps are `ink(0.05)` — and
+/// halving those produced 1.5% black on white, which is nothing. The composer
+/// lost its background entirely and selected tabs stopped reading as selected.
+///
+/// The established light-UI scales (Primer, Radix) land subtle ≈ 3–4%, hover ≈ 8%,
+/// selected ≈ 14% black — which is where the dark palette's white alphas already
+/// sit. So the honest multiplier is 1: the same number in both appearances, with
+/// only the *tone* flipping. Any per-state correction belongs in that state's
+/// token, not in a blanket multiplier.
+pub const INK_FILL_SCALE: f32 = 1.0;
+
+/// Light-mode alpha multiplier for **hairlines** (borders, dividers, rings).
+/// Opposite of fills: a 1px edge has to hold its own against a bright surround,
+/// and the dark palette's white hairlines are deliberately faint. Scaling up
+/// keeps separators legible instead of dissolving into the panel.
+pub const INK_HAIRLINE_SCALE: f32 = 1.35;
+
+/// The app theme. Two concrete instances — [`Theme::dark`] and [`Theme::light`].
 #[derive(Debug, Clone)]
 pub struct Theme {
-    // ---- paint: neutral surfaces (oklch chroma 0) ----
-    /// App background — oklch(0.145 0 0) ≡ `#0a0a0a`.
+    /// Which appearance these tokens were built for.
+    pub appearance: Appearance,
+
+    // ---- paint: neutral surfaces ----
+    /// Main content panel. Dark: the deepest plane (#060606). Light: pure white —
+    /// long-form content reads best on an unbroken white field.
     pub bg: Hsla,
-    /// Panel / sidebar surface — one scale step up.
+    /// Shell / sidebar surface. Dark: one step *up* from `bg`. Light: one step
+    /// *down* (grey) — chrome recedes from the content plane in both, which is
+    /// the direction a naive invert gets backwards.
     pub surface: Hsla,
-    /// Raised surface: popovers, dialogs, cards.
+    /// Raised surface: opaque pills and chips that sit proud of the panel.
+    /// Dark: lighter than `surface`. Light: white, separated by `border` +
+    /// shadow rather than by lightness.
     pub surface_raised: Hsla,
-    /// Hover wash for interactive rows/buttons (white, low alpha).
+
+    // ---- paint: elevation ladder ----
+    //
+    // Dark mode distinguishes floating planes by lightness, and the steps are
+    // *small* (#0e → #10 → #16 → #1e). They are not interchangeable: collapsing
+    // them onto one token visibly lifts popovers off their intended plane.
+    //
+    // Light mode cannot use the same trick, because the content plane is already
+    // white and there is nothing lighter to climb to. All three land on white and
+    // let `border` + shadow carry the separation instead — the standard light-UI
+    // answer, and the reason this is a ladder of tokens rather than an arithmetic
+    // offset applied to one.
+    /// Inline card resting on the main panel (auth gate, empty-state cards).
+    pub surface_card: Hsla,
+    /// Modal dialog, floating over a [`Theme::scrim`].
+    pub surface_dialog: Hsla,
+    /// Popover, menu and command-palette surface — the highest plane.
+    pub surface_overlay: Hsla,
+    /// Hover wash for interactive rows/buttons.
     pub element_hover: Hsla,
-    /// Active/selected wash (white, slightly higher alpha).
+    /// Active/selected wash.
     pub element_active: Hsla,
-    /// Hairline border — white at low alpha.
+    /// Hairline border.
     pub border: Hsla,
     /// Stronger border for focused/raised edges.
     pub border_strong: Hsla,
 
     // ---- paint: text ----
-    /// Primary text.
+    /// Primary text. ~17.5:1 on its own background in both appearances.
     pub text: Hsla,
-    /// Muted text: timestamps, secondary labels.
+    /// Muted text: timestamps, secondary labels. ~7.5–8:1.
     pub text_muted: Hsla,
-    /// Faint text: placeholders, disabled.
+    /// Faint text: placeholders, disabled. ~4.5:1 — AA for body copy.
     pub text_faint: Hsla,
+    /// One notch below `text_muted` — the diff file-path tone. It exists as its
+    /// own token rather than being folded into `text_muted` because the dark
+    /// value was sampled (#989898) and folding it would shift that label, which
+    /// is a palette change dressed up as a refactor.
+    pub text_dim: Hsla,
+
+    // ---- paint: high-contrast solid (primary buttons) ----
+    /// The maximum-contrast solid fill: near-white on dark, near-black on light.
+    /// This is the primary button plate.
+    pub solid: Hsla,
+    /// Label/icon color on top of [`Self::solid`] — its inverse.
+    pub on_solid: Hsla,
 
     // ---- paint: accents ----
-    /// Accent — indigo (working indicator, links, selection tint).
+    /// Accent — indigo. Text/icon weight: indigo-400 on dark, indigo-600 on light
+    /// (the 400 fails AA on white).
     pub accent: Hsla,
-    /// Stronger accent for fills.
+    /// Stronger accent for fills that carry [`Self::on_accent`] text.
     pub accent_strong: Hsla,
+    /// Label color on top of [`Self::accent_strong`].
+    pub on_accent: Hsla,
     /// Danger — red (errors, stop button).
     pub danger: Hsla,
+    /// Softer danger for secondary/inline error copy.
+    pub danger_muted: Hsla,
     /// Warning — amber (offline notices, awaiting-input).
     pub warning: Hsla,
+    /// Softer warning for secondary copy.
+    pub warning_muted: Hsla,
+    /// Success / online — emerald.
+    pub success: Hsla,
+    /// Working / streaming indicator — pink.
+    pub busy: Hsla,
+    /// Softer success for text on a success-tinted chip.
+    pub success_muted: Hsla,
+
+    // ---- paint: components ----
+    /// Hover tone for an *opaque* raised pill. Hover must brighten the plate in
+    /// dark mode, never swap it for a translucent wash (that made pills go
+    /// see-through — user-reported); in light mode it darkens instead, same idea.
+    pub surface_raised_hover: Hsla,
+    /// Recessed band behind a palette/picker header or footer strip. Translucent
+    /// so the glass still reads through.
+    pub band: Hsla,
+    /// The composer pill and other input plates.
+    ///
+    /// Its own token because "lifted" inverts between appearances. On dark, a
+    /// faint *white* wash over near-black reads as raised. The literal light
+    /// translation — a faint *black* wash on white — reads as **recessed**, a dent
+    /// rather than a plate, which is why the prompt looked like bare text on a
+    /// smudge. Light mode lifts the way light UIs actually do: pure white, with
+    /// the border and shadow carrying the elevation.
+    pub input_bg: Hsla,
+    /// Text-selection highlight in the composer and inputs.
+    pub selection: Hsla,
+    /// Terminal block cursor.
+    pub cursor: Hsla,
+    /// Composer text caret. A blue distinct from `accent` — sampled from the
+    /// original composer, not derived, so it keeps its own token.
+    pub caret: Hsla,
+    /// Destructive-action button fill (danger plate, carries [`Self::on_accent`]).
+    pub danger_strong: Hsla,
+
+    // ---- paint: code & diff ----
+    /// Inline-code text — violet, per the user's "a nice purple" request.
+    pub code_text: Hsla,
+    /// Inline-code wash behind [`Self::code_text`].
+    pub code_wash: Hsla,
+    /// Syntax: keywords (soft rose).
+    pub syntax_keyword: Hsla,
+    /// Syntax: string literals (soft green).
+    pub syntax_string: Hsla,
+    /// Syntax: numeric literals (soft amber).
+    pub syntax_number: Hsla,
+    /// Diff: added lines.
+    pub diff_add: Hsla,
+    /// Diff: deleted lines.
+    pub diff_del: Hsla,
+    /// Diff: hunk-header wash (bluish grey).
+    pub diff_hunk_bg: Hsla,
 
     // ---- fonts ----
     /// UI font family (bundling of Geist lands with asset work; until then the
@@ -70,6 +286,20 @@ impl Theme {
     /// backdrop blur has no material layer, so the scrim runs heavier to land
     /// on the same perceived tone (see [`Theme::glass`]).
     pub const GLASS_ALPHA: f32 = if cfg!(target_os = "macos") { 0.90 } else { 1.0 };
+    /// Light-mode frost alpha — **opaque, deliberately**.
+    ///
+    /// Translucent chrome only works when the tint is dark enough to dominate
+    /// whatever is behind it. A light tint cannot: at any alpha loose enough to
+    /// actually show the blur, the desktop's colour bleeds through and the sidebar
+    /// takes on whatever the wallpaper happens to be — which reads as a dirty,
+    /// muddy grey rather than glass, and drags every label on it below its
+    /// contrast target because the background is no longer a known colour.
+    ///
+    /// Light UIs that get this right (Codex, Linear, Xcode) don't use vibrancy for
+    /// chrome at all: opaque panes, separated by hairlines. That is what this
+    /// does. Dark mode keeps its frost, where a near-black tint stays in control
+    /// of the result.
+    pub const GLASS_ALPHA_LIGHT: f32 = 1.0;
     /// Main-panel header height (comet `h-11`) — in-card headers (changes pane).
     pub const HEADER_HEIGHT: f32 = 44.0;
     /// The unified window titlebar (traffic lights + cluster + tabs). Content
@@ -93,37 +323,92 @@ impl Theme {
     pub const SPACE_MD: f32 = 12.0;
     pub const SPACE_LG: f32 = 16.0;
 
-    /// The frost tint painted over the blurred window background (macOS
-    /// glass). Darker than `surface` — matched to the reference dark
-    /// vibrancy scrim: `hsl(0 0% 3%)` (#080808) at [`Self::GLASS_ALPHA`].
-    /// On opaque platforms this IS the surface tone (no tint swap).
+    /// The frost tint painted over the blurred window background (macOS glass).
+    /// Dark: darker than `surface`, matched to the reference vibrancy scrim
+    /// `hsl(0 0% 3%)`. Light: opaque — see [`Self::GLASS_ALPHA_LIGHT`]. On opaque
+    /// platforms this IS the surface tone (no tint swap).
     pub fn glass(&self) -> Hsla {
-        if Self::GLASS_ALPHA < 1.0 {
-            grey(8).opacity(Self::GLASS_ALPHA)
-        } else {
-            self.surface
+        match self.appearance {
+            Appearance::Dark => {
+                if Self::GLASS_ALPHA < 1.0 {
+                    grey(8).opacity(Self::GLASS_ALPHA)
+                } else {
+                    self.surface
+                }
+            }
+            Appearance::Light => self.surface,
         }
     }
 
-    /// Build the (only) theme. The surface tones are sampled straight from the
+    /// The standard modal backdrop — see [`scrim`].
+    pub fn scrim(&self) -> Hsla {
+        scrim_for(self.appearance, SCRIM_ALPHA_DARK)
+    }
+
+    /// How the platform should composite the window behind our paint.
+    ///
+    /// Both appearances want the blurred desktop on macOS — the frost tint on top
+    /// is what differs. This is a method rather than a constant because it has to
+    /// be *re-applied* after every theme swap: gpui's macOS backend tears the
+    /// `NSVisualEffectView` out of the hierarchy whenever the value is anything
+    /// but `Blurred`, so a single lost re-apply kills vibrancy permanently.
+    /// See `appearance::apply`, and zed's `crates/zed/src/main.rs`, which runs the
+    /// same loop on every settings change.
+    pub fn window_background_appearance(&self) -> gpui::WindowBackgroundAppearance {
+        if cfg!(target_os = "macos") {
+            gpui::WindowBackgroundAppearance::Blurred
+        } else {
+            gpui::WindowBackgroundAppearance::Opaque
+        }
+    }
+
+    /// Build the dark theme. The surface tones are sampled straight from the
     /// reference screenshots of the original app (docs/reference): main panel
     /// `#060606`, shell/sidebar `#0d0d0d`.
     pub fn dark() -> Self {
         Self {
+            appearance: Appearance::Dark,
             bg: grey(6),       // main panel — sampled #060606
             surface: grey(13), // shell / sidebar — sampled #0d0d0d
             surface_raised: neutral(0.235),
-            element_hover: wash(0.14),
-            element_active: wash(0.16),
-            border: white_alpha(0.08),
-            border_strong: white_alpha(0.14),
-            text: neutral(0.922),                        // ~neutral-200
-            text_muted: neutral(0.708),                  // ~neutral-400
-            text_faint: neutral(0.556),                  // ~neutral-500
-            accent: oklch(0.673, 0.182, 276.935),        // indigo-400
+            surface_card: grey(0x0e),
+            surface_dialog: grey(0x10),
+            surface_overlay: grey(0x16),
+            element_hover: hsla(0.0, 0.0, 0.92, 0.14),
+            element_active: hsla(0.0, 0.0, 0.92, 0.16),
+            border: hsla(0.0, 0.0, 1.0, 0.08),
+            border_strong: hsla(0.0, 0.0, 1.0, 0.14),
+            text: neutral(0.922),       // ~neutral-200
+            text_muted: neutral(0.708), // ~neutral-400
+            text_faint: neutral(0.556), // ~neutral-500
+            text_dim: grey(0x98),
+            solid: neutral(0.922),      // near-white plate
+            on_solid: grey(0x0e),       // near-black label
+            accent: oklch(0.673, 0.182, 276.935), // indigo-400
             accent_strong: oklch(0.585, 0.233, 277.117), // indigo-500
-            danger: oklch(0.704, 0.191, 22.216),         // red-400
-            warning: oklch(0.828, 0.189, 84.429),        // amber-400
+            on_accent: neutral(0.985),
+            danger: oklch(0.704, 0.191, 22.216), // red-400
+            danger_muted: oklch(0.808, 0.114, 19.571), // red-300
+            warning: oklch(0.828, 0.189, 84.429), // amber-400
+            warning_muted: oklch(0.924, 0.12, 95.746), // amber-200
+            success: oklch(0.765, 0.177, 163.223), // emerald-400
+            busy: oklch(0.718, 0.202, 349.761),  // pink-400
+            success_muted: oklch(0.845, 0.143, 164.978), // emerald-300
+            surface_raised_hover: neutral(0.29),
+            band: band_for(Appearance::Dark),
+            input_bg: hsla(0.0, 0.0, 1.0, 0.03),
+            selection: hsla(0.66, 0.6, 0.55, 0.35),
+            cursor: hsla(0.0, 0.0, 1.0, 0.35),
+            caret: hsla(0.66, 0.7, 0.7, 1.0),
+            danger_strong: oklch(0.58, 0.16, 25.0),
+            code_text: oklch(0.811, 0.111, 293.571), // violet-300
+            code_wash: oklch(0.702, 0.183, 293.541).opacity(0.12), // violet-400/12
+            syntax_keyword: oklch(0.709, 0.129, 20.0), // soft rose
+            syntax_string: oklch(0.77, 0.11, 168.0), // soft green
+            syntax_number: oklch(0.78, 0.12, 80.0), // soft amber
+            diff_add: oklch(0.765, 0.177, 163.223), // emerald-400
+            diff_del: oklch(0.704, 0.191, 22.216), // red-400
+            diff_hunk_bg: hsla(0.6, 0.35, 0.6, 0.05),
             font_sans: "Geist".into(),
             font_mono: "Geist Mono".into(),
             font_sans_fallback: system_sans().into(),
@@ -131,9 +416,118 @@ impl Theme {
         }
     }
 
+    /// Build the light theme.
+    ///
+    /// Neutrals are the same oklch scale read from the other end, but the *roles*
+    /// are reassigned rather than mirrored (see the module docs): content plane
+    /// white, chrome grey, raised surfaces white-plus-shadow. Text tones are
+    /// picked to reproduce the dark theme's contrast ratios, and accents drop
+    /// from the 400 to the 600 step at identical hue so they clear WCAG AA on
+    /// white instead of glowing.
+    pub fn light() -> Self {
+        Self {
+            appearance: Appearance::Light,
+            bg: grey(0xff),           // main panel — clean white
+            // Deeper than ~neutral-100 looks on paper: the content card is pure
+            // white and sits *inside* this surface, so too small a step leaves the
+            // whole window one flat sheet with a hairline drawn on it.
+            surface: neutral(0.968),
+            // A real grey, NOT white. This is the opaque-plate tone — user
+            // message bubbles, the jump-to-bottom pill — and those sit directly
+            // on the white content plane with no border or shadow to save them.
+            // White here made the user's own messages vanish into the page.
+            // Popovers do not use this; they have their own ladder below.
+            surface_raised: neutral(0.940),
+            surface_card: grey(0xff),
+            surface_dialog: grey(0xff),
+            surface_overlay: grey(0xff),
+            element_hover: hsla(0.0, 0.0, 0.10, 0.06),
+            element_active: hsla(0.0, 0.0, 0.10, 0.10),
+            border: hsla(0.0, 0.0, 0.0, 0.10),
+            border_strong: hsla(0.0, 0.0, 0.0, 0.17),
+            // ~neutral-850. Pure neutral-900 measures 17.9:1 on white — *more*
+            // contrast than dark mode's 16.1:1, which reads as harsh rather than
+            // crisp. Backing off to 0.25 lands at ~16:1: the same perceived
+            // weight as the dark theme, not the maximum available.
+            text: neutral(0.25),
+            text_muted: neutral(0.439), // ~neutral-600 → ~7.7:1
+            // A touch darker than dark mode's neutral-500 counterpart: the light
+            // sidebar is a real grey, and faint text has to clear its floor there
+            // too, not just on the white content plane.
+            text_faint: neutral(0.535),
+            text_dim: neutral(0.50),
+            solid: neutral(0.205),      // near-black plate, deeper than body text
+            on_solid: neutral(0.985),   // near-white label
+            accent: oklch(0.511, 0.262, 276.966), // indigo-600
+            accent_strong: oklch(0.511, 0.262, 276.966), // indigo-600 fill
+            on_accent: neutral(0.985),
+            danger: oklch(0.577, 0.245, 27.325), // red-600
+            danger_muted: oklch(0.505, 0.213, 27.518), // red-700
+            warning: oklch(0.555, 0.163, 48.998), // amber-700 — carries 12px text
+            warning_muted: oklch(0.473, 0.137, 46.201), // amber-800
+            success: oklch(0.596, 0.145, 163.225), // emerald-600
+            busy: oklch(0.592, 0.249, 0.584),    // pink-600
+            success_muted: oklch(0.508, 0.118, 165.612), // emerald-700
+            // Opaque pills darken on hover here rather than brighten — same
+            // "brighten the plate, don't wash it out" rule, read the other way.
+            surface_raised_hover: neutral(0.900),
+            // A recessed strip on white needs far less ink than on near-black;
+            // the dark 16% would read as a bruise.
+            band: band_for(Appearance::Light),
+            input_bg: grey(0xff),
+            selection: hsla(0.66, 0.75, 0.62, 0.28),
+            cursor: hsla(0.0, 0.0, 0.0, 0.55),
+            caret: hsla(0.66, 0.78, 0.42, 1.0),
+            danger_strong: oklch(0.51, 0.20, 25.0),
+            code_text: oklch(0.491, 0.27, 292.581), // violet-700
+            code_wash: oklch(0.541, 0.281, 293.009).opacity(0.10), // violet-600/10
+            syntax_keyword: oklch(0.52, 0.19, 20.0),
+            syntax_string: oklch(0.46, 0.11, 168.0),
+            syntax_number: oklch(0.52, 0.13, 70.0),
+            diff_add: oklch(0.596, 0.145, 163.225), // emerald-600
+            diff_del: oklch(0.577, 0.245, 27.325), // red-600
+            diff_hunk_bg: hsla(0.6, 0.35, 0.35, 0.07),
+            font_sans: "Geist".into(),
+            font_mono: "Geist Mono".into(),
+            font_sans_fallback: system_sans().into(),
+            font_mono_fallback: system_mono().into(),
+        }
+    }
+
+    /// Build the theme for an appearance.
+    pub fn for_appearance(appearance: Appearance) -> Self {
+        match appearance {
+            Appearance::Dark => Self::dark(),
+            Appearance::Light => Self::light(),
+        }
+    }
+
+    /// Install the theme for `appearance` as the gpui global and point the
+    /// context-free paint helpers at it. The **only** way the appearance should
+    /// change — setting the global directly leaves [`current_appearance`] stale.
+    pub fn install(appearance: Appearance, cx: &mut App) {
+        set_current_appearance(appearance);
+        cx.set_global(Self::for_appearance(appearance));
+    }
+
     /// Read the theme global.
     pub fn of(cx: &App) -> &Theme {
         cx.global::<Theme>()
+    }
+
+    /// Overlay ink at `alpha` — see [`ink`].
+    pub fn ink(&self, alpha: f32) -> Hsla {
+        ink_for(self.appearance, alpha)
+    }
+
+    /// Hairline ink at `alpha` — see [`hairline`].
+    pub fn hairline(&self, alpha: f32) -> Hsla {
+        hairline_for(self.appearance, alpha)
+    }
+
+    /// State wash at `alpha` — see [`wash`].
+    pub fn wash(&self, alpha: f32) -> Hsla {
+        wash_for(self.appearance, alpha)
     }
 }
 
@@ -173,19 +567,95 @@ pub fn neutral(lightness: f32) -> Hsla {
     hsla(0.0, 0.0, v, 1.0)
 }
 
-/// Interactive-state wash: TRANSLUCENT soft-white, with alphas high enough to
-/// stay visible at the brightest backdrop the 0.90 glass scrim can produce
-/// (~L 0.13 over pure white — a 12% wash still adds ~+24 luma there). Fully
-/// opaque washes killed the glass and flashed dark mid-fade (user reports);
-/// hover fades must rest on `wash(0.0)`, never transparent BLACK, so the
-/// interpolation stays white-toned.
-pub fn wash(alpha: f32) -> Hsla {
-    hsla(0.0, 0.0, 0.92, alpha)
+/// Translucent **fill** ink for interactive states and chip plates: soft-white on
+/// dark, soft-black on light at [`INK_FILL_SCALE`] of the alpha.
+///
+/// Alphas are quoted in *dark-mode terms* at every call site — the dark theme is
+/// the tuned one — and the light value is derived. Callers keep one number and
+/// both appearances stay in the relationship the dark tuning established.
+///
+/// Fills must never rest on transparent BLACK in dark mode: fully opaque washes
+/// killed the glass and flashed dark mid-fade (user reports), so hover fades rest
+/// on `ink(0.0)`, which stays tonally correct at zero alpha.
+pub fn ink(alpha: f32) -> Hsla {
+    ink_for(current_appearance(), alpha)
 }
 
-/// White at the given alpha — the hairline/wash primitive.
-pub fn white_alpha(alpha: f32) -> Hsla {
-    hsla(0.0, 0.0, 1.0, alpha)
+fn ink_for(appearance: Appearance, alpha: f32) -> Hsla {
+    match appearance {
+        // Soft-white, not pure white: alphas are high enough to stay visible at
+        // the brightest backdrop the 0.90 glass scrim can produce.
+        Appearance::Dark => hsla(0.0, 0.0, 1.0, alpha),
+        Appearance::Light => hsla(0.0, 0.0, 0.0, alpha * INK_FILL_SCALE),
+    }
+}
+
+/// Translucent **hairline** ink for borders, dividers and rings: white on dark,
+/// black on light at [`INK_HAIRLINE_SCALE`] of the alpha.
+///
+/// Separate from [`ink`] because edges and fills scale in opposite directions
+/// when the field brightens — a 1px line needs *more* ink on white, a plate needs
+/// less.
+pub fn hairline(alpha: f32) -> Hsla {
+    hairline_for(current_appearance(), alpha)
+}
+
+fn hairline_for(appearance: Appearance, alpha: f32) -> Hsla {
+    match appearance {
+        Appearance::Dark => hsla(0.0, 0.0, 1.0, alpha),
+        Appearance::Light => hsla(0.0, 0.0, 0.0, (alpha * INK_HAIRLINE_SCALE).min(0.5)),
+    }
+}
+
+/// Interactive-state wash: a softened [`ink`] that stops short of pure black or
+/// white so hover plates read as tinted glass rather than paint.
+pub fn wash(alpha: f32) -> Hsla {
+    wash_for(current_appearance(), alpha)
+}
+
+fn wash_for(appearance: Appearance, alpha: f32) -> Hsla {
+    match appearance {
+        Appearance::Dark => hsla(0.0, 0.0, 0.92, alpha),
+        Appearance::Light => hsla(0.0, 0.0, 0.10, alpha * INK_FILL_SCALE),
+    }
+}
+
+/// Alpha of the standard modal backdrop in dark mode. Call sites that need a
+/// heavier or lighter scrim pass their own dark-mode alpha to [`scrim`].
+pub const SCRIM_ALPHA_DARK: f32 = 0.60;
+
+/// Modal backdrop at `alpha_dark` (quoted, as everywhere, in dark-mode terms).
+///
+/// Black in both appearances — a scrim's job is to darken what is behind it, and
+/// a "light scrim" of white would wash the modal out rather than seat it. What
+/// changes is strength: on a bright field a dark-mode-weight scrim reads as a
+/// blackout, so light mode scales to roughly half.
+pub fn scrim(alpha_dark: f32) -> Hsla {
+    scrim_for(current_appearance(), alpha_dark)
+}
+
+fn scrim_for(appearance: Appearance, alpha_dark: f32) -> Hsla {
+    match appearance {
+        Appearance::Dark => hsla(0.0, 0.0, 0.0, alpha_dark),
+        Appearance::Light => hsla(0.0, 0.0, 0.0, 0.32 * (alpha_dark / SCRIM_ALPHA_DARK)),
+    }
+}
+
+/// Recessed band behind a palette/picker header or footer strip.
+///
+/// A free function as well as a [`Theme`] field because the picker chrome that
+/// paints it is built from context-free helpers; both resolve to the same value.
+pub fn band() -> Hsla {
+    band_for(current_appearance())
+}
+
+fn band_for(appearance: Appearance) -> Hsla {
+    match appearance {
+        Appearance::Dark => hsla(0.0, 0.0, 0.0, 0.16),
+        // A recessed strip on white needs far less ink than on near-black; the
+        // dark 16% would read as a bruise.
+        Appearance::Light => hsla(0.0, 0.0, 0.0, 0.045),
+    }
 }
 
 /// Selected-state glass treatment (tabs, session rows, space rows): a
@@ -202,7 +672,7 @@ pub fn glass_selected_bg() -> Hsla {
 /// greyed ring (user report) — nothing may paint behind a glass chip.
 pub fn glass_selected_shadows() -> Vec<gpui::BoxShadow> {
     vec![gpui::BoxShadow {
-        color: white_alpha(0.09),
+        color: hairline(0.09),
         offset: gpui::point(gpui::px(0.0), gpui::px(0.0)),
         blur_radius: gpui::px(0.0),
         spread_radius: gpui::px(1.0),
@@ -277,6 +747,69 @@ pub(crate) fn rgb_to_hsl(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
     (h, s, l)
 }
 
+/// HSL (gpui convention, all 0..1) → sRGB components 0..1.
+pub(crate) fn hsl_to_rgb(h: f32, s: f32, l: f32) -> [f32; 3] {
+    if s <= f32::EPSILON {
+        return [l, l, l];
+    }
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
+    let p = 2.0 * l - q;
+    let hue = |mut t: f32| {
+        t = t.rem_euclid(1.0);
+        if t < 1.0 / 6.0 {
+            p + (q - p) * 6.0 * t
+        } else if t < 0.5 {
+            q
+        } else if t < 2.0 / 3.0 {
+            p + (q - p) * (2.0 / 3.0 - t) * 6.0
+        } else {
+            p
+        }
+    };
+    [hue(h + 1.0 / 3.0), hue(h), hue(h - 1.0 / 3.0)]
+}
+
+/// WCAG 2.1 relative luminance of an opaque color.
+pub fn relative_luminance(color: Hsla) -> f32 {
+    let lin = |c: f32| {
+        if c <= 0.040_45 {
+            c / 12.92
+        } else {
+            ((c + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    let [r, g, b] = hsl_to_rgb(color.h, color.s, color.l);
+    0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+}
+
+/// WCAG 2.1 contrast ratio between two opaque colors (1.0 … 21.0).
+///
+/// Used by the palette tests to prove each light token reproduces the contrast
+/// its dark counterpart had, rather than merely looking plausible.
+pub fn contrast_ratio(a: Hsla, b: Hsla) -> f32 {
+    let (la, lb) = (relative_luminance(a), relative_luminance(b));
+    let (hi, lo) = if la >= lb { (la, lb) } else { (lb, la) };
+    (hi + 0.05) / (lo + 0.05)
+}
+
+/// Composite `fg` (which may be translucent) over an opaque `bg`, returning the
+/// opaque result — the color the eye actually receives.
+pub fn flatten(fg: Hsla, bg: Hsla) -> Hsla {
+    let a = fg.a.clamp(0.0, 1.0);
+    let [fr, fg_, fb] = hsl_to_rgb(fg.h, fg.s, fg.l);
+    let [br, bg_, bb] = hsl_to_rgb(bg.h, bg.s, bg.l);
+    let (h, s, l) = rgb_to_hsl(
+        fr * a + br * (1.0 - a),
+        fg_ * a + bg_ * (1.0 - a),
+        fb * a + bb * (1.0 - a),
+    );
+    hsla(h, s, l, 1.0)
+}
+
 /// Linear per-component mix of two colors (paint helper for the gradient spinner).
 pub fn mix(a: Hsla, b: Hsla, t: f32) -> Hsla {
     let t = t.clamp(0.0, 1.0);
@@ -294,6 +827,15 @@ pub fn mix(a: Hsla, b: Hsla, t: f32) -> Hsla {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// [`CURRENT_APPEARANCE`] is process-wide, so the tests that flip it would
+    /// race each other under the default parallel test runner. They take this
+    /// lock and restore Dark on the way out.
+    static APPEARANCE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_appearance() -> std::sync::MutexGuard<'static, ()> {
+        APPEARANCE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     fn srgb_u8(c: [f32; 3]) -> [u8; 3] {
         [
@@ -325,67 +867,415 @@ mod tests {
     }
 
     #[test]
-    fn neutral_scale_is_ordered() {
-        let t = Theme::dark();
-        assert!(t.bg.l < t.surface.l);
-        assert!(t.surface.l < t.surface_raised.l);
-        assert!(t.surface_raised.l < t.text_faint.l);
-        assert!(t.text_faint.l < t.text_muted.l);
-        assert!(t.text_muted.l < t.text.l);
-        // Monochrome: neutrals carry no saturation.
+    fn hsl_roundtrips_through_rgb() {
         for c in [
-            t.bg,
-            t.surface,
-            t.surface_raised,
-            t.text,
-            t.text_muted,
-            t.text_faint,
+            Theme::dark().accent,
+            Theme::dark().warning,
+            Theme::light().accent,
+            Theme::light().danger,
+            neutral(0.556),
         ] {
-            assert_eq!(c.s, 0.0);
-            assert_eq!(c.a, 1.0);
+            let [r, g, b] = hsl_to_rgb(c.h, c.s, c.l);
+            let (h, s, l) = rgb_to_hsl(r, g, b);
+            assert!((l - c.l).abs() < 1e-3, "lightness drift for {c:?}");
+            assert!((s - c.s).abs() < 1e-3, "saturation drift for {c:?}");
+            if c.s > 1e-3 {
+                assert!((h - c.h).abs() < 1e-3, "hue drift for {c:?}");
+            }
         }
     }
 
     #[test]
-    fn hairlines_are_white_and_washes_are_mid_grey() {
-        let t = Theme::dark();
-        // Hairlines stay white — they only need to read on dark surfaces.
-        for c in [t.border, t.border_strong] {
-            assert_eq!(c.l, 1.0, "hairlines are white");
-            assert!(c.a > 0.0 && c.a < 0.25, "low alpha, got {}", c.a);
+    fn contrast_ratio_hits_known_anchors() {
+        let white = grey(0xff);
+        let black = grey(0x00);
+        assert!((contrast_ratio(white, black) - 21.0).abs() < 0.01);
+        assert!((contrast_ratio(white, white) - 1.0).abs() < 0.01);
+        // Symmetric regardless of argument order.
+        assert!((contrast_ratio(black, white) - contrast_ratio(white, black)).abs() < 1e-4);
+    }
+
+    /// The core claim of the light palette: it is *paired* to dark by contrast
+    /// ratio, not mirrored by lightness. Each text token must land within 1.0 of
+    /// its counterpart's ratio against its own background.
+    #[test]
+    fn text_contrast_is_paired_across_appearances() {
+        let (d, l) = (Theme::dark(), Theme::light());
+        for (name, dark_fg, light_fg) in [
+            ("text", d.text, l.text),
+            ("text_muted", d.text_muted, l.text_muted),
+            ("text_faint", d.text_faint, l.text_faint),
+        ] {
+            let dr = contrast_ratio(dark_fg, d.bg);
+            let lr = contrast_ratio(light_fg, l.bg);
+            assert!(
+                (dr - lr).abs() < 1.0,
+                "{name}: dark {dr:.2}:1 vs light {lr:.2}:1 — not a matched pair"
+            );
         }
-        // Washes are translucent soft-white with enough alpha to read at the
-        // glass scrim's brightness ceiling.
-        for c in [t.element_hover, t.element_active] {
-            assert_eq!(c.l, 0.92, "washes are soft-white");
-            assert!(c.a >= 0.05 && c.a < 0.35, "alpha in band, got {}", c.a);
+    }
+
+    /// Body and secondary text must clear WCAG AA (4.5:1) against **both** planes
+    /// they can land on, in both appearances.
+    ///
+    /// `text_faint` is held to a lower floor on purpose. It is placeholder and
+    /// disabled-control copy only, which WCAG 1.4.3 exempts, and the *existing
+    /// dark palette* already measures ~4.2:1 there (neutral-500 on #060606). The
+    /// light tone is matched to that inherited number rather than raised past it,
+    /// so the two appearances stay siblings; raising the floor is a palette
+    /// decision for both modes at once, not something light mode should do alone.
+    #[test]
+    fn text_tones_clear_wcag_aa() {
+        for t in [Theme::dark(), Theme::light()] {
+            for (name, fg, floor) in [
+                ("text", t.text, 4.5),
+                ("text_muted", t.text_muted, 4.5),
+                ("text_dim", t.text_dim, 4.5),
+                ("text_faint", t.text_faint, 4.1),
+            ] {
+                let on_bg = contrast_ratio(fg, t.bg);
+                let on_surface = contrast_ratio(fg, t.surface);
+                assert!(
+                    on_bg >= floor,
+                    "{:?} {name} on bg is {on_bg:.2}:1, below {floor}",
+                    t.appearance
+                );
+                assert!(
+                    on_surface >= floor,
+                    "{:?} {name} on surface is {on_surface:.2}:1, below {floor}",
+                    t.appearance
+                );
+            }
         }
-        assert!(t.border.a < t.border_strong.a);
-        // Hover intentionally equals the active fill (selection differs by
-        // its ring, not brightness — user request).
-        assert!(t.element_hover.a <= t.element_active.a);
+    }
+
+    /// Accents are the tokens a naive invert gets most wrong: the dark theme's
+    /// 400-step indigo/red land near 3:1 on white. The light palette drops to the
+    /// 600 step at the same hue, which must clear AA for non-text UI (3:1) and,
+    /// for the accent proper, body-text AA.
+    #[test]
+    fn accents_clear_contrast_on_their_background() {
+        let l = Theme::light();
+        assert!(
+            contrast_ratio(l.accent, l.bg) >= 4.5,
+            "light accent {:.2}:1",
+            contrast_ratio(l.accent, l.bg)
+        );
+        assert!(
+            contrast_ratio(l.danger, l.bg) >= 4.0,
+            "light danger {:.2}:1",
+            contrast_ratio(l.danger, l.bg)
+        );
+        for c in [l.warning, l.success, l.busy] {
+            assert!(
+                contrast_ratio(c, l.bg) >= 3.0,
+                "light status color {:.2}:1 — below the 3:1 non-text floor",
+                contrast_ratio(c, l.bg)
+            );
+        }
+        // And the dark 400-step accents would NOT have cleared it — this is why
+        // the light theme reassigns rather than reuses.
+        let d = Theme::dark();
+        assert!(
+            contrast_ratio(d.warning, l.bg) < 3.0,
+            "dark amber-400 unexpectedly passes on white; the invert-is-wrong \
+             premise needs rechecking"
+        );
+    }
+
+    /// Code is *text*, so syntax tones are held to the body-copy bar, not the
+    /// 3:1 non-text floor. These are the tokens most likely to be picked by eye
+    /// from a dark-theme screenshot and silently fail once the page turns white.
+    #[test]
+    fn code_and_syntax_tones_are_readable() {
+        for t in [Theme::dark(), Theme::light()] {
+            for (name, fg) in [
+                ("code_text", t.code_text),
+                ("syntax_keyword", t.syntax_keyword),
+                ("syntax_string", t.syntax_string),
+                ("syntax_number", t.syntax_number),
+            ] {
+                let r = contrast_ratio(fg, t.bg);
+                assert!(r >= 4.5, "{:?} {name} is {r:.2}:1 on bg", t.appearance);
+            }
+            // Diff tints mark whole rows; the 3:1 non-text floor applies.
+            for (name, fg) in [("diff_add", t.diff_add), ("diff_del", t.diff_del)] {
+                let r = contrast_ratio(fg, t.bg);
+                assert!(r >= 3.0, "{:?} {name} is {r:.2}:1 on bg", t.appearance);
+            }
+        }
+    }
+
+    /// The caret is a 2px bar, so the 3:1 non-text floor applies — but it is the
+    /// one element the user is actively hunting for, and the dark-mode blue is
+    /// far too light to survive on white unchanged.
+    #[test]
+    fn caret_is_findable_on_its_background() {
+        for t in [Theme::dark(), Theme::light()] {
+            let r = contrast_ratio(t.caret, t.bg);
+            assert!(r >= 3.0, "{:?} caret is {r:.2}:1 on bg", t.appearance);
+        }
+    }
+
+    /// Solid (primary button) plates must carry their label at AA in both modes.
+    ///
+    /// The accent plate is held to 4.0 rather than 4.5: dark mode's indigo-500
+    /// fill — inherited unchanged from the original palette — measures 4.38:1
+    /// under white, which clears WCAG AA for the medium-weight 14px labels these
+    /// buttons use (large-text AA is 3:1) but not body copy. Light mode's
+    /// indigo-600 clears the stricter bar with room to spare.
+    #[test]
+    fn solid_button_is_legible_in_both_appearances() {
+        for t in [Theme::dark(), Theme::light()] {
+            let r = contrast_ratio(t.on_solid, t.solid);
+            assert!(r >= 7.0, "{:?} solid button {r:.2}:1", t.appearance);
+            let a = contrast_ratio(t.on_accent, t.accent_strong);
+            assert!(a >= 4.0, "{:?} accent button {a:.2}:1", t.appearance);
+        }
+    }
+
+    /// Surfaces must stay *distinguishable*, but the direction differs: dark
+    /// stacks upward in lightness, light puts the content plane on top and lets
+    /// chrome recede. Asserting separation (not a fixed order) is the point.
+    #[test]
+    fn surfaces_are_separated_in_both_appearances() {
+        let d = Theme::dark();
+        assert!(d.bg.l < d.surface.l, "dark: chrome sits above content");
+        assert!(d.surface.l < d.surface_raised.l, "dark: raised is lighter");
+
+        let l = Theme::light();
+        assert!(
+            l.surface.l < l.bg.l,
+            "light: chrome recedes *below* the content plane"
+        );
+        assert!(
+            (l.bg.l - l.surface.l) > 0.015,
+            "light: sidebar must be visibly separated from the panel"
+        );
+        // Raised surfaces are white in light mode; separation comes from the
+        // border, so the border must be strong enough to carry it alone.
+        assert!(contrast_ratio(flatten(l.border, l.bg), l.bg) > 1.15);
+    }
+
+    /// The dark elevation steps are small but deliberate, and each plane must
+    /// stay strictly above the one below. This test exists because collapsing the
+    /// ladder onto a single `surface_raised` is the tempting simplification — and
+    /// it visibly lifts every popover off its plane.
+    #[test]
+    fn dark_elevation_ladder_is_strictly_ordered() {
+        let d = Theme::dark();
+        let ladder = [
+            ("bg", d.bg),
+            ("surface_card", d.surface_card),
+            ("surface_dialog", d.surface_dialog),
+            ("surface_overlay", d.surface_overlay),
+            ("surface_raised", d.surface_raised),
+        ];
+        for pair in ladder.windows(2) {
+            let ((lower, lo), (upper, hi)) = (pair[0], pair[1]);
+            assert!(
+                lo.l < hi.l,
+                "dark: {upper} ({:.4}) must sit above {lower} ({:.4})",
+                hi.l,
+                lo.l
+            );
+        }
+    }
+
+    /// Light mode flattens the ladder onto white on purpose — separation comes
+    /// from border and shadow. Assert that explicitly so nobody "fixes" it by
+    /// reintroducing lightness steps that would tint popovers grey.
+    #[test]
+    fn light_elevation_is_flat_white_and_leans_on_borders() {
+        let l = Theme::light();
+        for (name, c) in [
+            ("surface_card", l.surface_card),
+            ("surface_dialog", l.surface_dialog),
+            ("surface_overlay", l.surface_overlay),
+        ] {
+            assert_eq!(c.l, 1.0, "light {name} should be white");
+        }
+        // With no lightness step available, the border is the only separator —
+        // it has to actually register against the plane behind it.
+        assert!(contrast_ratio(flatten(l.border, l.bg), l.bg) > 1.15);
+    }
+
+    /// `surface_raised` is the *bare plate* tone — user message bubbles, the
+    /// jump-to-bottom pill. Unlike the popover ladder it gets no border and no
+    /// shadow, so lightness is the only thing separating it from the panel. It
+    /// was white in light mode once, which made the user's own messages
+    /// indistinguishable from the page.
+    #[test]
+    fn bare_plates_are_visible_against_their_panel() {
+        for t in [Theme::dark(), Theme::light()] {
+            let delta = (t.surface_raised.l - t.bg.l).abs();
+            assert!(
+                delta > 0.03,
+                "{:?} surface_raised ({:.3}) is only {delta:.3} from bg ({:.3}) — \
+                 a plate with no border needs lightness to read",
+                t.appearance,
+                t.surface_raised.l,
+                t.bg.l
+            );
+            // And hovering it has to go somewhere visible too.
+            let hover_delta = (t.surface_raised_hover.l - t.surface_raised.l).abs();
+            assert!(
+                hover_delta > 0.02,
+                "{:?} raised-plate hover moves only {hover_delta:.3}",
+                t.appearance
+            );
+        }
+    }
+
+    /// Monochrome discipline: neutrals carry no saturation in either appearance.
+    #[test]
+    fn neutrals_are_achromatic() {
+        for t in [Theme::dark(), Theme::light()] {
+            for c in [
+                t.bg,
+                t.surface,
+                t.surface_raised,
+                t.text,
+                t.text_muted,
+                t.text_faint,
+                t.solid,
+                t.on_solid,
+            ] {
+                assert_eq!(c.s, 0.0, "{:?} neutral has chroma", t.appearance);
+                assert_eq!(c.a, 1.0, "{:?} neutral is translucent", t.appearance);
+            }
+        }
     }
 
     #[test]
-    fn accent_hues_land_in_their_bands() {
-        let t = Theme::dark();
-        // Hsla hue is 0..1 of the wheel. Indigo ≈ 230-250°, red < 15°, amber ≈ 40-55°.
-        let deg = |c: Hsla| c.h * 360.0;
-        assert!(
-            (215.0..265.0).contains(&deg(t.accent)),
-            "indigo hue {}",
-            deg(t.accent)
+    fn hairlines_and_washes_flip_tone_with_appearance() {
+        let _guard = lock_appearance();
+        set_current_appearance(Appearance::Dark);
+        assert_eq!(hairline(0.1).l, 1.0, "dark hairlines are white");
+        assert_eq!(ink(0.1).l, 1.0, "dark fills are white");
+        assert_eq!(ink(0.1).a, 0.1, "dark alphas pass through untouched");
+        assert_eq!(wash(0.14).l, 0.92, "dark washes are soft-white");
+
+        set_current_appearance(Appearance::Light);
+        assert_eq!(hairline(0.1).l, 0.0, "light hairlines are black");
+        assert_eq!(ink(0.1).l, 0.0, "light fills are black");
+        assert_eq!(wash(0.14).l, 0.10, "light washes are soft-black");
+        // Fills keep their alpha; only hairlines are scaled.
+        assert_eq!(ink(0.10).a, 0.10, "light fills keep their alpha");
+        assert!(hairline(0.10).a > 0.10, "light hairlines strengthen");
+        assert!(hairline(0.60).a <= 0.5, "hairline alpha is capped");
+
+        set_current_appearance(Appearance::Dark);
+    }
+
+    /// A hover wash has to actually be *visible* against the surface it lands on,
+    /// in both appearances — the failure mode of a halved light alpha.
+    #[test]
+    fn hover_wash_is_visible_on_its_surface() {
+        let _guard = lock_appearance();
+        for (appearance, theme) in [
+            (Appearance::Dark, Theme::dark()),
+            (Appearance::Light, Theme::light()),
+        ] {
+            set_current_appearance(appearance);
+            let hovered = flatten(wash(0.14), theme.surface);
+            let delta = (hovered.l - theme.surface.l).abs();
+            assert!(
+                delta > 0.02,
+                "{appearance:?} hover wash shifts lightness by only {delta:.4}"
+            );
+        }
+        set_current_appearance(Appearance::Dark);
+    }
+
+    /// The regression that shipped: subtle fills are quoted at very low alphas
+    /// (`ink(0.03)` is the composer plate, `ink(0.05)` a key cap), and scaling
+    /// those down for light mode erased them — the composer rendered as bare text
+    /// on white. Assert the faintest fill we actually use still moves the surface
+    /// it lands on, in *both* appearances.
+    #[test]
+    fn faintest_fills_survive_in_both_appearances() {
+        let _guard = lock_appearance();
+        for (appearance, theme) in [
+            (Appearance::Dark, Theme::dark()),
+            (Appearance::Light, Theme::light()),
+        ] {
+            set_current_appearance(appearance);
+            for alpha in [0.03, 0.05] {
+                let plate = flatten(ink(alpha), theme.bg);
+                let delta = (plate.l - theme.bg.l).abs();
+                assert!(
+                    delta >= 0.02,
+                    "{appearance:?} ink({alpha}) shifts its background by only \
+                     {delta:.4} — the fill is invisible"
+                );
+            }
+        }
+        set_current_appearance(Appearance::Dark);
+    }
+
+    /// Light chrome is opaque on purpose. A translucent light tint lets the
+    /// desktop's colour through, so the sidebar becomes whatever the wallpaper is
+    /// — muddy, and no longer a known background to compute contrast against.
+    /// Dark keeps its frost, where the tint stays in control.
+    #[test]
+    fn light_chrome_is_opaque_and_dark_stays_frosted() {
+        assert_eq!(
+            Theme::light().glass().a,
+            1.0,
+            "light chrome must not sample the desktop"
         );
-        assert!(
-            deg(t.danger) < 15.0 || deg(t.danger) > 345.0,
-            "red hue {}",
-            deg(t.danger)
-        );
-        assert!(
-            (35.0..60.0).contains(&deg(t.warning)),
-            "amber hue {}",
-            deg(t.warning)
-        );
+        if Theme::GLASS_ALPHA < 1.0 {
+            assert!(
+                Theme::dark().glass().a < 1.0,
+                "dark mode keeps its translucent frost"
+            );
+        }
+    }
+
+    /// An input plate has to read as *lifted* in both appearances. Dark does that
+    /// with a faint white wash; the literal light translation is a faint black
+    /// wash, which reads as a dent instead — so light lifts with white plus its
+    /// border. Assert the plate is never darker than the panel it sits on.
+    #[test]
+    fn input_plate_never_reads_as_recessed() {
+        for t in [Theme::dark(), Theme::light()] {
+            let plate = flatten(t.input_bg, t.bg);
+            assert!(
+                plate.l >= t.bg.l,
+                "{:?} input plate ({:.3}) is darker than its panel ({:.3}) — \
+                 that reads as recessed, not raised",
+                t.appearance,
+                plate.l,
+                t.bg.l
+            );
+        }
+    }
+
+    #[test]
+    fn appearance_mirror_tracks_installed_theme() {
+        let _guard = lock_appearance();
+        set_current_appearance(Appearance::Light);
+        assert_eq!(current_appearance(), Appearance::Light);
+        set_current_appearance(Appearance::Dark);
+        assert_eq!(current_appearance(), Appearance::Dark);
+    }
+
+    #[test]
+    fn window_appearance_maps_onto_ours() {
+        use gpui::WindowAppearance as W;
+        assert_eq!(Appearance::from_window(W::Light), Appearance::Light);
+        assert_eq!(Appearance::from_window(W::VibrantLight), Appearance::Light);
+        assert_eq!(Appearance::from_window(W::Dark), Appearance::Dark);
+        assert_eq!(Appearance::from_window(W::VibrantDark), Appearance::Dark);
+    }
+
+    #[test]
+    fn scrim_is_black_but_lighter_in_light_mode() {
+        let (d, l) = (Theme::dark(), Theme::light());
+        assert_eq!(d.scrim().l, 0.0);
+        assert_eq!(l.scrim().l, 0.0);
+        assert!(l.scrim().a < d.scrim().a);
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -1484,8 +1484,8 @@ impl Transcript {
                     frame
                         .id(SharedString::from(format!("{row_id}#att{aix}")))
                         .border_1()
-                        .border_color(crate::theme::white_alpha(0.11))
-                        .bg(crate::theme::white_alpha(0.035))
+                        .border_color(crate::theme::hairline(0.11))
+                        .bg(crate::theme::ink(0.035))
                         .cursor_pointer()
                         .on_click(cx.listener(move |this, _, _, cx| {
                             this.attachment_preview = Some(preview.clone());
@@ -1502,14 +1502,14 @@ impl Transcript {
                 AttachmentSnapshot::Error { .. } => frame
                     .border_1()
                     .border_dashed()
-                    .border_color(crate::theme::white_alpha(0.14))
-                    .bg(crate::theme::white_alpha(0.025))
+                    .border_color(crate::theme::hairline(0.14))
+                    .bg(crate::theme::ink(0.025))
                     .into_any_element(),
                 // Loading: the pulsing skeleton (same wash as popover skeletons).
                 AttachmentSnapshot::Loading => frame
                     .border_1()
-                    .border_color(crate::theme::white_alpha(0.08))
-                    .bg(crate::theme::white_alpha(0.055))
+                    .border_color(crate::theme::hairline(0.08))
+                    .bg(crate::theme::ink(0.055))
                     .with_animation(
                         SharedString::from(format!("{row_id}#att-pulse{aix}")),
                         motion::COMET_PULSE.repeating(),
@@ -1855,7 +1855,7 @@ impl Transcript {
             // chips (destructive tint, comet tool-chip.tsx) and in the
             // summary's "· N failed" count.
             .text_color(theme.text_muted)
-            .hover(|s| s.text_color(Theme::dark().text))
+            .hover(|s| s.text_color(theme.text))
             .on_click(cx.listener(move |this, _, _, cx| {
                 this.toggle_fold(toggle_id.clone(), tool_count, auto_open);
                 cx.notify();
@@ -1865,7 +1865,7 @@ impl Transcript {
                     .size(px(18.0))
                     .flex_none()
                     .rounded(px(5.0))
-                    .bg(crate::theme::white_alpha(0.06))
+                    .bg(crate::theme::ink(0.06))
                     .flex()
                     .items_center()
                     .justify_center()
@@ -1932,7 +1932,7 @@ impl Transcript {
 /// "Error" label, then the human message truncating at `text-foreground/80` —
 /// a subtle red-tinted wash, never a bare red-stroke box.
 fn error_chip(message: SharedString, theme: &Theme) -> AnyElement {
-    let red_300 = crate::theme::oklch(0.808, 0.114, 19.571); // tailwind red-300
+    let red_300 = theme.danger_muted; // tailwind red-300
     let danger = theme.danger; // red-400
     div()
         .py(px(4.0))
@@ -2011,8 +2011,8 @@ fn input_chip(header: SharedString, resolved: bool, theme: &Theme) -> AnyElement
                 .overflow_hidden()
                 .rounded(px(10.0))
                 .border_1()
-                .border_color(crate::theme::white_alpha(0.08))
-                .bg(crate::theme::white_alpha(0.045))
+                .border_color(crate::theme::hairline(0.08))
+                .bg(crate::theme::ink(0.045))
                 .px(px(8.0))
                 .text_size(px(12.0))
                 .child(
@@ -2020,7 +2020,7 @@ fn input_chip(header: SharedString, resolved: bool, theme: &Theme) -> AnyElement
                         .flex_none()
                         .size(px(20.0))
                         .rounded(px(6.0))
-                        .bg(crate::theme::white_alpha(0.09))
+                        .bg(crate::theme::ink(0.09))
                         .flex()
                         .items_center()
                         .justify_center()
@@ -2090,7 +2090,7 @@ fn tool_chip(tool: &ToolItem, theme: &Theme) -> AnyElement {
                 .h_full()
                 .w(px(1.0))
                 .flex_none()
-                .bg(crate::theme::white_alpha(0.08)),
+                .bg(crate::theme::ink(0.08)),
         )
         .child(
             div()
@@ -2105,8 +2105,8 @@ fn tool_chip(tool: &ToolItem, theme: &Theme) -> AnyElement {
                 .overflow_hidden()
                 .rounded(px(9.0))
                 .border_1()
-                .border_color(crate::theme::white_alpha(0.07))
-                .bg(crate::theme::white_alpha(0.03))
+                .border_color(crate::theme::hairline(0.07))
+                .bg(crate::theme::ink(0.03))
                 .px(px(8.0))
                 .text_size(px(12.0))
                 .child(
@@ -2116,7 +2116,7 @@ fn tool_chip(tool: &ToolItem, theme: &Theme) -> AnyElement {
                         .size(px(18.0))
                         .flex_none()
                         .rounded(px(5.0))
-                        .bg(crate::theme::white_alpha(0.08))
+                        .bg(crate::theme::ink(0.08))
                         .flex()
                         .items_center()
                         .justify_center()


### PR DESCRIPTION
Adds light mode. Dark mode is unchanged.


<img width="1496" height="846" alt="Screenshot 2026-08-02 at 8 20 13 PM" src="https://github.com/user-attachments/assets/0eb2e87e-a437-4a41-aa1b-3793691b3514" />

<img width="1496" height="846" alt="Screenshot 2026-08-02 at 8 45 53 PM" src="https://github.com/user-attachments/assets/242d19ef-8f41-4c5b-86bc-9a75fc6abb3e" />



## How it works

Copied Zed's approach:

- `Theme` is a gpui global with two instances. Components read it with `Theme::of(cx)`.
- The OS appearance is watched with `observe_window_appearance`. On a change we swap the global and call `cx.refresh_windows()`. Colors are read at paint time, so `notify()` is not enough.
- Window vibrancy is re-applied after every theme swap, because gpui's macOS backend drops the `NSVisualEffectView` otherwise.

## Colors

Light is not an inversion of dark:

- Text tones are matched to their dark counterpart by contrast ratio, not by lightness.
- Accents move from the 400 step to 600. amber-400 measures 1.9:1 on white.
- Light chrome is opaque. A translucent light tint picks up the desktop colour and goes muddy.
- Elevation reverses: on dark a faint white wash means raised, on light that reads as recessed, so light lifts with white plus a border.

Tests check the contrast ratios rather than eyeballing them.

## UI

Settings → Appearance picks System / Light / Dark. Same options in the View menu. The preview cards use a new `option_card` widget that takes any preview element, so it is reusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788275158&installation_model_id=425430&pr_number=10&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F10&signature=fc0140de648af22c4bafad55155f5cf9c0674dd0daf44b23a813f994e1492a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->