### PR TITLE
Add workspace file mentions to the composer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1236,7 @@ dependencies = [
  "comet-sync",
  "comet-update",
  "futures",
+ "ignore",
  "libc",
  "loro",
  "notify",
@@ -2736,6 +2747,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "glow"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,6 +3571,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ alacritty_terminal = "0.26"
 pulldown-cmark = "0.12"
 unicode-segmentation = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
+ignore = "0.4"
 
 [profile.release]
 # Distribution profile (scripts/package-linux.sh): thin LTO buys most of fat

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -30,6 +30,7 @@ base64 = "0.22"
 libc.workspace = true
 sha2.workspace = true
 reqwest.workspace = true
+ignore.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/engine/src/repos.rs
+++ b/crates/engine/src/repos.rs
@@ -12,6 +12,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use sha2::{Digest, Sha256};
@@ -30,8 +31,6 @@ const FOLDER_LIST_TIMEOUT: Duration = Duration::from_secs(6);
 const FOLDER_LIST_MAX_ENTRIES: usize = 500;
 /// File mentions should remain responsive even in very large checkouts.
 const FILE_SEARCH_MAX_RESULTS: usize = 8;
-/// Bound work for pathological repositories even when few paths match.
-const FILE_SEARCH_MAX_ENTRIES: usize = 50_000;
 /// A dead network mount must not leave the composer search spinning forever.
 const FILE_SEARCH_TIMEOUT: Duration = Duration::from_secs(6);
 
@@ -82,6 +81,7 @@ struct ReposInner {
     data_dir: PathBuf,
     device_id: String,
     worktrees_root: PathBuf,
+    file_searches: std::sync::Mutex<HashMap<PathBuf, std::sync::Weak<tokio::sync::Mutex<()>>>>,
 }
 
 #[derive(Clone)]
@@ -103,6 +103,7 @@ impl Repos {
                 data_dir: data_dir.to_path_buf(),
                 device_id: device_id.to_string(),
                 worktrees_root,
+                file_searches: std::sync::Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -432,20 +433,29 @@ impl Repos {
             .collect())
     }
 
-    /// Whether `candidate` is one of the repository's existing linked
-    /// worktrees. Both sides are canonicalized so a client cannot smuggle a
-    /// sibling path through lexical `..` or symlink spelling.
-    pub async fn is_linked_worktree(&self, repo_path: &Path, candidate: &Path) -> bool {
-        let Ok(candidate) = std::fs::canonicalize(candidate) else {
-            return false;
-        };
-        self.refs(repo_path)
+    /// Whether `candidate` is the repository root or one of its linked
+    /// worktrees. Filesystem resolution happens on a disposable thread because
+    /// user-selected paths may be dead mounts.
+    pub async fn workspace_checkout(&self, repo_path: &Path, candidate: &Path) -> Option<PathBuf> {
+        let repo_path = repo_path.to_path_buf();
+        let candidate = candidate.to_path_buf();
+        let worktrees: Vec<_> = self
+            .refs(&repo_path)
             .await
             .unwrap_or_default()
             .into_iter()
-            .filter_map(|row| row.worktree_path)
-            .filter_map(|path| std::fs::canonicalize(path).ok())
-            .any(|path| path == candidate)
+            .filter_map(|row| row.worktree_path.map(PathBuf::from))
+            .collect();
+        disposable_worker("checkout-auth", move || {
+            let candidate = std::fs::canonicalize(candidate).ok()?;
+            std::iter::once(repo_path)
+                .chain(worktrees)
+                .filter_map(|path| std::fs::canonicalize(path).ok())
+                .any(|path| path == candidate)
+                .then_some(candidate)
+        })
+        .await
+        .flatten()
     }
 
     /// Switch the checkout at `cwd` (a main folder OR a linked worktree) to
@@ -674,22 +684,53 @@ impl Repos {
     }
 
     /// Search a checkout's files and directories by fuzzy relative path. The
-    /// `ignore` walker honors `.gitignore`, `.ignore`, global git excludes, and
-    /// skips hidden directories by default; callers have already authorized
-    /// `root` against workspace state.
+    /// `ignore` walker honors `.gitignore`, `.ignore`, and global git excludes.
+    /// Dotfiles remain searchable; only repository metadata is always pruned.
     pub async fn search_files(
         &self,
         root: PathBuf,
         query: String,
         featured_paths: Vec<String>,
     ) -> Result<Vec<FileSearchMatch>, EngineError> {
-        let worker = tokio::task::spawn_blocking(move || {
-            search_files_blocking(&root, &query, &featured_paths)
-        });
-        tokio::time::timeout(FILE_SEARCH_TIMEOUT, worker)
+        let deadline = tokio::time::Instant::now() + FILE_SEARCH_TIMEOUT;
+        let gate = {
+            let mut searches = self
+                .inner
+                .file_searches
+                .lock()
+                .map_err(|_| EngineError::Other("file search registry poisoned".into()))?;
+            if let Some(gate) = searches.get(&root).and_then(std::sync::Weak::upgrade) {
+                gate
+            } else {
+                let gate = std::sync::Arc::new(tokio::sync::Mutex::new(()));
+                searches.insert(root.clone(), std::sync::Arc::downgrade(&gate));
+                gate
+            }
+        };
+        let gate = tokio::time::timeout_at(deadline, gate.lock_owned())
             .await
-            .map_err(|_| EngineError::Other("file search timed out".into()))?
-            .map_err(|e| EngineError::Other(format!("file search worker failed: {e}")))?
+            .map_err(|_| EngineError::Other("file search timed out".into()))?;
+        let cancelled = std::sync::Arc::new(AtomicBool::new(false));
+        let _cancel_on_drop = CancelOnDrop(cancelled.clone());
+        let worker_cancelled = cancelled.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        std::thread::Builder::new()
+            .name("file-search".into())
+            .spawn(move || {
+                let _gate = gate;
+                let _ = tx.send(search_files_blocking_with_cancel(
+                    &root,
+                    &query,
+                    &featured_paths,
+                    || worker_cancelled.load(Ordering::Relaxed),
+                ));
+            })
+            .map_err(|e| EngineError::Other(format!("file search failed: {e}")))?;
+        match tokio::time::timeout_at(deadline, rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(EngineError::Other("file search worker exited".into())),
+            Err(_) => Err(EngineError::Other("file search timed out".into())),
+        }
     }
 
     /// `hang_for_test` makes the worker never respond — exercises the timeout path.
@@ -734,6 +775,28 @@ impl Repos {
     }
 }
 
+struct CancelOnDrop(std::sync::Arc<AtomicBool>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+async fn disposable_worker<T: Send + 'static>(
+    name: &'static str,
+    work: impl FnOnce() -> T + Send + 'static,
+) -> Option<T> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name(name.into())
+        .spawn(move || {
+            let _ = tx.send(work());
+        })
+        .ok()?;
+    rx.await.ok()
+}
+
 /// The blocking walk: ONE readdir of the target; `is_repo` is a cheap `.git`
 /// existence probe per directory entry.
 fn list_folders_blocking(target: &Path) -> Result<FolderListing, EngineError> {
@@ -775,27 +838,68 @@ fn list_folders_blocking(target: &Path) -> Result<FolderListing, EngineError> {
 /// Case-insensitive subsequence score. Lower is better: adjacent and earlier
 /// characters win, while still allowing `cmp rs` to find `composer.rs`.
 fn fuzzy_score(query: &str, candidate: &str) -> Option<usize> {
-    let query = query.to_lowercase();
     let candidate = candidate.to_lowercase();
-    let mut at = 0;
-    let mut score = 0;
-    let mut previous_end = None;
-    for needle in query.chars().filter(|ch| !ch.is_whitespace()) {
-        let found = candidate[at..].find(needle)? + at;
-        score += found;
-        if previous_end == Some(found) {
-            score = score.saturating_sub(2);
-        }
-        at = found + needle.len_utf8();
-        previous_end = Some(at);
-    }
-    Some(score)
+    query
+        .split_whitespace()
+        .map(str::to_lowercase)
+        .try_fold(0usize, |total, term| {
+            let mut at = 0;
+            let mut score = 0usize;
+            let mut previous_end = None;
+            for needle in term.chars() {
+                let found = candidate[at..].find(needle)? + at;
+                score += found;
+                if previous_end == Some(found) {
+                    score = score.saturating_sub(2);
+                }
+                at = found + needle.len_utf8();
+                previous_end = Some(at);
+            }
+            Some(total.saturating_add(score))
+        })
 }
 
+type RankedFileMatch = (Option<usize>, usize, String, bool);
+
+fn compare_file_matches(
+    query: &str,
+    (featured_a, score_a, path_a, dir_a): &RankedFileMatch,
+    (featured_b, score_b, path_b, dir_b): &RankedFileMatch,
+) -> std::cmp::Ordering {
+    let empty_query = query.trim().is_empty();
+    featured_a
+        .is_none()
+        .cmp(&featured_b.is_none())
+        .then_with(|| featured_a.cmp(featured_b))
+        .then_with(|| score_a.cmp(score_b))
+        .then_with(|| {
+            empty_query
+                .then(|| path_a.split('/').count().cmp(&path_b.split('/').count()))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .then_with(|| {
+            empty_query
+                .then(|| dir_a.cmp(dir_b))
+                .unwrap_or_else(|| dir_b.cmp(dir_a))
+        })
+        .then_with(|| path_a.len().cmp(&path_b.len()))
+        .then_with(|| path_a.cmp(path_b))
+}
+
+#[cfg(test)]
 fn search_files_blocking(
     root: &Path,
     query: &str,
     featured_paths: &[String],
+) -> Result<Vec<FileSearchMatch>, EngineError> {
+    search_files_blocking_with_cancel(root, query, featured_paths, || false)
+}
+
+fn search_files_blocking_with_cancel<F: Fn() -> bool>(
+    root: &Path,
+    query: &str,
+    featured_paths: &[String],
+    cancelled: F,
 ) -> Result<Vec<FileSearchMatch>, EngineError> {
     let root = std::fs::canonicalize(root)
         .map_err(|e| EngineError::Other(format!("could not search workspace: {e}")))?;
@@ -818,14 +922,17 @@ fn search_files_blocking(
             paths
         });
     let mut matches = Vec::new();
-    let mut examined = 0usize;
     let walker = ignore::WalkBuilder::new(&root)
-        .hidden(true)
+        .hidden(false)
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true)
+        .filter_entry(|entry| entry.depth() == 0 || entry.file_name() != ".git")
         .build();
     for entry in walker {
+        if cancelled() {
+            return Err(EngineError::Other("file search cancelled".into()));
+        }
         let entry = match entry {
             Ok(entry) => entry,
             Err(err) => {
@@ -837,10 +944,6 @@ fn search_files_blocking(
         if path == root {
             continue;
         }
-        examined += 1;
-        if examined > FILE_SEARCH_MAX_ENTRIES {
-            break;
-        }
         let Ok(relative) = path.strip_prefix(&root) else {
             continue;
         };
@@ -848,42 +951,26 @@ fn search_files_blocking(
         if relative.starts_with(".git/") || relative == ".git" {
             continue;
         }
-        let Some(score) = fuzzy_score(query, &relative) else {
+        let Some(path_score) = fuzzy_score(query, &relative) else {
             continue;
         };
+        let score = relative
+            .rsplit('/')
+            .next()
+            .and_then(|name| fuzzy_score(query, name))
+            .unwrap_or_else(|| path_score.saturating_add(1_000));
         matches.push((
             featured.get(&relative).copied(),
             score,
             relative,
             entry.file_type().is_some_and(|kind| kind.is_dir()),
         ));
+        if matches.len() > FILE_SEARCH_MAX_RESULTS {
+            matches.sort_by(|a, b| compare_file_matches(query, a, b));
+            matches.truncate(FILE_SEARCH_MAX_RESULTS);
+        }
     }
-    matches.sort_by(
-        |(featured_a, score_a, path_a, dir_a), (featured_b, score_b, path_b, dir_b)| {
-            featured_a
-                .is_none()
-                .cmp(&featured_b.is_none())
-                .then_with(|| featured_a.cmp(featured_b))
-                .then_with(|| score_a.cmp(score_b))
-                .then_with(|| {
-                    if query.is_empty() {
-                        path_a.split('/').count().cmp(&path_b.split('/').count())
-                    } else {
-                        std::cmp::Ordering::Equal
-                    }
-                })
-                .then_with(|| {
-                    if query.is_empty() {
-                        dir_a.cmp(dir_b)
-                    } else {
-                        dir_b.cmp(dir_a)
-                    }
-                })
-                .then_with(|| path_a.len().cmp(&path_b.len()))
-                .then_with(|| path_a.cmp(path_b))
-        },
-    );
-    matches.truncate(FILE_SEARCH_MAX_RESULTS);
+    matches.sort_by(|a, b| compare_file_matches(query, a, b));
     Ok(matches
         .into_iter()
         .map(|(_, _, path, is_dir)| FileSearchMatch { path, is_dir })
@@ -937,6 +1024,7 @@ mod tests {
     #[test]
     fn fuzzy_score_matches_a_path_subsequence() {
         assert!(fuzzy_score("cmp rs", "crates/ui/src/composer.rs").is_some());
+        assert!(fuzzy_score("composer crates", "crates/ui/src/composer.rs").is_some());
         assert!(fuzzy_score("xyz", "crates/ui/src/composer.rs").is_none());
     }
 
@@ -966,8 +1054,10 @@ mod tests {
         assert!(
             search_files_blocking(root.path(), "secret", &[])
                 .unwrap()
-                .is_empty()
+                .iter()
+                .any(|entry| entry.path == ".secret")
         );
+        assert!(!matches.iter().any(|entry| entry.path.starts_with(".git/")));
     }
 
     #[test]
@@ -983,5 +1073,76 @@ mod tests {
             Some("src/deep.rs")
         );
         assert!(matches.iter().any(|entry| entry.path == "README.md"));
+    }
+
+    #[test]
+    fn search_files_prefers_filename_matches() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("composer/docs")).unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("composer/docs/readme.md"), "").unwrap();
+        std::fs::write(root.path().join("src/composer.rs"), "").unwrap();
+
+        let matches = search_files_blocking(root.path(), "composer", &[]).unwrap();
+        let composer = matches
+            .iter()
+            .position(|entry| entry.path == "src/composer.rs")
+            .unwrap();
+        let path_only = matches
+            .iter()
+            .position(|entry| entry.path == "composer/docs/readme.md")
+            .unwrap();
+        assert!(composer < path_only);
+    }
+
+    #[test]
+    fn cancelled_search_stops_before_walking() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("README.md"), "").unwrap();
+        let cancelled = AtomicBool::new(true);
+
+        let err = search_files_blocking_with_cancel(root.path(), "", &[], || {
+            cancelled.load(Ordering::Relaxed)
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn workspace_checkout_rejects_sibling_paths() {
+        let data = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let sibling = tempfile::tempdir().unwrap();
+        let repos =
+            Repos::with_worktrees_root(data.path(), "device", data.path().join("worktrees"));
+
+        assert_eq!(
+            repos.workspace_checkout(root.path(), root.path()).await,
+            std::fs::canonicalize(root.path()).ok()
+        );
+        assert!(
+            repos
+                .workspace_checkout(root.path(), sibling.path())
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_searches_of_one_checkout_do_not_cancel_each_other() {
+        let data = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("alpha.rs"), "").unwrap();
+        std::fs::write(root.path().join("beta.rs"), "").unwrap();
+        let repos =
+            Repos::with_worktrees_root(data.path(), "device", data.path().join("worktrees"));
+
+        let alpha = repos.search_files(root.path().into(), "alpha".into(), Vec::new());
+        let beta = repos.search_files(root.path().into(), "beta".into(), Vec::new());
+        let (alpha, beta) = tokio::join!(alpha, beta);
+
+        assert_eq!(alpha.unwrap()[0].path, "alpha.rs");
+        assert_eq!(beta.unwrap()[0].path, "beta.rs");
     }
 }

--- a/crates/engine/src/repos.rs
+++ b/crates/engine/src/repos.rs
@@ -10,13 +10,13 @@
 //!
 //! All git access is via subprocess (`tokio::process`) — never libgit2.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use sha2::{Digest, Sha256};
 
-use comet_proto::{FolderEntry, FolderListing, Repo, RepoRef, Worktree};
+use comet_proto::{FileSearchMatch, FolderEntry, FolderListing, Repo, RepoRef, Worktree};
 
 use crate::EngineError;
 
@@ -28,6 +28,12 @@ const PATH_EXISTS_TIMEOUT: Duration = Duration::from_secs(2);
 const FOLDER_LIST_TIMEOUT: Duration = Duration::from_secs(6);
 /// Cap on returned folder entries (bounds response size).
 const FOLDER_LIST_MAX_ENTRIES: usize = 500;
+/// File mentions should remain responsive even in very large checkouts.
+const FILE_SEARCH_MAX_RESULTS: usize = 8;
+/// Bound work for pathological repositories even when few paths match.
+const FILE_SEARCH_MAX_ENTRIES: usize = 50_000;
+/// A dead network mount must not leave the composer search spinning forever.
+const FILE_SEARCH_TIMEOUT: Duration = Duration::from_secs(6);
 
 const ADJECTIVES: &[&str] = &[
     "swift", "calm", "bright", "bold", "keen", "brave", "clever", "lucky", "quiet", "warm", "cool",
@@ -426,6 +432,22 @@ impl Repos {
             .collect())
     }
 
+    /// Whether `candidate` is one of the repository's existing linked
+    /// worktrees. Both sides are canonicalized so a client cannot smuggle a
+    /// sibling path through lexical `..` or symlink spelling.
+    pub async fn is_linked_worktree(&self, repo_path: &Path, candidate: &Path) -> bool {
+        let Ok(candidate) = std::fs::canonicalize(candidate) else {
+            return false;
+        };
+        self.refs(repo_path)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|row| row.worktree_path)
+            .filter_map(|path| std::fs::canonicalize(path).ok())
+            .any(|path| path == candidate)
+    }
+
     /// Switch the checkout at `cwd` (a main folder OR a linked worktree) to
     /// `ref_name` — the t3code `switchRef` port: an existing local branch is
     /// checked out directly; a remote-only branch gets a local tracking
@@ -651,6 +673,25 @@ impl Repos {
             .await
     }
 
+    /// Search a checkout's files and directories by fuzzy relative path. The
+    /// `ignore` walker honors `.gitignore`, `.ignore`, global git excludes, and
+    /// skips hidden directories by default; callers have already authorized
+    /// `root` against workspace state.
+    pub async fn search_files(
+        &self,
+        root: PathBuf,
+        query: String,
+        featured_paths: Vec<String>,
+    ) -> Result<Vec<FileSearchMatch>, EngineError> {
+        let worker = tokio::task::spawn_blocking(move || {
+            search_files_blocking(&root, &query, &featured_paths)
+        });
+        tokio::time::timeout(FILE_SEARCH_TIMEOUT, worker)
+            .await
+            .map_err(|_| EngineError::Other("file search timed out".into()))?
+            .map_err(|e| EngineError::Other(format!("file search worker failed: {e}")))?
+    }
+
     /// `hang_for_test` makes the worker never respond — exercises the timeout path.
     ///
     /// The walk runs on a DETACHED OS thread (not the tokio blocking pool): a
@@ -731,6 +772,124 @@ fn list_folders_blocking(target: &Path) -> Result<FolderListing, EngineError> {
     })
 }
 
+/// Case-insensitive subsequence score. Lower is better: adjacent and earlier
+/// characters win, while still allowing `cmp rs` to find `composer.rs`.
+fn fuzzy_score(query: &str, candidate: &str) -> Option<usize> {
+    let query = query.to_lowercase();
+    let candidate = candidate.to_lowercase();
+    let mut at = 0;
+    let mut score = 0;
+    let mut previous_end = None;
+    for needle in query.chars().filter(|ch| !ch.is_whitespace()) {
+        let found = candidate[at..].find(needle)? + at;
+        score += found;
+        if previous_end == Some(found) {
+            score = score.saturating_sub(2);
+        }
+        at = found + needle.len_utf8();
+        previous_end = Some(at);
+    }
+    Some(score)
+}
+
+fn search_files_blocking(
+    root: &Path,
+    query: &str,
+    featured_paths: &[String],
+) -> Result<Vec<FileSearchMatch>, EngineError> {
+    let root = std::fs::canonicalize(root)
+        .map_err(|e| EngineError::Other(format!("could not search workspace: {e}")))?;
+    let featured: HashMap<String, usize> = featured_paths
+        .iter()
+        .filter_map(|path| {
+            let path = Path::new(path);
+            let full = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                root.join(path)
+            };
+            let canonical = std::fs::canonicalize(full).ok()?;
+            let relative = canonical.strip_prefix(&root).ok()?;
+            Some(relative.to_string_lossy().replace('\\', "/"))
+        })
+        .enumerate()
+        .fold(HashMap::new(), |mut paths, (rank, path)| {
+            paths.entry(path).or_insert(rank);
+            paths
+        });
+    let mut matches = Vec::new();
+    let mut examined = 0usize;
+    let walker = ignore::WalkBuilder::new(&root)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build();
+    for entry in walker {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                tracing::debug!(%err, "file mention search walk skipped entry");
+                continue;
+            }
+        };
+        let path = entry.path();
+        if path == root {
+            continue;
+        }
+        examined += 1;
+        if examined > FILE_SEARCH_MAX_ENTRIES {
+            break;
+        }
+        let Ok(relative) = path.strip_prefix(&root) else {
+            continue;
+        };
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        if relative.starts_with(".git/") || relative == ".git" {
+            continue;
+        }
+        let Some(score) = fuzzy_score(query, &relative) else {
+            continue;
+        };
+        matches.push((
+            featured.get(&relative).copied(),
+            score,
+            relative,
+            entry.file_type().is_some_and(|kind| kind.is_dir()),
+        ));
+    }
+    matches.sort_by(
+        |(featured_a, score_a, path_a, dir_a), (featured_b, score_b, path_b, dir_b)| {
+            featured_a
+                .is_none()
+                .cmp(&featured_b.is_none())
+                .then_with(|| featured_a.cmp(featured_b))
+                .then_with(|| score_a.cmp(score_b))
+                .then_with(|| {
+                    if query.is_empty() {
+                        path_a.split('/').count().cmp(&path_b.split('/').count())
+                    } else {
+                        std::cmp::Ordering::Equal
+                    }
+                })
+                .then_with(|| {
+                    if query.is_empty() {
+                        dir_a.cmp(dir_b)
+                    } else {
+                        dir_b.cmp(dir_a)
+                    }
+                })
+                .then_with(|| path_a.len().cmp(&path_b.len()))
+                .then_with(|| path_a.cmp(path_b))
+        },
+    );
+    matches.truncate(FILE_SEARCH_MAX_RESULTS);
+    Ok(matches
+        .into_iter()
+        .map(|(_, _, path, is_dir)| FileSearchMatch { path, is_dir })
+        .collect())
+}
+
 /// Turn a generated chat title into the semantic portion of a Comet branch
 /// (port of comet's `worktreeBranchFromTitle`). Comet NFKD-normalizes accented
 /// letters first; native keeps it ASCII-only (generated titles are Title Case
@@ -769,4 +928,60 @@ pub(crate) fn hex(bytes: &[u8]) -> String {
         out.push_str(&format!("{byte:02x}"));
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fuzzy_score_matches_a_path_subsequence() {
+        assert!(fuzzy_score("cmp rs", "crates/ui/src/composer.rs").is_some());
+        assert!(fuzzy_score("xyz", "crates/ui/src/composer.rs").is_none());
+    }
+
+    #[test]
+    fn search_files_obeys_gitignore_and_returns_directories() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join(".git")).unwrap();
+        std::fs::create_dir(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/composer.rs"), "").unwrap();
+        std::fs::write(root.path().join(".secret"), "").unwrap();
+        std::fs::write(root.path().join(".gitignore"), "ignored\n").unwrap();
+        std::fs::create_dir(root.path().join("ignored")).unwrap();
+        std::fs::write(root.path().join("ignored/nope.rs"), "").unwrap();
+
+        let matches = search_files_blocking(root.path(), "src", &[]).unwrap();
+        assert!(
+            matches
+                .iter()
+                .any(|entry| entry.path == "src" && entry.is_dir)
+        );
+        assert!(matches.iter().any(|entry| entry.path == "src/composer.rs"));
+        assert!(
+            !matches
+                .iter()
+                .any(|entry| entry.path.starts_with("ignored"))
+        );
+        assert!(
+            search_files_blocking(root.path(), "secret", &[])
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn empty_search_features_recent_paths_before_shallow_entries() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("README.md"), "").unwrap();
+        std::fs::write(root.path().join("src/deep.rs"), "").unwrap();
+
+        let matches = search_files_blocking(root.path(), "", &["src/deep.rs".into()]).unwrap();
+        assert_eq!(
+            matches.first().map(|entry| entry.path.as_str()),
+            Some("src/deep.rs")
+        );
+        assert!(matches.iter().any(|entry| entry.path == "README.md"));
+    }
 }

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -50,6 +50,8 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use futures::stream::BoxStream;
 use serde::Deserialize;
+use std::collections::HashSet;
+use std::time::Duration;
 use tokio::sync::watch;
 
 use comet_doc::{MessagePart, SessionCommandPayload};
@@ -66,6 +68,9 @@ use crate::sessions::SessionsEngine;
 use crate::terminals::Terminals;
 use crate::uploads::Uploads;
 use crate::workspace_host::WorkspaceHost;
+
+const FILE_SEARCH_RPC_TIMEOUT: Duration = Duration::from_secs(6);
+const FILE_SEARCH_FEATURED_PATHS: usize = 32;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -440,9 +445,35 @@ impl EngineRpc {
                 if chat.device_id != local_device {
                     return Err(RpcError::Failed("chat belongs to another device".into()));
                 }
-                chat.cwd
+                let cwd = chat
+                    .cwd
                     .map(std::path::PathBuf::from)
-                    .ok_or_else(|| RpcError::Failed("chat has no workspace folder".into()))
+                    .ok_or_else(|| RpcError::Failed("chat has no workspace folder".into()))?;
+                let space_id = chat
+                    .space_id
+                    .ok_or_else(|| RpcError::Failed("chat has no workspace space".into()))?;
+                let space = self
+                    .workspace
+                    .doc()
+                    .space(&space_id)
+                    .map_err(|e| RpcError::Failed(e.to_string()))?
+                    .ok_or_else(|| RpcError::Failed("chat workspace space not found".into()))?;
+                if space.device_id != local_device {
+                    return Err(RpcError::Failed(
+                        "chat space belongs to another device".into(),
+                    ));
+                }
+                if let Some(cwd) = self
+                    .repos
+                    .workspace_checkout(std::path::Path::new(&space.path), &cwd)
+                    .await
+                {
+                    Ok(cwd)
+                } else {
+                    Err(RpcError::Failed(
+                        "chat folder is not a workspace checkout".into(),
+                    ))
+                }
             }
             (None, Some(space_id)) => {
                 let space = self
@@ -455,15 +486,13 @@ impl EngineRpc {
                     return Err(RpcError::Failed("space belongs to another device".into()));
                 }
                 let space_path = std::path::PathBuf::from(&space.path);
-                let Some(requested) = p.path.as_deref() else {
-                    return Ok(space_path);
-                };
-                let requested = std::path::PathBuf::from(requested);
-                let same_as_space = std::fs::canonicalize(&space_path)
-                    .ok()
-                    .zip(std::fs::canonicalize(&requested).ok())
-                    .is_some_and(|(space, requested)| space == requested);
-                if same_as_space || self.repos.is_linked_worktree(&space_path, &requested).await {
+                let requested = p
+                    .path
+                    .as_deref()
+                    .map_or_else(|| space_path.clone(), std::path::PathBuf::from);
+                if let Some(requested) =
+                    self.repos.workspace_checkout(&space_path, &requested).await
+                {
                     Ok(requested)
                 } else {
                     Err(RpcError::BadParams(
@@ -480,6 +509,7 @@ impl EngineRpc {
     /// hints, so stale or out-of-workspace tool paths simply disappear.
     fn featured_file_paths(&self, chat_id: &str) -> Vec<String> {
         let mut paths = Vec::new();
+        let mut seen = HashSet::new();
         if let Ok(handle) = self.doc_host.open(chat_id)
             && let Ok(entries) = handle.doc().read_entries()
         {
@@ -488,9 +518,16 @@ impl EngineRpc {
                     if let MessagePart::Tool { call, .. } = part
                         && let Some(path) = tool_file_path(&call)
                         && !path.trim().is_empty()
+                        && seen.insert(path.to_string())
                     {
                         paths.push(path.to_string());
+                        if paths.len() == FILE_SEARCH_FEATURED_PATHS {
+                            break;
+                        }
                     }
+                }
+                if paths.len() == FILE_SEARCH_FEATURED_PATHS {
+                    break;
                 }
             }
         }
@@ -507,7 +544,14 @@ impl EngineRpc {
                         .and_then(|cwd| diffs.iter().find(|diff| diff.cwd == cwd))
                 });
             if let Some(diff) = diff {
-                paths.extend(diff.files.iter().map(|file| file.path.clone()));
+                for file in &diff.files {
+                    if paths.len() == FILE_SEARCH_FEATURED_PATHS {
+                        break;
+                    }
+                    if seen.insert(file.path.clone()) {
+                        paths.push(file.path.clone());
+                    }
+                }
             }
         }
         paths
@@ -1012,18 +1056,21 @@ impl RpcService for EngineRpc {
                         "SearchFiles query must not exceed 256 characters".into(),
                     ));
                 }
-                let root = self.file_search_root(&p).await?;
-                let featured_paths = p
-                    .chat_id
-                    .as_deref()
-                    .filter(|_| p.query.is_empty())
-                    .map(|chat_id| self.featured_file_paths(chat_id))
-                    .unwrap_or_default();
-                let matches = self
-                    .repos
-                    .search_files(root, p.query, featured_paths)
-                    .await
-                    .map_err(|e| RpcError::Failed(e.to_string()))?;
+                let matches = tokio::time::timeout(FILE_SEARCH_RPC_TIMEOUT, async {
+                    let root = self.file_search_root(&p).await?;
+                    let featured_paths = p
+                        .chat_id
+                        .as_deref()
+                        .filter(|_| p.query.is_empty())
+                        .map(|chat_id| self.featured_file_paths(chat_id))
+                        .unwrap_or_default();
+                    self.repos
+                        .search_files(root, p.query, featured_paths)
+                        .await
+                        .map_err(|e| RpcError::Failed(e.to_string()))
+                })
+                .await
+                .map_err(|_| RpcError::Failed("file search timed out".into()))??;
                 RpcReply::value(&matches)
             }
             methods::CREATE_WORKTREE => {

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -52,8 +52,8 @@ use futures::stream::BoxStream;
 use serde::Deserialize;
 use tokio::sync::watch;
 
-use comet_doc::SessionCommandPayload;
-use comet_proto::{ChatConfig, HarnessId};
+use comet_doc::{MessagePart, SessionCommandPayload};
+use comet_proto::{ChatConfig, HarnessId, ToolCall};
 use comet_rpc::{LinkCache, RpcError, RpcReply, RpcService, methods, parse_params};
 
 use crate::agent_accounts::AgentAccounts;
@@ -124,6 +124,36 @@ struct DeleteWorktreeParams {
 struct ListFoldersParams {
     #[serde(default)]
     path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FileSearchParams {
+    query: String,
+    #[serde(default)]
+    chat_id: Option<String>,
+    #[serde(default)]
+    space_id: Option<String>,
+    /// Existing linked worktree selected for a new chat. The engine accepts it
+    /// only after verifying it against the space repository's worktree list.
+    #[serde(default)]
+    path: Option<String>,
+}
+
+fn tool_file_path(call: &ToolCall) -> Option<&str> {
+    match call {
+        ToolCall::ReadFile { path }
+        | ToolCall::WriteFile { path, .. }
+        | ToolCall::EditFile { path, .. } => Some(path),
+        ToolCall::ApplyPatch { path } | ToolCall::Search { path, .. } => path.as_deref(),
+        ToolCall::Exec { .. }
+        | ToolCall::Glob { .. }
+        | ToolCall::WebFetch { .. }
+        | ToolCall::WebSearch { .. }
+        | ToolCall::Todo { .. }
+        | ToolCall::Mcp { .. }
+        | ToolCall::Unknown { .. } => None,
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -386,6 +416,103 @@ impl EngineRpc {
             .ok_or_else(|| RpcError::Failed("updates unavailable".into()))
     }
 
+    /// Resolve a mention-search root from synced workspace rows. A client may
+    /// name an existing linked worktree for a new chat, but it is verified
+    /// against the space repository before any filesystem walk begins.
+    async fn file_search_root(&self, p: &FileSearchParams) -> Result<std::path::PathBuf, RpcError> {
+        let local_device = self.doc_host.device_id();
+        match (&p.chat_id, &p.space_id) {
+            (Some(_), Some(_)) | (None, None) => Err(RpcError::BadParams(
+                "SearchFiles needs exactly one of chatId or spaceId".into(),
+            )),
+            (Some(chat_id), None) => {
+                if p.path.is_some() {
+                    return Err(RpcError::BadParams(
+                        "SearchFiles path applies only to a space".into(),
+                    ));
+                }
+                let chat = self
+                    .workspace
+                    .doc()
+                    .chat(chat_id)
+                    .map_err(|e| RpcError::Failed(e.to_string()))?
+                    .ok_or_else(|| RpcError::Failed("chat not found".into()))?;
+                if chat.device_id != local_device {
+                    return Err(RpcError::Failed("chat belongs to another device".into()));
+                }
+                chat.cwd
+                    .map(std::path::PathBuf::from)
+                    .ok_or_else(|| RpcError::Failed("chat has no workspace folder".into()))
+            }
+            (None, Some(space_id)) => {
+                let space = self
+                    .workspace
+                    .doc()
+                    .space(space_id)
+                    .map_err(|e| RpcError::Failed(e.to_string()))?
+                    .ok_or_else(|| RpcError::Failed("space not found".into()))?;
+                if space.device_id != local_device {
+                    return Err(RpcError::Failed("space belongs to another device".into()));
+                }
+                let space_path = std::path::PathBuf::from(&space.path);
+                let Some(requested) = p.path.as_deref() else {
+                    return Ok(space_path);
+                };
+                let requested = std::path::PathBuf::from(requested);
+                let same_as_space = std::fs::canonicalize(&space_path)
+                    .ok()
+                    .zip(std::fs::canonicalize(&requested).ok())
+                    .is_some_and(|(space, requested)| space == requested);
+                if same_as_space || self.repos.is_linked_worktree(&space_path, &requested).await {
+                    Ok(requested)
+                } else {
+                    Err(RpcError::BadParams(
+                        "SearchFiles path is not a workspace checkout".into(),
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Most-recent-first paths the current chat actually touched, followed by
+    /// files still changed in its checkout. The search worker validates and
+    /// normalizes them against the resolved root before using them as ranking
+    /// hints, so stale or out-of-workspace tool paths simply disappear.
+    fn featured_file_paths(&self, chat_id: &str) -> Vec<String> {
+        let mut paths = Vec::new();
+        if let Ok(handle) = self.doc_host.open(chat_id)
+            && let Ok(entries) = handle.doc().read_entries()
+        {
+            for entry in entries.into_iter().rev() {
+                for part in entry.parts.into_iter().rev() {
+                    if let MessagePart::Tool { call, .. } = part
+                        && let Some(path) = tool_file_path(&call)
+                        && !path.trim().is_empty()
+                    {
+                        paths.push(path.to_string());
+                    }
+                }
+            }
+        }
+
+        if let Ok(Some(chat)) = self.workspace.doc().chat(chat_id) {
+            let diffs = self.diff_sync.watch_diffs().borrow().clone();
+            let diff = chat
+                .checkout_id
+                .as_deref()
+                .and_then(|id| diffs.iter().find(|diff| diff.checkout_id == id))
+                .or_else(|| {
+                    chat.cwd
+                        .as_deref()
+                        .and_then(|cwd| diffs.iter().find(|diff| diff.cwd == cwd))
+                });
+            if let Some(diff) = diff {
+                paths.extend(diff.files.iter().map(|file| file.path.clone()));
+            }
+        }
+        paths
+    }
+
     /// Forward a device-addressed call over the target device's relay. On transport
     /// failure the cached link is invalidated so the next call re-dials.
     async fn forward(
@@ -559,6 +686,7 @@ fn forwardable(method: &str) -> bool {
             | methods::LIST_REFS
             | methods::SWITCH_REF
             | methods::LIST_FOLDERS
+            | methods::SEARCH_FILES
             | methods::CREATE_WORKTREE
             | methods::DELETE_WORKTREE
             // Checkout diffs are produced on the device holding the checkout.
@@ -877,6 +1005,27 @@ impl RpcService for EngineRpc {
                     .map_err(|e| RpcError::Failed(e.to_string()))?;
                 RpcReply::value(&listing)
             }
+            methods::SEARCH_FILES => {
+                let p: FileSearchParams = parse_params(params)?;
+                if p.query.chars().count() > 256 {
+                    return Err(RpcError::BadParams(
+                        "SearchFiles query must not exceed 256 characters".into(),
+                    ));
+                }
+                let root = self.file_search_root(&p).await?;
+                let featured_paths = p
+                    .chat_id
+                    .as_deref()
+                    .filter(|_| p.query.is_empty())
+                    .map(|chat_id| self.featured_file_paths(chat_id))
+                    .unwrap_or_default();
+                let matches = self
+                    .repos
+                    .search_files(root, p.query, featured_paths)
+                    .await
+                    .map_err(|e| RpcError::Failed(e.to_string()))?;
+                RpcReply::value(&matches)
+            }
             methods::CREATE_WORKTREE => {
                 let p: CreateWorktreeParams = parse_params(params)?;
                 let worktree = self
@@ -1069,5 +1218,24 @@ mod tests {
     fn local_device_is_not_forwardable() {
         assert!(!forwardable(methods::LOCAL_DEVICE));
         assert!(forwardable(methods::QUEUE_COMMAND));
+        assert!(forwardable(methods::SEARCH_FILES));
+    }
+
+    #[test]
+    fn tool_file_paths_keep_workspace_activity_only() {
+        assert_eq!(
+            tool_file_path(&ToolCall::EditFile {
+                path: "src/main.rs".into(),
+                old_string: None,
+                new_string: None,
+            }),
+            Some("src/main.rs")
+        );
+        assert_eq!(
+            tool_file_path(&ToolCall::Exec {
+                command: "cargo test".into(),
+            }),
+            None
+        );
     }
 }

--- a/crates/engine/tests/m5_repos_diffs_terminals.rs
+++ b/crates/engine/tests/m5_repos_diffs_terminals.rs
@@ -707,6 +707,65 @@ async fn rpc_dispatch_for_m5_methods() {
     git(&repo_dir, &["add", "."]).await;
     git(&repo_dir, &["commit", "-m", "seed"]).await;
 
+    // SearchFiles resolves both space and chat roots, while rejecting a chat
+    // whose cwd was retargeted outside the owning repository.
+    core.workspace
+        .create_space("space-term", &core.device_id, &repo_path, None, true)
+        .expect("search space");
+    core.workspace
+        .create_chat("search-chat", "space-term", None, None)
+        .expect("search chat");
+    let space_matches = client
+        .call(
+            methods::SEARCH_FILES,
+            serde_json::json!({ "spaceId": "space-term", "query": "file" }),
+        )
+        .await
+        .expect("SearchFiles by space");
+    assert_eq!(space_matches[0]["path"], "file.txt");
+    let chat_matches = client
+        .call(
+            methods::SEARCH_FILES,
+            serde_json::json!({ "chatId": "search-chat", "query": "file" }),
+        )
+        .await
+        .expect("SearchFiles by chat");
+    assert_eq!(chat_matches[0]["path"], "file.txt");
+    assert!(
+        client
+            .call(
+                methods::SEARCH_FILES,
+                serde_json::json!({
+                    "chatId": "search-chat",
+                    "spaceId": "space-term",
+                    "query": "file"
+                }),
+            )
+            .await
+            .is_err(),
+        "exactly one root id is required"
+    );
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir(&outside).expect("outside directory");
+    core.workspace
+        .create_chat(
+            "outside-chat",
+            "space-term",
+            None,
+            Some(outside.to_string_lossy().into_owned()),
+        )
+        .expect("outside chat row");
+    assert!(
+        client
+            .call(
+                methods::SEARCH_FILES,
+                serde_json::json!({ "chatId": "outside-chat", "query": "file" }),
+            )
+            .await
+            .is_err(),
+        "chat cwd must stay inside its workspace checkout"
+    );
+
     // ListBranches: default (checked-out) branch first.
     let branches = client
         .call(

--- a/crates/proto/src/entities.rs
+++ b/crates/proto/src/entities.rs
@@ -236,6 +236,16 @@ pub struct FolderListing {
     pub truncated: bool,
 }
 
+/// A workspace-relative file or directory returned by `SearchFiles`.
+/// Contents deliberately never cross this boundary: mentioning a path leaves
+/// the harness to read it through its normal workspace tools when needed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileSearchMatch {
+    pub path: String,
+    pub is_dir: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiffFileSummary {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -67,6 +67,8 @@ pub mod methods {
     pub const LIST_REFS: &str = "ListRefs";
     pub const SWITCH_REF: &str = "SwitchRef";
     pub const LIST_FOLDERS: &str = "ListFolders";
+    /// Fuzzy relative-path search rooted in a known chat or space checkout.
+    pub const SEARCH_FILES: &str = "SearchFiles";
     pub const CREATE_WORKTREE: &str = "CreateWorktree";
     pub const DELETE_WORKTREE: &str = "DeleteWorktree";
     // Terminals (ControlRpc, relay-forwardable; SubscribeTerminal streams).

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -1021,6 +1021,51 @@ fn mention_display_labels(links: &[FileMentionLink]) -> Vec<String> {
         .collect()
 }
 
+/// One chip in a *sent* message: its byte range over the projected display
+/// string, the em-space slot the icon paints into, and which icon. The
+/// transcript renders these read-only — no editing state, no tooltip machinery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SentMentionSpan {
+    pub range: Range<usize>,
+    pub icon_slot: Range<usize>,
+    /// Full workspace-relative path (labels can be shortened to basenames).
+    pub path: SharedString,
+    pub is_dir: bool,
+}
+
+/// Project a sent message's raw Markdown for transcript display: mention links
+/// collapse to the same chip labels the composer shows, everything else passes
+/// through untouched. `None` when the text has no valid mention — the
+/// substring probe keeps ordinary prompts on the zero-allocation path, so this
+/// is safe to call for every user row.
+pub fn sent_mention_display(raw: &str) -> Option<(String, Vec<SentMentionSpan>)> {
+    if !raw.contains(FILE_MENTION_SCHEME) {
+        return None;
+    }
+    let projection = TextProjection::new(raw);
+    if projection.mentions.is_empty() {
+        return None;
+    }
+    let spans = projection
+        .mentions
+        .iter()
+        .map(|(link, display)| {
+            let icon_start = display.start + MENTION_SIDE_PAD.len();
+            SentMentionSpan {
+                range: display.clone(),
+                icon_slot: icon_start..icon_start + MENTION_ICON_SLOT.len(),
+                path: SharedString::from(format!(
+                    "{}{}",
+                    link.path,
+                    if link.is_dir { "/" } else { "" }
+                )),
+                is_dir: link.is_dir,
+            }
+        })
+        .collect();
+    Some((projection.display, spans))
+}
+
 /// Direction of the last edit — a run only merges with edits of its own kind.
 #[derive(Clone, Copy, PartialEq)]
 enum EditKind {
@@ -5175,6 +5220,46 @@ mod tests {
         assert_eq!(
             projection.normalize_range(link.range.start + 2..link.range.end - 2),
             link.range
+        );
+    }
+
+    #[test]
+    fn sent_mention_display_projects_chips_for_the_transcript() {
+        let raw = format!(
+            "check {} and {}",
+            local_file_link("src/composer.rs", false),
+            local_file_link("src/components", true)
+        );
+        let (display, spans) = sent_mention_display(&raw).expect("mentions project");
+        assert!(!display.contains(FILE_MENTION_SCHEME));
+        assert!(display.contains("composer.rs"));
+        assert!(display.contains("components"));
+        assert_eq!(spans.len(), 2);
+        assert_eq!(
+            &display[spans[0].range.clone()],
+            "\u{00A0}\u{2003}\u{202F}composer.rs\u{00A0}"
+        );
+        assert_eq!(&display[spans[0].icon_slot.clone()], MENTION_ICON_SLOT);
+        assert!(!spans[0].is_dir);
+        assert_eq!(spans[0].path.as_ref(), "src/composer.rs");
+        assert!(spans[1].is_dir);
+        assert_eq!(spans[1].path.as_ref(), "src/components/");
+    }
+
+    /// Ordinary prompts must stay on the zero-cost path, including ones that
+    /// merely *talk about* the scheme without containing a valid mention.
+    #[test]
+    fn sent_mention_display_leaves_plain_prompts_untouched() {
+        assert_eq!(sent_mention_display("fix the composer"), None);
+        assert_eq!(
+            sent_mention_display("what is a comet-file: link?"),
+            None,
+            "scheme substring without a valid mention link"
+        );
+        assert_eq!(
+            sent_mention_display("[a.rs](comet-file:../a.rs)"),
+            None,
+            "a hostile path never becomes a chip in the transcript either"
         );
     }
 

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -627,6 +627,8 @@ const UNDO_LIMIT: usize = 200;
 /// mention label. Keeping this in the projection makes the icon participate in
 /// wrapping, hit testing, and selection without changing the raw Markdown.
 const MENTION_ICON_SLOT: &str = "\u{2003}";
+const MENTION_TOOLTIP_DELAY: Duration = Duration::from_millis(420);
+const MENTION_TOOLTIP_HEIGHT: f32 = 24.0;
 const MENTION_SIDE_PAD: &str = "\u{00A0}";
 
 /// A restorable point in the input's history: text plus where the caret and
@@ -770,6 +772,110 @@ fn file_mention_links(text: &str) -> Vec<FileMentionLink> {
 struct TextProjection {
     display: String,
     mentions: Vec<(FileMentionLink, Range<usize>)>,
+}
+
+/// A path alone is not enough: two identical relative paths can appear in a
+/// draft, so the raw range remains part of the hover identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MentionTooltipTarget {
+    range: Range<usize>,
+    path: SharedString,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MentionTooltipPhase {
+    Hidden,
+    Waiting {
+        target: MentionTooltipTarget,
+        generation: u64,
+    },
+    Visible {
+        target: MentionTooltipTarget,
+        generation: u64,
+    },
+}
+
+impl MentionTooltipPhase {
+    fn target(&self) -> Option<&MentionTooltipTarget> {
+        match self {
+            Self::Hidden => None,
+            Self::Waiting { target, .. } | Self::Visible { target, .. } => Some(target),
+        }
+    }
+}
+
+/// Pure tooltip lifecycle reducer. Pointer motion restarts a waiting timer;
+/// after promotion, ordinary motion inside the same chip keeps the tooltip
+/// stable so the popup does not flicker while it is visible.
+fn mention_tooltip_reduce(
+    phase: MentionTooltipPhase,
+    pointer_target: Option<MentionTooltipTarget>,
+    pointer_in_popup: bool,
+    generation: u64,
+) -> MentionTooltipPhase {
+    match pointer_target {
+        Some(target)
+            if phase.target() == Some(&target)
+                && matches!(phase, MentionTooltipPhase::Visible { .. }) =>
+        {
+            phase
+        }
+        Some(target) => MentionTooltipPhase::Waiting { target, generation },
+        None if pointer_in_popup && matches!(phase, MentionTooltipPhase::Visible { .. }) => phase,
+        None => MentionTooltipPhase::Hidden,
+    }
+}
+
+fn mention_tooltip_promote(
+    phase: MentionTooltipPhase,
+    generation: u64,
+    target_is_live: bool,
+) -> MentionTooltipPhase {
+    match phase {
+        MentionTooltipPhase::Waiting {
+            target,
+            generation: current,
+        } if current == generation && target_is_live => MentionTooltipPhase::Visible {
+            target,
+            generation: current,
+        },
+        MentionTooltipPhase::Waiting {
+            generation: current,
+            ..
+        } if current == generation => MentionTooltipPhase::Hidden,
+        phase => phase,
+    }
+}
+
+fn mention_tooltip_contains(in_chip: bool, in_popup: bool) -> bool {
+    in_chip || in_popup
+}
+
+fn display_row_segments(
+    range: Range<usize>,
+    row_ends: impl IntoIterator<Item = usize>,
+) -> Vec<(usize, usize, Range<usize>)> {
+    let mut segments = Vec::new();
+    let mut row_start = 0usize;
+    for (row_ix, row_end) in row_ends.into_iter().enumerate() {
+        let start = range.start.max(row_start);
+        let end = range.end.min(row_end);
+        if start < end {
+            segments.push((row_ix, row_start, start..end));
+        }
+        row_start = row_end;
+        if row_start >= range.end {
+            break;
+        }
+    }
+    segments
+}
+
+#[derive(Debug, Clone)]
+struct MentionHit {
+    target: MentionTooltipTarget,
+    bounds: Bounds<Pixels>,
+    anchor: Point<Pixels>,
 }
 
 impl TextProjection {
@@ -1070,6 +1176,16 @@ pub struct ComposerInput {
     /// mention token is active, keeping input focus and native text editing.
     mention_open: bool,
     mention_has_selection: bool,
+    /// Last prepainted chip bounds; the paint-phase pointer listener uses
+    /// these instead of attempting to infer text geometry from the cursor.
+    mention_hits: Vec<MentionHit>,
+    mention_tooltip: MentionTooltipPhase,
+    mention_tooltip_generation: u64,
+    mention_tooltip_popup: Option<Bounds<Pixels>>,
+    mention_tooltip_task: Option<Task<()>>,
+    /// Created once when Waiting promotes; retaining this entity preserves
+    /// GPUI's global animation state across prepaint frames.
+    mention_tooltip_view: Option<Entity<MentionPathTooltip>>,
 }
 
 impl ComposerInput {
@@ -1116,6 +1232,12 @@ impl ComposerInput {
             last_edit: None,
             mention_open: false,
             mention_has_selection: false,
+            mention_hits: Vec::new(),
+            mention_tooltip: MentionTooltipPhase::Hidden,
+            mention_tooltip_generation: 0,
+            mention_tooltip_popup: None,
+            mention_tooltip_task: None,
+            mention_tooltip_view: None,
         }
     }
 
@@ -1172,6 +1294,7 @@ impl ComposerInput {
         is_dir: bool,
         cx: &mut Context<Self>,
     ) {
+        self.invalidate_mention_tooltip();
         let path = local_file_link(path, is_dir);
         let next = self.content[range.end..].chars().next();
         let existing_separator = next.filter(|ch| ch.is_whitespace() && *ch != '\n' && *ch != '\r');
@@ -1220,6 +1343,7 @@ impl ComposerInput {
     }
 
     pub fn set_text(&mut self, text: impl Into<String>, cx: &mut Context<Self>) {
+        self.invalidate_mention_tooltip();
         self.content = text.into();
         let end = self.content.len();
         self.selected_range = end..end;
@@ -1235,6 +1359,131 @@ impl ComposerInput {
         self.reset_blink();
         cx.emit(ComposerInputEvent::Edited);
         cx.notify();
+    }
+
+    fn invalidate_mention_tooltip(&mut self) {
+        self.mention_tooltip_generation = self.mention_tooltip_generation.wrapping_add(1);
+        self.mention_tooltip = MentionTooltipPhase::Hidden;
+        self.mention_tooltip_popup = None;
+        self.mention_tooltip_task = None;
+        self.mention_tooltip_view = None;
+    }
+
+    fn set_mention_hits(&mut self, hits: Vec<MentionHit>) {
+        self.mention_hits = hits;
+        let live = self
+            .mention_tooltip
+            .target()
+            .is_none_or(|target| self.mention_hits.iter().any(|hit| &hit.target == target));
+        if !live {
+            self.invalidate_mention_tooltip();
+        }
+    }
+
+    fn start_mention_tooltip_wait(&mut self, target: MentionTooltipTarget, cx: &mut Context<Self>) {
+        self.mention_tooltip_generation = self.mention_tooltip_generation.wrapping_add(1);
+        let generation = self.mention_tooltip_generation;
+        self.mention_tooltip = MentionTooltipPhase::Waiting { target, generation };
+        self.mention_tooltip_popup = None;
+        self.mention_tooltip_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(MENTION_TOOLTIP_DELAY).await;
+            this.update(cx, |input, cx| {
+                let live = input.mention_tooltip.target().is_some_and(|target| {
+                    input.mention_hits.iter().any(|hit| &hit.target == target)
+                });
+                let next = mention_tooltip_promote(input.mention_tooltip.clone(), generation, live);
+                if next != input.mention_tooltip {
+                    input.mention_tooltip = next;
+                    input.mention_tooltip_task = None;
+                    if let MentionTooltipPhase::Visible { target, generation } =
+                        &input.mention_tooltip
+                    {
+                        input.mention_tooltip_view = Some(cx.new(|_| MentionPathTooltip {
+                            path: target.path.clone(),
+                            activation: *generation,
+                        }));
+                    }
+                    cx.notify();
+                }
+            })
+            .ok();
+        }));
+    }
+
+    fn on_mention_pointer_move(&mut self, position: Point<Pixels>, cx: &mut Context<Self>) {
+        if self.is_selecting {
+            self.invalidate_mention_tooltip();
+            return;
+        }
+        let target = self
+            .mention_hits
+            .iter()
+            .find(|hit| hit.bounds.contains(&position))
+            .map(|hit| hit.target.clone());
+        let in_popup = self
+            .mention_tooltip_popup
+            .is_some_and(|popup| popup.contains(&position));
+        let next_generation = self.mention_tooltip_generation.wrapping_add(1);
+        let next = mention_tooltip_reduce(
+            self.mention_tooltip.clone(),
+            target.clone(),
+            in_popup,
+            next_generation,
+        );
+        if next == self.mention_tooltip {
+            return;
+        }
+        match next {
+            MentionTooltipPhase::Waiting { target, .. } => {
+                self.start_mention_tooltip_wait(target, cx)
+            }
+            _ => {
+                self.invalidate_mention_tooltip();
+                self.mention_tooltip = next;
+                cx.notify();
+            }
+        }
+    }
+
+    fn visible_mention_tooltip(
+        &self,
+    ) -> Option<(
+        MentionTooltipTarget,
+        Point<Pixels>,
+        u64,
+        Entity<MentionPathTooltip>,
+    )> {
+        let MentionTooltipPhase::Visible { target, generation } = &self.mention_tooltip else {
+            return None;
+        };
+        self.mention_hits
+            .iter()
+            .find(|hit| hit.target == *target)
+            .and_then(|hit| {
+                let view = self.mention_tooltip_view.clone()?;
+                Some((target.clone(), hit.anchor, *generation, view))
+            })
+    }
+
+    fn check_mention_tooltip_visibility(
+        &mut self,
+        popup: Bounds<Pixels>,
+        pointer: Point<Pixels>,
+    ) -> bool {
+        let Some((target, _, _, _)) = self.visible_mention_tooltip() else {
+            return false;
+        };
+        let in_chip = self
+            .mention_hits
+            .iter()
+            .any(|hit| hit.target == target && hit.bounds.contains(&pointer));
+        if mention_tooltip_contains(in_chip, popup.contains(&pointer)) {
+            self.mention_tooltip_popup = Some(popup);
+            true
+        } else {
+            self.invalidate_mention_tooltip();
+            false
+        }
     }
 
     // ---- undo history ----
@@ -1288,6 +1537,7 @@ impl ComposerInput {
     }
 
     fn restore(&mut self, snapshot: EditSnapshot, cx: &mut Context<Self>) {
+        self.invalidate_mention_tooltip();
         self.content = snapshot.content;
         self.selected_range = snapshot.selected_range;
         self.selection_reversed = snapshot.selection_reversed;
@@ -1730,6 +1980,56 @@ impl ComposerInput {
         None
     }
 
+    /// Content-local boxes occupied by a projected byte range, split at every
+    /// soft wrap. A caret exactly at a wrap boundary belongs visually to both
+    /// rows in GPUI; using the explicit wrap indices lets the range's first
+    /// glyph start at x=0 on the new row instead of inheriting the old row's
+    /// end caret (which previously caused mention washes to be discarded).
+    fn bounds_for_display_range(&self, range: Range<usize>) -> Vec<Bounds<Pixels>> {
+        let mut bounds = Vec::new();
+        let mut y_offset = px(0.0);
+        for (line_ix, line) in self.last_lines.iter().enumerate() {
+            let line_start = self.line_starts.get(line_ix).copied().unwrap_or(0);
+            let local_start = range.start.saturating_sub(line_start).min(line.len());
+            let local_end = range.end.saturating_sub(line_start).min(line.len());
+            if local_start >= local_end
+                || range.end <= line_start
+                || range.start >= line_start + line.len()
+            {
+                y_offset += line.size(self.line_height).height;
+                continue;
+            }
+
+            let row_ends = line
+                .wrap_boundaries()
+                .iter()
+                .map(|boundary| line.runs()[boundary.run_ix].glyphs[boundary.glyph_ix].index)
+                .chain(std::iter::once(line.len()));
+            for (row_ix, row_start, segment) in
+                display_row_segments(local_start..local_end, row_ends)
+            {
+                let row_y = y_offset + self.line_height * row_ix;
+                let start_x = if segment.start == row_start {
+                    px(0.0)
+                } else {
+                    line.position_for_index(segment.start, self.line_height)
+                        .map(|point| point.x)
+                        .unwrap_or(px(0.0))
+                };
+                if let Some(end_point) = line.position_for_index(segment.end, self.line_height)
+                    && end_point.x > start_x
+                {
+                    bounds.push(Bounds::new(
+                        point(start_x, row_y),
+                        size(end_point.x - start_x, self.line_height),
+                    ));
+                }
+            }
+            y_offset += line.size(self.line_height).height;
+        }
+        bounds
+    }
+
     /// Byte index closest to a content-local point.
     fn index_for_point(&self, position: Point<Pixels>) -> usize {
         if self.display_is_placeholder {
@@ -1773,6 +2073,7 @@ impl ComposerInput {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.invalidate_mention_tooltip();
         window.focus(&self.focus_handle, cx);
         self.is_selecting = true;
         self.drag_position = Some(event.position);
@@ -1794,6 +2095,7 @@ impl ComposerInput {
     }
 
     fn on_mouse_move(&mut self, event: &MouseMoveEvent, cx: &mut Context<Self>) {
+        self.on_mention_pointer_move(event.position, cx);
         if self.is_selecting {
             self.drag_position = Some(event.position);
             let position = self.drag_selection_position(event.position);
@@ -1894,6 +2196,7 @@ impl ComposerInput {
         if next == self.scroll_top {
             return;
         }
+        self.invalidate_mention_tooltip();
         self.scroll_top = next;
         self.follow_cursor = false;
         cx.stop_propagation();
@@ -2111,6 +2414,7 @@ impl EntityInputHandler for ComposerInput {
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
         let range = TextProjection::new(&self.content).normalize_range(range);
+        self.invalidate_mention_tooltip();
         // An IME commit is the tail of a composition whose pre-composition
         // snapshot was already taken (`replace_and_mark_text_in_range`);
         // recording here would pin undo to the half-composed text instead.
@@ -2142,6 +2446,7 @@ impl EntityInputHandler for ComposerInput {
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
         let range = TextProjection::new(&self.content).normalize_range(range);
+        self.invalidate_mention_tooltip();
         // First keystroke of a composition: snapshot the text as it stood
         // before any of it existed, so one undo drops the whole composition.
         if self.marked_range.is_none() {
@@ -2207,22 +2512,30 @@ struct ComposerTextElement {
 
 struct MentionPathTooltip {
     path: SharedString,
+    /// Stable for one `Waiting → Visible` promotion; a later activation gets
+    /// a new key and therefore exactly one fresh fade-in.
+    activation: u64,
 }
 
 impl Render for MentionPathTooltip {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = Theme::of(cx);
-        div()
-            .px(px(8.0))
-            .py(px(5.0))
-            .rounded(px(5.0))
-            .border_1()
-            .border_color(theme.border_strong)
-            .bg(theme.surface_raised)
-            .font_family(theme.font_mono.clone())
-            .text_size(px(11.0))
-            .text_color(theme.text_muted)
-            .child(self.path.clone())
+        motion::fade_quick(
+            ("file-mention-path-tooltip", self.activation),
+            div()
+                .h(px(MENTION_TOOLTIP_HEIGHT))
+                .flex()
+                .items_center()
+                .px(px(8.0))
+                .rounded(px(5.0))
+                .border_1()
+                .border_color(theme.border_strong)
+                .bg(theme.surface_raised)
+                .font_family(theme.font_mono.clone())
+                .text_size(px(11.0))
+                .text_color(theme.text_muted)
+                .child(self.path.clone()),
+        )
     }
 }
 
@@ -2230,6 +2543,7 @@ struct ComposerTextPrepaint {
     cursor: Option<PaintQuad>,
     mention_quads: Vec<PaintQuad>,
     mention_icons: Vec<(Bounds<Pixels>, &'static str)>,
+    mention_hits: Vec<MentionHit>,
     selection_quads: Vec<PaintQuad>,
 }
 
@@ -2298,62 +2612,65 @@ impl gpui::Element for ComposerTextElement {
 
         let mut mention_quads = Vec::new();
         let mut mention_icons = Vec::new();
-        let mut hovered_mention = None;
+        let mut mention_hits = Vec::new();
         for (mention, display) in &input.projection.mentions {
-            let (Some(start), Some(end)) = (
-                input.point_for_index(mention.range.start),
-                input.point_for_index(mention.range.end),
-            ) else {
-                continue;
+            let target = MentionTooltipTarget {
+                range: mention.range.clone(),
+                path: SharedString::from(format!(
+                    "{}{}",
+                    mention.path,
+                    if mention.is_dir { "/" } else { "" }
+                )),
             };
-            if start.y != end.y {
-                continue;
-            }
-            let chip_bounds = Bounds::from_corners(
-                point(origin.x + start.x, origin.y + start.y + px(2.0)),
-                point(
-                    origin.x + end.x,
-                    origin.y + start.y + input.line_height - px(2.0),
-                ),
-            );
-            mention_quads.push(quad(
-                chip_bounds,
-                px(5.0),
-                mention_color,
-                px(0.0),
-                gpui::transparent_black(),
-                BorderStyle::default(),
-            ));
-            if bounds.contains(&window.mouse_position())
-                && chip_bounds.contains(&window.mouse_position())
-            {
-                hovered_mention = Some((
+            for local_bounds in input.bounds_for_display_range(display.clone()) {
+                let chip_bounds = Bounds::new(
+                    point(
+                        origin.x + local_bounds.origin.x,
+                        origin.y + local_bounds.origin.y + px(2.0),
+                    ),
+                    size(local_bounds.size.width, local_bounds.size.height - px(4.0)),
+                );
+                mention_quads.push(quad(
                     chip_bounds,
-                    SharedString::from(format!(
-                        "{}{}",
-                        mention.path,
-                        if mention.is_dir { "/" } else { "" }
-                    )),
+                    px(5.0),
+                    mention_color,
+                    px(0.0),
+                    gpui::transparent_black(),
+                    BorderStyle::default(),
                 ));
+                let above_anchor = chip_bounds.top() - px(MENTION_TOOLTIP_HEIGHT) - px(1.0);
+                let anchor_y = if above_anchor >= px(0.0) {
+                    above_anchor
+                } else {
+                    // GPUI positions at anchor + 1px; subtracting one keeps the
+                    // below fallback flush so the pointer can enter the popup.
+                    chip_bounds.bottom() - px(1.0)
+                };
+                mention_hits.push(MentionHit {
+                    target: target.clone(),
+                    bounds: chip_bounds,
+                    // The fixed-height popup starts at anchor + 1px. Moving
+                    // the anchor above the chip therefore yields conventional
+                    // above-target placement without cursor tracking.
+                    anchor: point(chip_bounds.left(), anchor_y),
+                });
             }
             let slot_start = display.start + MENTION_SIDE_PAD.len();
             let slot_end = slot_start + MENTION_ICON_SLOT.len();
-            let (Some(slot_start), Some(slot_end)) = (
-                input.point_for_display_index(slot_start),
-                input.point_for_display_index(slot_end),
-            ) else {
+            let Some(slot_bounds) = input
+                .bounds_for_display_range(slot_start..slot_end)
+                .into_iter()
+                .next()
+            else {
                 continue;
             };
-            if slot_start.y != slot_end.y {
-                continue;
-            }
-            let slot_width = (slot_end.x - slot_start.x).max(px(8.0));
+            let slot_width = slot_bounds.size.width.max(px(8.0));
             let icon_size = slot_width.min(px(12.0));
             mention_icons.push((
                 Bounds::new(
                     point(
-                        origin.x + slot_start.x + (slot_width - icon_size) / 2.0,
-                        origin.y + slot_start.y + (input.line_height - icon_size) / 2.0,
+                        origin.x + slot_bounds.origin.x + (slot_width - icon_size) / 2.0,
+                        origin.y + slot_bounds.origin.y + (input.line_height - icon_size) / 2.0,
                     ),
                     size(icon_size, icon_size),
                 ),
@@ -2421,13 +2738,17 @@ impl gpui::Element for ComposerTextElement {
                 ));
             }
         }
-        if let Some((chip_bounds, path)) = hovered_mention {
-            let view = cx.new(|_| MentionPathTooltip { path }).into();
+        let tooltip = input.visible_mention_tooltip();
+        if let Some((_target, anchor, _activation, view)) = tooltip {
+            let view = view.into();
+            let input = self.input.clone();
             window.set_tooltip(AnyTooltip {
                 view,
-                mouse_position: window.mouse_position(),
-                check_visible_and_update: Rc::new(move |_, window, _| {
-                    chip_bounds.contains(&window.mouse_position())
+                mouse_position: anchor,
+                check_visible_and_update: Rc::new(move |popup, window, cx| {
+                    input.update(cx, |input, _| {
+                        input.check_mention_tooltip_visibility(popup, window.mouse_position())
+                    })
                 }),
             });
         }
@@ -2435,6 +2756,7 @@ impl gpui::Element for ComposerTextElement {
             cursor,
             mention_quads,
             mention_icons,
+            mention_hits,
             selection_quads,
         }
     }
@@ -2450,21 +2772,18 @@ impl gpui::Element for ComposerTextElement {
         cx: &mut App,
     ) {
         let focus_handle = self.input.read(cx).focus_handle.clone();
+        self.input.update(cx, |input, _| {
+            input.set_mention_hits(prepaint.mention_hits.clone())
+        });
         window.handle_input(
             &focus_handle,
             ElementInputHandler::new(bounds, self.input.clone()),
             cx,
         );
         let input = self.input.clone();
-        window.on_mouse_event(move |event: &MouseMoveEvent, phase, window, cx| {
+        window.on_mouse_event(move |event: &MouseMoveEvent, phase, _, cx| {
             if phase == DispatchPhase::Bubble {
-                if event.pressed_button == Some(MouseButton::Left) {
-                    input.update(cx, |input, cx| input.on_mouse_move(event, cx));
-                } else {
-                    // Hover-only movement does not mutate the input entity, so
-                    // explicitly refresh to update mention tooltip hit testing.
-                    window.refresh();
-                }
+                input.update(cx, |input, cx| input.on_mouse_move(event, cx));
             }
         });
 
@@ -4508,6 +4827,86 @@ impl Render for Composer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn tooltip_target(range: Range<usize>, path: &str) -> MentionTooltipTarget {
+        MentionTooltipTarget {
+            range,
+            path: path.into(),
+        }
+    }
+
+    #[test]
+    fn mention_tooltip_wait_restarts_and_promotes_only_the_current_generation() {
+        let target = tooltip_target(3..20, "src/composer.rs");
+        let waiting = MentionTooltipPhase::Waiting {
+            target: target.clone(),
+            generation: 1,
+        };
+        let restarted = mention_tooltip_reduce(waiting, Some(target.clone()), false, 2);
+        assert!(matches!(
+            restarted,
+            MentionTooltipPhase::Waiting { generation: 2, .. }
+        ));
+        assert_eq!(
+            mention_tooltip_promote(restarted.clone(), 1, true),
+            restarted,
+            "a stale timer must not reveal the tooltip"
+        );
+        let visible = mention_tooltip_promote(restarted, 2, true);
+        assert!(matches!(
+            visible,
+            MentionTooltipPhase::Visible { generation: 2, .. }
+        ));
+        assert_eq!(
+            mention_tooltip_reduce(visible.clone(), Some(target), false, 3),
+            visible,
+            "one visible activation keeps its presentation generation stable"
+        );
+    }
+
+    #[test]
+    fn mention_tooltip_changes_target_and_cancels_disappeared_target() {
+        let first = tooltip_target(0..10, "src/a.rs");
+        let second = tooltip_target(20..30, "src/a.rs");
+        let visible = MentionTooltipPhase::Visible {
+            target: first,
+            generation: 4,
+        };
+        assert!(matches!(
+            mention_tooltip_reduce(visible, Some(second), false, 5),
+            MentionTooltipPhase::Waiting { generation: 5, .. }
+        ));
+        assert_eq!(
+            mention_tooltip_promote(
+                MentionTooltipPhase::Waiting {
+                    target: tooltip_target(20..30, "src/a.rs"),
+                    generation: 5,
+                },
+                5,
+                false,
+            ),
+            MentionTooltipPhase::Hidden
+        );
+    }
+
+    #[test]
+    fn mention_tooltip_stays_visible_over_chip_or_popup_only() {
+        assert!(mention_tooltip_contains(true, false));
+        assert!(mention_tooltip_contains(false, true));
+        assert!(!mention_tooltip_contains(false, false));
+    }
+
+    #[test]
+    fn mention_wash_moves_wholly_to_the_next_visual_row_at_a_wrap() {
+        assert_eq!(
+            display_row_segments(12..24, [12, 40]),
+            vec![(1, 12, 12..24)]
+        );
+        assert_eq!(
+            display_row_segments(8..24, [12, 40]),
+            vec![(0, 0, 8..12), (1, 12, 12..24)]
+        );
+    }
 
     #[test]
     fn mention_token_requires_a_token_boundary_and_tracks_full_token() {

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -630,6 +630,9 @@ const MENTION_ICON_SLOT: &str = "\u{2003}";
 const MENTION_TOOLTIP_DELAY: Duration = Duration::from_millis(420);
 const MENTION_TOOLTIP_HEIGHT: f32 = 24.0;
 const MENTION_SIDE_PAD: &str = "\u{00A0}";
+/// A private URI scheme keeps file mentions distinguishable from ordinary
+/// Markdown links pasted into the composer.
+const FILE_MENTION_SCHEME: &str = "comet-file:";
 
 /// A restorable point in the input's history: text plus where the caret and
 /// selection sat when the edit landed.
@@ -696,8 +699,9 @@ fn local_file_link(path: &str, is_dir: bool) -> String {
         .filter(|part| !part.is_empty())
         .unwrap_or(path);
     format!(
-        "[{}]({})",
+        "[{}]({}{})",
         escape_mention_label(basename),
+        FILE_MENTION_SCHEME,
         percent_encode_path(&format!("{path}{}", if is_dir { "/" } else { "" }))
     )
 }
@@ -742,7 +746,10 @@ fn file_mention_links(text: &str) -> Vec<FileMentionLink> {
         };
         let end = target_start + relative_end + 1;
         let label = &text[start + 1..label_end];
-        let encoded = &text[target_start..end - 1];
+        let Some(encoded) = text[target_start..end - 1].strip_prefix(FILE_MENTION_SCHEME) else {
+            search = end;
+            continue;
+        };
         let parsed = percent_decode_path(encoded).and_then(|target| {
             let is_dir = target.ends_with('/');
             let path = target.strip_suffix('/').unwrap_or(&target);
@@ -804,9 +811,9 @@ impl MentionTooltipPhase {
     }
 }
 
-/// Pure tooltip lifecycle reducer. Pointer motion restarts a waiting timer;
-/// after promotion, ordinary motion inside the same chip keeps the tooltip
-/// stable so the popup does not flicker while it is visible.
+/// Pure tooltip lifecycle reducer. Motion within the same chip preserves both
+/// waiting and visible phases, so normal pointer jitter cannot starve the
+/// delay or flicker an already-visible tooltip.
 fn mention_tooltip_reduce(
     phase: MentionTooltipPhase,
     pointer_target: Option<MentionTooltipTarget>,
@@ -814,12 +821,7 @@ fn mention_tooltip_reduce(
     generation: u64,
 ) -> MentionTooltipPhase {
     match pointer_target {
-        Some(target)
-            if phase.target() == Some(&target)
-                && matches!(phase, MentionTooltipPhase::Visible { .. }) =>
-        {
-            phase
-        }
+        Some(target) if phase.target() == Some(&target) => phase,
         Some(target) => MentionTooltipPhase::Waiting { target, generation },
         None if pointer_in_popup && matches!(phase, MentionTooltipPhase::Visible { .. }) => phase,
         None => MentionTooltipPhase::Hidden,
@@ -881,9 +883,10 @@ struct MentionHit {
 impl TextProjection {
     fn new(raw: &str) -> Self {
         let links = file_mention_links(raw);
+        let labels = mention_display_labels(&links);
         let mut projection = Self::default();
         let mut raw_at = 0;
-        for link in links {
+        for (link, label) in links.into_iter().zip(labels) {
             projection.display.push_str(&raw[raw_at..link.range.start]);
             let display_start = projection.display.len();
             // Text runs cannot host an inline element. Reserve a stable
@@ -892,7 +895,7 @@ impl TextProjection {
             projection.display.push_str(MENTION_SIDE_PAD);
             projection.display.push_str(MENTION_ICON_SLOT);
             projection.display.push('\u{202F}');
-            for ch in link.basename.chars() {
+            for ch in label.chars() {
                 projection
                     .display
                     .push(if ch == ' ' { '\u{00A0}' } else { ch });
@@ -980,6 +983,42 @@ impl TextProjection {
             .iter()
             .find_map(|(link, _)| (raw == link.range.start).then_some(link.range.end))
     }
+}
+
+/// Basenames are compact in the common case. When the same basename appears
+/// more than once, use the shortest unique path suffix so chips remain
+/// distinguishable without always expanding to full paths.
+fn mention_display_labels(links: &[FileMentionLink]) -> Vec<String> {
+    links
+        .iter()
+        .enumerate()
+        .map(|(ix, link)| {
+            if links
+                .iter()
+                .filter(|other| other.basename == link.basename)
+                .count()
+                == 1
+            {
+                return link.basename.clone();
+            }
+            let parts: Vec<_> = link.path.split('/').collect();
+            (1..=parts.len())
+                .map(|count| parts[parts.len() - count..].join("/"))
+                .find(|suffix| {
+                    let suffix: Vec<_> = suffix.split('/').collect();
+                    links.iter().enumerate().all(|(other_ix, other)| {
+                        other_ix == ix
+                            || !other
+                                .path
+                                .split('/')
+                                .rev()
+                                .take(suffix.len())
+                                .eq(suffix.iter().rev().copied())
+                    })
+                })
+                .unwrap_or_else(|| link.path.clone())
+        })
+        .collect()
 }
 
 /// Direction of the last edit — a run only merges with edits of its own kind.
@@ -1115,6 +1154,7 @@ pub enum ComposerInputEvent {
     Submitted,
     Edited,
     CursorMoved,
+    ViewportChanged,
     MentionNavigate(isize),
     MentionAccept,
     MentionDismiss,
@@ -1156,6 +1196,9 @@ pub struct ComposerInput {
     last_width: f32,
     /// Raw Markdown → chip display projection from the last layout pass.
     projection: TextProjection,
+    /// File mentions are a composer feature, not a behavior of generic inputs
+    /// (picker searches and rename fields also use this type).
+    mentions_enabled: bool,
     /// Bumped once per `layout_text` pass — the flip logic uses it to apply at
     /// most one compact↔expanded flip per layout (a flip is only re-evaluated
     /// after the input has been measured in the new mode).
@@ -1223,6 +1266,7 @@ impl ComposerInput {
             max_line_width: 0.0,
             last_width: 0.0,
             projection: TextProjection::default(),
+            mentions_enabled: false,
             layout_epoch: 0,
             display_is_placeholder: true,
             blink_anchor: Instant::now(),
@@ -1281,9 +1325,28 @@ impl ComposerInput {
         has_selection: bool,
         cx: &mut Context<Self>,
     ) {
+        if self.mention_open == open && self.mention_has_selection == has_selection {
+            return;
+        }
         self.mention_open = open;
         self.mention_has_selection = has_selection;
         cx.notify();
+    }
+
+    fn enable_mentions(&mut self) {
+        self.mentions_enabled = true;
+        self.refresh_projection();
+    }
+
+    fn refresh_projection(&mut self) {
+        self.projection = if self.mentions_enabled {
+            TextProjection::new(&self.content)
+        } else {
+            TextProjection {
+                display: self.content.clone(),
+                mentions: Vec::new(),
+            }
+        };
     }
 
     /// Replace a completed `@query` token as one non-coalescing undo step.
@@ -1306,6 +1369,7 @@ impl ComposerInput {
         self.record_edit(&range, &inserted);
         self.content =
             self.content[..range.start].to_owned() + &inserted + &self.content[range.end..];
+        self.refresh_projection();
         let cursor =
             range.start + inserted.len() + existing_separator.map(char::len_utf8).unwrap_or(0);
         self.selected_range = cursor..cursor;
@@ -1345,6 +1409,7 @@ impl ComposerInput {
     pub fn set_text(&mut self, text: impl Into<String>, cx: &mut Context<Self>) {
         self.invalidate_mention_tooltip();
         self.content = text.into();
+        self.refresh_projection();
         let end = self.content.len();
         self.selected_range = end..end;
         self.selection_reversed = false;
@@ -1539,6 +1604,7 @@ impl ComposerInput {
     fn restore(&mut self, snapshot: EditSnapshot, cx: &mut Context<Self>) {
         self.invalidate_mention_tooltip();
         self.content = snapshot.content;
+        self.refresh_projection();
         self.selected_range = snapshot.selected_range;
         self.selection_reversed = snapshot.selection_reversed;
         self.marked_range = None;
@@ -1577,9 +1643,7 @@ impl ComposerInput {
     }
 
     fn move_to(&mut self, offset: usize, cx: &mut Context<Self>) {
-        let offset = TextProjection::new(&self.content)
-            .normalize_range(offset..offset)
-            .start;
+        let offset = self.projection.normalize_range(offset..offset).start;
         self.selected_range = offset..offset;
         self.follow_cursor = true;
         self.reset_blink();
@@ -1588,9 +1652,7 @@ impl ComposerInput {
     }
 
     fn select_to(&mut self, offset: usize, cx: &mut Context<Self>) {
-        let offset = TextProjection::new(&self.content)
-            .normalize_range(offset..offset)
-            .start;
+        let offset = self.projection.normalize_range(offset..offset).start;
         if self.selection_reversed {
             self.selected_range.start = offset;
         } else {
@@ -1607,7 +1669,7 @@ impl ComposerInput {
     }
 
     fn previous_boundary(&self, offset: usize) -> usize {
-        if let Some(boundary) = TextProjection::new(&self.content).previous_boundary(offset) {
+        if let Some(boundary) = self.projection.previous_boundary(offset) {
             return boundary;
         }
         self.content
@@ -1618,7 +1680,7 @@ impl ComposerInput {
     }
 
     fn next_boundary(&self, offset: usize) -> usize {
-        if let Some(boundary) = TextProjection::new(&self.content).next_boundary(offset) {
+        if let Some(boundary) = self.projection.next_boundary(offset) {
             return boundary;
         }
         self.content
@@ -1628,7 +1690,7 @@ impl ComposerInput {
     }
 
     fn previous_word_boundary(&self, offset: usize) -> usize {
-        if let Some(boundary) = TextProjection::new(&self.content).previous_boundary(offset) {
+        if let Some(boundary) = self.projection.previous_boundary(offset) {
             return boundary;
         }
         self.content
@@ -1639,7 +1701,7 @@ impl ComposerInput {
     }
 
     fn next_word_boundary(&self, offset: usize) -> usize {
-        if let Some(boundary) = TextProjection::new(&self.content).next_boundary(offset) {
+        if let Some(boundary) = self.projection.next_boundary(offset) {
             return boundary;
         }
         self.content
@@ -1705,7 +1767,7 @@ impl ComposerInput {
     }
 
     fn up(&mut self, _: &Up, _: &mut Window, cx: &mut Context<Self>) {
-        if self.mention_open {
+        if self.mention_has_selection {
             cx.emit(ComposerInputEvent::MentionNavigate(-1));
             return;
         }
@@ -1715,7 +1777,7 @@ impl ComposerInput {
     }
 
     fn down(&mut self, _: &Down, _: &mut Window, cx: &mut Context<Self>) {
-        if self.mention_open {
+        if self.mention_has_selection {
             cx.emit(ComposerInputEvent::MentionNavigate(1));
             return;
         }
@@ -1940,12 +2002,16 @@ impl ComposerInput {
     fn mention_tab(&mut self, _: &MentionTab, _: &mut Window, cx: &mut Context<Self>) {
         if self.mention_has_selection {
             cx.emit(ComposerInputEvent::MentionAccept);
+        } else {
+            cx.propagate();
         }
     }
 
     fn mention_escape(&mut self, _: &MentionEscape, _: &mut Window, cx: &mut Context<Self>) {
         if self.mention_open {
             cx.emit(ComposerInputEvent::MentionDismiss);
+        } else {
+            cx.propagate();
         }
     }
 
@@ -1954,6 +2020,13 @@ impl ComposerInput {
     /// Content-local point for a byte index (y grows down from content top).
     fn point_for_index(&self, index: usize) -> Option<Point<Pixels>> {
         self.point_for_display_index(self.projection.raw_to_display(index))
+    }
+
+    fn visible_point_for_index(&self, index: usize) -> Option<Point<Pixels>> {
+        let point = self.point_for_index(index)?;
+        let height = self.last_bounds?.size.height;
+        let y = point.y - px(self.scroll_top);
+        (y >= px(0.0) && y + self.line_height <= height).then_some(gpui::point(point.x, y))
     }
 
     /// Content-local point for a shaped projection byte index. The icon layer
@@ -2200,6 +2273,7 @@ impl ComposerInput {
         self.scroll_top = next;
         self.follow_cursor = false;
         cx.stop_propagation();
+        cx.emit(ComposerInputEvent::ViewportChanged);
         cx.notify();
     }
 
@@ -2246,7 +2320,7 @@ impl ComposerInput {
         // mention can leave its previous paint geometry alive while the
         // placeholder is already being shaped, tinting "Do anything" for a
         // frame (or longer when no subsequent layout is requested).
-        self.projection = TextProjection::new(&self.content);
+        self.refresh_projection();
         let (display, is_placeholder) = if self.content.is_empty() {
             (self.placeholder.clone(), true)
         } else {
@@ -2337,7 +2411,8 @@ impl ComposerInput {
     }
 
     /// Keep the cursor visible when content exceeds the element height.
-    fn clamp_scroll(&mut self, element_height: f32) {
+    fn clamp_scroll(&mut self, element_height: f32) -> bool {
+        let previous = self.scroll_top;
         if self.follow_cursor {
             if let Some(cursor) = self.point_for_index(self.cursor_offset()) {
                 self.scroll_top = input_scroll_offset_for_cursor(
@@ -2352,6 +2427,7 @@ impl ComposerInput {
         self.scroll_top = self
             .scroll_top
             .clamp(0.0, input_max_scroll(self.content_height, element_height));
+        self.scroll_top != previous
     }
 }
 
@@ -2371,8 +2447,9 @@ impl EntityInputHandler for ComposerInput {
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) -> Option<String> {
-        let range =
-            TextProjection::new(&self.content).normalize_range(self.range_from_utf16(&range_utf16));
+        let range = self
+            .projection
+            .normalize_range(self.range_from_utf16(&range_utf16));
         actual_range.replace(self.range_to_utf16(&range));
         Some(self.content.get(range)?.to_string())
     }
@@ -2383,8 +2460,7 @@ impl EntityInputHandler for ComposerInput {
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) -> Option<UTF16Selection> {
-        self.selected_range =
-            TextProjection::new(&self.content).normalize_range(self.selected_range.clone());
+        self.selected_range = self.projection.normalize_range(self.selected_range.clone());
         Some(UTF16Selection {
             range: self.range_to_utf16(&self.selected_range),
             reversed: self.selection_reversed,
@@ -2413,7 +2489,7 @@ impl EntityInputHandler for ComposerInput {
             .map(|r| self.range_from_utf16(r))
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
-        let range = TextProjection::new(&self.content).normalize_range(range);
+        let range = self.projection.normalize_range(range);
         self.invalidate_mention_tooltip();
         // An IME commit is the tail of a composition whose pre-composition
         // snapshot was already taken (`replace_and_mark_text_in_range`);
@@ -2423,6 +2499,7 @@ impl EntityInputHandler for ComposerInput {
         }
         self.content =
             self.content[0..range.start].to_owned() + new_text + &self.content[range.end..];
+        self.refresh_projection();
         let cursor = range.start + new_text.len();
         self.selected_range = cursor..cursor;
         self.marked_range.take();
@@ -2445,7 +2522,7 @@ impl EntityInputHandler for ComposerInput {
             .map(|r| self.range_from_utf16(r))
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
-        let range = TextProjection::new(&self.content).normalize_range(range);
+        let range = self.projection.normalize_range(range);
         self.invalidate_mention_tooltip();
         // First keystroke of a composition: snapshot the text as it stood
         // before any of it existed, so one undo drops the whole composition.
@@ -2459,6 +2536,7 @@ impl EntityInputHandler for ComposerInput {
         }
         self.content =
             self.content[0..range.start].to_owned() + new_text + &self.content[range.end..];
+        self.refresh_projection();
         if new_text.is_empty() {
             self.marked_range = None;
         } else {
@@ -2482,8 +2560,9 @@ impl EntityInputHandler for ComposerInput {
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) -> Option<Bounds<Pixels>> {
-        let range =
-            TextProjection::new(&self.content).normalize_range(self.range_from_utf16(&range_utf16));
+        let range = self
+            .projection
+            .normalize_range(self.range_from_utf16(&range_utf16));
         let start = self.point_for_index(range.start)?;
         let origin = point(
             bounds.left() + start.x,
@@ -2524,6 +2603,7 @@ impl Render for MentionPathTooltip {
             ("file-mention-path-tooltip", self.activation),
             div()
                 .h(px(MENTION_TOOLTIP_HEIGHT))
+                .max_w(px(480.0))
                 .flex()
                 .items_center()
                 .px(px(8.0))
@@ -2600,9 +2680,12 @@ impl gpui::Element for ComposerTextElement {
         window: &mut Window,
         cx: &mut App,
     ) -> Self::PrepaintState {
-        self.input.update(cx, |input, _| {
-            input.clamp_scroll(f32::from(bounds.size.height));
+        self.input.update(cx, |input, cx| {
+            let scrolled = input.clamp_scroll(f32::from(bounds.size.height));
             input.last_bounds = Some(bounds);
+            if scrolled {
+                cx.emit(ComposerInputEvent::ViewportChanged);
+            }
         });
         let input = self.input.read(cx);
         let scroll = px(input.scroll_top);
@@ -2646,9 +2729,13 @@ impl gpui::Element for ComposerTextElement {
                     // below fallback flush so the pointer can enter the popup.
                     chip_bounds.bottom() - px(1.0)
                 };
+                let visible_bounds = chip_bounds.intersect(&bounds);
+                if visible_bounds.size.width == px(0.0) || visible_bounds.size.height == px(0.0) {
+                    continue;
+                }
                 mention_hits.push(MentionHit {
                     target: target.clone(),
-                    bounds: chip_bounds,
+                    bounds: visible_bounds,
                     // The fixed-height popup starts at anchor + 1px. Moving
                     // the anchor above the chip therefore yields conventional
                     // above-target placement without cursor tracking.
@@ -2974,6 +3061,10 @@ struct FileMentionState {
     dismissed: Option<(Range<usize>, String)>,
 }
 
+fn mention_response_is_current(state: &FileMentionState, request: u64) -> bool {
+    state.request == request && state.token.is_some()
+}
+
 pub struct Composer {
     state: Entity<AppState>,
     input: Entity<ComposerInput>,
@@ -3038,7 +3129,11 @@ impl EventEmitter<ComposerEvent> for Composer {}
 
 impl Composer {
     pub fn new(state: Entity<AppState>, cx: &mut Context<Self>) -> Self {
-        let input = cx.new(|cx| ComposerInput::new("Do anything…", cx));
+        let input = cx.new(|cx| {
+            let mut input = ComposerInput::new("Do anything…", cx);
+            input.enable_mentions();
+            input
+        });
         let pickers = cx.new(|cx| Pickers::new(state.clone(), cx));
         // The footer toolbar (checkout kind + ref picker) is rendered INLINE
         // by the composer from picker state — a pickers-side notify (refs
@@ -3050,6 +3145,7 @@ impl Composer {
             ComposerInputEvent::Edited | ComposerInputEvent::CursorMoved => {
                 this.on_input_edited(cx)
             }
+            ComposerInputEvent::ViewportChanged => cx.notify(),
             ComposerInputEvent::MentionNavigate(delta) => this.move_mention(*delta, cx),
             ComposerInputEvent::MentionAccept => this.accept_mention(cx),
             ComposerInputEvent::MentionDismiss => this.dismiss_mention(cx),
@@ -3294,7 +3390,27 @@ impl Composer {
         });
     }
 
+    /// Tear down the entire completion lifecycle. Advancing the generation is
+    /// important even when the spawned task is dropped: an RPC response may
+    /// already be queued for delivery on the UI executor.
+    fn reset_mention(&mut self, dismissed: Option<(Range<usize>, String)>, cx: &mut Context<Self>) {
+        let request = self.mention.request.wrapping_add(1);
+        self.mention_task = None;
+        self.mention = FileMentionState {
+            request,
+            dismissed,
+            ..FileMentionState::default()
+        };
+        self.sync_mention_controls(cx);
+    }
+
     fn on_input_edited(&mut self, cx: &mut Context<Self>) {
+        if self.wizard.is_some() {
+            if self.mention.token.is_some() || self.mention_task.is_some() {
+                self.reset_mention(None, cx);
+            }
+            return;
+        }
         let (text, cursor) = {
             let input = self.input.read(cx);
             (input.text().to_string(), input.cursor_offset())
@@ -3310,6 +3426,7 @@ impl Composer {
         });
         if still_dismissed {
             self.mention.token = None;
+            self.mention_task = None;
             self.sync_mention_controls(cx);
             cx.notify();
             return;
@@ -3321,6 +3438,7 @@ impl Composer {
             return;
         }
         self.mention.request = self.mention.request.wrapping_add(1);
+        self.mention_task = None;
         self.mention.token = token.clone();
         self.mention.results.clear();
         self.mention.active = None;
@@ -3375,7 +3493,7 @@ impl Composer {
                 .await;
             let result = engine.client().call(methods::SEARCH_FILES, params).await;
             this.update(cx, |composer, cx| {
-                if composer.mention.request != request {
+                if !mention_response_is_current(&composer.mention, request) {
                     return;
                 }
                 composer.mention.loading = false;
@@ -3398,13 +3516,8 @@ impl Composer {
     }
 
     fn move_mention(&mut self, delta: isize, cx: &mut Context<Self>) {
-        let count = self.mention.results.len();
-        if count > 0 {
-            self.mention.active = Some(
-                (self.mention.active.unwrap_or(0) as isize + delta).rem_euclid(count as isize)
-                    as usize,
-            );
-        }
+        self.mention.active =
+            crate::popover::menu_step(self.mention.active, self.mention.results.len(), delta);
         self.sync_mention_controls(cx);
         cx.notify();
     }
@@ -3417,12 +3530,7 @@ impl Composer {
                 .get(token.range.clone())
                 .map(|text| (token.range.clone(), text.to_string()))
         });
-        self.mention.dismissed = dismissed;
-        self.mention.token = None;
-        self.mention.results.clear();
-        self.mention.active = None;
-        self.mention.loading = false;
-        self.sync_mention_controls(cx);
+        self.reset_mention(dismissed, cx);
         cx.notify();
     }
 
@@ -3441,8 +3549,7 @@ impl Composer {
         self.input.update(cx, |input, cx| {
             input.replace_mention(token.range, &path, is_dir, cx)
         });
-        self.mention = FileMentionState::default();
-        self.sync_mention_controls(cx);
+        self.reset_mention(None, cx);
         cx.notify();
     }
 
@@ -3455,7 +3562,8 @@ impl Composer {
         let mut card = crate::popover::popover_card(theme)
             .w(px(380.0))
             .max_h(px(280.0))
-            .overflow_hidden();
+            .overflow_hidden()
+            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.dismiss_mention(cx)));
         if self.mention.loading {
             card = card.child(crate::popover::skeleton_rows(
                 "file-mention-loading",
@@ -3479,17 +3587,16 @@ impl Composer {
             for (ix, result) in self.mention.results.iter().enumerate() {
                 let selected = self.mention.active == Some(ix);
                 let path = result.path.clone();
+                let tooltip_path: SharedString = path.clone().into();
                 card = card.child(
-                    div()
+                    crate::popover::menu_row(theme, selected, format!("file-mention-result-{ix}"))
                         .id(("file-mention-result", ix))
-                        .px(px(10.0))
-                        .py(px(7.0))
-                        .rounded(px(8.0))
-                        .cursor_pointer()
-                        .bg(if selected {
-                            crate::theme::white_alpha(0.10)
-                        } else {
-                            gpui::transparent_black()
+                        .tooltip(move |_, cx| {
+                            cx.new(|_| MentionPathTooltip {
+                                path: tooltip_path.clone(),
+                                activation: ix as u64,
+                            })
+                            .into()
                         })
                         .on_click(cx.listener(move |this, _, _, cx| {
                             this.mention.active = Some(ix);
@@ -3514,6 +3621,8 @@ impl Composer {
                                     div()
                                         .min_w_0()
                                         .flex_1()
+                                        .overflow_hidden()
+                                        .truncate()
                                         .text_size(px(12.5))
                                         .text_color(theme.text)
                                         .child(path),
@@ -3522,10 +3631,22 @@ impl Composer {
                 );
             }
         }
-        Some(crate::popover::anchored_menu_above(
+        let anchor = self
+            .input
+            .read(cx)
+            .visible_point_for_index(token.range.start)?;
+        Some(crate::popover::anchored_menu_above_at(
             "file-mention-popup",
+            anchor,
             card.into_any_element(),
         ))
+    }
+
+    fn render_input_with_completion(&self, theme: &Theme, cx: &mut Context<Self>) -> gpui::Div {
+        div()
+            .relative()
+            .child(self.input.clone())
+            .children(self.render_file_mention_popup(theme, cx))
     }
 
     fn on_state_changed(&mut self, cx: &mut Context<Self>) {
@@ -3552,8 +3673,7 @@ impl Composer {
             // Attachments stay stashed under their chat key (the map swap IS
             // the navigation); only the transient chrome resets.
             self.preview = None;
-            self.mention = FileMentionState::default();
-            self.sync_mention_controls(cx);
+            self.reset_mention(None, cx);
             // Route changes snap (round 5/6): a mode difference between the
             // old and new session's composer must not glide across
             // navigation. Killing the in-flight morph here isn't enough —
@@ -3574,6 +3694,7 @@ impl Composer {
                     .as_ref()
                     .is_some_and(|w| w.request_id == request_id);
                 if !same {
+                    self.reset_mention(None, cx);
                     self.wizard = Some(Wizard::new(request_id, questions));
                     self.advance_task = None;
                     // The shared input becomes the panel's free-text override.
@@ -4419,6 +4540,11 @@ impl Render for Composer {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = Theme::of(cx).clone();
         let wizard_active = self.wizard.is_some();
+        if self.mention.token.is_some()
+            && (wizard_active || !self.input.focus_handle(cx).is_focused(window))
+        {
+            self.reset_mention(None, cx);
+        }
         let mode = self.button_mode(cx);
         let (text_width, has_newline, content_height, last_width, epoch) = {
             let input = self.input.read(cx);
@@ -4700,12 +4826,7 @@ impl Render for Composer {
                         .px(px(16.0))
                         .pt(px(text_pt))
                         .pb(px(4.0))
-                        .child(
-                            div()
-                                .relative()
-                                .child(self.input.clone())
-                                .children(self.render_file_mention_popup(&theme, cx)),
-                        ),
+                        .child(self.render_input_with_completion(&theme, cx)),
                 )
                 .child(
                     div()
@@ -4763,12 +4884,7 @@ impl Render for Composer {
                                 .pr(px(8.0))
                                 .relative()
                                 .top(px(-text_glide))
-                                .child(
-                                    div()
-                                        .relative()
-                                        .child(self.input.clone())
-                                        .children(self.render_file_mention_popup(&theme, cx)),
-                                ),
+                                .child(self.render_input_with_completion(&theme, cx)),
                         )
                         .child(
                             div()
@@ -4836,26 +4952,27 @@ mod tests {
     }
 
     #[test]
-    fn mention_tooltip_wait_restarts_and_promotes_only_the_current_generation() {
+    fn mention_tooltip_wait_survives_pointer_jitter_and_promotes_once() {
         let target = tooltip_target(3..20, "src/composer.rs");
         let waiting = MentionTooltipPhase::Waiting {
             target: target.clone(),
             generation: 1,
         };
-        let restarted = mention_tooltip_reduce(waiting, Some(target.clone()), false, 2);
+        let restarted = mention_tooltip_reduce(waiting.clone(), Some(target.clone()), false, 2);
+        assert_eq!(restarted, waiting);
         assert!(matches!(
             restarted,
-            MentionTooltipPhase::Waiting { generation: 2, .. }
+            MentionTooltipPhase::Waiting { generation: 1, .. }
         ));
         assert_eq!(
-            mention_tooltip_promote(restarted.clone(), 1, true),
+            mention_tooltip_promote(restarted.clone(), 2, true),
             restarted,
             "a stale timer must not reveal the tooltip"
         );
-        let visible = mention_tooltip_promote(restarted, 2, true);
+        let visible = mention_tooltip_promote(restarted, 1, true);
         assert!(matches!(
             visible,
-            MentionTooltipPhase::Visible { generation: 2, .. }
+            MentionTooltipPhase::Visible { generation: 1, .. }
         ));
         assert_eq!(
             mention_tooltip_reduce(visible.clone(), Some(target), false, 3),
@@ -4927,9 +5044,26 @@ mod tests {
     }
 
     #[test]
+    fn dismissed_mentions_reject_stale_responses() {
+        let mut state = FileMentionState {
+            token: mention_token("@src", 4),
+            request: 7,
+            ..FileMentionState::default()
+        };
+        assert!(mention_response_is_current(&state, 7));
+        state.request += 1;
+        state.token = None;
+        assert!(!mention_response_is_current(&state, 7));
+        assert!(!mention_response_is_current(&state, 8));
+    }
+
+    #[test]
     fn file_mentions_serialize_to_strict_local_markdown() {
         let raw = local_file_link("src/a file#[x].rs", false);
-        assert_eq!(raw, "[a file#\\[x\\].rs](src/a%20file%23%5Bx%5D.rs)");
+        assert_eq!(
+            raw,
+            "[a file#\\[x\\].rs](comet-file:src/a%20file%23%5Bx%5D.rs)"
+        );
         let links = file_mention_links(&raw);
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].path, "src/a file#[x].rs");
@@ -4937,7 +5071,7 @@ mod tests {
         assert!(!links[0].is_dir);
 
         let folder = local_file_link("src/components", true);
-        assert_eq!(folder, "[components](src/components/)");
+        assert_eq!(folder, "[components](comet-file:src/components/)");
         let links = file_mention_links(&folder);
         assert_eq!(links[0].path, "src/components");
         assert!(links[0].is_dir);
@@ -4949,8 +5083,43 @@ mod tests {
         assert!(file_mention_links("[a.rs](../a.rs)").is_empty());
         assert!(file_mention_links("[a.rs](src/a file.rs)").is_empty());
         assert!(file_mention_links("[other](src/a.rs)").is_empty());
+        assert!(file_mention_links("[a.rs](src/a.rs)").is_empty());
         assert!(file_mention_links("[a.rs](src%5Cfake%5Ca.rs)").is_empty());
         assert!(file_mention_links("[a.rs](src/a%0A.rs)").is_empty());
+    }
+
+    #[test]
+    fn duplicate_mention_basenames_use_unique_suffixes() {
+        let raw = format!(
+            "{} {}",
+            local_file_link("src/one/mod.rs", false),
+            local_file_link("src/two/mod.rs", false)
+        );
+        let projection = TextProjection::new(&raw);
+        assert!(projection.display.contains("one/mod.rs"));
+        assert!(projection.display.contains("two/mod.rs"));
+    }
+
+    #[test]
+    fn mention_suffixes_compare_path_components() {
+        let links = vec![
+            FileMentionLink {
+                range: 0..0,
+                basename: "mod.rs".into(),
+                path: "foo/mod.rs".into(),
+                is_dir: false,
+            },
+            FileMentionLink {
+                range: 0..0,
+                basename: "oomod.rs".into(),
+                path: "bar/oomod.rs".into(),
+                is_dir: false,
+            },
+        ];
+        assert_eq!(
+            mention_display_labels(&links),
+            vec!["mod.rs".to_string(), "oomod.rs".to_string()]
+        );
     }
 
     #[test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -13,18 +13,18 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use gpui::{
-    App, Bounds, ClipboardEntry, ClipboardItem, Context, CursorStyle, DispatchPhase,
+    App, BorderStyle, Bounds, ClipboardEntry, ClipboardItem, Context, CursorStyle, DispatchPhase,
     ElementInputHandler, Entity, EntityInputHandler, EventEmitter, FocusHandle, Focusable,
     GlobalElementId, KeyBinding, KeyDownEvent, LayoutId, MouseButton, MouseDownEvent,
     MouseMoveEvent, MouseUpEvent, ObjectFit, PaintQuad, PathPromptOptions, Pixels, Point,
     ScrollWheelEvent, SharedString, Style, StyledImage as _, Subscription, Task, TextRun,
     TextStyle, UTF16Selection, UnderlineStyle, Window, WrappedLine, actions, div, fill, img, point,
-    prelude::*, px, relative, size,
+    prelude::*, px, quad, relative, size,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
 use comet_doc::{MessagePart, MessageRole, SessionCommandPayload, SessionMessageEntry};
-use comet_proto::{RunRequest, SandboxLevel, UserInputAnswer, UserInputQuestion};
+use comet_proto::{FileSearchMatch, RunRequest, SandboxLevel, UserInputAnswer, UserInputQuestion};
 use comet_rpc::methods;
 
 use crate::attachments::{self, StagedAttachment};
@@ -609,6 +609,8 @@ actions!(
         Submit,
         Undo,
         Redo,
+        MentionTab,
+        MentionEscape,
     ]
 );
 
@@ -629,6 +631,236 @@ struct EditSnapshot {
     selection_reversed: bool,
 }
 
+/// A strict, local-only Markdown representation of a file mention. The
+/// underlying prompt always contains this form; the editor projects it to a
+/// chip for display without leaking a second data model into submission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileMentionLink {
+    range: Range<usize>,
+    basename: String,
+    path: String,
+}
+
+fn percent_encode_path(path: &str) -> String {
+    let mut out = String::new();
+    for byte in path.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/') {
+            out.push(byte as char);
+        } else {
+            out.push('%');
+            out.push_str(&format!("{byte:02X}"));
+        }
+    }
+    out
+}
+
+fn percent_decode_path(encoded: &str) -> Option<String> {
+    let mut bytes = Vec::with_capacity(encoded.len());
+    let raw = encoded.as_bytes();
+    let mut at = 0;
+    while at < raw.len() {
+        if raw[at] == b'%' {
+            let hex = std::str::from_utf8(raw.get(at + 1..at + 3)?).ok()?;
+            bytes.push(u8::from_str_radix(hex, 16).ok()?);
+            at += 3;
+        } else {
+            bytes.push(raw[at]);
+            at += 1;
+        }
+    }
+    String::from_utf8(bytes).ok()
+}
+
+fn escape_mention_label(label: &str) -> String {
+    label
+        .replace('\\', "\\\\")
+        .replace('[', "\\[")
+        .replace(']', "\\]")
+}
+
+fn local_file_link(path: &str) -> String {
+    let basename = path
+        .rsplit('/')
+        .next()
+        .filter(|part| !part.is_empty())
+        .unwrap_or(path);
+    format!(
+        "[{}]({})",
+        escape_mention_label(basename),
+        percent_encode_path(path)
+    )
+}
+
+fn local_path_is_safe(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.contains('\\')
+        && !path.chars().any(char::is_control)
+        && !path
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
+}
+
+fn label_close(text: &str, start: usize) -> Option<usize> {
+    let mut escaped = false;
+    for (at, ch) in text[start..].char_indices() {
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else if ch == ']' && text[start + at + 1..].starts_with('(') {
+            return Some(start + at);
+        }
+    }
+    None
+}
+
+fn file_mention_links(text: &str) -> Vec<FileMentionLink> {
+    let mut links = Vec::new();
+    let mut search = 0;
+    while let Some(relative_start) = text[search..].find('[') {
+        let start = search + relative_start;
+        let Some(label_end) = label_close(text, start + 1) else {
+            search = start + 1;
+            continue;
+        };
+        let target_start = label_end + 2;
+        let Some(relative_end) = text[target_start..].find(')') else {
+            search = start + 1;
+            continue;
+        };
+        let end = target_start + relative_end + 1;
+        let label = &text[start + 1..label_end];
+        let encoded = &text[target_start..end - 1];
+        let parsed = percent_decode_path(encoded).filter(|path| {
+            local_path_is_safe(path)
+                && percent_encode_path(path) == encoded
+                && path
+                    .rsplit('/')
+                    .next()
+                    .is_some_and(|basename| escape_mention_label(basename) == label)
+        });
+        if let Some(path) = parsed {
+            let basename = path.rsplit('/').next().unwrap_or_default().to_string();
+            links.push(FileMentionLink {
+                range: start..end,
+                basename,
+                path,
+            });
+        }
+        search = end;
+    }
+    links
+}
+
+#[derive(Debug, Clone, Default)]
+struct TextProjection {
+    display: String,
+    mentions: Vec<(FileMentionLink, Range<usize>)>,
+}
+
+impl TextProjection {
+    fn new(raw: &str) -> Self {
+        let links = file_mention_links(raw);
+        let mut projection = Self::default();
+        let mut raw_at = 0;
+        for link in links {
+            projection.display.push_str(&raw[raw_at..link.range.start]);
+            let display_start = projection.display.len();
+            // Text runs cannot host a rounded inline element, but non-breaking
+            // side bearings give the tinted run the compact padding of a chip
+            // and keep names containing spaces together when the line wraps.
+            projection.display.push('\u{00A0}');
+            for ch in link.basename.chars() {
+                projection
+                    .display
+                    .push(if ch == ' ' { '\u{00A0}' } else { ch });
+            }
+            projection.display.push('\u{00A0}');
+            let display_end = projection.display.len();
+            projection
+                .mentions
+                .push((link.clone(), display_start..display_end));
+            raw_at = link.range.end;
+        }
+        projection.display.push_str(&raw[raw_at..]);
+        projection
+    }
+
+    fn raw_to_display(&self, raw: usize) -> usize {
+        let mut raw_at = 0;
+        let mut display_at = 0;
+        for (link, display) in &self.mentions {
+            if raw <= link.range.start {
+                return display_at + raw.saturating_sub(raw_at);
+            }
+            if raw < link.range.end {
+                return display.start;
+            }
+            raw_at = link.range.end;
+            display_at = display.end;
+        }
+        display_at + raw.saturating_sub(raw_at)
+    }
+
+    fn display_to_raw(&self, display_offset: usize) -> usize {
+        let mut raw_at = 0;
+        let mut display_at = 0;
+        for (link, display) in &self.mentions {
+            if display_offset <= display.start {
+                return raw_at + display_offset.saturating_sub(display_at);
+            }
+            if display_offset < display.end {
+                return if display_offset - display.start < display.len() / 2 {
+                    link.range.start
+                } else {
+                    link.range.end
+                };
+            }
+            raw_at = link.range.end;
+            display_at = display.end;
+        }
+        raw_at + display_offset.saturating_sub(display_at)
+    }
+
+    fn normalize_range(&self, range: Range<usize>) -> Range<usize> {
+        if range.is_empty() {
+            for (link, _) in &self.mentions {
+                if link.range.start < range.start && range.start < link.range.end {
+                    let midpoint = link.range.start + link.range.len() / 2;
+                    let at = if range.start < midpoint {
+                        link.range.start
+                    } else {
+                        link.range.end
+                    };
+                    return at..at;
+                }
+            }
+            return range;
+        }
+        let mut normalized = range;
+        for (link, _) in &self.mentions {
+            if normalized.start < link.range.end && normalized.end > link.range.start {
+                normalized.start = normalized.start.min(link.range.start);
+                normalized.end = normalized.end.max(link.range.end);
+            }
+        }
+        normalized
+    }
+
+    fn previous_boundary(&self, raw: usize) -> Option<usize> {
+        self.mentions
+            .iter()
+            .find_map(|(link, _)| (raw == link.range.end).then_some(link.range.start))
+    }
+
+    fn next_boundary(&self, raw: usize) -> Option<usize> {
+        self.mentions
+            .iter()
+            .find_map(|(link, _)| (raw == link.range.start).then_some(link.range.end))
+    }
+}
+
 /// Direction of the last edit — a run only merges with edits of its own kind.
 #[derive(Clone, Copy, PartialEq)]
 enum EditKind {
@@ -641,6 +873,8 @@ pub fn init(cx: &mut App) {
     let ctx = Some("Composer");
     let mut bindings = vec![
         KeyBinding::new("enter", Submit, ctx),
+        KeyBinding::new("tab", MentionTab, ctx),
+        KeyBinding::new("escape", MentionEscape, ctx),
         KeyBinding::new("shift-enter", Newline, ctx),
         KeyBinding::new("backspace", Backspace, ctx),
         KeyBinding::new("delete", Delete, ctx),
@@ -759,6 +993,10 @@ pub fn init(cx: &mut App) {
 pub enum ComposerInputEvent {
     Submitted,
     Edited,
+    CursorMoved,
+    MentionNavigate(isize),
+    MentionAccept,
+    MentionDismiss,
     /// Images pasted from the clipboard (screenshots / copied image data) —
     /// the wrapper stages them as attachments (use-attachments.ts onPaste).
     PastedImages(Vec<gpui::Image>),
@@ -795,6 +1033,8 @@ pub struct ComposerInput {
     content_height: f32,
     max_line_width: f32,
     last_width: f32,
+    /// Raw Markdown → chip display projection from the last layout pass.
+    projection: TextProjection,
     /// Bumped once per `layout_text` pass — the flip logic uses it to apply at
     /// most one compact↔expanded flip per layout (a flip is only re-evaluated
     /// after the input has been measured in the new mode).
@@ -811,6 +1051,10 @@ pub struct ComposerInput {
     /// Kind, trailing offset, and time of the last edit — the merge test that
     /// decides whether the next edit extends the current undo step.
     last_edit: Option<(EditKind, usize, Instant)>,
+    /// The wrapper owns mention state; this only redirects bound keys while a
+    /// mention token is active, keeping input focus and native text editing.
+    mention_open: bool,
+    mention_has_selection: bool,
 }
 
 impl ComposerInput {
@@ -847,6 +1091,7 @@ impl ComposerInput {
             content_height: INPUT_LINE_HEIGHT,
             max_line_width: 0.0,
             last_width: 0.0,
+            projection: TextProjection::default(),
             layout_epoch: 0,
             display_is_placeholder: true,
             blink_anchor: Instant::now(),
@@ -854,6 +1099,8 @@ impl ComposerInput {
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             last_edit: None,
+            mention_open: false,
+            mention_has_selection: false,
         }
     }
 
@@ -889,6 +1136,40 @@ impl ComposerInput {
 
     pub fn text(&self) -> &str {
         &self.content
+    }
+
+    pub fn set_mention_controls(
+        &mut self,
+        open: bool,
+        has_selection: bool,
+        cx: &mut Context<Self>,
+    ) {
+        self.mention_open = open;
+        self.mention_has_selection = has_selection;
+        cx.notify();
+    }
+
+    /// Replace a completed `@query` token as one non-coalescing undo step.
+    pub fn replace_mention(&mut self, range: Range<usize>, path: &str, cx: &mut Context<Self>) {
+        let path = local_file_link(path);
+        let next = self.content[range.end..].chars().next();
+        let existing_separator = next.filter(|ch| ch.is_whitespace() && *ch != '\n' && *ch != '\r');
+        let inserted = if existing_separator.is_some() {
+            path
+        } else {
+            format!("{path} ")
+        };
+        self.record_edit(&range, &inserted);
+        self.content =
+            self.content[..range.start].to_owned() + &inserted + &self.content[range.end..];
+        let cursor =
+            range.start + inserted.len() + existing_separator.map(char::len_utf8).unwrap_or(0);
+        self.selected_range = cursor..cursor;
+        self.selection_reversed = false;
+        self.follow_cursor = true;
+        self.reset_blink();
+        cx.emit(ComposerInputEvent::Edited);
+        cx.notify();
     }
 
     pub fn is_empty(&self) -> bool {
@@ -1016,7 +1297,7 @@ impl ComposerInput {
 
     // ---- editing ops ----
 
-    fn cursor_offset(&self) -> usize {
+    pub fn cursor_offset(&self) -> usize {
         if self.selection_reversed {
             self.selected_range.start
         } else {
@@ -1025,13 +1306,20 @@ impl ComposerInput {
     }
 
     fn move_to(&mut self, offset: usize, cx: &mut Context<Self>) {
+        let offset = TextProjection::new(&self.content)
+            .normalize_range(offset..offset)
+            .start;
         self.selected_range = offset..offset;
         self.follow_cursor = true;
         self.reset_blink();
+        cx.emit(ComposerInputEvent::CursorMoved);
         cx.notify();
     }
 
     fn select_to(&mut self, offset: usize, cx: &mut Context<Self>) {
+        let offset = TextProjection::new(&self.content)
+            .normalize_range(offset..offset)
+            .start;
         if self.selection_reversed {
             self.selected_range.start = offset;
         } else {
@@ -1043,10 +1331,14 @@ impl ComposerInput {
         }
         self.follow_cursor = true;
         self.reset_blink();
+        cx.emit(ComposerInputEvent::CursorMoved);
         cx.notify();
     }
 
     fn previous_boundary(&self, offset: usize) -> usize {
+        if let Some(boundary) = TextProjection::new(&self.content).previous_boundary(offset) {
+            return boundary;
+        }
         self.content
             .grapheme_indices(true)
             .rev()
@@ -1055,6 +1347,9 @@ impl ComposerInput {
     }
 
     fn next_boundary(&self, offset: usize) -> usize {
+        if let Some(boundary) = TextProjection::new(&self.content).next_boundary(offset) {
+            return boundary;
+        }
         self.content
             .grapheme_indices(true)
             .find_map(|(ix, _)| (ix > offset).then_some(ix))
@@ -1062,6 +1357,9 @@ impl ComposerInput {
     }
 
     fn previous_word_boundary(&self, offset: usize) -> usize {
+        if let Some(boundary) = TextProjection::new(&self.content).previous_boundary(offset) {
+            return boundary;
+        }
         self.content
             .split_word_bound_indices()
             .rev()
@@ -1070,6 +1368,9 @@ impl ComposerInput {
     }
 
     fn next_word_boundary(&self, offset: usize) -> usize {
+        if let Some(boundary) = TextProjection::new(&self.content).next_boundary(offset) {
+            return boundary;
+        }
         self.content
             .split_word_bound_indices()
             .find_map(|(ix, word)| {
@@ -1133,12 +1434,20 @@ impl ComposerInput {
     }
 
     fn up(&mut self, _: &Up, _: &mut Window, cx: &mut Context<Self>) {
+        if self.mention_open {
+            cx.emit(ComposerInputEvent::MentionNavigate(-1));
+            return;
+        }
         if let Some(ix) = self.vertical_target(-1.0) {
             self.move_to(ix, cx);
         }
     }
 
     fn down(&mut self, _: &Down, _: &mut Window, cx: &mut Context<Self>) {
+        if self.mention_open {
+            cx.emit(ComposerInputEvent::MentionNavigate(1));
+            return;
+        }
         if let Some(ix) = self.vertical_target(1.0) {
             self.move_to(ix, cx);
         }
@@ -1350,13 +1659,30 @@ impl ComposerInput {
     }
 
     fn submit(&mut self, _: &Submit, _: &mut Window, cx: &mut Context<Self>) {
-        cx.emit(ComposerInputEvent::Submitted);
+        cx.emit(if self.mention_has_selection {
+            ComposerInputEvent::MentionAccept
+        } else {
+            ComposerInputEvent::Submitted
+        });
+    }
+
+    fn mention_tab(&mut self, _: &MentionTab, _: &mut Window, cx: &mut Context<Self>) {
+        if self.mention_has_selection {
+            cx.emit(ComposerInputEvent::MentionAccept);
+        }
+    }
+
+    fn mention_escape(&mut self, _: &MentionEscape, _: &mut Window, cx: &mut Context<Self>) {
+        if self.mention_open {
+            cx.emit(ComposerInputEvent::MentionDismiss);
+        }
     }
 
     // ---- geometry ----
 
     /// Content-local point for a byte index (y grows down from content top).
     fn point_for_index(&self, index: usize) -> Option<Point<Pixels>> {
+        let index = self.projection.raw_to_display(index);
         for (line_ix, line) in self.last_lines.iter().enumerate() {
             let line_start = *self.line_starts.get(line_ix)?;
             let line_len = line.len();
@@ -1394,7 +1720,9 @@ impl ComposerInput {
                 let ix = line
                     .closest_index_for_position(local, self.line_height)
                     .unwrap_or_else(|ix| ix);
-                return (line_start + ix).min(self.content.len());
+                return self
+                    .projection
+                    .display_to_raw((line_start + ix).min(self.projection.display.len()));
             }
             y -= height;
         }
@@ -1584,18 +1912,25 @@ impl ComposerInput {
     /// Shape the text at a width; store measured layout; return content height.
     /// Called from the element's measured-layout closure.
     fn layout_text(&mut self, width: Pixels, style: &TextStyle, window: &mut Window) -> f32 {
+        // Rebuild this even for an empty draft. Otherwise deleting the final
+        // mention can leave its previous paint geometry alive while the
+        // placeholder is already being shaped, tinting "Do anything" for a
+        // frame (or longer when no subsequent layout is requested).
+        self.projection = TextProjection::new(&self.content);
         let (display, is_placeholder) = if self.content.is_empty() {
             (self.placeholder.clone(), true)
         } else {
-            (SharedString::from(self.content.clone()), false)
+            (SharedString::from(self.projection.display.clone()), false)
         };
         let font_size = style.font_size.to_pixels(window.rem_size());
         self.line_height = px(INPUT_LINE_HEIGHT);
 
-        let run_for = |len: usize, underline: bool| TextRun {
+        let run_for = |len: usize, underline: bool, _chip: bool| TextRun {
             len,
             font: style.font(),
             color: style.color,
+            // Rounded mention washes are painted explicitly beneath the text;
+            // TextRun backgrounds are square and can disappear in wrapped runs.
             background_color: None,
             underline: underline.then_some(UnderlineStyle {
                 color: Some(style.color),
@@ -1605,15 +1940,34 @@ impl ComposerInput {
             strikethrough: None,
         };
         let runs: Vec<TextRun> = match self.marked_range.as_ref() {
-            Some(marked) if !is_placeholder => vec![
-                run_for(marked.start, false),
-                run_for(marked.len(), true),
-                run_for(display.len() - marked.end, false),
-            ]
-            .into_iter()
-            .filter(|r| r.len > 0)
-            .collect(),
-            _ => vec![run_for(display.len(), false)],
+            Some(marked) if !is_placeholder => {
+                let start = self.projection.raw_to_display(marked.start);
+                let end = self.projection.raw_to_display(marked.end);
+                vec![
+                    run_for(start, false, false),
+                    run_for(end.saturating_sub(start), true, false),
+                    run_for(display.len() - end, false, false),
+                ]
+                .into_iter()
+                .filter(|r| r.len > 0)
+                .collect()
+            }
+            _ if is_placeholder => vec![run_for(display.len(), false, false)],
+            _ => {
+                let mut runs = Vec::new();
+                let mut at = 0;
+                for (_, chip) in &self.projection.mentions {
+                    if at < chip.start {
+                        runs.push(run_for(chip.start - at, false, false));
+                    }
+                    runs.push(run_for(chip.len(), false, true));
+                    at = chip.end;
+                }
+                if at < display.len() {
+                    runs.push(run_for(display.len() - at, false, false));
+                }
+                runs
+            }
         };
 
         let lines = window
@@ -1687,7 +2041,8 @@ impl EntityInputHandler for ComposerInput {
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) -> Option<String> {
-        let range = self.range_from_utf16(&range_utf16);
+        let range =
+            TextProjection::new(&self.content).normalize_range(self.range_from_utf16(&range_utf16));
         actual_range.replace(self.range_to_utf16(&range));
         Some(self.content.get(range)?.to_string())
     }
@@ -1698,6 +2053,8 @@ impl EntityInputHandler for ComposerInput {
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) -> Option<UTF16Selection> {
+        self.selected_range =
+            TextProjection::new(&self.content).normalize_range(self.selected_range.clone());
         Some(UTF16Selection {
             range: self.range_to_utf16(&self.selected_range),
             reversed: self.selection_reversed,
@@ -1726,6 +2083,7 @@ impl EntityInputHandler for ComposerInput {
             .map(|r| self.range_from_utf16(r))
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
+        let range = TextProjection::new(&self.content).normalize_range(range);
         // An IME commit is the tail of a composition whose pre-composition
         // snapshot was already taken (`replace_and_mark_text_in_range`);
         // recording here would pin undo to the half-composed text instead.
@@ -1756,6 +2114,7 @@ impl EntityInputHandler for ComposerInput {
             .map(|r| self.range_from_utf16(r))
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
+        let range = TextProjection::new(&self.content).normalize_range(range);
         // First keystroke of a composition: snapshot the text as it stood
         // before any of it existed, so one undo drops the whole composition.
         if self.marked_range.is_none() {
@@ -1791,7 +2150,8 @@ impl EntityInputHandler for ComposerInput {
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) -> Option<Bounds<Pixels>> {
-        let range = self.range_from_utf16(&range_utf16);
+        let range =
+            TextProjection::new(&self.content).normalize_range(self.range_from_utf16(&range_utf16));
         let start = self.point_for_index(range.start)?;
         let origin = point(
             bounds.left() + start.x,
@@ -1820,6 +2180,7 @@ struct ComposerTextElement {
 
 struct ComposerTextPrepaint {
     cursor: Option<PaintQuad>,
+    mention_quads: Vec<PaintQuad>,
     selection_quads: Vec<PaintQuad>,
 }
 
@@ -1884,7 +2245,34 @@ impl gpui::Element for ComposerTextElement {
         let scroll = px(input.scroll_top);
         let origin = point(bounds.left(), bounds.top() - scroll);
         let selection_color = gpui::hsla(0.66, 0.6, 0.55, 0.35);
+        let mention_color = Theme::of(cx).accent.opacity(0.22);
 
+        let mut mention_quads = Vec::new();
+        for (mention, _) in &input.projection.mentions {
+            let (Some(start), Some(end)) = (
+                input.point_for_index(mention.range.start),
+                input.point_for_index(mention.range.end),
+            ) else {
+                continue;
+            };
+            if start.y != end.y {
+                continue;
+            }
+            mention_quads.push(quad(
+                Bounds::from_corners(
+                    point(origin.x + start.x, origin.y + start.y + px(2.0)),
+                    point(
+                        origin.x + end.x,
+                        origin.y + start.y + input.line_height - px(2.0),
+                    ),
+                ),
+                px(5.0),
+                mention_color,
+                px(0.0),
+                gpui::transparent_black(),
+                BorderStyle::default(),
+            ));
+        }
         let mut selection_quads = Vec::new();
         let mut cursor = None;
         if input.selected_range.is_empty() || input.display_is_placeholder {
@@ -1944,6 +2332,7 @@ impl gpui::Element for ComposerTextElement {
         }
         ComposerTextPrepaint {
             cursor,
+            mention_quads,
             selection_quads,
         }
     }
@@ -1982,6 +2371,9 @@ impl gpui::Element for ComposerTextElement {
         });
 
         window.with_content_mask(Some(gpui::ContentMask { bounds }), |window| {
+            for quad in prepaint.mention_quads.drain(..) {
+                window.paint_quad(quad);
+            }
             for quad in prepaint.selection_quads.drain(..) {
                 window.paint_quad(quad);
             }
@@ -2048,6 +2440,8 @@ impl Render for ComposerInput {
             .on_action(cx.listener(Self::select_doc_end))
             .on_action(cx.listener(Self::word_left))
             .on_action(cx.listener(Self::word_right))
+            .on_action(cx.listener(Self::mention_tab))
+            .on_action(cx.listener(Self::mention_escape))
             .on_action(cx.listener(Self::select_word_left))
             .on_action(cx.listener(Self::select_word_right))
             .on_action(cx.listener(Self::delete_word_left))
@@ -2090,6 +2484,57 @@ pub enum ComposerEvent {
     Sent { chat_id: String },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MentionToken {
+    range: Range<usize>,
+    query: String,
+}
+
+/// The `@` must begin a token. This intentionally excludes `name@example.com`
+/// and ordinary words while allowing punctuation such as `(@src`.
+fn mention_token(text: &str, cursor: usize) -> Option<MentionToken> {
+    if cursor > text.len() || !text.is_char_boundary(cursor) {
+        return None;
+    }
+    let token_start = text[..cursor]
+        .char_indices()
+        .rev()
+        .find_map(|(at, ch)| ch.is_whitespace().then_some(at + ch.len_utf8()))
+        .unwrap_or(0);
+    let Some(relative_at) = text[token_start..cursor].rfind('@') else {
+        return None;
+    };
+    let at = token_start + relative_at;
+    let valid_boundary = at == 0
+        || text[..at]
+            .chars()
+            .next_back()
+            .is_some_and(|ch| ch.is_whitespace() || matches!(ch, '(' | '[' | '{'));
+    if text[at + 1..cursor].contains('@') || !valid_boundary {
+        return None;
+    }
+    let end = text[cursor..]
+        .char_indices()
+        .find_map(|(at, ch)| ch.is_whitespace().then_some(cursor + at))
+        .unwrap_or(text.len());
+    Some(MentionToken {
+        range: at..end,
+        query: text[at + 1..cursor].to_string(),
+    })
+}
+
+#[derive(Debug, Clone, Default)]
+struct FileMentionState {
+    token: Option<MentionToken>,
+    results: Vec<FileSearchMatch>,
+    active: Option<usize>,
+    request: u64,
+    loading: bool,
+    /// Full token text, not just the cursor-relative query: moving within a
+    /// dismissed token keeps it closed, while any edit re-enables completion.
+    dismissed: Option<(Range<usize>, String)>,
+}
+
 pub struct Composer {
     state: Entity<AppState>,
     input: Entity<ComposerInput>,
@@ -2104,6 +2549,8 @@ pub struct Composer {
     preview: Option<attachments::PreviewImage>,
     /// In-flight file-picker prompt (paperclip).
     picker_task: Option<Task<()>>,
+    mention_task: Option<Task<()>>,
+    mention: FileMentionState,
     current_key: String,
     sending: bool,
     failure: Option<SharedString>,
@@ -2161,7 +2608,12 @@ impl Composer {
         let observe = cx.observe(&state, |this: &mut Self, _, cx| this.on_state_changed(cx));
         let input_events = cx.subscribe(&input, |this: &mut Self, _, event, cx| match event {
             ComposerInputEvent::Submitted => this.on_submit(cx),
-            ComposerInputEvent::Edited => cx.notify(),
+            ComposerInputEvent::Edited | ComposerInputEvent::CursorMoved => {
+                this.on_input_edited(cx)
+            }
+            ComposerInputEvent::MentionNavigate(delta) => this.move_mention(*delta, cx),
+            ComposerInputEvent::MentionAccept => this.accept_mention(cx),
+            ComposerInputEvent::MentionDismiss => this.dismiss_mention(cx),
             ComposerInputEvent::PastedImages(images) => {
                 let staged = images
                     .iter()
@@ -2180,6 +2632,8 @@ impl Composer {
             attachments: HashMap::new(),
             preview: None,
             picker_task: None,
+            mention_task: None,
+            mention: FileMentionState::default(),
             current_key,
             sending: false,
             failure: None,
@@ -2393,6 +2847,248 @@ impl Composer {
         }));
     }
 
+    fn sync_mention_controls(&mut self, cx: &mut Context<Self>) {
+        let open = self.mention.token.is_some();
+        let has_selection = self.mention.active.is_some();
+        self.input.update(cx, |input, cx| {
+            input.set_mention_controls(open, has_selection, cx)
+        });
+    }
+
+    fn on_input_edited(&mut self, cx: &mut Context<Self>) {
+        let (text, cursor) = {
+            let input = self.input.read(cx);
+            (input.text().to_string(), input.cursor_offset())
+        };
+        let token = mention_token(&text, cursor);
+        let still_dismissed = token.as_ref().is_some_and(|token| {
+            self.mention
+                .dismissed
+                .as_ref()
+                .is_some_and(|(range, value)| {
+                    token.range == *range && text.get(range.clone()) == Some(value.as_str())
+                })
+        });
+        if still_dismissed {
+            self.mention.token = None;
+            self.sync_mention_controls(cx);
+            cx.notify();
+            return;
+        }
+        self.mention.dismissed = None;
+        if token == self.mention.token {
+            self.sync_mention_controls(cx);
+            cx.notify();
+            return;
+        }
+        self.mention.request = self.mention.request.wrapping_add(1);
+        self.mention.token = token.clone();
+        self.mention.results.clear();
+        self.mention.active = None;
+        self.mention.loading = token.is_some();
+        self.sync_mention_controls(cx);
+        let Some(token) = token else {
+            cx.notify();
+            return;
+        };
+        let Some(engine) = self.state.read(cx).engine().cloned() else {
+            self.mention.loading = false;
+            cx.notify();
+            return;
+        };
+        let selected_worktree = match self.pickers.read(cx).checkout_plan() {
+            crate::pickers::CheckoutPlan::ReuseWorktree { path, .. } => Some(path),
+            _ => None,
+        };
+        let (params, target) = {
+            let state = self.state.read(cx);
+            let mut params = serde_json::Map::new();
+            params.insert("query".into(), token.query.clone().into());
+            let target = if let Some(chat) = state.selected_chat_row() {
+                params.insert("chatId".into(), chat.id.clone().into());
+                Some(chat.device_id.clone())
+            } else if let Some(space) = state.selected_space_row() {
+                params.insert("spaceId".into(), space.id.clone().into());
+                if let Some(path) = selected_worktree {
+                    params.insert("path".into(), path.into());
+                }
+                Some(space.device_id.clone())
+            } else {
+                None
+            };
+            if let Some(target) = &target {
+                params.insert("targetDeviceId".into(), target.clone().into());
+            }
+            (serde_json::Value::Object(params), target)
+        };
+        if target.is_none() {
+            self.mention.loading = false;
+            cx.notify();
+            return;
+        }
+        let request = self.mention.request;
+        self.mention_task = Some(cx.spawn(async move |this, cx| {
+            // A short debounce prevents one full workspace walk per keystroke
+            // during normal typing. The generation check below still guards
+            // requests that were already in flight when the query changed.
+            cx.background_executor()
+                .timer(Duration::from_millis(80))
+                .await;
+            let result = engine.client().call(methods::SEARCH_FILES, params).await;
+            this.update(cx, |composer, cx| {
+                if composer.mention.request != request {
+                    return;
+                }
+                composer.mention.loading = false;
+                match result {
+                    Ok(value) => match serde_json::from_value::<Vec<FileSearchMatch>>(value) {
+                        Ok(results) => {
+                            composer.mention.active = (!results.is_empty()).then_some(0);
+                            composer.mention.results = results;
+                        }
+                        Err(err) => tracing::warn!(%err, "file mention response decode failed"),
+                    },
+                    Err(err) => tracing::debug!(%err, "file mention search failed"),
+                }
+                composer.sync_mention_controls(cx);
+                cx.notify();
+            })
+            .ok();
+        }));
+        cx.notify();
+    }
+
+    fn move_mention(&mut self, delta: isize, cx: &mut Context<Self>) {
+        let count = self.mention.results.len();
+        if count > 0 {
+            self.mention.active = Some(
+                (self.mention.active.unwrap_or(0) as isize + delta).rem_euclid(count as isize)
+                    as usize,
+            );
+        }
+        self.sync_mention_controls(cx);
+        cx.notify();
+    }
+
+    fn dismiss_mention(&mut self, cx: &mut Context<Self>) {
+        let dismissed = self.mention.token.as_ref().and_then(|token| {
+            self.input
+                .read(cx)
+                .text()
+                .get(token.range.clone())
+                .map(|text| (token.range.clone(), text.to_string()))
+        });
+        self.mention.dismissed = dismissed;
+        self.mention.token = None;
+        self.mention.results.clear();
+        self.mention.active = None;
+        self.mention.loading = false;
+        self.sync_mention_controls(cx);
+        cx.notify();
+    }
+
+    fn accept_mention(&mut self, cx: &mut Context<Self>) {
+        let Some(token) = self.mention.token.clone() else {
+            return;
+        };
+        let Some(path) = self
+            .mention
+            .active
+            .and_then(|active| self.mention.results.get(active))
+            .map(|result| result.path.clone())
+        else {
+            return;
+        };
+        self.input.update(cx, |input, cx| {
+            input.replace_mention(token.range, &path, cx)
+        });
+        self.mention = FileMentionState::default();
+        self.sync_mention_controls(cx);
+        cx.notify();
+    }
+
+    fn render_file_mention_popup(
+        &self,
+        theme: &Theme,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        let token = self.mention.token.as_ref()?;
+        let mut card = crate::popover::popover_card(theme)
+            .w(px(380.0))
+            .max_h(px(280.0))
+            .overflow_hidden();
+        if self.mention.loading {
+            card = card.child(crate::popover::skeleton_rows(
+                "file-mention-loading",
+                theme,
+                3,
+            ));
+        } else if self.mention.results.is_empty() {
+            card = card.child(
+                div()
+                    .px(px(12.0))
+                    .py(px(10.0))
+                    .text_size(px(12.0))
+                    .text_color(theme.text_muted)
+                    .child(if token.query.is_empty() {
+                        "No files available"
+                    } else {
+                        "No matching files"
+                    }),
+            );
+        } else {
+            for (ix, result) in self.mention.results.iter().enumerate() {
+                let selected = self.mention.active == Some(ix);
+                let path = result.path.clone();
+                card = card.child(
+                    div()
+                        .id(("file-mention-result", ix))
+                        .px(px(10.0))
+                        .py(px(7.0))
+                        .rounded(px(8.0))
+                        .cursor_pointer()
+                        .bg(if selected {
+                            crate::theme::white_alpha(0.10)
+                        } else {
+                            gpui::transparent_black()
+                        })
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.mention.active = Some(ix);
+                            this.accept_mention(cx);
+                        }))
+                        .child(
+                            div()
+                                .flex()
+                                .flex_row()
+                                .items_center()
+                                .gap(px(8.0))
+                                .child(
+                                    crate::icons::icon(if result.is_dir {
+                                        crate::icons::FOLDER
+                                    } else {
+                                        crate::icons::DOCUMENT
+                                    })
+                                    .size(px(14.0))
+                                    .text_color(theme.text_muted),
+                                )
+                                .child(
+                                    div()
+                                        .min_w_0()
+                                        .flex_1()
+                                        .text_size(px(12.5))
+                                        .text_color(theme.text)
+                                        .child(path),
+                                ),
+                        ),
+                );
+            }
+        }
+        Some(crate::popover::anchored_menu_above(
+            "file-mention-popup",
+            card.into_any_element(),
+        ))
+    }
+
     fn on_state_changed(&mut self, cx: &mut Context<Self>) {
         let (key, pending) = {
             let s = self.state.read(cx);
@@ -2417,6 +3113,8 @@ impl Composer {
             // Attachments stay stashed under their chat key (the map swap IS
             // the navigation); only the transient chrome resets.
             self.preview = None;
+            self.mention = FileMentionState::default();
+            self.sync_mention_controls(cx);
             // Route changes snap (round 5/6): a mode difference between the
             // old and new session's composer must not glide across
             // navigation. Killing the in-flight morph here isn't enough —
@@ -3563,7 +4261,12 @@ impl Render for Composer {
                         .px(px(16.0))
                         .pt(px(text_pt))
                         .pb(px(4.0))
-                        .child(self.input.clone()),
+                        .child(
+                            div()
+                                .relative()
+                                .child(self.input.clone())
+                                .children(self.render_file_mention_popup(&theme, cx)),
+                        ),
                 )
                 .child(
                     div()
@@ -3621,7 +4324,12 @@ impl Render for Composer {
                                 .pr(px(8.0))
                                 .relative()
                                 .top(px(-text_glide))
-                                .child(self.input.clone()),
+                                .child(
+                                    div()
+                                        .relative()
+                                        .child(self.input.clone())
+                                        .children(self.render_file_mention_popup(&theme, cx)),
+                                ),
                         )
                         .child(
                             div()
@@ -3680,6 +4388,69 @@ impl Render for Composer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mention_token_requires_a_token_boundary_and_tracks_full_token() {
+        assert_eq!(
+            mention_token("Fix @src/com", 12),
+            Some(MentionToken {
+                range: 4..12,
+                query: "src/com".into(),
+            })
+        );
+        assert!(mention_token("mail@example.com", 16).is_none());
+        assert!(mention_token("word@file", 9).is_none());
+        assert!(mention_token("path/@file", 10).is_none());
+        assert_eq!(
+            mention_token("See (@lib", 9).map(|token| token.range),
+            Some(5..9)
+        );
+    }
+
+    #[test]
+    fn file_mentions_serialize_to_strict_local_markdown() {
+        let raw = local_file_link("src/a file#[x].rs");
+        assert_eq!(raw, "[a file#\\[x\\].rs](src/a%20file%23%5Bx%5D.rs)");
+        let links = file_mention_links(&raw);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].path, "src/a file#[x].rs");
+        assert_eq!(links[0].basename, "a file#[x].rs");
+    }
+
+    #[test]
+    fn file_mentions_reject_external_or_noncanonical_markdown() {
+        assert!(file_mention_links("[site](https://example.com/a)").is_empty());
+        assert!(file_mention_links("[a.rs](../a.rs)").is_empty());
+        assert!(file_mention_links("[a.rs](src/a file.rs)").is_empty());
+        assert!(file_mention_links("[other](src/a.rs)").is_empty());
+        assert!(file_mention_links("[a.rs](src%5Cfake%5Ca.rs)").is_empty());
+        assert!(file_mention_links("[a.rs](src/a%0A.rs)").is_empty());
+    }
+
+    #[test]
+    fn projection_maps_and_expands_atomic_chip_ranges() {
+        let raw = format!("open {} now", local_file_link("src/composer.rs"));
+        let projection = TextProjection::new(&raw);
+        let (link, chip) = &projection.mentions[0];
+        assert_eq!(
+            &projection.display[chip.clone()],
+            "\u{00A0}composer.rs\u{00A0}"
+        );
+        assert_eq!(projection.display_to_raw(chip.start + 1), link.range.start);
+        assert_eq!(projection.display_to_raw(chip.end - 1), link.range.end);
+        assert_eq!(
+            projection.previous_boundary(link.range.end),
+            Some(link.range.start)
+        );
+        assert_eq!(
+            projection.next_boundary(link.range.start),
+            Some(link.range.end)
+        );
+        assert_eq!(
+            projection.normalize_range(link.range.start + 2..link.range.end - 2),
+            link.range
+        );
+    }
 
     fn question(id: &str, options: &[&str], multi: bool) -> UserInputQuestion {
         UserInputQuestion {

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -10,12 +10,13 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use gpui::{
-    App, BorderStyle, Bounds, ClipboardEntry, ClipboardItem, Context, CursorStyle, DispatchPhase,
-    ElementInputHandler, Entity, EntityInputHandler, EventEmitter, FocusHandle, Focusable,
-    GlobalElementId, KeyBinding, KeyDownEvent, LayoutId, MouseButton, MouseDownEvent,
+    AnyTooltip, App, BorderStyle, Bounds, ClipboardEntry, ClipboardItem, Context, CursorStyle,
+    DispatchPhase, ElementInputHandler, Entity, EntityInputHandler, EventEmitter, FocusHandle,
+    Focusable, GlobalElementId, KeyBinding, KeyDownEvent, LayoutId, MouseButton, MouseDownEvent,
     MouseMoveEvent, MouseUpEvent, ObjectFit, PaintQuad, PathPromptOptions, Pixels, Point,
     ScrollWheelEvent, SharedString, Style, StyledImage as _, Subscription, Task, TextRun,
     TextStyle, UTF16Selection, UnderlineStyle, Window, WrappedLine, actions, div, fill, img, point,
@@ -622,6 +623,12 @@ const UNDO_COALESCE: Duration = Duration::from_millis(700);
 /// Cap on retained undo steps — a long-lived composer must not grow forever.
 const UNDO_LIMIT: usize = 200;
 
+/// Invisible but shaped em-space reserved for the SVG painted beside every
+/// mention label. Keeping this in the projection makes the icon participate in
+/// wrapping, hit testing, and selection without changing the raw Markdown.
+const MENTION_ICON_SLOT: &str = "\u{2003}";
+const MENTION_SIDE_PAD: &str = "\u{00A0}";
+
 /// A restorable point in the input's history: text plus where the caret and
 /// selection sat when the edit landed.
 #[derive(Clone)]
@@ -639,6 +646,7 @@ struct FileMentionLink {
     range: Range<usize>,
     basename: String,
     path: String,
+    is_dir: bool,
 }
 
 fn percent_encode_path(path: &str) -> String {
@@ -678,7 +686,8 @@ fn escape_mention_label(label: &str) -> String {
         .replace(']', "\\]")
 }
 
-fn local_file_link(path: &str) -> String {
+fn local_file_link(path: &str, is_dir: bool) -> String {
+    let path = path.trim_end_matches('/');
     let basename = path
         .rsplit('/')
         .next()
@@ -687,7 +696,7 @@ fn local_file_link(path: &str) -> String {
     format!(
         "[{}]({})",
         escape_mention_label(basename),
-        percent_encode_path(path)
+        percent_encode_path(&format!("{path}{}", if is_dir { "/" } else { "" }))
     )
 }
 
@@ -732,20 +741,24 @@ fn file_mention_links(text: &str) -> Vec<FileMentionLink> {
         let end = target_start + relative_end + 1;
         let label = &text[start + 1..label_end];
         let encoded = &text[target_start..end - 1];
-        let parsed = percent_decode_path(encoded).filter(|path| {
-            local_path_is_safe(path)
-                && percent_encode_path(path) == encoded
+        let parsed = percent_decode_path(encoded).and_then(|target| {
+            let is_dir = target.ends_with('/');
+            let path = target.strip_suffix('/').unwrap_or(&target);
+            (local_path_is_safe(path)
+                && percent_encode_path(&target) == encoded
                 && path
                     .rsplit('/')
                     .next()
-                    .is_some_and(|basename| escape_mention_label(basename) == label)
+                    .is_some_and(|basename| escape_mention_label(basename) == label))
+            .then(|| (path.to_string(), is_dir))
         });
-        if let Some(path) = parsed {
+        if let Some((path, is_dir)) = parsed {
             let basename = path.rsplit('/').next().unwrap_or_default().to_string();
             links.push(FileMentionLink {
                 range: start..end,
                 basename,
                 path,
+                is_dir,
             });
         }
         search = end;
@@ -767,10 +780,12 @@ impl TextProjection {
         for link in links {
             projection.display.push_str(&raw[raw_at..link.range.start]);
             let display_start = projection.display.len();
-            // Text runs cannot host a rounded inline element, but non-breaking
-            // side bearings give the tinted run the compact padding of a chip
-            // and keep names containing spaces together when the line wraps.
-            projection.display.push('\u{00A0}');
+            // Text runs cannot host an inline element. Reserve a stable
+            // em-space for the SVG which `ComposerTextElement::paint`
+            // draws into, then retain non-breaking side bearings around it.
+            projection.display.push_str(MENTION_SIDE_PAD);
+            projection.display.push_str(MENTION_ICON_SLOT);
+            projection.display.push('\u{202F}');
             for ch in link.basename.chars() {
                 projection
                     .display
@@ -1150,8 +1165,14 @@ impl ComposerInput {
     }
 
     /// Replace a completed `@query` token as one non-coalescing undo step.
-    pub fn replace_mention(&mut self, range: Range<usize>, path: &str, cx: &mut Context<Self>) {
-        let path = local_file_link(path);
+    pub fn replace_mention(
+        &mut self,
+        range: Range<usize>,
+        path: &str,
+        is_dir: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let path = local_file_link(path, is_dir);
         let next = self.content[range.end..].chars().next();
         let existing_separator = next.filter(|ch| ch.is_whitespace() && *ch != '\n' && *ch != '\r');
         let inserted = if existing_separator.is_some() {
@@ -1682,7 +1703,13 @@ impl ComposerInput {
 
     /// Content-local point for a byte index (y grows down from content top).
     fn point_for_index(&self, index: usize) -> Option<Point<Pixels>> {
-        let index = self.projection.raw_to_display(index);
+        self.point_for_display_index(self.projection.raw_to_display(index))
+    }
+
+    /// Content-local point for a shaped projection byte index. The icon layer
+    /// uses this to occupy its explicit projection slot without inventing a
+    /// second coordinate system beside the custom text editor.
+    fn point_for_display_index(&self, index: usize) -> Option<Point<Pixels>> {
         for (line_ix, line) in self.last_lines.iter().enumerate() {
             let line_start = *self.line_starts.get(line_ix)?;
             let line_len = line.len();
@@ -2178,9 +2205,31 @@ struct ComposerTextElement {
     max_content_height: f32,
 }
 
+struct MentionPathTooltip {
+    path: SharedString,
+}
+
+impl Render for MentionPathTooltip {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = Theme::of(cx);
+        div()
+            .px(px(8.0))
+            .py(px(5.0))
+            .rounded(px(5.0))
+            .border_1()
+            .border_color(theme.border_strong)
+            .bg(theme.surface_raised)
+            .font_family(theme.font_mono.clone())
+            .text_size(px(11.0))
+            .text_color(theme.text_muted)
+            .child(self.path.clone())
+    }
+}
+
 struct ComposerTextPrepaint {
     cursor: Option<PaintQuad>,
     mention_quads: Vec<PaintQuad>,
+    mention_icons: Vec<(Bounds<Pixels>, &'static str)>,
     selection_quads: Vec<PaintQuad>,
 }
 
@@ -2234,7 +2283,7 @@ impl gpui::Element for ComposerTextElement {
         _inspector_id: Option<&gpui::InspectorElementId>,
         bounds: Bounds<Pixels>,
         _state: &mut Self::RequestLayoutState,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut App,
     ) -> Self::PrepaintState {
         self.input.update(cx, |input, _| {
@@ -2248,7 +2297,9 @@ impl gpui::Element for ComposerTextElement {
         let mention_color = Theme::of(cx).accent.opacity(0.22);
 
         let mut mention_quads = Vec::new();
-        for (mention, _) in &input.projection.mentions {
+        let mut mention_icons = Vec::new();
+        let mut hovered_mention = None;
+        for (mention, display) in &input.projection.mentions {
             let (Some(start), Some(end)) = (
                 input.point_for_index(mention.range.start),
                 input.point_for_index(mention.range.end),
@@ -2258,19 +2309,59 @@ impl gpui::Element for ComposerTextElement {
             if start.y != end.y {
                 continue;
             }
-            mention_quads.push(quad(
-                Bounds::from_corners(
-                    point(origin.x + start.x, origin.y + start.y + px(2.0)),
-                    point(
-                        origin.x + end.x,
-                        origin.y + start.y + input.line_height - px(2.0),
-                    ),
+            let chip_bounds = Bounds::from_corners(
+                point(origin.x + start.x, origin.y + start.y + px(2.0)),
+                point(
+                    origin.x + end.x,
+                    origin.y + start.y + input.line_height - px(2.0),
                 ),
+            );
+            mention_quads.push(quad(
+                chip_bounds,
                 px(5.0),
                 mention_color,
                 px(0.0),
                 gpui::transparent_black(),
                 BorderStyle::default(),
+            ));
+            if bounds.contains(&window.mouse_position())
+                && chip_bounds.contains(&window.mouse_position())
+            {
+                hovered_mention = Some((
+                    chip_bounds,
+                    SharedString::from(format!(
+                        "{}{}",
+                        mention.path,
+                        if mention.is_dir { "/" } else { "" }
+                    )),
+                ));
+            }
+            let slot_start = display.start + MENTION_SIDE_PAD.len();
+            let slot_end = slot_start + MENTION_ICON_SLOT.len();
+            let (Some(slot_start), Some(slot_end)) = (
+                input.point_for_display_index(slot_start),
+                input.point_for_display_index(slot_end),
+            ) else {
+                continue;
+            };
+            if slot_start.y != slot_end.y {
+                continue;
+            }
+            let slot_width = (slot_end.x - slot_start.x).max(px(8.0));
+            let icon_size = slot_width.min(px(12.0));
+            mention_icons.push((
+                Bounds::new(
+                    point(
+                        origin.x + slot_start.x + (slot_width - icon_size) / 2.0,
+                        origin.y + slot_start.y + (input.line_height - icon_size) / 2.0,
+                    ),
+                    size(icon_size, icon_size),
+                ),
+                if mention.is_dir {
+                    crate::icons::FOLDER
+                } else {
+                    crate::icons::DOCUMENT
+                },
             ));
         }
         let mut selection_quads = Vec::new();
@@ -2330,9 +2421,20 @@ impl gpui::Element for ComposerTextElement {
                 ));
             }
         }
+        if let Some((chip_bounds, path)) = hovered_mention {
+            let view = cx.new(|_| MentionPathTooltip { path }).into();
+            window.set_tooltip(AnyTooltip {
+                view,
+                mouse_position: window.mouse_position(),
+                check_visible_and_update: Rc::new(move |_, window, _| {
+                    chip_bounds.contains(&window.mouse_position())
+                }),
+            });
+        }
         ComposerTextPrepaint {
             cursor,
             mention_quads,
+            mention_icons,
             selection_quads,
         }
     }
@@ -2354,9 +2456,15 @@ impl gpui::Element for ComposerTextElement {
             cx,
         );
         let input = self.input.clone();
-        window.on_mouse_event(move |event: &MouseMoveEvent, phase, _, cx| {
-            if phase == DispatchPhase::Bubble && event.pressed_button == Some(MouseButton::Left) {
-                input.update(cx, |input, cx| input.on_mouse_move(event, cx));
+        window.on_mouse_event(move |event: &MouseMoveEvent, phase, window, cx| {
+            if phase == DispatchPhase::Bubble {
+                if event.pressed_button == Some(MouseButton::Left) {
+                    input.update(cx, |input, cx| input.on_mouse_move(event, cx));
+                } else {
+                    // Hover-only movement does not mutate the input entity, so
+                    // explicitly refresh to update mention tooltip hit testing.
+                    window.refresh();
+                }
             }
         });
 
@@ -2389,6 +2497,18 @@ impl gpui::Element for ComposerTextElement {
                     cx,
                 );
                 y += height;
+            }
+            // The icon paints after the filename text so selection washes and
+            // glyphs cannot cover it; its em-space slot is blank text.
+            for (bounds, icon) in prepaint.mention_icons.drain(..) {
+                let _ = window.paint_svg(
+                    bounds,
+                    SharedString::from(icon),
+                    None,
+                    gpui::TransformationMatrix::default(),
+                    Theme::of(cx).text_muted,
+                    cx,
+                );
             }
             // Caret only when this input is actually focused in an active
             // window (Electron hides it on window deactivation too), and only
@@ -2991,16 +3111,16 @@ impl Composer {
         let Some(token) = self.mention.token.clone() else {
             return;
         };
-        let Some(path) = self
+        let Some((path, is_dir)) = self
             .mention
             .active
             .and_then(|active| self.mention.results.get(active))
-            .map(|result| result.path.clone())
+            .map(|result| (result.path.clone(), result.is_dir))
         else {
             return;
         };
         self.input.update(cx, |input, cx| {
-            input.replace_mention(token.range, &path, cx)
+            input.replace_mention(token.range, &path, is_dir, cx)
         });
         self.mention = FileMentionState::default();
         self.sync_mention_controls(cx);
@@ -4409,12 +4529,19 @@ mod tests {
 
     #[test]
     fn file_mentions_serialize_to_strict_local_markdown() {
-        let raw = local_file_link("src/a file#[x].rs");
+        let raw = local_file_link("src/a file#[x].rs", false);
         assert_eq!(raw, "[a file#\\[x\\].rs](src/a%20file%23%5Bx%5D.rs)");
         let links = file_mention_links(&raw);
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].path, "src/a file#[x].rs");
         assert_eq!(links[0].basename, "a file#[x].rs");
+        assert!(!links[0].is_dir);
+
+        let folder = local_file_link("src/components", true);
+        assert_eq!(folder, "[components](src/components/)");
+        let links = file_mention_links(&folder);
+        assert_eq!(links[0].path, "src/components");
+        assert!(links[0].is_dir);
     }
 
     #[test]
@@ -4429,12 +4556,17 @@ mod tests {
 
     #[test]
     fn projection_maps_and_expands_atomic_chip_ranges() {
-        let raw = format!("open {} now", local_file_link("src/composer.rs"));
+        let raw = format!("open {} now", local_file_link("src/composer.rs", false));
         let projection = TextProjection::new(&raw);
         let (link, chip) = &projection.mentions[0];
         assert_eq!(
             &projection.display[chip.clone()],
-            "\u{00A0}composer.rs\u{00A0}"
+            "\u{00A0}\u{2003}\u{202F}composer.rs\u{00A0}"
+        );
+        assert_eq!(
+            &projection.display[chip.start + MENTION_SIDE_PAD.len()
+                ..chip.start + MENTION_SIDE_PAD.len() + MENTION_ICON_SLOT.len()],
+            MENTION_ICON_SLOT
         );
         assert_eq!(projection.display_to_raw(chip.start + 1), link.range.start);
         assert_eq!(projection.display_to_raw(chip.end - 1), link.range.end);

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -881,7 +881,7 @@ fn register_selection_listeners(
 /// text's own geometry. `pad_x` overhangs the box horizontally (inline code);
 /// `inset_y` shrinks it vertically — both 0 for a selection wash, which wants
 /// full-line-height boxes that tile seamlessly across wrapped rows.
-fn range_rects(
+pub(crate) fn range_rects(
     layout: &gpui::TextLayout,
     range: &Range<usize>,
     pad_x: f32,

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -317,7 +317,12 @@ impl Pickers {
             }
             ComposerInputEvent::Submitted => this.on_search_submit(cx),
             // Pasted images/files don't apply to a search box.
-            ComposerInputEvent::PastedImages(_) | ComposerInputEvent::PastedPaths(_) => {}
+            ComposerInputEvent::PastedImages(_)
+            | ComposerInputEvent::PastedPaths(_)
+            | ComposerInputEvent::CursorMoved
+            | ComposerInputEvent::MentionNavigate(_)
+            | ComposerInputEvent::MentionAccept
+            | ComposerInputEvent::MentionDismiss => {}
         });
         // Chat selection / config changes must re-render the chips (child views
         // only re-render on their own notify). A selection change also drops

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -320,6 +320,7 @@ impl Pickers {
             ComposerInputEvent::PastedImages(_)
             | ComposerInputEvent::PastedPaths(_)
             | ComposerInputEvent::CursorMoved
+            | ComposerInputEvent::ViewportChanged
             | ComposerInputEvent::MentionNavigate(_)
             | ComposerInputEvent::MentionAccept
             | ComposerInputEvent::MentionDismiss => {}

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -226,6 +226,23 @@ pub fn anchored_menu_above(id: impl Into<ElementId>, content: AnyElement) -> Any
     )
 }
 
+/// Open an upward menu at a point inside a relative trigger. Useful for text
+/// completions, whose natural anchor is the token/caret rather than the input
+/// element's outer edge.
+pub fn anchored_menu_above_at(
+    id: impl Into<ElementId>,
+    position: Point<Pixels>,
+    content: AnyElement,
+) -> AnyElement {
+    div()
+        .absolute()
+        .left(position.x)
+        .top(position.y)
+        .size_0()
+        .child(anchored_menu_above(id, content))
+        .into_any_element()
+}
+
 /// [`anchored_menu_above`] right-aligned to the trigger's right edge (t3code
 /// ComboboxPopup `align="end"` — right-side triggers like the composer's ref
 /// picker open leftward instead of running off the window).

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -30,9 +30,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use gpui::{
-    AnyElement, ClipboardItem, Context, Entity, ListAlignment, ListScrollEvent, ListState,
-    ObjectFit, SharedString, StyledImage as _, Subscription, Task, Window, div, img, list,
-    prelude::*, px,
+    AnyElement, BorderStyle, Bounds, ClipboardItem, Context, Entity, ListAlignment,
+    ListScrollEvent, ListState, ObjectFit, SharedString, StyledImage as _, StyledText,
+    Subscription, Task, TextRun, Window, canvas, div, img, list, point, prelude::*, px, quad, size,
 };
 
 use comet_doc::{MessagePart, MessageRole, MessageStatus, SessionMessageEntry};
@@ -198,8 +198,14 @@ pub struct ToolItem {
 #[derive(Clone)]
 pub enum RowKind {
     User {
-        /// Visible prompt (attachment-ref trailer already stripped).
+        /// Visible prompt (attachment-ref trailer already stripped). When the
+        /// prompt carries file mentions this is the *projected* display text —
+        /// chip labels in place of the raw Markdown links.
         text: SharedString,
+        /// File-mention chips over `text`, in display-byte terms. Computed
+        /// once per entry change in [`rows_for_entry`] (rows are cached by
+        /// fingerprint), never per frame. Empty for ordinary prompts.
+        mentions: Arc<Vec<crate::composer::SentMentionSpan>>,
         /// Image refs parsed out of the message text (message-attachments.ts):
         /// thumbnails load from the owning device via ReadAttachmentChunk.
         attachments: Arc<Vec<crate::attachments::UserImageAttachment>>,
@@ -319,12 +325,20 @@ pub fn rows_for_entry(
         // Attachment refs ride the plain text (the `withAttachments`
         // transport); split them back out for the thumbnail strip.
         let parsed = crate::attachments::parse_user_message_images(&raw);
+        // File mentions render as chips here too, not just in the composer.
+        // The projection is pure over the text, so the raw-length row version
+        // below stays a valid cache/diff key.
+        let (text, mentions) = match crate::composer::sent_mention_display(&parsed.text) {
+            Some((display, spans)) => (display, spans),
+            None => (parsed.text, Vec::new()),
+        };
         return vec![Row {
             id: entry.id.clone().into(),
             version: (raw.len() as u64) << 1 | pending as u64,
             turn_start: true,
             kind: RowKind::User {
-                text: parsed.text.into(),
+                text: text.into(),
+                mentions: Arc::new(mentions),
                 attachments: Arc::new(parsed.attachments),
                 pending,
             },
@@ -1539,11 +1553,13 @@ impl Transcript {
         let inner: AnyElement = match &row.kind {
             RowKind::User {
                 text,
+                mentions,
                 attachments,
                 pending,
             } => {
                 let attachments = attachments.clone();
                 let text = text.clone();
+                let mentions = mentions.clone();
                 let pending = *pending;
                 // Attachment thumbnails ride ABOVE the bubble, right-aligned
                 // (chat-view.tsx RowView: UserAttachmentStrip then the text
@@ -1572,7 +1588,11 @@ impl Transcript {
                                 .line_height(px(22.0))
                                 .text_color(theme.text)
                                 .when(pending, |el| el.opacity(0.65))
-                                .child(text),
+                                .child(if mentions.is_empty() {
+                                    text.into_any_element()
+                                } else {
+                                    user_mention_text(text, mentions, &theme)
+                                }),
                         ),
                     );
                 }
@@ -1923,6 +1943,88 @@ impl Transcript {
             .child(body)
             .into_any_element()
     }
+}
+
+/// A sent message's text with its file-mention chips. The same underlay recipe
+/// as the markdown renderer's inline-code wash (`flat_text_element`):
+/// [`StyledText`] supplies wrapped glyph geometry through its layout handle, a
+/// canvas paints the rounded washes *beneath* the glyphs and the file/folder
+/// icons into their reserved em-space slots — so chips wrap, clip, and scroll
+/// exactly like the text they decorate.
+///
+/// Per-frame cost while an assistant message streams below: shaping hits
+/// gpui's line-layout cache (identical text + runs ⇒ reuse) and the underlay
+/// repaints O(chips) quads — no layout work, no re-projection (spans were
+/// computed once in [`rows_for_entry`]).
+fn user_mention_text(
+    text: SharedString,
+    mentions: Arc<Vec<crate::composer::SentMentionSpan>>,
+    theme: &Theme,
+) -> AnyElement {
+    // One run: chips keep the body color; the wash and icon do the signaling.
+    // Font/size/line-height flow from the bubble's div like every text child.
+    let styled = StyledText::new(text.clone()).with_runs(vec![TextRun {
+        len: text.len(),
+        font: gpui::font(theme.font_sans.clone()),
+        color: theme.text,
+        background_color: None,
+        underline: None,
+        strikethrough: None,
+    }]);
+    let layout = styled.layout().clone();
+    // The composer's chip wash, quoted from its prepaint (accent at 0.22).
+    let wash = theme.accent.opacity(0.22);
+    let icon_color = theme.text_muted;
+    let underlay = canvas(
+        |_, _, _| (),
+        move |_, _, window, cx| {
+            for span in mentions.iter() {
+                for rect in render::range_rects(&layout, &span.range, 0.0, 2.0) {
+                    window.paint_quad(quad(
+                        rect,
+                        px(5.0),
+                        wash,
+                        px(0.0),
+                        gpui::transparent_black(),
+                        BorderStyle::default(),
+                    ));
+                }
+                let Some(slot) = render::range_rects(&layout, &span.icon_slot, 0.0, 0.0)
+                    .into_iter()
+                    .next()
+                else {
+                    continue;
+                };
+                let icon_size = slot.size.width.min(px(12.0));
+                let icon_bounds = Bounds::new(
+                    point(
+                        slot.origin.x + (slot.size.width - icon_size) / 2.0,
+                        slot.origin.y + (slot.size.height - icon_size) / 2.0,
+                    ),
+                    size(icon_size, icon_size),
+                );
+                let _ = window.paint_svg(
+                    icon_bounds,
+                    SharedString::from(if span.is_dir {
+                        crate::icons::FOLDER
+                    } else {
+                        crate::icons::DOCUMENT
+                    }),
+                    None,
+                    gpui::TransformationMatrix::default(),
+                    icon_color,
+                    cx,
+                );
+            }
+        },
+    )
+    .absolute()
+    .size_full();
+    div()
+        .relative()
+        .child(underlay)
+        .child(styled)
+        .into_any_element()
 }
 
 /// The transcript ErrorChip — an exact port of comet chat-view.tsx
@@ -2645,6 +2747,44 @@ mod tests {
         };
         assert_eq!(text.as_ref(), "");
         assert_eq!(attachments.len(), 1);
+    }
+
+    /// A sent prompt's file mentions render as chips in the transcript: the
+    /// row carries the projected display text plus spans, while ordinary
+    /// prompts keep the empty-spans fast path. The row version derives from
+    /// the RAW text either way, so projection never perturbs the diff key.
+    #[test]
+    fn user_rows_project_file_mentions_into_chips() {
+        let raw = "look at [composer.rs](comet-file:crates/ui/src/composer.rs) please";
+        let mut entry = assistant("u3", MessageStatus::Complete, vec![]);
+        entry.role = MessageRole::User;
+        entry.status = None;
+        entry.parts = vec![text_part("t0", raw)];
+        let rows = rows_for_entry(&entry, false, &mut parse);
+        let RowKind::User { text, mentions, .. } = &rows[0].kind else {
+            panic!("expected a user row");
+        };
+        assert!(
+            !text.contains("comet-file:"),
+            "raw link left visible: {text}"
+        );
+        assert!(text.contains("composer.rs"));
+        assert_eq!(mentions.len(), 1);
+        assert!(!mentions[0].is_dir);
+        assert_eq!(mentions[0].path.as_ref(), "crates/ui/src/composer.rs");
+        assert_eq!(&text[mentions[0].range.clone()], {
+            let projected: &str = "\u{00A0}\u{2003}\u{202F}composer.rs\u{00A0}";
+            projected
+        });
+        assert_eq!(rows[0].version, (raw.len() as u64) << 1);
+
+        entry.parts = vec![text_part("t0", "no mentions here")];
+        let rows = rows_for_entry(&entry, false, &mut parse);
+        let RowKind::User { text, mentions, .. } = &rows[0].kind else {
+            panic!("expected a user row");
+        };
+        assert_eq!(text.as_ref(), "no mentions here");
+        assert!(mentions.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Add workspace file mentions to the composer

This PR adds `@` file and directory mentions to the chat composer.

Typing `@` or `@query` opens a workspace-relative picker. Selecting a result inserts a Markdown link such as:

```text
[composer.rs](comet-file:crates/ui/src/composer.rs)
[components](comet-file:crates/ui/src/components/)
```

The editor renders these links as atomic file or folder chips while keeping the raw Markdown prompt as the single source of truth.

### Highlights

* Searches files and directories within the active repository or a validated linked worktree.
* Supports case-insensitive, whitespace-separated subsequence matching.
* Prioritizes filename matches, recent files, changed files, and shallow paths.
* Respects Git and repository ignore rules while allowing hidden files.
* Returns up to eight results after an 80 ms debounce.
* Uses shortest unique path suffixes for duplicate filenames.
* Supports keyboard navigation, dismissal, tooltips, wrapped chips, deletion, undo, and selection as a single atomic unit.

### Safety and lifecycle

* The client sends only a chat or space identity; the engine resolves and validates the checkout.
* Searches outside known repository roots and linked worktrees are rejected.
* Filesystem walks are cancellable, serialized per checkout, and bounded by a six-second deadline.
* Blocking filesystem work runs on a disposable OS thread rather than Tokio’s shared blocking pool.
* Request generations prevent stale results from replacing newer UI state.
* Mention behavior is enabled only for the chat composer and is cleared when the token, draft, chat, submission state, or wizard mode changes.

### GPUI structure

* `Composer` handles token detection, search requests, selection, dismissal, and popover rendering.
* `ComposerInput` handles Markdown projection, atomic chip editing, layout, painting, hit testing, and tooltips.
* The menu reuses existing popover and menu helpers and is anchored to the visible token position.

### Validation

* `cargo fmt --all -- --check`
* `git diff --check`
* `cargo test --workspace --all-targets`

All passed. Six environment-dependent tests remain ignored, and only pre-existing warnings were emitted.

Focused tests cover root validation, ignore rules, hidden files, directories, ranking, cancellation, concurrent callers, stale responses, Markdown validation, duplicate labels, atomic editing, wrapped geometry, tooltips, and menu navigation.

**Reviewed locally with no blocking findings. Safe to merge.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788284804&installation_model_id=425430&pr_number=11&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F11&signature=a3259711514c3f27d4b6d427e1b798d742da911b301cc87e455f64399fbb4f98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->