### PR TITLE
Transcript: fix end-of-turn scroll jump (hold anchor across the live→complete resplice)

### DIFF
--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -1476,7 +1476,21 @@ impl Transcript {
                 for row in &self.rows[old_range.clone()] {
                     self.render_cache.borrow_mut().invalidate_row(&row.id);
                 }
-                self.list.splice(old_range, count);
+                if old_range.len() == count {
+                    // In-place content change, same row count — notably the
+                    // live→complete flip, where EVERY row of the streamed
+                    // message changes version (streaming bit, tool auto_open,
+                    // timestamp bit) with identical ids. `splice` would reset
+                    // those items to hint-less Unmeasured (heights read 0
+                    // until the next paint) and, when the viewport-top item is
+                    // inside the range, clobber the scroll anchor to the range
+                    // start — the end-of-turn up/down jump the spring then has
+                    // to walk back. `remeasure_items` keeps old sizes as hints
+                    // and holds the anchor across the remeasure.
+                    self.list.remeasure_items(old_range);
+                } else {
+                    self.list.splice(old_range, count);
+                }
             }
         }
         self.rows = new_rows;


### PR DESCRIPTION
## Bug

Sometimes when an agent turn finishes streaming, the transcript scroll jumps up/down before settling.

## Root cause

On the live→complete flip, every row of the streamed message changes diff `version` (streaming LSB, tool group `auto_open`, timestamp bit) while row ids and count stay identical, so `Transcript::sync` fed the entire message as one equal-count range to `ListState::splice`. That splice:

- resets the items to hint-less `Unmeasured` — their heights read 0 in the list sum-tree until the next paint, momentarily collapsing the scroll geometry, and
- clobbers the scroll anchor to the range start with zero offset whenever the viewport-top item falls inside the range (true whenever the message is roughly taller than the viewport — hence "sometimes"), teleporting the view to the top of the message.

The bottom-pin spring then glides back down: the visible up/down before settling.

## Fix

When the diffed range has the same row count on both sides (a pure in-place content change — exactly what the completion flip is), `sync` now calls `remeasure_items(old_range)` instead of `splice`. The gpui fork added that method for precisely this case: it keeps each item's previous measured size as its hint and preserves `logical_scroll_top`, holding the pixel position across the remeasure via `PendingScroll::Absolute`. Appends/removals still go through `splice`.

This also smooths mid-stream in-place updates (e.g. a tool result landing in an existing `ToolGroup` row while scrolled at it), which hit the same anchor-clobber path.

## Testing

- `cargo test -p comet-ui`: 378 passed
- `diff_handles_live_to_split_growth` already pins the equal-count shape of the completion diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788763200&installation_model_id=425430&pr_number=26&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F26&signature=6ce74c5929d6fc353001c93a6dcb2c7ac2fba3fd183c6b920ea8cbb143e74efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->