### PR TITLE
Terminal: new-tab, select-all and close-tab shortcuts

### DIFF
--- a/crates/ui/src/app_menus.rs
+++ b/crates/ui/src/app_menus.rs
@@ -91,7 +91,13 @@ fn macos_key_bindings() -> Vec<KeyBinding> {
         KeyBinding::new("cmd-h", Hide, None),
         KeyBinding::new("alt-cmd-h", HideOthers, None),
         KeyBinding::new("cmd-m", Minimize, None),
-        KeyBinding::new("cmd-w", CloseWindow, None),
+        // AppKit fires menu key equivalents in `performKeyEquivalent:`, before
+        // the key reaches any view, so a menu item holding ⌘W would make every
+        // view-level ⌘W binding unreachable. ⌘⇧W leaves the chord free for the
+        // terminal's close-tab, as zed and Safari do. Keep this the action's
+        // only binding: gpui derives the menu equivalent from the keymap, and a
+        // second ⌘W binding could hand the menu back the chord it just gave up.
+        KeyBinding::new("cmd-shift-w", CloseWindow, None),
     ]
 }
 
@@ -264,7 +270,9 @@ mod tests {
         };
         let combo = |source: &str| vec![Keystroke::parse(source).unwrap()];
         assert_eq!(find(Quit.name()), Some(combo("cmd-q")));
-        assert_eq!(find(CloseWindow.name()), Some(combo("cmd-w")));
+        // Not ⌘W: that chord belongs to the terminal's close-tab, and a menu
+        // equivalent would intercept it before any view saw it.
+        assert_eq!(find(CloseWindow.name()), Some(combo("cmd-shift-w")));
         assert_eq!(find(Minimize.name()), Some(combo("cmd-m")));
     }
 }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -44,7 +44,9 @@ use crate::state::{
     AppState, ConnectionStatus, EngineBootConfig, GatePhase, Indicator, OrgRow, format_time_ago,
     org_name_valid, parse_orgs, sort_memberships,
 };
-use crate::terminal::panel::{TerminalPanel, ToggleTerminal, clamp_terminal_height};
+use crate::terminal::panel::{
+    NewTerminalTab, TerminalPanel, ToggleTerminal, clamp_terminal_height,
+};
 use crate::theme::Theme;
 use crate::transcript::{self, Transcript};
 
@@ -136,6 +138,9 @@ pub fn apply_keymap(cx: &mut App, keymap: &KeymapConfig) {
         // bar); pressing it again dismisses.
         KeyBinding::new(&platform_combo("mod-k"), AddSpacePalette, None),
     ]);
+    // The `clear_key_bindings` above drops whatever `terminal::panel::init`
+    // bound at app start, so these have to be re-registered here.
+    cx.bind_keys(crate::terminal::panel::fixed_key_bindings());
 }
 
 /// The settings sections (feature-inventory §1.5 routes).
@@ -203,6 +208,15 @@ impl SessionPanels {
         let entry = self.map.entry(key.to_string()).or_default();
         entry.terminal_open = !entry.terminal_open;
         entry.terminal_open
+    }
+
+    /// Returns whether the flag changed, so callers can run the open-only side
+    /// effects exactly once.
+    pub fn open_terminal(&mut self, key: &str) -> bool {
+        let entry = self.map.entry(key.to_string()).or_default();
+        let was_open = entry.terminal_open;
+        entry.terminal_open = true;
+        !was_open
     }
 
     /// Flip the changes flag for `key`; returns the new value.
@@ -989,6 +1003,37 @@ impl Shell {
             })
             .ok();
         }));
+        cx.notify();
+    }
+
+    /// Opens the panel when closed, adds a tab when already open: `set_open`
+    /// creates the first tab itself, so doing both would open two.
+    fn new_terminal_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // `terminal_target` reads the flag, so sample before flipping it or the
+        // tween starts from its own destination.
+        let from = self.terminal_target(cx);
+        let key = self.panel_key(cx);
+        let opened = self.panels.open_terminal(&key);
+        let panel = self.terminal_panel(cx);
+        if opened {
+            self.terminal_tween = Some(WidthTween::new(from, self.terminal_target(cx)));
+            panel.update(cx, |panel, cx| panel.set_open(true, cx));
+            self.terminal_tween_task = Some(cx.spawn(async move |this, cx| {
+                cx.background_executor()
+                    .timer(
+                        RESIZE.total().mul_f32(motion::speed_scale()) + Duration::from_millis(30),
+                    )
+                    .await;
+                this.update(cx, |shell, cx| {
+                    shell.terminal_tween = None;
+                    cx.notify();
+                })
+                .ok();
+            }));
+        } else {
+            panel.update(cx, |panel, cx| panel.open_new_tab(cx));
+        }
+        window.focus(&panel.read(cx).focus_handle(), cx);
         cx.notify();
     }
 
@@ -3817,6 +3862,11 @@ impl Render for Shell {
             .on_action(cx.listener(|this, _: &ToggleTerminal, window, cx| {
                 if matches!(this.route, Route::Chat) {
                     this.toggle_terminal(window, cx)
+                }
+            }))
+            .on_action(cx.listener(|this, _: &NewTerminalTab, window, cx| {
+                if matches!(this.route, Route::Chat) {
+                    this.new_terminal_tab(window, cx)
                 }
             }))
             .on_action(cx.listener(|this, _: &ToggleSidebar, _, cx| this.toggle_sidebar(cx)))

--- a/crates/ui/src/terminal/emulator.rs
+++ b/crates/ui/src/terminal/emulator.rs
@@ -7,9 +7,8 @@
 //! That split makes the whole escape-sequence surface unit-testable with
 //! scripted byte strings.
 //!
-//! Selection lives here too ([`Emulator::start_selection`] and friends) rather
-//! than in the panel, because `Term` is what knows how to keep anchors on their
-//! text as output scrolls the grid underneath them.
+//! Selection lives here rather than in the panel because `Term` is what keeps
+//! anchors on their text as output scrolls the grid underneath them.
 //!
 //! API notes for the pinned `alacritty_terminal 0.26` / `vte 0.15`:
 //! - `Processor::advance` consumes a byte slice; `Term` implements the
@@ -32,10 +31,8 @@ use alacritty_terminal::vte::ansi::{
     Color as AnsiColor, CursorShape, NamedColor, Processor, Rgb as AnsiRgb,
 };
 
-/// Grid coordinates and selection granularity, re-exported so the panel and
-/// view speak the emulator's vocabulary without depending on
-/// `alacritty_terminal` directly — the same seam [`CellColor`] draws for
-/// colors.
+/// Re-exported so the panel and view need no direct `alacritty_terminal`
+/// dependency, the same seam [`CellColor`] draws for colors.
 pub use alacritty_terminal::index::{Point as GridPoint, Side};
 pub use alacritty_terminal::selection::SelectionType;
 
@@ -130,7 +127,6 @@ pub struct CellSnapshot {
     pub wide: bool,
     /// The spacer half of a wide char — never shaped, only background-painted.
     pub wide_spacer: bool,
-    /// Inside the active selection: the view paints a wash over this cell.
     pub selected: bool,
 }
 
@@ -262,18 +258,12 @@ impl Emulator {
 
     // ---- selection ----
     //
-    // `Term` owns the selection outright, which is what makes this cheap: it
-    // rotates the anchors when output scrolls the grid and drops them on clear
-    // and resize, so a selection tracks live output without any bookkeeping
-    // here. The panel supplies pointer positions; everything below is a thin
-    // translation into grid coordinates.
+    // `Term` owns the selection: it rotates anchors when output scrolls the
+    // grid and drops them on clear and resize, so a selection tracks live
+    // output without bookkeeping here.
 
-    /// The grid point under a viewport cell (row 0 = top of the visible area).
-    ///
-    /// Viewport rows are what the pointer hits; grid lines are what a selection
-    /// anchors to, and the two differ by the scrollback offset. Anchoring in
-    /// grid space is what lets a selection stay on its text while the view
-    /// scrolls out from under it.
+    /// Anchors live in grid space, not viewport space, so a selection stays on
+    /// its text while the view scrolls out from under it.
     pub fn grid_point(&self, viewport_row: usize, col: usize) -> Point {
         Point::new(
             Line(viewport_row as i32 - self.display_offset() as i32),
@@ -281,14 +271,10 @@ impl Emulator {
         )
     }
 
-    /// Begin a selection. `ty` picks the granularity: [`SelectionType::Simple`]
-    /// for a drag, `Semantic` for a double-click word, `Lines` for a triple-
-    /// click row.
     pub fn start_selection(&mut self, ty: SelectionType, point: Point, side: Side) {
         self.term.selection = Some(Selection::new(ty, point, side));
     }
 
-    /// Extend the in-progress selection to `point`. No-op without one.
     pub fn update_selection(&mut self, point: Point, side: Side) {
         if let Some(selection) = self.term.selection.as_mut() {
             selection.update(point, side);
@@ -299,14 +285,24 @@ impl Emulator {
         self.term.selection = None;
     }
 
-    /// The selected text, or `None` when there is no selection or it covers
-    /// nothing (a click without a drag leaves an empty one behind).
+    /// Covers scrollback, not just the viewport: the text that scrolled past is
+    /// usually the part worth copying.
+    pub fn select_all(&mut self) {
+        let top = Point::new(Line(-(self.history_lines() as i32)), Column(0));
+        let bottom = Point::new(
+            Line(self.rows().saturating_sub(1) as i32),
+            Column(self.cols().saturating_sub(1)),
+        );
+        self.start_selection(SelectionType::Simple, top, Side::Left);
+        self.update_selection(bottom, Side::Right);
+    }
+
+    /// `None` when nothing is selected, including the empty selection a click
+    /// without a drag leaves behind.
     pub fn selection_text(&self) -> Option<String> {
         self.term.selection_to_string().filter(|s| !s.is_empty())
     }
 
-    /// Whether a non-empty selection is active — drives the copy action and
-    /// the "clear it" branch on the next click.
     pub fn has_selection(&self) -> bool {
         self.selection_range().is_some()
     }
@@ -323,9 +319,8 @@ impl Emulator {
         self.line_inner(viewport_row, self.selection_range())
     }
 
-    /// The shared body of [`Self::line`], taking the selection range as an
-    /// argument so [`Self::lines`] resolves it once per frame rather than once
-    /// per row — `to_range` re-walks the grid for semantic and line selections.
+    /// Takes the range as an argument so [`Self::lines`] resolves it once per
+    /// frame; `to_range` re-walks the grid for semantic and line selections.
     fn line_inner(
         &self,
         viewport_row: usize,
@@ -621,9 +616,6 @@ mod tests {
         assert_eq!(e.cursor(), Some(CursorSnapshot { row: 0, col: 3 }));
     }
 
-    /// Viewport row → grid line, which is the translation every selection
-    /// anchor goes through. Unscrolled they coincide; scrolled back, the same
-    /// viewport row names a line further up history.
     #[test]
     fn grid_point_offsets_by_the_scrollback_position() {
         let mut e = emu(10, 3);
@@ -633,8 +625,6 @@ mod tests {
         assert_eq!(e.grid_point(0, 2), Point::new(Line(0), Column(2)));
         e.scroll(4);
         assert_eq!(e.grid_point(0, 2), Point::new(Line(-4), Column(2)));
-        // Columns clamp into the grid so an over-wide pointer cannot anchor
-        // outside it.
         assert_eq!(e.grid_point(0, 99).column, Column(9));
     }
 
@@ -645,7 +635,6 @@ mod tests {
         assert!(!e.has_selection());
         assert_eq!(e.selection_text(), None);
 
-        // Drag across "hello".
         e.start_selection(SelectionType::Simple, e.grid_point(0, 0), Side::Left);
         e.update_selection(e.grid_point(0, 4), Side::Right);
         assert!(e.has_selection());
@@ -660,8 +649,6 @@ mod tests {
         assert!(e.line(0).iter().all(|c| !c.selected));
     }
 
-    /// Double-click granularity: the anchor expands to the whole word without
-    /// the caller computing any boundaries.
     #[test]
     fn semantic_selection_expands_to_the_word() {
         let mut e = emu(30, 2);
@@ -670,9 +657,8 @@ mod tests {
         assert_eq!(e.selection_text().as_deref(), Some("beta"));
     }
 
-    /// Triple-click granularity. The trailing newline is part of the copy —
-    /// pasting a line-selection should reproduce the line break, the way it
-    /// does in every other terminal.
+    /// The trailing newline is part of the copy, so pasting reproduces the
+    /// line break.
     #[test]
     fn line_selection_takes_the_whole_row() {
         let mut e = emu(30, 3);
@@ -681,8 +667,6 @@ mod tests {
         assert_eq!(e.selection_text().as_deref(), Some("second row\n"));
     }
 
-    /// A selection made across a line break keeps the newline, so pasting the
-    /// copy reproduces the rows.
     #[test]
     fn selection_spans_rows_with_a_newline() {
         let mut e = emu(10, 3);
@@ -692,8 +676,8 @@ mod tests {
         assert_eq!(e.selection_text().as_deref(), Some("ab\ncd"));
     }
 
-    /// The reason anchors live in grid space: output that scrolls the grid must
-    /// carry the selection with its text, not leave it pinned to a screen row.
+    /// Anchors live in grid space so scrolling output carries the selection
+    /// with its text instead of pinning it to a screen row.
     #[test]
     fn selection_follows_its_text_when_output_scrolls() {
         let mut e = emu(10, 3);
@@ -701,13 +685,39 @@ mod tests {
         e.start_selection(SelectionType::Simple, e.grid_point(0, 0), Side::Left);
         e.update_selection(e.grid_point(0, 5), Side::Right);
         assert_eq!(e.selection_text().as_deref(), Some("target"));
-        // Push it up the screen; the text is unchanged, so the copy is too.
         e.feed(b"a\r\nb\r\nc\r\n");
         assert_eq!(e.selection_text().as_deref(), Some("target"));
     }
 
-    /// A click with no drag selects nothing, and must not report a selection —
-    /// otherwise the copy action fires on every bare click.
+    #[test]
+    fn select_all_covers_scrollback_and_screen() {
+        let mut e = emu(10, 3);
+        for i in 1..=8 {
+            e.feed(format!("line{i}\r\n").as_bytes());
+        }
+        assert!(e.history_lines() > 0, "test needs real scrollback");
+        e.select_all();
+
+        let text = e.selection_text().expect("a selection");
+        assert!(text.contains("line1"), "scrollback missing from {text:?}");
+        assert!(text.contains("line8"), "screen missing from {text:?}");
+        assert!(e.lines().iter().flatten().all(|cell| cell.selected));
+    }
+
+    /// Must not panic reaching for a history that isn't there.
+    #[test]
+    fn select_all_on_an_empty_grid_is_harmless() {
+        let mut e = emu(10, 3);
+        e.select_all();
+        assert_eq!(e.history_lines(), 0);
+        let text = e.selection_text().unwrap_or_default();
+        assert!(
+            text.chars().all(char::is_whitespace),
+            "empty grid should yield only blank rows, got {text:?}"
+        );
+    }
+
+    /// Otherwise the copy action would fire on every bare click.
     #[test]
     fn a_click_without_a_drag_selects_nothing() {
         let mut e = emu(20, 2);

--- a/crates/ui/src/terminal/panel.rs
+++ b/crates/ui/src/terminal/panel.rs
@@ -27,7 +27,7 @@ use comet_proto::{TerminalEvent, TerminalSession};
 use comet_rpc::methods;
 
 use crate::motion::{self, AnimationExt as _, TAB_SLIDE};
-use crate::settings::{TERMINAL_MAX_VH, TERMINAL_MIN_HEIGHT};
+use crate::settings::{TERMINAL_MAX_VH, TERMINAL_MIN_HEIGHT, platform_combo};
 use crate::state::{AppState, EngineHandle};
 use crate::theme::Theme;
 
@@ -41,9 +41,45 @@ use super::view::{
 pub const TAB_WIDTH: f32 = 118.0;
 pub const TAB_BAR_HEIGHT: f32 = 40.0;
 
-actions!(terminal, [ToggleTerminal]);
+actions!(
+    terminal,
+    [
+        ToggleTerminal,
+        NewTerminalTab,
+        SelectAllTerminal,
+        CloseTerminalTab
+    ]
+);
 
-/// Bind the terminal keymap (global): Cmd+J on macOS, Ctrl+J elsewhere.
+/// Terminal shortcuts that are not user-customizable.
+///
+/// Register these from [`crate::shell::apply_keymap`], never from [`init`]:
+/// that function clears the keymap first and runs after it, so bindings placed
+/// in `init` disappear before the first frame with no error.
+///
+/// Shifted punctuation must be written as the character it produces —
+/// `ctrl-~`, not `ctrl-shift-\``. The platform reports `~` with no shift
+/// modifier, so the second form matches nothing. Letters keep shift as a
+/// modifier (`ctrl-shift-a`).
+///
+/// The `Terminal` scope on select-all and close-tab is load-bearing: gpui ranks
+/// matches by context depth before registration order, so scoping is what lets
+/// these outrank the global bindings on the same chords.
+pub fn fixed_key_bindings() -> Vec<KeyBinding> {
+    vec![
+        // Ctrl even on macOS, matching VS Code and zed.
+        KeyBinding::new("ctrl-~", NewTerminalTab, None),
+        KeyBinding::new(
+            &platform_combo("mod-a"),
+            SelectAllTerminal,
+            Some("Terminal"),
+        ),
+        KeyBinding::new(&platform_combo("mod-w"), CloseTerminalTab, Some("Terminal")),
+    ]
+}
+
+/// Covers the gap between app init and the first shell; `apply_keymap` then
+/// clears this and re-binds the toggle from the user's keymap.
 pub fn init(cx: &mut App) {
     let toggle = if cfg!(target_os = "macos") {
         "cmd-j"
@@ -175,13 +211,8 @@ pub struct GridSnapshot {
     pub cursor: Option<CursorSnapshot>,
 }
 
-/// Where the grid landed this frame, in window coordinates.
-///
-/// Reported by element prepaint because that is the only place the measured
-/// font metrics exist. Mouse events arrive on the wrapping div in window
-/// space, so mapping a pointer to a cell needs the glyph origin and the cell
-/// size the *current* frame used — a stale one puts the selection a row off
-/// after a resize.
+/// Where the grid landed this frame, in window coordinates. Reported from
+/// element prepaint, which is the only place the measured font metrics exist.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GridGeometry {
     /// Top-left of the first glyph (bounds origin plus padding).
@@ -192,17 +223,11 @@ pub struct GridGeometry {
     pub rows: u16,
 }
 
-/// An in-flight left-button gesture.
-///
-/// A press alone does not select. It arms this, and only pointer travel past
-/// [`SELECTION_DRAG_THRESHOLD`] promotes it to a real selection — otherwise the
-/// click that focuses the panel would leave a one-cell selection behind
-/// whenever the hand moves a pixel.
 #[derive(Debug, Clone, Copy)]
 struct SelectionDrag {
-    /// Press position, in window space: both the threshold origin and the
-    /// selection's anchor, so the selection starts where the press landed
-    /// rather than where the threshold happened to trip.
+    /// Press position, in window space. Doubles as the threshold origin and the
+    /// selection anchor, so a promoted drag covers the whole gesture rather
+    /// than starting where the threshold happened to trip.
     origin: gpui::Point<Pixels>,
     armed: bool,
 }
@@ -685,9 +710,8 @@ impl TerminalPanel {
             cx.stop_propagation();
             return;
         }
-        // Copy: Cmd+C (macOS) / Ctrl+Shift+C. Only swallowed when it actually
-        // copied — so Ctrl+Shift+C with nothing selected still falls through
-        // to the interrupt, and plain Ctrl+C (no shift) never reaches here.
+        // Swallowed only when it actually copied, so Ctrl+Shift+C with nothing
+        // selected still falls through to the interrupt.
         if ks.key == "c"
             && (mods.platform || (mods.control && mods.shift))
             && self.copy_selection(cx)
@@ -710,9 +734,8 @@ impl TerminalPanel {
     /// Called from element prepaint with the frame's grid placement. Resizes
     /// the emulator immediately; the `ResizeTerminal` RPC debounces 80 ms.
     pub fn on_grid_metrics(&mut self, geometry: GridGeometry, cx: &mut Context<Self>) {
-        // Stash unconditionally, before the early returns below: pointer
-        // mapping needs the placement even on frames where nothing resized,
-        // which is almost all of them.
+        // Before the early returns: pointer mapping needs the placement on
+        // every frame, not just resizing ones.
         self.geometry = Some(geometry);
         let (cols, rows) = (geometry.cols, geometry.rows);
         let Some(chat) = self.selected_chat(cx) else {
@@ -778,7 +801,6 @@ impl TerminalPanel {
 
     // ---- selection ----
 
-    /// Run `f` against the active tab's emulator.
     fn with_active_emulator<R>(
         &mut self,
         cx: &App,
@@ -790,8 +812,7 @@ impl TerminalPanel {
         tabs.tabs.get_mut(active).map(|tab| f(&mut tab.emulator))
     }
 
-    /// Window position → grid point, using this frame's placement. `None`
-    /// before the first prepaint, or when no tab is active.
+    /// `None` before the first prepaint, or with no active tab.
     fn grid_point_at(
         &mut self,
         position: gpui::Point<Pixels>,
@@ -820,8 +841,6 @@ impl TerminalPanel {
         let Some((point, side)) = self.grid_point_at(event.position, cx) else {
             return;
         };
-        // Click count picks the granularity, the same mapping every terminal
-        // uses: drag, word, line.
         let ty = match event.click_count {
             0 => return,
             1 => SelectionType::Simple,
@@ -830,9 +849,6 @@ impl TerminalPanel {
         };
         let shift = event.modifiers.shift;
         if ty == SelectionType::Simple {
-            // Shift+click extends an existing selection instead of replacing
-            // it — the one gesture that reaches text off the bottom of a long
-            // drag without redoing the whole thing.
             let extended = shift
                 && self
                     .with_active_emulator(cx, |emu| {
@@ -851,17 +867,14 @@ impl TerminalPanel {
                 cx.notify();
                 return;
             }
-            // A plain press clears and arms; the selection itself only begins
-            // once the pointer travels far enough to mean it.
             self.with_active_emulator(cx, |emu| emu.clear_selection());
             self.selection_drag = Some(SelectionDrag {
                 origin: event.position,
                 armed: false,
             });
         } else {
-            // Word and line selections are complete on the press, so they need
-            // no threshold — but keep the drag live so the pointer can extend
-            // them at that granularity.
+            // Already complete on the press, so no threshold — but stay armed
+            // so the pointer can extend at this granularity.
             self.with_active_emulator(cx, |emu| emu.start_selection(ty, point, side));
             self.selection_drag = Some(SelectionDrag {
                 origin: event.position,
@@ -889,8 +902,6 @@ impl TerminalPanel {
             if dx.hypot(dy) < SELECTION_DRAG_THRESHOLD {
                 return;
             }
-            // Threshold tripped: anchor at the *press*, not here, so the
-            // selection covers the whole gesture.
             let Some((anchor, side)) = self.grid_point_at(drag.origin, cx) else {
                 return;
             };
@@ -918,8 +929,40 @@ impl TerminalPanel {
         self.selection_drag = None;
     }
 
-    /// Copy the selection. Returns whether anything was copied, so the caller
-    /// can decide whether to swallow the keystroke.
+    pub fn open_new_tab(&mut self, cx: &mut Context<Self>) {
+        let Some(chat) = self.selected_chat(cx) else {
+            return;
+        };
+        self.open_tab(chat, cx);
+    }
+
+    fn on_select_all(
+        &mut self,
+        _: &SelectAllTerminal,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.with_active_emulator(cx, |emu| emu.select_all());
+        cx.notify();
+    }
+
+    fn on_close_tab(&mut self, _: &CloseTerminalTab, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(chat) = self.selected_chat(cx) else {
+            return;
+        };
+        let Some(key) = self
+            .chats
+            .get(&chat)
+            .and_then(|tabs| tabs.tabs.get(tabs.active))
+            .map(|tab| tab.key)
+        else {
+            return;
+        };
+        self.close_tab(&chat, key, window, cx);
+    }
+
+    /// Returns whether anything was copied, so the caller can decide whether to
+    /// swallow the keystroke.
     fn copy_selection(&mut self, cx: &mut Context<Self>) -> bool {
         let Some(text) = self
             .with_active_emulator(cx, |emu| emu.selection_text())
@@ -1309,13 +1352,13 @@ impl Render for TerminalPanel {
                     .min_h_0()
                     .key_context("Terminal")
                     .track_focus(&self.focus_handle)
+                    .on_action(cx.listener(Self::on_select_all))
+                    .on_action(cx.listener(Self::on_close_tab))
                     .on_key_down(cx.listener(Self::on_key_down))
                     .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
                     .on_mouse_move(cx.listener(Self::on_mouse_move))
-                    // Bound on the window, not the element: a drag that ends
-                    // outside the panel still has to end the gesture, or the
-                    // next unrelated pointer move keeps extending a selection
-                    // the user let go of.
+                    // A drag released outside the panel must still end the
+                    // gesture, or later pointer moves keep extending it.
                     .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_mouse_up))
                     .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
                     .on_scroll_wheel(cx.listener(|this, event: &gpui::ScrollWheelEvent, _, cx| {
@@ -1346,6 +1389,74 @@ mod tests {
         // Tiny windows: min wins over the 55vh cap.
         assert_eq!(clamp_terminal_height(200.0, 100.0), 160.0);
         assert_eq!(clamp_terminal_height(f32::NAN, 900.0), 160.0);
+    }
+
+    /// `KeyBinding::new` panics on an unparseable combo, so building the table
+    /// is itself the parse check.
+    #[test]
+    fn fixed_bindings_parse_and_scope_correctly() {
+        use gpui::Action as _;
+        let bindings = fixed_key_bindings();
+        assert_eq!(bindings.len(), 3);
+
+        let find = |name: &str| {
+            bindings
+                .iter()
+                .find(|binding| binding.action().name() == name)
+                .expect("binding present")
+        };
+        assert_eq!(find(NewTerminalTab.name()).predicate(), None);
+
+        // `ctrl-shift-\`` would parse and build, then never fire: the platform
+        // reports the shifted character and drops the modifier.
+        let strokes = find(NewTerminalTab.name()).keystrokes();
+        assert_eq!(strokes.len(), 1, "new-tab is a single chord");
+        let chord = strokes[0].inner();
+        assert_eq!(chord.key, "~", "bind the shifted character, not shift + `");
+        assert!(
+            chord.modifiers.control,
+            "VS Code and zed both use Ctrl here"
+        );
+        assert!(
+            !chord.modifiers.shift,
+            "shift is folded into '~'; demanding it too matches nothing"
+        );
+        assert!(!chord.modifiers.platform, "not Cmd, even on macOS");
+        for scoped in [SelectAllTerminal.name(), CloseTerminalTab.name()] {
+            assert!(
+                find(scoped).predicate().is_some(),
+                "{scoped} must stay scoped to the Terminal context"
+            );
+        }
+
+        let primary = |name: &str| {
+            let chord = find(name).keystrokes()[0].inner().clone();
+            (chord.key, chord.modifiers)
+        };
+        for name in [SelectAllTerminal.name(), CloseTerminalTab.name()] {
+            let (_, mods) = primary(name);
+            if cfg!(target_os = "macos") {
+                assert!(mods.platform, "{name} should use Cmd on macOS");
+                assert!(!mods.control, "{name} should not also demand Ctrl");
+            } else {
+                assert!(mods.control, "{name} should use Ctrl off macOS");
+                assert!(!mods.platform, "{name} should not demand the super key");
+            }
+        }
+        assert_eq!(primary(SelectAllTerminal.name()).0, "a");
+        assert_eq!(primary(CloseTerminalTab.name()).0, "w");
+    }
+
+    /// `apply_keymap` clears the keymap after `init` runs, so anything `init`
+    /// owns beyond the toggle would be silently dropped.
+    #[test]
+    fn fixed_bindings_are_not_bound_by_init() {
+        use gpui::Action as _;
+        let names: Vec<_> = fixed_key_bindings()
+            .iter()
+            .map(|b| b.action().name().to_string())
+            .collect();
+        assert!(!names.contains(&ToggleTerminal.name().to_string()));
     }
 
     #[test]


### PR DESCRIPTION
> **Stacked on #21** (which is itself stacked on #20). The first three commits belong to those PRs and drop out of this diff as they merge. The commit to review here is `8e63b6f`.

| Chord | Action | Scope |
|---|---|---|
| <kbd>Ctrl+Shift+`</kbd> | New terminal tab | Global |
| <kbd>Cmd/Ctrl+A</kbd> | Select all, scrollback included | Terminal |
| <kbd>Cmd/Ctrl+W</kbd> | Close active tab | Terminal |

New-tab opens the panel when it is closed and adds a tab when it is already open — `set_open` creates the first tab itself, so doing both would open two. Close-tab goes through the same path as middle-click and the tab's ×, so closing the last one still collapses the drawer and still tells the engine to reap the PTY.

### Three things that fail silently if you get them wrong

**Bindings must be registered from `apply_keymap`, not `terminal::panel::init`.** That function clears the keymap, and `Shell::new` runs it during startup — so anything bound at app init is gone before the first frame. No error; the shortcut simply never fires. There is a test keeping these out of `init`.

**Shifted punctuation is written as the character it produces.** `ctrl-shift-\`` parses, builds, and then never matches: the platform reports `~` with no shift modifier, so a binding demanding both matches nothing. Letters are the opposite — `ctrl-shift-a` is right, because Shift stays a modifier. zed's keymaps show the same split (`ctrl-~`, `ctrl-?` for punctuation; `ctrl-shift-c`, `ctrl-shift-n` for letters). A test pins the chord to key `~`, ctrl on, shift off.

**macOS "Close Window" moves off ⌘W to ⌘⇧W.** AppKit fires menu key equivalents in `performKeyEquivalent:`, before the key reaches any view, so a menu item holding ⌘W makes every view-level ⌘W binding unreachable. zed and Safari move it for the same reason.

### Consequences worth flagging

- **⌘W no longer closes the window.** ⌘⇧W does, and that is now the action's only binding — gpui derives the menu equivalent from the keymap, and a second ⌘W binding risks handing the menu back the chord it just gave up. Outside the terminal, ⌘W does nothing.
- **On Windows and Linux, select-all and close-tab resolve to Ctrl+A and Ctrl+W**, shadowing readline's beginning-of-line and delete-word inside the terminal. Same trade VS Code makes; shifted forms are the alternative if it grates.
- New-tab keeps literal Ctrl on macOS rather than Cmd, matching VS Code and zed.

Scoping select-all and close-tab to the `Terminal` context is also what gives them precedence: gpui ranks matches by context depth before registration order.

### Testing

`comet-ui` is 380/380 green, clippy and fmt clean. New coverage: select-all reaching into scrollback and not panicking on an empty grid; the binding table parsing, scoping, and resolving `mod-` per platform.

Verified in the running app that ⌘⇧W closes the window. The remaining chords are covered by unit tests but have not been through a manual pass end to end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788555112&installation_model_id=425430&pr_number=22&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F22&signature=8fcb2d69db867d0c95ff4671ea9084672a37219b08a4fe2a68e549377f0decc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->