### PR TITLE
Fix phantom worktree spaces and missing harness glyph from the claim race

### DIFF
--- a/apps/ios/Comet/Models/Entities.swift
+++ b/apps/ios/Comet/Models/Entities.swift
@@ -242,6 +242,10 @@ let commandDefaultTtlMs: Int64 = 86_400_000
 /// kebab-case ("claude-code").
 struct RunRequest: Codable {
     var prompt: String
+    /// Harness id ("claude-code") picked at send time; rides the command so
+    /// the host's claim-on-first-command records it even when the chat row is
+    /// still syncing.
+    var harness: String?
     var model: String?
     var reasoning: String?
     var modelOptions: [String: String] = [:]

--- a/apps/ios/Comet/Sync/SessionStore.swift
+++ b/apps/ios/Comet/Sync/SessionStore.swift
@@ -301,6 +301,7 @@ final class SessionStore {
         }
         let messageId = UUID().uuidString.lowercased()
         let request = RunRequest(prompt: prompt,
+                                 harness: chat.config?.harness,
                                  model: chat.config?.model,
                                  reasoning: chat.config?.reasoning,
                                  cwd: chat.cwd ?? "",

--- a/crates/doc/src/commands.rs
+++ b/crates/doc/src/commands.rs
@@ -304,6 +304,7 @@ mod tests {
     fn run_request() -> RunRequest {
         RunRequest {
             prompt: "hello".into(),
+            harness: None,
             model: None,
             reasoning: None,
             model_options: Default::default(),

--- a/crates/doc/src/registry.rs
+++ b/crates/doc/src/registry.rs
@@ -834,6 +834,32 @@ impl RegistryDoc {
         Ok(())
     }
 
+    /// Claim-on-first-command row: ONLY the fields the claim actually knows
+    /// (identity, cwd, space). Absent fields carry no clocked write, so the
+    /// real `createChat` upsert — racing behind on the registry channel with
+    /// older clocks — still lands its `config`/`title` under per-field LWW
+    /// instead of losing them to `Null` deletes.
+    pub fn claim_chat(
+        &mut self,
+        chat_id: &str,
+        cwd: Option<&str>,
+        space_id: Option<&str>,
+        created_at: DateTime<Utc>,
+    ) {
+        let mut set = fields([
+            ("id", json!(chat_id)),
+            ("deviceId", json!(self.device_id())),
+            ("createdAt", json!(created_at.timestamp_millis())),
+        ]);
+        if let Some(cwd) = cwd {
+            set.insert("cwd".into(), json!(cwd));
+        }
+        if let Some(space_id) = space_id {
+            set.insert("spaceId".into(), json!(space_id));
+        }
+        self.write(KIND_CHATS, chat_id, OpKind::Upsert, set);
+    }
+
     /// Synced seen marker (LWW) with a monotonic guard: no write when the
     /// stored stamp is already >= `at`.
     pub fn set_chat_seen(&mut self, chat_id: &str, at: DateTime<Utc>) -> Result<bool, DocError> {

--- a/crates/doc/src/registry/tests.rs
+++ b/crates/doc/src/registry/tests.rs
@@ -499,6 +499,39 @@ fn two_docs_converge_through_a_server() {
     ));
 }
 
+/// The command plane outruns the registry channel: the host's
+/// claim-on-first-command lands with NEWER clocks than the viewer's earlier
+/// `createChat`. The claim writes only the fields it knows, so the viewer's
+/// `config`/`title` must still land on merge (a full-row claim's `Null`
+/// writes deleted them — the missing-harness-icon clobber).
+#[test]
+fn late_create_chat_config_survives_a_prior_claim() {
+    let mut viewer = RegistryDoc::new("dev-viewer");
+    let mut host = RegistryDoc::new("dev-a");
+
+    // Viewer writes the real row first (older clocks)…
+    viewer.upsert_chat(&chat("chat-race", "dev-a")).unwrap();
+    // …then the host claims the same chat before that row reaches it. (Real
+    // claims trail by whole seconds; the sleep keeps the HLCs out of the
+    // same-millisecond device-id tiebreak.)
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    host.claim_chat("chat-race", Some("/tmp/repo"), Some("space-1"), ts(9_000));
+
+    let mut server = HashMap::new();
+    let mut seq = 0u64;
+    server_round(&mut server, &mut seq, &mut [&mut viewer, &mut host]);
+
+    for doc in [&viewer, &host] {
+        let merged = doc.chat("chat-race").unwrap().expect("merged row");
+        // Claimed fields (newer clocks) stand…
+        assert_eq!(merged.device_id, "dev-a");
+        assert_eq!(merged.space_id.as_deref(), Some("space-1"));
+        // …and the fields the claim never wrote come from the createChat.
+        assert_eq!(merged.config, chat("chat-race", "dev-a").config);
+        assert_eq!(merged.title.as_deref(), Some("First chat"));
+    }
+}
+
 #[test]
 fn delete_space_cascades_and_converges() {
     let mut a = RegistryDoc::new("dev-a");

--- a/crates/doc/tests/attachments_roundtrip.rs
+++ b/crates/doc/tests/attachments_roundtrip.rs
@@ -8,6 +8,7 @@ fn run_request_attachments_survive_command_round_trip() {
     let doc = SessionDoc::init("chat-1").unwrap();
     let request = comet_proto::RunRequest {
         prompt: "p".into(),
+        harness: None,
         model: None,
         reasoning: None,
         model_options: Default::default(),

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -688,6 +688,17 @@ impl DocHost {
             .unwrap_or(self.inner.config.default_harness)
     }
 
+    /// The harness a request dispatches on: the request's own pick when it
+    /// carries one (rides the command plane, immune to registry-row races),
+    /// else [`Self::harness_for`].
+    pub(crate) fn harness_for_request(
+        &self,
+        chat_id: &str,
+        request: &comet_proto::RunRequest,
+    ) -> HarnessId {
+        request.harness.unwrap_or_else(|| self.harness_for(chat_id))
+    }
+
     /// Drain pending commands (host-only): evaluate → mark processed BEFORE execute →
     /// execute → write the outcome as the sole outcome writer.
     pub async fn drain_commands(&self, handle: &Arc<ChatDocHandle>) {
@@ -797,7 +808,26 @@ impl DocHost {
                 if let Some(ws) = self.workspace() {
                     ws.claim_chat(chat_id, Some(&request.cwd))?;
                 }
-                let harness = self.harness_for(chat_id);
+                let harness = self.harness_for_request(chat_id, request);
+                // A row with no config renders no harness glyph (and every
+                // later dispatch falls back to the engine default), so stamp
+                // what this run actually executes with. Claimed rows and
+                // catalog-not-loaded createChats both land here; the racing
+                // real createChat carries the same picked values.
+                if let Some(ws) = self.workspace()
+                    && ws.chat_config(chat_id).is_none()
+                {
+                    let config = comet_proto::ChatConfig {
+                        harness,
+                        model: request.model.clone(),
+                        reasoning: request.reasoning,
+                        model_options: request.model_options.clone(),
+                        sandbox: request.sandbox,
+                    };
+                    if let Err(err) = ws.set_chat_config(chat_id, &config) {
+                        tracing::warn!(chat = %chat_id, error = %err, "run-config backfill failed");
+                    }
+                }
                 sessions
                     .dispatch(chat_id, harness, request.clone(), Some(message_id.clone()))
                     .await?;
@@ -829,13 +859,9 @@ impl DocHost {
                         // turn's images; this steer's own refs (if any) already
                         // ride the prompt text.
                         request.attachments = Vec::new();
+                        let harness = self.harness_for_request(chat_id, &request);
                         sessions
-                            .dispatch(
-                                chat_id,
-                                self.harness_for(chat_id),
-                                request,
-                                message_id.clone(),
-                            )
+                            .dispatch(chat_id, harness, request, message_id.clone())
                             .await?;
                         Ok((
                             SessionCommandStatus::Applied,
@@ -907,9 +933,8 @@ impl DocHost {
                     tracing::warn!(chat = %chat_id, request = %request_id, error = %err,
                         "orphaned input resolve failed");
                 }
-                sessions
-                    .dispatch(chat_id, self.harness_for(chat_id), request, None)
-                    .await?;
+                let harness = self.harness_for_request(chat_id, &request);
+                sessions.dispatch(chat_id, harness, request, None).await?;
                 Ok((
                     SessionCommandStatus::Applied,
                     Some("answered as new turn".into()),
@@ -939,6 +964,7 @@ impl DocHost {
         let config = chat.config;
         Some(comet_proto::RunRequest {
             prompt: prompt.to_string(),
+            harness: config.as_ref().map(|c| c.harness),
             model: config.as_ref().and_then(|c| c.model.clone()),
             reasoning: config.as_ref().and_then(|c| c.reasoning),
             model_options: config

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -542,6 +542,7 @@ impl SessionsEngine {
                         let (_, cwd) = sessions.inner.journal_harness_session(&chat_id)?;
                         Some(RunRequest {
                             prompt: String::new(),
+                            harness: None,
                             model: None,
                             reasoning: None,
                             model_options: Default::default(),
@@ -559,7 +560,7 @@ impl SessionsEngine {
                 request.prompt = prompt_text;
                 request.resume = None; // dispatch re-injects the remembered session
                 request.attachments = Vec::new();
-                let harness_id = host.harness_for(&chat_id);
+                let harness_id = host.harness_for_request(&chat_id, &request);
                 match sessions
                     .dispatch(&chat_id, harness_id, request, Some(user_id))
                     .await

--- a/crates/engine/src/titles.rs
+++ b/crates/engine/src/titles.rs
@@ -163,6 +163,7 @@ impl TitleGenerator {
         for attempt in 0..=RETRY_DELAYS_MS.len() {
             let request = RunRequest {
                 prompt: title_prompt.clone(),
+                harness: Some(harness_id),
                 model: cheap.clone(),
                 reasoning: Some(ReasoningLevel::Minimal),
                 model_options: serde_json::Map::new(),

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -498,13 +498,17 @@ impl WorkspaceHost {
     /// Claim-on-first-command: create the chat row under OUR device id when a run
     /// command arrives for a chat with no row yet. No-op when the row exists.
     ///
+    /// The claim is a PARTIAL row write (identity/cwd/space only): the command
+    /// plane is nudged and outruns the registry channel, so the client's
+    /// `createChat` for the same chat routinely arrives AFTER the claim with
+    /// older clocks — fields the claim never wrote (`config`, `title`) must
+    /// still land then.
+    ///
     /// Spaces invariant: every chat belongs to a space, so the claim resolves an
     /// own-device space matching `cwd` — or auto-creates one (gitDetected false;
     /// SpacesSync corrects on its next pass). A cwd-less claim (e.g. note_message
     /// racing ahead of the run command) leaves `spaceId` unset; the row is
-    /// invisible to the UI until a spaced claim/create lands. NOTE: a worktree
-    /// cwd claims a space *at the worktree path*, not the repo root — acceptable
-    /// for tooling-only (raw doc command) traffic.
+    /// invisible to the UI until a spaced claim/create lands.
     pub fn claim_chat(&self, chat_id: &str, cwd: Option<&str>) -> Result<(), EngineError> {
         if self.read(|doc| doc.chat(chat_id))?.is_some() {
             return Ok(());
@@ -513,42 +517,37 @@ impl WorkspaceHost {
             Some(cwd) => Some(self.space_for_path(cwd)?),
             None => None,
         };
-        self.mutate(|doc| {
-            doc.upsert_chat(&Chat {
-                id: chat_id.to_string(),
-                device_id: doc.device_id().to_string(),
-                title: None,
-                archived: false,
-                cwd: cwd.map(str::to_string),
-                branch: None,
-                checkout_id: None,
-                config: None,
-                last_message_preview: None,
-                last_message_at: None,
-                created_at: Utc::now(),
-                harness_session_id: None,
-                harness_session_cwd: None,
-                space_id,
-                last_seen_at: None,
-            })
-        })?;
+        self.mutate(|doc| doc.claim_chat(chat_id, cwd, space_id.as_deref(), Utc::now()));
         Ok(())
     }
 
-    /// An own-device space whose path matches, else a freshly created one.
+    /// An own-device space whose path matches, else one at the path's parent
+    /// checkout root, else a freshly created one at that root.
+    ///
+    /// A linked-worktree cwd resolves to the checkout root FIRST: claiming at
+    /// the worktree path itself minted a phantom sidebar space named after the
+    /// worktree folder ("clever-ember") next to the project's real space.
     fn space_for_path(&self, path: &str) -> Result<String, EngineError> {
         let device_id = &self.inner.config.device_id;
-        if let Some(space) = self
-            .read(|doc| doc.read_spaces())?
-            .into_iter()
+        let spaces = self.read(|doc| doc.read_spaces())?;
+        if let Some(space) = spaces
+            .iter()
             .find(|s| s.device_id == *device_id && s.path == path)
         {
-            return Ok(space.id);
+            return Ok(space.id.clone());
+        }
+        let root = linked_worktree_root(std::path::Path::new(path));
+        if let Some(root) = root.as_deref()
+            && let Some(space) = spaces
+                .iter()
+                .find(|s| s.device_id == *device_id && s.path == root)
+        {
+            return Ok(space.id.clone());
         }
         let space = Space {
             id: crate::new_id(),
             device_id: device_id.clone(),
-            path: path.to_string(),
+            path: root.unwrap_or_else(|| path.to_string()),
             name: None,
             git_detected: false,
             git_checked_at: None,
@@ -992,6 +991,35 @@ impl WorkspaceHostInner {
     }
 }
 
+/// The parent checkout root of a linked git worktree: `<path>/.git` is a FILE
+/// containing `gitdir: <root>/.git/worktrees/<name>`. `None` for a primary
+/// checkout (`.git` is a directory), a non-repo folder, or any other layout
+/// (bare-repo worktrees have no `<root>` working copy to attribute to). Pure
+/// fs reads — no git subprocess; this runs on the synchronous claim path.
+fn linked_worktree_root(path: &std::path::Path) -> Option<String> {
+    let gitfile = path.join(".git");
+    if !std::fs::metadata(&gitfile).ok()?.is_file() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&gitfile).ok()?;
+    let target = content
+        .lines()
+        .find_map(|line| line.strip_prefix("gitdir:"))?
+        .trim();
+    let mut target = std::path::PathBuf::from(target);
+    if target.is_relative() {
+        // Rare (`worktree.useRelativePaths`); canonicalize resolves the
+        // `../..` hops against the real filesystem.
+        target = std::fs::canonicalize(path.join(target)).ok()?;
+    }
+    let worktrees = target.parent()?;
+    let dot_git = worktrees.parent()?;
+    if worktrees.file_name()? != "worktrees" || dot_git.file_name()? != ".git" {
+        return None;
+    }
+    Some(dot_git.parent()?.to_string_lossy().into_owned())
+}
+
 /// Local live statuses win for this device's chats; every other device's rows come
 /// from the registry. Sorted by chat id (stable stream output).
 fn merge_sessions(device_id: &str, rows: &[Session], local: &[Session]) -> Vec<Session> {
@@ -1128,5 +1156,49 @@ async fn workspace_task(weak: Weak<WorkspaceHostInner>, mut changed_rx: watch::R
                 inner.publish();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::linked_worktree_root;
+
+    #[test]
+    fn linked_worktree_resolves_to_the_checkout_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("proj");
+        let wt = dir.path().join("clever-ember");
+        std::fs::create_dir_all(root.join(".git").join("worktrees").join("clever-ember")).unwrap();
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(
+            wt.join(".git"),
+            format!(
+                "gitdir: {}\n",
+                root.join(".git/worktrees/clever-ember").display()
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            linked_worktree_root(&wt).as_deref(),
+            Some(root.to_str().unwrap())
+        );
+    }
+
+    #[test]
+    fn primary_checkouts_and_plain_folders_resolve_to_none() {
+        let dir = tempfile::tempdir().unwrap();
+        // Primary checkout: `.git` is a directory.
+        let primary = dir.path().join("primary");
+        std::fs::create_dir_all(primary.join(".git")).unwrap();
+        assert_eq!(linked_worktree_root(&primary), None);
+        // Not a repo at all.
+        let plain = dir.path().join("plain");
+        std::fs::create_dir_all(&plain).unwrap();
+        assert_eq!(linked_worktree_root(&plain), None);
+        // A `.git` file pointing somewhere that is not `<root>/.git/worktrees/<name>`.
+        let odd = dir.path().join("odd");
+        std::fs::create_dir_all(&odd).unwrap();
+        std::fs::write(odd.join(".git"), "gitdir: /somewhere/else\n").unwrap();
+        assert_eq!(linked_worktree_root(&odd), None);
     }
 }

--- a/crates/engine/tests/device_routing.rs
+++ b/crates/engine/tests/device_routing.rs
@@ -299,6 +299,7 @@ async fn target_device_id_routes_over_the_relay() {
     let command = serde_json::to_value(SessionCommandPayload::Run {
         request: RunRequest {
             prompt: "run remotely".into(),
+            harness: None,
             model: None,
             reasoning: None,
             model_options: serde_json::Map::new(),

--- a/crates/engine/tests/e2e.rs
+++ b/crates/engine/tests/e2e.rs
@@ -28,6 +28,7 @@ const VIEWER: &str = "viewer-device";
 fn run_request(prompt: &str) -> RunRequest {
     RunRequest {
         prompt: prompt.into(),
+        harness: None,
         model: None,
         reasoning: None,
         model_options: Default::default(),
@@ -1647,6 +1648,7 @@ async fn real_claude_sees_uploaded_image_inline() {
     );
     let request = RunRequest {
         prompt,
+        harness: None,
         model: Some("haiku".into()),
         reasoning: None,
         model_options: Default::default(),

--- a/crates/engine/tests/m5c_accounts_uploads_titles.rs
+++ b/crates/engine/tests/m5c_accounts_uploads_titles.rs
@@ -554,6 +554,7 @@ async fn titling_e2e_names_chat_and_renames_worktree_branch() {
 
     let request = comet_proto::RunRequest {
         prompt: "please fix the login flow".into(),
+        harness: None,
         model: None,
         reasoning: None,
         model_options: serde_json::Map::new(),
@@ -597,6 +598,7 @@ async fn titling_e2e_names_chat_and_renames_worktree_branch() {
         .expect("rename");
     let request = comet_proto::RunRequest {
         prompt: "another request".into(),
+        harness: None,
         model: None,
         reasoning: None,
         model_options: serde_json::Map::new(),
@@ -611,11 +613,7 @@ async fn titling_e2e_names_chat_and_renames_worktree_branch() {
         .await
         .expect("second dispatch");
     tokio::time::sleep(Duration::from_millis(400)).await;
-    let chat = core
-        .workspace
-        .chat(chat_id)
-        .expect("chat")
-        .expect("row");
+    let chat = core.workspace.chat(chat_id).expect("chat").expect("row");
     assert_eq!(chat.title.as_deref(), Some("My Custom Name"));
     core.shutdown().await;
 }

--- a/crates/engine/tests/restart_resume.rs
+++ b/crates/engine/tests/restart_resume.rs
@@ -37,6 +37,7 @@ type RequestLog = Arc<Mutex<Vec<RunRequest>>>;
 fn run_request(prompt: &str, cwd: &str) -> RunRequest {
     RunRequest {
         prompt: prompt.into(),
+        harness: None,
         model: None,
         reasoning: None,
         model_options: Default::default(),
@@ -779,6 +780,7 @@ async fn real_claude_remembers_codeword_across_engine_restart() {
 
     let real_request = |prompt: &str| RunRequest {
         prompt: prompt.into(),
+        harness: None,
         model: Some("haiku".into()),
         reasoning: None,
         model_options: Default::default(),

--- a/crates/engine/tests/workspace_sync.rs
+++ b/crates/engine/tests/workspace_sync.rs
@@ -146,6 +146,7 @@ where
 fn run_request(prompt: &str) -> RunRequest {
     RunRequest {
         prompt: prompt.into(),
+        harness: None,
         model: None,
         reasoning: None,
         model_options: Default::default(),
@@ -159,6 +160,22 @@ fn run_request(prompt: &str) -> RunRequest {
 
 /// Queue a run command into a chat doc the way a remote viewer would (ledger rule 1).
 fn queue_run(core: &EngineCore, chat_id: &str, command_id: &str, message_id: &str) {
+    queue_run_with(
+        core,
+        chat_id,
+        command_id,
+        message_id,
+        run_request("go do it"),
+    );
+}
+
+fn queue_run_with(
+    core: &EngineCore,
+    chat_id: &str,
+    command_id: &str,
+    message_id: &str,
+    request: RunRequest,
+) {
     let handle = core.doc_host.open(chat_id).expect("open chat");
     let now = chrono::Utc::now().timestamp_millis();
     handle
@@ -166,7 +183,7 @@ fn queue_run(core: &EngineCore, chat_id: &str, command_id: &str, message_id: &st
         .queue_command(&SessionCommandEntry {
             id: command_id.into(),
             payload: SessionCommandPayload::Run {
-                request: run_request("go do it"),
+                request,
                 message_id: message_id.into(),
             },
             issued_by: VIEWER.into(),
@@ -352,6 +369,97 @@ async fn claim_on_first_command_creates_the_chat_row() {
     drop(link);
     a.shutdown().await;
     b.shutdown().await;
+}
+
+/// A first command whose cwd is a linked WORKTREE must attribute the chat to
+/// the parent checkout's space — claiming at the worktree path minted a
+/// phantom sidebar space named after the worktree folder.
+#[tokio::test]
+async fn claim_resolves_a_worktree_cwd_to_the_repo_root_space() {
+    let dir = tempfile::tempdir().unwrap();
+    let core = assemble(dir.path(), "dev-a");
+    let client = comet_rpc::memory_client(core.rpc_service());
+
+    // A checkout with a linked worktree — fs layout only; the claim path
+    // reads `.git` without spawning git.
+    let repo = tempfile::tempdir().unwrap();
+    let root = repo.path().join("proj");
+    let wt = repo.path().join("clever-ember");
+    std::fs::create_dir_all(root.join(".git/worktrees/clever-ember")).unwrap();
+    std::fs::create_dir_all(&wt).unwrap();
+    std::fs::write(
+        wt.join(".git"),
+        format!(
+            "gitdir: {}\n",
+            root.join(".git/worktrees/clever-ember").display()
+        ),
+    )
+    .unwrap();
+
+    // The project's space already exists (the normal state — sessions are
+    // created FROM a space).
+    client
+        .call(
+            methods::MUTATE,
+            serde_json::json!({
+                "op": "createSpace", "spaceId": "space-proj", "deviceId": "dev-a",
+                "path": root.to_string_lossy(),
+            }),
+        )
+        .await
+        .expect("create space");
+
+    let request = RunRequest {
+        cwd: wt.to_string_lossy().into_owned(),
+        ..run_request("go do it")
+    };
+    queue_run_with(&core, "chat-wt", "cmd-wt-1", "m-1", request);
+    wait_for(
+        || {
+            core.workspace
+                .chat("chat-wt")
+                .ok()
+                .flatten()
+                .is_some_and(|c| c.space_id.as_deref() == Some("space-proj"))
+        },
+        "worktree chat attributed to the project space",
+    )
+    .await;
+    let spaces = core.workspace.read_spaces().unwrap_or_default();
+    assert_eq!(
+        spaces.len(),
+        1,
+        "no phantom space for the worktree: {spaces:?}"
+    );
+    core.shutdown().await;
+}
+
+/// The claimed row records the harness the run actually dispatched on (the
+/// request carries the picked harness) — without it the sidebar renders no
+/// harness glyph and later dispatches silently fall back to the default.
+#[tokio::test]
+async fn claimed_chat_row_records_the_run_harness() {
+    let dir = tempfile::tempdir().unwrap();
+    let core = assemble(dir.path(), "dev-a");
+
+    let request = RunRequest {
+        harness: Some(HarnessId::Cursor),
+        ..run_request("go do it")
+    };
+    queue_run_with(&core, "chat-glyph", "cmd-glyph-1", "m-1", request);
+    wait_for(
+        || {
+            core.workspace
+                .chat("chat-glyph")
+                .ok()
+                .flatten()
+                .and_then(|c| c.config)
+                .is_some_and(|c| c.harness == HarnessId::Cursor)
+        },
+        "claimed row carries the dispatched harness",
+    )
+    .await;
+    core.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/harness/tests/claude.rs
+++ b/crates/harness/tests/claude.rs
@@ -36,6 +36,7 @@ fn harness() -> ClaudeHarness {
 fn request(prompt: &str) -> RunRequest {
     RunRequest {
         prompt: prompt.into(),
+        harness: None,
         model: None,
         reasoning: None,
         model_options: serde_json::Map::new(),

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -36,6 +36,7 @@ fn harness() -> CodexHarness {
 fn request(prompt: &str) -> RunRequest {
     RunRequest {
         prompt: prompt.into(),
+        harness: None,
         model: Some("gpt-5.6-sol".into()),
         reasoning: Some(ReasoningLevel::Ultra),
         model_options: serde_json::Map::new(),

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -80,6 +80,12 @@ pub struct ModelOptionChoice {
 #[serde(rename_all = "camelCase")]
 pub struct RunRequest {
     pub prompt: String,
+    /// The harness picked at send time. Rides the command plane so
+    /// claim-on-first-command (chat row still in flight on the registry
+    /// channel) dispatches — and records — the picked harness instead of the
+    /// engine default. Additive + serde-defaulted for wire compat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness: Option<HarnessId>,
     pub model: Option<String>,
     pub reasoning: Option<ReasoningLevel>,
     /// Harness-specific option selections (option id -> choice id), JSON round-tripped.

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -4087,7 +4087,7 @@ impl Composer {
                         }
                     }
                     if let Err(err) = engine.client().call(methods::MUTATE, mutate).await {
-                        tracing::debug!(error = %err, "CreateChat mutate unavailable; doc host will materialize the chat");
+                        tracing::warn!(error = %err, "CreateChat mutate unavailable; doc host will materialize the chat");
                     }
                 }
 
@@ -4163,6 +4163,7 @@ impl Composer {
                     SessionCommandPayload::Run {
                         request: RunRequest {
                             prompt: content.clone(),
+                            harness: resolved.harness,
                             model: resolved.model.clone(),
                             reasoning: resolved.reasoning,
                             model_options: resolved.model_options.clone(),


### PR DESCRIPTION
## Bug

Creating a session with a **new worktree** sometimes produced two visible defects (screenshot repro: a `clever-ember @ personal-metal` space appearing in the sidebar, and its session "ACP Integration Feasibility Study" rendering no harness glyph):

1. A phantom **space named after the worktree folder**, next to the project's real space.
2. The session row **missing its harness icon**, with later dispatches silently falling back to the engine default harness.

## Root cause

Send writes on two channels: `Mutate createChat` (registry room, passive sync) and the `Run` command (session doc room, actively nudged to the host). The Run routinely reaches the hosting engine **before the chat row syncs**, so claim-on-first-command (`doc_host.rs` → `WorkspaceHost::claim_chat`) materialized the row itself:

- `space_for_path` matched/created a space **at the worktree path** — display name is `basename(path)`, hence `clever-ember`.
- The claim wrote a **full row** with `config: None`, serialized as an explicit `Null` field write. Its clocks are newer than the in-flight `createChat`, so per-field LWW **deleted the picked config** when the real row arrived — the icon reads `chat.config.harness`, so the glyph vanished, and the phantom `spaceId` won too. One write, both symptoms.

## Fix (three layers)

- **`space_for_path` resolves the checkout root.** A linked-worktree cwd (`<wt>/.git` file → `gitdir: <root>/.git/worktrees/<name>`, pure fs reads, no git subprocess) now reuses the parent project's space; a fresh space, if ever needed, is created at the root — never at the worktree path.
- **The claim is a partial row write** (`RegistryDoc::claim_chat`: identity/cwd/space only). Fields it never wrote carry no clock, so the late `createChat` still lands `config`/`title` instead of losing them to `Null` deletes.
- **`RunRequest` carries the picked harness** (additive + serde-defaulted; iOS sends it too), and the host **backfills the chat row's config** at dispatch when the row has none — the glyph is present and truthful even for claimed rows or createChats sent before the harness catalog loaded, and dispatch no longer depends on registry sync to run the right harness.

Also raises the swallowed `createChat` mutate failure from `debug!` to `warn!`.

## Tests

- `registry/tests.rs`: `late_create_chat_config_survives_a_prior_claim` — two-doc server-round merge reproducing the exact clock race (fails against the old full-row claim).
- `workspace_sync.rs`: `claim_resolves_a_worktree_cwd_to_the_repo_root_space` (asserts no phantom space) and `claimed_chat_row_records_the_run_harness`.
- `workspace_host.rs`: unit tests for `linked_worktree_root` (linked worktree, primary checkout, non-repo, odd gitdir).
- Full workspace suite: 643 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788761794&installation_model_id=425430&pr_number=25&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F25&signature=a5cfaa7254242644baf8b82939b94a9ef970873f123ef79b5a84153cb992977e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->