### PR TITLE
Tool detail cards: clip fix, open/close tween, queued-steer hint

### DIFF
--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -35,6 +35,7 @@ fn harness() -> AcpHarness {
 fn request(prompt: &str) -> RunRequest {
     RunRequest {
         prompt: prompt.into(),
+        harness: None,
         model: Some("grok-4.5".into()),
         reasoning: None,
         model_options: serde_json::Map::new(),

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -80,6 +80,18 @@ case "$promptline" in
   fi
   ;;
 
+*scenario:many*)
+  # A wide read pass: 14 expandable chips — regression surface for the
+  # analytic group-height accounting (auto-height cards clipped the tail).
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Reading the workspace."}}'
+  i=1
+  while [ $i -le 14 ]; do
+    update "{\"sessionUpdate\":\"tool_call\",\"toolCallId\":\"r$i\",\"title\":\"read file $i\",\"kind\":\"read\",\"status\":\"completed\",\"rawInput\":{\"path\":\"/w/src/file_$i.rs\"},\"content\":[{\"type\":\"content\",\"content\":{\"type\":\"text\",\"text\":\"contents of file $i\"}}]}"
+    i=$((i+1))
+  done
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  ;;
+
 *scenario:happy*)
   update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello"}}'
   update '{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking"}}'

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -5235,6 +5235,26 @@ impl Render for Composer {
                 )
             });
 
+        // Turn-boundary steering notice: for agents without mid-turn
+        // injection (Grok over ACP today), a "steer" is queued and applies
+        // when the current turn finishes. Without this hint the queue read
+        // as a dropped steer (user report: "my steer didn't apply until
+        // grok already finished").
+        let steer_queues = mode == SendButtonMode::Steer
+            && self.pickers.read(cx).resolved_steering_mode(cx)
+                == Some(comet_proto::SteeringMode::TurnBoundary);
+        let container = container.when(steer_queues, |el| {
+            el.child(
+                div()
+                    .mt(px(6.0))
+                    .px(px(12.0))
+                    .text_size(px(11.0))
+                    .line_height(px(15.0))
+                    .text_color(theme.text_muted.opacity(0.8))
+                    .child("This agent can't be steered mid-turn — your message will be queued and sent when the current turn finishes."),
+            )
+        });
+
         if wizard_active {
             let wizard = self.render_wizard(cx);
             return container.child(motion::fade_quick("composer-wizard", div().child(wizard)));

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -532,6 +532,17 @@ impl Pickers {
     /// The fully-resolved config the composer threads into the Run request and
     /// `Mutate createChat`: concrete model + reasoning whenever the catalog is
     /// loaded (no "engine picks a default" passthrough).
+    /// The resolved harness's steering mode, from the loaded descriptor list.
+    /// `None` while the catalog is loading (callers should assume the common
+    /// StepBoundary case and show nothing).
+    pub fn resolved_steering_mode(&self, cx: &App) -> Option<comet_proto::SteeringMode> {
+        let harness = self.effective_harness(cx)?;
+        self.harnesses
+            .ready()
+            .and_then(|list| list.iter().find(|d| d.id == harness))
+            .map(|d| d.steering_mode)
+    }
+
     pub fn resolved(&self, cx: &App) -> ResolvedRunConfig {
         ResolvedRunConfig {
             harness: self.effective_harness(cx),

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -1066,9 +1066,11 @@ pub struct Transcript {
     live_parsers: HashMap<String, IncrementalParser>,
     tree_cache: HashMap<String, (usize, Arc<BlockTree>)>,
     folds: HashMap<SharedString, FoldState>,
-    /// Open detail blocks (output/diff) per chip, keyed `"{row_id}#d{ix}"`.
-    /// Render-local like `folds` — never part of the row fingerprint.
-    tool_details: HashMap<SharedString, bool>,
+    /// Detail folds (output/diff) per chip, keyed `"{row_id}#d{ix}"` — full
+    /// [`FoldState`]s so detail bodies tween open/closed exactly like the
+    /// group fold. Render-local like `folds` — never part of the row
+    /// fingerprint.
+    tool_details: HashMap<SharedString, FoldState>,
     /// Streaming fade veils, one per live markdown row (dropped on completion).
     veils: HashMap<SharedString, Rc<RefCell<RowVeil>>>,
     /// Live rows present in the transcript's REPLAY after (re)attaching to a
@@ -2058,18 +2060,25 @@ impl Transcript {
     ) -> AnyElement {
         let fold = self.folds.get(row_id).copied().unwrap_or_default();
         let open = fold.open.unwrap_or(auto_open);
-        // Which chips have their detail block open (render-local, analytic).
-        let detail_opens: Vec<bool> = tools
+        // Which chips have their detail block open (render-local, analytic —
+        // the FINAL state; a mid-tween detail already counts as its target).
+        let detail_folds: Vec<FoldState> = tools
             .iter()
             .enumerate()
             .map(|(ix, tool)| {
-                tool.detail.is_some()
-                    && self
-                        .tool_details
-                        .get(&SharedString::from(format!("{row_id}#d{ix}")))
-                        .copied()
-                        .unwrap_or(false)
+                if tool.detail.is_none() {
+                    return FoldState::default();
+                }
+                self.tool_details
+                    .get(&SharedString::from(format!("{row_id}#d{ix}")))
+                    .copied()
+                    .unwrap_or_default()
             })
+            .collect();
+        let detail_opens: Vec<bool> = tools
+            .iter()
+            .zip(&detail_folds)
+            .map(|(tool, fold)| tool.detail.is_some() && fold.open.unwrap_or(false))
             .collect();
         let open_height = chips_height(tools.len())
             + tools
@@ -2135,11 +2144,27 @@ impl Transcript {
                     return tool_chip(tool, theme);
                 };
                 let open = detail_opens[ix];
+                let dfold = detail_folds[ix];
                 let key = SharedString::from(format!("{row_id}#d{ix}"));
                 // Expandable chip: ONE card whose header row is the chip and
                 // whose body is the detail — not a floating card below it.
                 // The guide rail stretches with the row, so an open detail
                 // never breaks the rail.
+                //
+                // The card's height is EXPLICIT (border-box), not intrinsic:
+                // an auto-height card adds its 2px of borders on top of the
+                // 30px header, and with N chips that overflowed the group's
+                // analytic height by 2N px — the last chips rendered clipped
+                // (user report: "tool calls cut off at the bottom"). The
+                // explicit height is also what the open/close tween animates.
+                let closed_h = CHIP_CARD_HEIGHT;
+                let open_h = CHIP_CARD_HEIGHT + detail_height(&detail);
+                let card_target = if open { open_h } else { closed_h };
+                let animating = dfold.epoch > 0
+                    && dfold
+                        .toggled_at
+                        .is_some_and(|at| at.elapsed() < FOLD_TWEEN_WINDOW);
+                let toggle_key = key.clone();
                 let mut card = div()
                     .my(px((CHIP_HEIGHT - CHIP_CARD_HEIGHT) / 2.0))
                     .ml(px(12.0))
@@ -2157,13 +2182,19 @@ impl Transcript {
                             .id(key.clone())
                             .cursor_pointer()
                             .on_click(cx.listener(move |this, _, _, cx| {
-                                let open = this.tool_details.entry(key.clone()).or_insert(false);
-                                *open = !*open;
+                                let entry =
+                                    this.tool_details.entry(toggle_key.clone()).or_default();
+                                let currently_open = entry.open.unwrap_or(false);
+                                entry.from = if currently_open { open_h } else { closed_h };
+                                entry.open = Some(!currently_open);
+                                entry.epoch += 1;
+                                entry.toggled_at = Some(Instant::now());
                                 cx.notify();
                             }))
                             .child(chip_header(tool, open, theme)),
                     );
-                if open {
+                // The body stays mounted while the close tween shrinks over it.
+                if open || animating {
                     card = card
                         .child(
                             div()
@@ -2173,6 +2204,18 @@ impl Transcript {
                         )
                         .child(detail_body(&detail, theme));
                 }
+                let card: AnyElement = if animating {
+                    let from = dfold.from;
+                    card.with_animation(
+                        SharedString::from(format!("{key}-tween{}", dfold.epoch)),
+                        RESIZE.animation(),
+                        move |el, t| el.h(px(motion::lerp(from, card_target, t))),
+                    )
+                    .into_any_element()
+                } else {
+                    card.h(px(card_target)).into_any_element()
+                };
+                let card = div().min_w_0().flex_1().child(card);
                 div()
                     .w_full()
                     .flex_none()


### PR DESCRIPTION
Fixes the three issues from Grok dogfooding on v0.1.22:

**Tool calls clipped at the bottom of wide passes.** Expandable chip cards were auto-height, so each card's 2px of borders stacked on top of the 30px header — the group's analytic fold height under-counted by 2px per chip, and a ~40-read pass clipped the last chips. Cards now carry explicit border-box heights (closed: `CHIP_CARD_HEIGHT`; open: header + separator + body), so the analytic math is exact at any chip count. Verified with a new `scenario:many` fixture (14 chips render fully, timestamp below).

**Detail bodies now tween like the group fold.** The explicit card height doubles as the animation property: per-chip `FoldState` (epoch/from/toggled_at) drives the same 200ms RESIZE tween with the same remount-arming discipline, and the body stays mounted while the close tween shrinks over it.

**Queued steers are labeled.** Steering an agent without mid-turn injection (Grok over ACP — no `_session/steering` extension) queues the message to the turn boundary by design, but the UI presented it as a normal steer, so it read as dropped. When the resolved harness is `TurnBoundary` and the send button is in steer mode, the composer shows a quiet hint: "This agent can't be steered mid-turn — your message will be queued and sent when the current turn finishes."

All verified live in the headless rig; full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788763431&installation_model_id=425430&pr_number=27&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F27&signature=7cf1ecb727efd26195f09efad1bbb47eed9857809284e2b3735bf7c4765623bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->