### PR TITLE
Terminal: mouse text selection and copy

### DIFF
--- a/crates/ui/src/terminal/emulator.rs
+++ b/crates/ui/src/terminal/emulator.rs
@@ -7,6 +7,10 @@
 //! That split makes the whole escape-sequence surface unit-testable with
 //! scripted byte strings.
 //!
+//! Selection lives here too ([`Emulator::start_selection`] and friends) rather
+//! than in the panel, because `Term` is what knows how to keep anchors on their
+//! text as output scrolls the grid underneath them.
+//!
 //! API notes for the pinned `alacritty_terminal 0.26` / `vte 0.15`:
 //! - `Processor::advance` consumes a byte slice; `Term` implements the
 //!   `vte::ansi::Handler` trait directly, so no event-loop machinery is needed.
@@ -21,11 +25,19 @@ use std::rc::Rc;
 use alacritty_terminal::event::{Event, EventListener};
 use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::{Column, Line, Point};
+use alacritty_terminal::selection::{Selection, SelectionRange};
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::{Config, Term, TermMode};
 use alacritty_terminal::vte::ansi::{
     Color as AnsiColor, CursorShape, NamedColor, Processor, Rgb as AnsiRgb,
 };
+
+/// Grid coordinates and selection granularity, re-exported so the panel and
+/// view speak the emulator's vocabulary without depending on
+/// `alacritty_terminal` directly — the same seam [`CellColor`] draws for
+/// colors.
+pub use alacritty_terminal::index::{Point as GridPoint, Side};
+pub use alacritty_terminal::selection::SelectionType;
 
 /// Scrollback history kept client-side (lines). The engine's replay window is
 /// bounded separately (1 MiB); this only caps what stays scrollable in the UI.
@@ -118,6 +130,8 @@ pub struct CellSnapshot {
     pub wide: bool,
     /// The spacer half of a wide char — never shaped, only background-painted.
     pub wide_spacer: bool,
+    /// Inside the active selection: the view paints a wash over this cell.
+    pub selected: bool,
 }
 
 impl CellSnapshot {
@@ -246,8 +260,77 @@ impl Emulator {
         self.term.scroll_display(Scroll::Bottom);
     }
 
+    // ---- selection ----
+    //
+    // `Term` owns the selection outright, which is what makes this cheap: it
+    // rotates the anchors when output scrolls the grid and drops them on clear
+    // and resize, so a selection tracks live output without any bookkeeping
+    // here. The panel supplies pointer positions; everything below is a thin
+    // translation into grid coordinates.
+
+    /// The grid point under a viewport cell (row 0 = top of the visible area).
+    ///
+    /// Viewport rows are what the pointer hits; grid lines are what a selection
+    /// anchors to, and the two differ by the scrollback offset. Anchoring in
+    /// grid space is what lets a selection stay on its text while the view
+    /// scrolls out from under it.
+    pub fn grid_point(&self, viewport_row: usize, col: usize) -> Point {
+        Point::new(
+            Line(viewport_row as i32 - self.display_offset() as i32),
+            Column(col.min(self.cols().saturating_sub(1))),
+        )
+    }
+
+    /// Begin a selection. `ty` picks the granularity: [`SelectionType::Simple`]
+    /// for a drag, `Semantic` for a double-click word, `Lines` for a triple-
+    /// click row.
+    pub fn start_selection(&mut self, ty: SelectionType, point: Point, side: Side) {
+        self.term.selection = Some(Selection::new(ty, point, side));
+    }
+
+    /// Extend the in-progress selection to `point`. No-op without one.
+    pub fn update_selection(&mut self, point: Point, side: Side) {
+        if let Some(selection) = self.term.selection.as_mut() {
+            selection.update(point, side);
+        }
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.term.selection = None;
+    }
+
+    /// The selected text, or `None` when there is no selection or it covers
+    /// nothing (a click without a drag leaves an empty one behind).
+    pub fn selection_text(&self) -> Option<String> {
+        self.term.selection_to_string().filter(|s| !s.is_empty())
+    }
+
+    /// Whether a non-empty selection is active — drives the copy action and
+    /// the "clear it" branch on the next click.
+    pub fn has_selection(&self) -> bool {
+        self.selection_range().is_some()
+    }
+
+    fn selection_range(&self) -> Option<SelectionRange> {
+        self.term
+            .selection
+            .as_ref()
+            .and_then(|selection| selection.to_range(&self.term))
+    }
+
     /// Snapshot one viewport row (0 = top) honoring the scrollback offset.
     pub fn line(&self, viewport_row: usize) -> Vec<CellSnapshot> {
+        self.line_inner(viewport_row, self.selection_range())
+    }
+
+    /// The shared body of [`Self::line`], taking the selection range as an
+    /// argument so [`Self::lines`] resolves it once per frame rather than once
+    /// per row — `to_range` re-walks the grid for semantic and line selections.
+    fn line_inner(
+        &self,
+        viewport_row: usize,
+        selection: Option<SelectionRange>,
+    ) -> Vec<CellSnapshot> {
         let offset = self.display_offset() as i32;
         let line = Line(viewport_row as i32 - offset);
         let grid = self.term.grid();
@@ -269,6 +352,8 @@ impl Emulator {
                     wide_spacer: cell
                         .flags
                         .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER),
+                    selected: selection
+                        .is_some_and(|range| range.contains(Point::new(line, Column(col)))),
                 }
             })
             .collect()
@@ -276,7 +361,10 @@ impl Emulator {
 
     /// All viewport rows, top to bottom.
     pub fn lines(&self) -> Vec<Vec<CellSnapshot>> {
-        (0..self.rows()).map(|r| self.line(r)).collect()
+        let selection = self.selection_range();
+        (0..self.rows())
+            .map(|r| self.line_inner(r, selection))
+            .collect()
     }
 
     /// Cursor in viewport coordinates; `None` when hidden or scrolled out.
@@ -531,6 +619,102 @@ mod tests {
         assert_eq!(line[2].ch, 'w');
         assert_eq!(e.row_text(0), "宽w");
         assert_eq!(e.cursor(), Some(CursorSnapshot { row: 0, col: 3 }));
+    }
+
+    /// Viewport row → grid line, which is the translation every selection
+    /// anchor goes through. Unscrolled they coincide; scrolled back, the same
+    /// viewport row names a line further up history.
+    #[test]
+    fn grid_point_offsets_by_the_scrollback_position() {
+        let mut e = emu(10, 3);
+        for i in 1..=8 {
+            e.feed(format!("line{i}\r\n").as_bytes());
+        }
+        assert_eq!(e.grid_point(0, 2), Point::new(Line(0), Column(2)));
+        e.scroll(4);
+        assert_eq!(e.grid_point(0, 2), Point::new(Line(-4), Column(2)));
+        // Columns clamp into the grid so an over-wide pointer cannot anchor
+        // outside it.
+        assert_eq!(e.grid_point(0, 99).column, Column(9));
+    }
+
+    #[test]
+    fn simple_selection_yields_its_text_and_marks_its_cells() {
+        let mut e = emu(20, 3);
+        e.feed(b"hello world");
+        assert!(!e.has_selection());
+        assert_eq!(e.selection_text(), None);
+
+        // Drag across "hello".
+        e.start_selection(SelectionType::Simple, e.grid_point(0, 0), Side::Left);
+        e.update_selection(e.grid_point(0, 4), Side::Right);
+        assert!(e.has_selection());
+        assert_eq!(e.selection_text().as_deref(), Some("hello"));
+
+        let line = e.line(0);
+        assert!(line[..5].iter().all(|c| c.selected));
+        assert!(!line[5].selected, "the space past the drag is not selected");
+
+        e.clear_selection();
+        assert!(!e.has_selection());
+        assert!(e.line(0).iter().all(|c| !c.selected));
+    }
+
+    /// Double-click granularity: the anchor expands to the whole word without
+    /// the caller computing any boundaries.
+    #[test]
+    fn semantic_selection_expands_to_the_word() {
+        let mut e = emu(30, 2);
+        e.feed(b"alpha beta gamma");
+        e.start_selection(SelectionType::Semantic, e.grid_point(0, 7), Side::Left);
+        assert_eq!(e.selection_text().as_deref(), Some("beta"));
+    }
+
+    /// Triple-click granularity. The trailing newline is part of the copy —
+    /// pasting a line-selection should reproduce the line break, the way it
+    /// does in every other terminal.
+    #[test]
+    fn line_selection_takes_the_whole_row() {
+        let mut e = emu(30, 3);
+        e.feed(b"first row\r\nsecond row");
+        e.start_selection(SelectionType::Lines, e.grid_point(1, 3), Side::Left);
+        assert_eq!(e.selection_text().as_deref(), Some("second row\n"));
+    }
+
+    /// A selection made across a line break keeps the newline, so pasting the
+    /// copy reproduces the rows.
+    #[test]
+    fn selection_spans_rows_with_a_newline() {
+        let mut e = emu(10, 3);
+        e.feed(b"ab\r\ncd");
+        e.start_selection(SelectionType::Simple, e.grid_point(0, 0), Side::Left);
+        e.update_selection(e.grid_point(1, 1), Side::Right);
+        assert_eq!(e.selection_text().as_deref(), Some("ab\ncd"));
+    }
+
+    /// The reason anchors live in grid space: output that scrolls the grid must
+    /// carry the selection with its text, not leave it pinned to a screen row.
+    #[test]
+    fn selection_follows_its_text_when_output_scrolls() {
+        let mut e = emu(10, 3);
+        e.feed(b"target\r\n");
+        e.start_selection(SelectionType::Simple, e.grid_point(0, 0), Side::Left);
+        e.update_selection(e.grid_point(0, 5), Side::Right);
+        assert_eq!(e.selection_text().as_deref(), Some("target"));
+        // Push it up the screen; the text is unchanged, so the copy is too.
+        e.feed(b"a\r\nb\r\nc\r\n");
+        assert_eq!(e.selection_text().as_deref(), Some("target"));
+    }
+
+    /// A click with no drag selects nothing, and must not report a selection —
+    /// otherwise the copy action fires on every bare click.
+    #[test]
+    fn a_click_without_a_drag_selects_nothing() {
+        let mut e = emu(20, 2);
+        e.feed(b"hello");
+        e.start_selection(SelectionType::Simple, e.grid_point(0, 2), Side::Left);
+        assert_eq!(e.selection_text(), None);
+        assert!(!e.has_selection());
     }
 
     #[test]

--- a/crates/ui/src/terminal/panel.rs
+++ b/crates/ui/src/terminal/panel.rs
@@ -18,8 +18,9 @@ use std::time::Duration;
 
 use base64::Engine as _;
 use gpui::{
-    App, Context, Entity, FocusHandle, IntoElement, KeyBinding, KeyDownEvent, MouseButton, Render,
-    ScrollDelta, SharedString, Subscription, Task, Window, actions, div, prelude::*, px,
+    App, Context, Entity, FocusHandle, IntoElement, KeyBinding, KeyDownEvent, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Render, ScrollDelta, SharedString,
+    Subscription, Task, Window, actions, div, prelude::*, px,
 };
 
 use comet_proto::{TerminalEvent, TerminalSession};
@@ -30,10 +31,10 @@ use crate::settings::{TERMINAL_MAX_VH, TERMINAL_MIN_HEIGHT};
 use crate::state::{AppState, EngineHandle};
 use crate::theme::Theme;
 
-use super::emulator::{CellSnapshot, CursorSnapshot, Emulator};
+use super::emulator::{CellSnapshot, CursorSnapshot, Emulator, GridPoint, SelectionType, Side};
 use super::view::{
-    COALESCE_MS, InputCoalescer, RESIZE_DEBOUNCE_MS, TerminalElement, keystroke_bytes, paste_bytes,
-    terminal_bg,
+    COALESCE_MS, InputCoalescer, RESIZE_DEBOUNCE_MS, SELECTION_DRAG_THRESHOLD, TerminalElement,
+    cell_at, keystroke_bytes, paste_bytes, terminal_bg,
 };
 
 /// Fixed tab width — drag-reorder math stays analytic.
@@ -174,6 +175,38 @@ pub struct GridSnapshot {
     pub cursor: Option<CursorSnapshot>,
 }
 
+/// Where the grid landed this frame, in window coordinates.
+///
+/// Reported by element prepaint because that is the only place the measured
+/// font metrics exist. Mouse events arrive on the wrapping div in window
+/// space, so mapping a pointer to a cell needs the glyph origin and the cell
+/// size the *current* frame used — a stale one puts the selection a row off
+/// after a resize.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GridGeometry {
+    /// Top-left of the first glyph (bounds origin plus padding).
+    pub origin: gpui::Point<Pixels>,
+    pub cell_w: f32,
+    pub line_h: f32,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+/// An in-flight left-button gesture.
+///
+/// A press alone does not select. It arms this, and only pointer travel past
+/// [`SELECTION_DRAG_THRESHOLD`] promotes it to a real selection — otherwise the
+/// click that focuses the panel would leave a one-cell selection behind
+/// whenever the hand moves a pixel.
+#[derive(Debug, Clone, Copy)]
+struct SelectionDrag {
+    /// Press position, in window space: both the threshold origin and the
+    /// selection's anchor, so the selection starts where the press landed
+    /// rather than where the threshold happened to trip.
+    origin: gpui::Point<Pixels>,
+    armed: bool,
+}
+
 struct TerminalTab {
     key: u64,
     title: SharedString,
@@ -242,6 +275,10 @@ pub struct TerminalPanel {
     tab_seq: u64,
     drag: Option<DragState>,
     last_selected: Option<String>,
+    /// Last reported grid placement; `None` until the first prepaint.
+    geometry: Option<GridGeometry>,
+    /// Left-button gesture in flight, if any.
+    selection_drag: Option<SelectionDrag>,
     _observe: Subscription,
 }
 
@@ -256,6 +293,8 @@ impl TerminalPanel {
             tab_seq: 0,
             drag: None,
             last_selected: None,
+            geometry: None,
+            selection_drag: None,
             _observe: observe,
         }
     }
@@ -646,6 +685,16 @@ impl TerminalPanel {
             cx.stop_propagation();
             return;
         }
+        // Copy: Cmd+C (macOS) / Ctrl+Shift+C. Only swallowed when it actually
+        // copied — so Ctrl+Shift+C with nothing selected still falls through
+        // to the interrupt, and plain Ctrl+C (no shift) never reaches here.
+        if ks.key == "c"
+            && (mods.platform || (mods.control && mods.shift))
+            && self.copy_selection(cx)
+        {
+            cx.stop_propagation();
+            return;
+        }
         let app_cursor = self
             .active_tab(cx)
             .map(|tab| tab.emulator.app_cursor_mode())
@@ -658,9 +707,14 @@ impl TerminalPanel {
 
     // ---- grid metrics / element hooks ----
 
-    /// Called from element prepaint with the measured cols×rows. Resizes the
-    /// emulator immediately; the `ResizeTerminal` RPC debounces 80 ms.
-    pub fn on_grid_metrics(&mut self, cols: u16, rows: u16, cx: &mut Context<Self>) {
+    /// Called from element prepaint with the frame's grid placement. Resizes
+    /// the emulator immediately; the `ResizeTerminal` RPC debounces 80 ms.
+    pub fn on_grid_metrics(&mut self, geometry: GridGeometry, cx: &mut Context<Self>) {
+        // Stash unconditionally, before the early returns below: pointer
+        // mapping needs the placement even on frames where nothing resized,
+        // which is almost all of them.
+        self.geometry = Some(geometry);
+        let (cols, rows) = (geometry.cols, geometry.rows);
         let Some(chat) = self.selected_chat(cx) else {
             return;
         };
@@ -720,6 +774,161 @@ impl TerminalPanel {
             lines: tab.emulator.lines(),
             cursor: tab.emulator.cursor(),
         })
+    }
+
+    // ---- selection ----
+
+    /// Run `f` against the active tab's emulator.
+    fn with_active_emulator<R>(
+        &mut self,
+        cx: &App,
+        f: impl FnOnce(&mut Emulator) -> R,
+    ) -> Option<R> {
+        let chat = self.selected_chat(cx)?;
+        let tabs = self.chats.get_mut(&chat)?;
+        let active = tabs.active;
+        tabs.tabs.get_mut(active).map(|tab| f(&mut tab.emulator))
+    }
+
+    /// Window position → grid point, using this frame's placement. `None`
+    /// before the first prepaint, or when no tab is active.
+    fn grid_point_at(
+        &mut self,
+        position: gpui::Point<Pixels>,
+        cx: &App,
+    ) -> Option<(GridPoint, Side)> {
+        let geometry = self.geometry?;
+        let hit = cell_at(
+            f32::from(position.x - geometry.origin.x),
+            f32::from(position.y - geometry.origin.y),
+            geometry.cell_w,
+            geometry.line_h,
+            geometry.cols as usize,
+            geometry.rows as usize,
+        );
+        let point = self.with_active_emulator(cx, |emu| emu.grid_point(hit.row, hit.col))?;
+        Some((point, hit.side))
+    }
+
+    fn on_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.focus(&self.focus_handle, cx);
+        let Some((point, side)) = self.grid_point_at(event.position, cx) else {
+            return;
+        };
+        // Click count picks the granularity, the same mapping every terminal
+        // uses: drag, word, line.
+        let ty = match event.click_count {
+            0 => return,
+            1 => SelectionType::Simple,
+            2 => SelectionType::Semantic,
+            _ => SelectionType::Lines,
+        };
+        let shift = event.modifiers.shift;
+        if ty == SelectionType::Simple {
+            // Shift+click extends an existing selection instead of replacing
+            // it — the one gesture that reaches text off the bottom of a long
+            // drag without redoing the whole thing.
+            let extended = shift
+                && self
+                    .with_active_emulator(cx, |emu| {
+                        let extend = emu.has_selection();
+                        if extend {
+                            emu.update_selection(point, side);
+                        }
+                        extend
+                    })
+                    .unwrap_or(false);
+            if extended {
+                self.selection_drag = Some(SelectionDrag {
+                    origin: event.position,
+                    armed: true,
+                });
+                cx.notify();
+                return;
+            }
+            // A plain press clears and arms; the selection itself only begins
+            // once the pointer travels far enough to mean it.
+            self.with_active_emulator(cx, |emu| emu.clear_selection());
+            self.selection_drag = Some(SelectionDrag {
+                origin: event.position,
+                armed: false,
+            });
+        } else {
+            // Word and line selections are complete on the press, so they need
+            // no threshold — but keep the drag live so the pointer can extend
+            // them at that granularity.
+            self.with_active_emulator(cx, |emu| emu.start_selection(ty, point, side));
+            self.selection_drag = Some(SelectionDrag {
+                origin: event.position,
+                armed: true,
+            });
+        }
+        cx.notify();
+    }
+
+    fn on_mouse_move(
+        &mut self,
+        event: &MouseMoveEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !event.dragging() {
+            return;
+        }
+        let Some(drag) = self.selection_drag else {
+            return;
+        };
+        if !drag.armed {
+            let dx = f32::from(event.position.x - drag.origin.x);
+            let dy = f32::from(event.position.y - drag.origin.y);
+            if dx.hypot(dy) < SELECTION_DRAG_THRESHOLD {
+                return;
+            }
+            // Threshold tripped: anchor at the *press*, not here, so the
+            // selection covers the whole gesture.
+            let Some((anchor, side)) = self.grid_point_at(drag.origin, cx) else {
+                return;
+            };
+            self.with_active_emulator(cx, |emu| {
+                emu.start_selection(SelectionType::Simple, anchor, side)
+            });
+            self.selection_drag = Some(SelectionDrag {
+                armed: true,
+                ..drag
+            });
+        }
+        let Some((point, side)) = self.grid_point_at(event.position, cx) else {
+            return;
+        };
+        self.with_active_emulator(cx, |emu| emu.update_selection(point, side));
+        cx.notify();
+    }
+
+    fn on_mouse_up(
+        &mut self,
+        _event: &MouseUpEvent,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+        self.selection_drag = None;
+    }
+
+    /// Copy the selection. Returns whether anything was copied, so the caller
+    /// can decide whether to swallow the keystroke.
+    fn copy_selection(&mut self, cx: &mut Context<Self>) -> bool {
+        let Some(text) = self
+            .with_active_emulator(cx, |emu| emu.selection_text())
+            .flatten()
+        else {
+            return false;
+        };
+        cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+        true
     }
 
     fn scroll_active(&mut self, delta_lines: i32, cx: &mut Context<Self>) {
@@ -1101,12 +1310,14 @@ impl Render for TerminalPanel {
                     .key_context("Terminal")
                     .track_focus(&self.focus_handle)
                     .on_key_down(cx.listener(Self::on_key_down))
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _, window: &mut Window, cx| {
-                            window.focus(&this.focus_handle, cx);
-                        }),
-                    )
+                    .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
+                    .on_mouse_move(cx.listener(Self::on_mouse_move))
+                    // Bound on the window, not the element: a drag that ends
+                    // outside the panel still has to end the gesture, or the
+                    // next unrelated pointer move keeps extending a selection
+                    // the user let go of.
+                    .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_mouse_up))
+                    .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
                     .on_scroll_wheel(cx.listener(|this, event: &gpui::ScrollWheelEvent, _, cx| {
                         let lines = match event.delta {
                             ScrollDelta::Lines(delta) => delta.y,

--- a/crates/ui/src/terminal/view.rs
+++ b/crates/ui/src/terminal/view.rs
@@ -20,7 +20,7 @@ use gpui::{
 
 use crate::theme::{Appearance, Theme, current_appearance, rgb_to_hsl};
 
-use super::emulator::{CellColor, CellSnapshot};
+use super::emulator::{CellColor, CellSnapshot, Side};
 use super::panel::TerminalPanel;
 
 /// Terminal font metrics (mono).
@@ -172,6 +172,84 @@ pub fn resolve_color(color: CellColor, theme: &Theme) -> Hsla {
         }
         CellColor::Rgb(r, g, b) => rgb8(r, g, b),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Pointer → cell
+// ---------------------------------------------------------------------------
+
+/// Minimum pointer travel before a press turns into a selection.
+///
+/// Without it, the click that focuses the panel starts a one-cell selection if
+/// the hand moves a pixel — and once anything copies on selection change, that
+/// silently clobbers the clipboard. Matches the threshold zed uses for the same
+/// reason (`SELECTION_DRAG_THRESHOLD`), which is gpui's own `div` drag
+/// threshold.
+pub const SELECTION_DRAG_THRESHOLD: f32 = 2.0;
+
+/// Which cell a pointer landed on, and which edge of it a selection anchors to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CellHit {
+    pub row: usize,
+    pub col: usize,
+    /// Selections anchor to a cell *edge*, not a cell: pressing on the left
+    /// half of a glyph includes it, the right half excludes it.
+    pub side: Side,
+}
+
+/// Map a position *relative to the grid's top-left glyph* onto a cell.
+///
+/// Positions outside the grid clamp to the nearest cell rather than returning
+/// `None`, because that is what a drag needs: the pointer routinely leaves the
+/// panel mid-gesture, and the selection should extend to the edge it left
+/// through instead of freezing at the last sample taken inside.
+///
+/// Overshoot also *forces the side*, which clamping alone does not give you.
+/// Dragging past the bottom should take the last line whole, even when the
+/// pointer drifted left of where it started — deriving the side from x there
+/// would stop the selection mid-row. Same rule going up, mirrored. This is the
+/// behaviour alacritty and zed's `grid_point_and_side` both implement.
+pub fn cell_at(x: f32, y: f32, cell_w: f32, line_h: f32, cols: usize, rows: usize) -> CellHit {
+    // Degenerate metrics (a zero-size grid, or a font probe that returned NaN)
+    // would otherwise divide into garbage cell indices.
+    let usable = |v: f32| v.is_finite() && v > 0.0;
+    if cols == 0 || rows == 0 || !usable(cell_w) || !usable(line_h) {
+        return CellHit {
+            row: 0,
+            col: 0,
+            side: Side::Left,
+        };
+    }
+    let x = if x.is_finite() { x } else { 0.0 };
+    let y = if y.is_finite() { y } else { 0.0 };
+    let last_col = cols - 1;
+    let last_row = rows - 1;
+
+    let raw_col = (x / cell_w).floor();
+    let mut side = if x.max(0.0) % cell_w > cell_w / 2.0 {
+        Side::Right
+    } else {
+        Side::Left
+    };
+    let col = if raw_col > last_col as f32 {
+        side = Side::Right;
+        last_col
+    } else {
+        raw_col.max(0.0) as usize
+    };
+
+    let raw_row = (y / line_h).floor();
+    let row = if raw_row > last_row as f32 {
+        side = Side::Right;
+        last_row
+    } else if raw_row < 0.0 {
+        side = Side::Left;
+        0
+    } else {
+        raw_row as usize
+    };
+
+    CellHit { row, col, side }
 }
 
 // ---------------------------------------------------------------------------
@@ -354,6 +432,10 @@ impl TerminalElement {
 
 pub struct TerminalPrepaint {
     bg_quads: Vec<PaintQuad>,
+    /// Selection wash. Painted after [`Self::bg_quads`] and before the glyphs:
+    /// it has to tint a cell's own background rather than replace it, and it
+    /// must not wash out the text it is highlighting.
+    sel_quads: Vec<PaintQuad>,
     lines: Vec<ShapedLine>,
     cursor: Option<PaintQuad>,
 }
@@ -418,27 +500,58 @@ impl gpui::Element for TerminalElement {
 
         // Report the measured grid, then snapshot for painting. Safe: the
         // panel entity is not borrowed during element prepaint.
+        let origin = point(
+            bounds.left() + px(TERM_PADDING),
+            bounds.top() + px(TERM_PADDING),
+        );
         let snapshot = self.panel.update(cx, |panel, cx| {
-            panel.on_grid_metrics(cols, rows, cx);
+            panel.on_grid_metrics(
+                super::panel::GridGeometry {
+                    origin,
+                    cell_w: f32::from(cell_w),
+                    line_h: f32::from(line_h),
+                    cols,
+                    rows,
+                },
+                cx,
+            );
             panel.active_grid_snapshot(cx)
         });
         let Some(snapshot) = snapshot else {
             return TerminalPrepaint {
                 bg_quads: Vec::new(),
+                sel_quads: Vec::new(),
                 lines: Vec::new(),
                 cursor: None,
             };
         };
 
-        let origin = point(
-            bounds.left() + px(TERM_PADDING),
-            bounds.top() + px(TERM_PADDING),
-        );
         let mut bg_quads = Vec::new();
+        let mut sel_quads = Vec::new();
         let mut lines = Vec::with_capacity(snapshot.lines.len());
 
         for (row_ix, row) in snapshot.lines.iter().enumerate() {
             let y = origin.y + line_h * row_ix as f32;
+            // Selected runs, merged the same way background runs are: one quad
+            // per contiguous span instead of one per cell.
+            let mut sel_start: Option<usize> = None;
+            for col in 0..=row.len() {
+                let selected = row.get(col).is_some_and(|cell| cell.selected);
+                match (sel_start, selected) {
+                    (None, true) => sel_start = Some(col),
+                    (Some(start), false) => {
+                        sel_quads.push(fill(
+                            Bounds::new(
+                                point(origin.x + cell_w * start as f32, y),
+                                size(cell_w * (col - start) as f32, line_h),
+                            ),
+                            theme.selection,
+                        ));
+                        sel_start = None;
+                    }
+                    _ => {}
+                }
+            }
             // Merge consecutive non-default background cells into quads.
             let mut run_start: Option<(usize, Hsla)> = None;
             for (col, color) in row
@@ -487,6 +600,7 @@ impl gpui::Element for TerminalElement {
 
         TerminalPrepaint {
             bg_quads,
+            sel_quads,
             lines,
             cursor,
         }
@@ -509,6 +623,9 @@ impl gpui::Element for TerminalElement {
         );
         window.with_content_mask(Some(gpui::ContentMask { bounds }), |window| {
             for quad in prepaint.bg_quads.drain(..) {
+                window.paint_quad(quad);
+            }
+            for quad in prepaint.sel_quads.drain(..) {
                 window.paint_quad(quad);
             }
             for (ix, line) in prepaint.lines.iter().enumerate() {
@@ -901,5 +1018,106 @@ mod tests {
     fn timing_constants_match_spec() {
         assert_eq!(COALESCE_MS, 12);
         assert_eq!(RESIZE_DEBOUNCE_MS, 80);
+    }
+
+    // ---- pointer → cell ----
+
+    /// 10x20 cells, an 8x4 grid: cols 0..7, rows 0..3.
+    fn hit(x: f32, y: f32) -> CellHit {
+        cell_at(x, y, 10.0, 20.0, 8, 4)
+    }
+
+    #[test]
+    fn pointer_maps_to_the_cell_it_is_over() {
+        assert_eq!(
+            hit(0.0, 0.0),
+            CellHit {
+                row: 0,
+                col: 0,
+                side: Side::Left
+            }
+        );
+        assert_eq!(
+            hit(25.0, 45.0),
+            CellHit {
+                row: 2,
+                col: 2,
+                side: Side::Left
+            }
+        );
+        // Last cell, exactly.
+        assert_eq!(
+            hit(70.0, 60.0),
+            CellHit {
+                row: 3,
+                col: 7,
+                side: Side::Left
+            }
+        );
+    }
+
+    #[test]
+    fn side_splits_the_cell_at_its_midpoint() {
+        // Cell 2 spans x 20..30, so the midpoint is 25.
+        assert_eq!(hit(21.0, 0.0).side, Side::Left);
+        assert_eq!(
+            hit(25.0, 0.0).side,
+            Side::Left,
+            "the midpoint itself is left"
+        );
+        assert_eq!(hit(26.0, 0.0).side, Side::Right);
+        // The cell is unaffected by which half.
+        assert_eq!(hit(21.0, 0.0).col, 2);
+        assert_eq!(hit(29.0, 0.0).col, 2);
+    }
+
+    /// Dragging out of the panel must extend to the edge it left through, not
+    /// freeze at the last sample inside.
+    #[test]
+    fn overshoot_clamps_into_the_grid() {
+        assert_eq!(hit(9_999.0, 0.0).col, 7);
+        assert_eq!(hit(0.0, 9_999.0).row, 3);
+        assert_eq!(hit(-50.0, 0.0).col, 0);
+        assert_eq!(hit(0.0, -50.0).row, 0);
+    }
+
+    /// The part clamping alone does not give you: past the right or bottom
+    /// edge the side is forced Right so the last cell is *included*, and above
+    /// the top it is forced Left. Dragging below-and-left must still take the
+    /// bottom row whole.
+    #[test]
+    fn overshoot_forces_the_side_to_the_edge() {
+        assert_eq!(hit(9_999.0, 10.0).side, Side::Right);
+        // x sits in cell 0's left half, but the row overshot — Right wins.
+        assert_eq!(hit(1.0, 9_999.0).side, Side::Right);
+        assert_eq!(hit(1.0, 9_999.0).col, 0);
+        // Above the top, mirrored.
+        assert_eq!(hit(75.0, -50.0).side, Side::Left);
+    }
+
+    #[test]
+    fn degenerate_metrics_do_not_panic() {
+        assert_eq!(
+            cell_at(5.0, 5.0, 0.0, 20.0, 8, 4),
+            CellHit {
+                row: 0,
+                col: 0,
+                side: Side::Left
+            }
+        );
+        assert_eq!(
+            cell_at(5.0, 5.0, 10.0, 20.0, 0, 0),
+            CellHit {
+                row: 0,
+                col: 0,
+                side: Side::Left
+            }
+        );
+        assert_eq!(cell_at(f32::NAN, f32::INFINITY, 10.0, 20.0, 8, 4).col, 0);
+    }
+
+    #[test]
+    fn drag_threshold_matches_the_gpui_default() {
+        assert_eq!(SELECTION_DRAG_THRESHOLD, 2.0);
     }
 }

--- a/crates/ui/src/terminal/view.rs
+++ b/crates/ui/src/terminal/view.rs
@@ -60,6 +60,29 @@ pub fn terminal_bg() -> Hsla {
     terminal_bg_for(current_appearance())
 }
 
+/// Selection wash over the grid.
+///
+/// Deliberately *achromatic*, which is where this differs from
+/// [`Theme::selection`] — the composer's blue. A saturated wash sits on top of
+/// sixteen ANSI hues and drags every one of them toward itself: red text under
+/// blue reads purple, green reads teal. A neutral veil changes lightness only,
+/// so selected output keeps the colors the program asked for — the whole point
+/// of tuning those palettes per appearance in the first place.
+///
+/// White on dark, black on light, the same direction [`crate::theme::ink`]
+/// takes. The alpha is heavier than a hover wash because this has to read as a
+/// deliberate highlight at a glance, and lighter than a plate because the
+/// glyphs underneath still have to be legible through it.
+pub fn terminal_selection_for(appearance: Appearance) -> Hsla {
+    match appearance {
+        Appearance::Dark => gpui::hsla(0.0, 0.0, 1.0, 0.22),
+        // Slightly heavier: an equal alpha of black on near-white reads fainter
+        // than white on near-black, because the surround is brighter to begin
+        // with.
+        Appearance::Light => gpui::hsla(0.0, 0.0, 0.0, 0.16),
+    }
+}
+
 /// The 16 ANSI colors tuned for the near-black background (indexes 0-7 normal,
 /// 8-15 bright).
 const ANSI16_DARK: [(u8, u8, u8); 16] = [
@@ -545,7 +568,7 @@ impl gpui::Element for TerminalElement {
                                 point(origin.x + cell_w * start as f32, y),
                                 size(cell_w * (col - start) as f32, line_h),
                             ),
-                            theme.selection,
+                            terminal_selection_for(theme.appearance),
                         ));
                         sel_start = None;
                     }
@@ -1119,5 +1142,22 @@ mod tests {
     #[test]
     fn drag_threshold_matches_the_gpui_default() {
         assert_eq!(SELECTION_DRAG_THRESHOLD, 2.0);
+    }
+
+    /// The selection veil must stay achromatic, or it tints the ANSI text it
+    /// covers instead of just lifting it.
+    #[test]
+    fn selection_wash_is_neutral_and_translucent() {
+        for appearance in [Appearance::Dark, Appearance::Light] {
+            let wash = terminal_selection_for(appearance);
+            assert_eq!(wash.s, 0.0, "{appearance:?} selection must have no hue");
+            assert!(
+                wash.a > 0.0 && wash.a < 0.5,
+                "{appearance:?} selection must veil the cell, not replace it"
+            );
+        }
+        // Opposite directions: lighten the dark grid, darken the light one.
+        assert_eq!(terminal_selection_for(Appearance::Dark).l, 1.0);
+        assert_eq!(terminal_selection_for(Appearance::Light).l, 0.0);
     }
 }


### PR DESCRIPTION
> **Stacked on #20.** The first of the three commits (`15e424d`, the light/dark palette) belongs to that PR and will drop out of this diff once it merges. The two commits to review here are `59f7c54` and `d645210`.

The terminal grid painted output but never let you take it back out — there was no way to highlight anything, so nothing could be copied.

### What works now

- **Drag** to select
- **Double-click** for a word, **triple-click** for a line
- **Shift+click** extends an existing selection
- **Cmd+C** (or Ctrl+Shift+C) copies

### How

`Term` already owns a selection and already knows how to keep its anchors on their text as output scrolls the grid underneath. So the emulator layer is a thin translation: viewport rows in, grid points out, `selection_to_string` for the copy. Cells carry a `selected` flag; the view merges selected runs into wash quads, painted over the cell background but under the glyphs so highlighted text stays readable.

### Two details from reading zed's terminal

Zed embeds the same `alacritty_terminal`, and their mouse layer handles two things that are not obvious until they bite:

**Overshoot has to force the selection *side*, not just clamp the cell.** Drag past the bottom edge and drift left of where you started, and a side derived from x stops the selection mid-row instead of taking the last line whole. Clamping alone leaves that bug. Alacritty and zed both force `Right` past the right/bottom edge and `Left` above the top; so does this.

**A press must not select on its own.** Without a travel threshold, the click that focuses the panel leaves a one-cell selection behind whenever the hand moves a pixel. Harmless today, but it is exactly what clobbers the clipboard the moment anything copies on selection change. 2px, matching zed's `SELECTION_DRAG_THRESHOLD` and gpui's own `div` threshold.

### Selection color

Deliberately achromatic — white at 22% on dark, black at 16% on light — rather than reusing `Theme::selection`, which is the composer's blue. A saturated veil sits on top of sixteen ANSI hues and drags every one toward itself: red output reads purple under selection, green reads teal. Neutral moves lightness only, so selected text keeps the colors the program asked for.

### Not implemented: mouse reporting

Programs that ask for the mouse (vim, htop) still do not receive events. That was already true before this change — but it means selection now owns the mouse unconditionally instead of going dead inside those programs, which is the more useful behaviour while reporting is missing. Zed gates all of this behind `mouse_mode(shift)`; when reporting lands here, that is the gate it has to go behind, and the check belongs in `TerminalPanel::on_mouse_down`.

### Tests

12 new. Pointer hit-testing including overshoot sides and degenerate metrics; word and line granularity; a selection surviving the output that scrolls it; a click without a drag reporting no selection; the wash staying achromatic in both appearances.

`comet-ui` is 375/375 green, clippy and fmt clean. Verified by hand in the running app.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788552823&installation_model_id=425430&pr_number=21&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F21&signature=4d7f69d4d540c62078874ffb2851eb3a4888279f735a145d9c89aca2da740d64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->