### PR TITLE
Live-refresh the composer's harness catalog on Settings → Agents toggles

### DIFF
--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -39,6 +39,26 @@ use crate::state::{AppState, EngineHandle};
 use crate::theme::Theme;
 
 // ---------------------------------------------------------------------------
+// Catalog invalidation (Settings → Agents toggles)
+// ---------------------------------------------------------------------------
+
+/// Marker global: [`bump_harness_catalog`] pokes it whenever a Settings →
+/// Agents toggle changes some device's enabled set, and every [`Pickers`]
+/// observes it to force-refresh its cached harness catalog — without this the
+/// composer served the boot-time list until restart (user report).
+#[derive(Default)]
+pub struct HarnessCatalogChanged;
+
+impl gpui::Global for HarnessCatalogChanged {}
+
+/// Notify all composers that some device's harness catalog changed. The
+/// global carries no data — `default_global` pushes the observer effect, and
+/// the observers re-fetch from the engine (the source of truth).
+pub fn bump_harness_catalog(cx: &mut App) {
+    cx.default_global::<HarnessCatalogChanged>();
+}
+
+// ---------------------------------------------------------------------------
 // Draft config (what the pickers accumulate)
 // ---------------------------------------------------------------------------
 
@@ -305,6 +325,7 @@ pub struct Pickers {
     mutate_task: Option<Task<()>>,
     _search_events: Subscription,
     _state_observe: Subscription,
+    _catalog_observe: Subscription,
 }
 
 impl Pickers {
@@ -312,7 +333,15 @@ impl Pickers {
         let search = cx.new(|cx| ComposerInput::new("Search…", cx));
         let search_events = cx.subscribe(&search, |this: &mut Self, _, event, cx| match event {
             ComposerInputEvent::Edited => {
-                this.active = 0;
+                // Typing in the filter resets the highlight — but only the
+                // Branch picker HAS a filter. `set_text` emits Edited on
+                // programmatic clears too, and this subscription runs AFTER
+                // `toggle` returns, so an unscoped reset clobbers the
+                // just-anchored selected-model row back to 0 (regression:
+                // the top row wore a second highlight again).
+                if this.open == Some(PickerKind::Branch) {
+                    this.active = 0;
+                }
                 cx.notify();
             }
             ComposerInputEvent::Submitted => this.on_search_submit(cx),
@@ -354,6 +383,14 @@ impl Pickers {
             }
             cx.notify();
         });
+        // A Settings → Agents toggle changed some device's enabled set:
+        // force-refresh the cached catalog so the rail/chips follow without a
+        // restart (stale rows stay visible while the reload runs).
+        let catalog_observe =
+            cx.observe_global::<HarnessCatalogChanged>(|this: &mut Self, cx| {
+                this.ensure_harnesses(true, cx);
+                cx.notify();
+            });
         // Dev/testing knob: `COMET_OPEN_PICKER=model|traits|repo|branch` boots
         // with that popover open — synthetic input can't reach the app on
         // headless compositors, so captures need a data-side path.
@@ -399,6 +436,7 @@ impl Pickers {
             mutate_task: None,
             _search_events: search_events,
             _state_observe: state_observe,
+            _catalog_observe: catalog_observe,
         }
     }
 
@@ -591,7 +629,12 @@ impl Pickers {
         self.open = Some(kind);
         self.search.update(cx, |input, cx| {
             input.set_placeholder("Search…", cx);
-            input.set_text("", cx);
+            // Skip the no-op clear: `set_text` emits Edited unconditionally,
+            // and the Branch arm of the subscription above would reset the
+            // highlight this function is about to anchor.
+            if !input.text().is_empty() {
+                input.set_text("", cx);
+            }
         });
         // The keyboard-nav highlight starts ON the selected row — row 0
         // otherwise reads as a second active row (user report).
@@ -627,7 +670,10 @@ impl Pickers {
             // revalidates, keeping stale rows visible until fresh ones land.
             PickerKind::Branch | PickerKind::Checkout => self.ensure_refs(true, cx),
             PickerKind::HarnessModel | PickerKind::Traits => {
-                self.ensure_harnesses(cx);
+                // Force: the enabled set moves under us (Settings → Agents,
+                // possibly from another viewer) — every open revalidates,
+                // keeping current rows visible until the fresh catalog lands.
+                self.ensure_harnesses(true, cx);
                 self.prefetch_models(cx);
             }
         }
@@ -636,18 +682,30 @@ impl Pickers {
 
     // ---- loads ----
 
-    fn ensure_harnesses(&mut self, cx: &mut Context<Self>) {
-        // Only load from Idle: `render` re-runs this every frame, so an Error
-        // that could re-trigger a load would flip back to Loading before the
-        // retry row ever painted (and spam the engine). Retry resets to Idle.
-        if !matches!(self.harnesses, Loadable::Idle) {
+    fn ensure_harnesses(&mut self, force: bool, cx: &mut Context<Self>) {
+        // Non-forced (the render loop's eager kick) only loads from Idle: an
+        // Error that could re-trigger a load would flip back to Loading
+        // before the retry row ever painted (and spam the engine); Retry
+        // resets to Idle. FORCED refreshes (a Settings → Agents toggle, a
+        // picker open) reload through Ready/Error too — the enabled set just
+        // changed under the cache, which otherwise served the boot-time
+        // catalog until restart (user report). Stale-while-revalidate: loaded
+        // rows stay on screen while the fresh catalog lands.
+        let reload = match self.harnesses {
+            Loadable::Idle => true,
+            Loadable::Loading => false,
+            Loadable::Ready(_) | Loadable::Error(_) => force,
+        };
+        if !reload {
             return;
         }
         let Some(engine) = self.engine(cx) else {
             return;
         };
         let target = self.space_target(cx);
-        self.harnesses = Loadable::Loading;
+        if !matches!(self.harnesses, Loadable::Ready(_)) {
+            self.harnesses = Loadable::Loading;
+        }
         self.load_task = Some(cx.spawn(async move |this, cx| {
             let mut params = serde_json::Map::new();
             if let Some(target) = &target {
@@ -1707,7 +1765,7 @@ impl Pickers {
                         PickerKind::HarnessModel | PickerKind::Traits => {
                             this.harnesses = Loadable::Idle;
                             this.models.clear();
-                            this.ensure_harnesses(cx);
+                            this.ensure_harnesses(false, cx);
                         }
                     }))
                     .child(SharedString::from("Retry")),
@@ -2435,7 +2493,7 @@ impl Render for Pickers {
         // Eager-load the harness catalog + every offered harness's models so
         // the chip reads "Fable 5" (a concrete pick) before any popover
         // opens, and rail switches inside the picker are instant.
-        self.ensure_harnesses(cx);
+        self.ensure_harnesses(false, cx);
         self.prefetch_models(cx);
         // A popover opened data-side (COMET_OPEN_PICKER) never went through
         // `toggle`, so kick its loads here (all ensure_* are idempotent).

--- a/crates/ui/src/settings/harnesses.rs
+++ b/crates/ui/src/settings/harnesses.rs
@@ -159,6 +159,10 @@ impl HarnessesPage {
                         if let Ok(list) = serde_json::from_value::<Vec<HarnessDescriptor>>(value) {
                             page.harnesses = Loadable::Ready(list);
                         }
+                        // The composer caches its catalog per space — poke
+                        // every Pickers to re-fetch, or the rail keeps the
+                        // old set until restart.
+                        crate::pickers::bump_harness_catalog(cx);
                     }
                     Err(err) => page.error = Some(err.to_string()),
                 }


### PR DESCRIPTION
Fixes the report that enabling/disabling an agent in Settings → Agents didn't change the composer's harness list until a full restart: the `Pickers` cached its `ListHarnesses` result and only a space switch invalidated it.

## Live invalidation, two paths

- **Settings toggle → marker global**: every successful `SetHarnessEnabled` pokes a `HarnessCatalogChanged` global; every `Pickers` observes it (`observe_global`) and force-refreshes its catalog immediately — the rail and chips follow without reopening anything.
- **Every picker open force-revalidates** (the `ensure_refs(force)` pattern): catches enabled-set changes the global can't see, like a toggle made from *another viewer device* targeting this one.

Forced refreshes are stale-while-revalidate — loaded rows stay on screen while the fresh catalog lands, no skeleton flash.

## Interactive-open highlight regression (caught in the retest)

`toggle()` cleared the shared search box on open; `set_text` emits `Edited` unconditionally and the subscription ran **after** toggle returned, resetting the keyboard highlight to row 0 right after the selected-row anchor was set — the picker showed the top model washed alongside the selected one again. The dev boot path (`COMET_OPEN_PICKER`) bypasses `toggle()`, which is why the original captures looked right. The `Edited` reset is now scoped to the Branch picker (the only one with a filter, and the same event a real keystroke fires) and the no-op clear is skipped entirely.

## "Must leave at least 1 enabled"

Already enforced where the state lives — `registry::set_enabled` refuses disabling the last enabled harness and the page renders that toggle inert; the stale-catalog bug just made it look absent. Re-verified live over RPC:

```
SetHarnessEnabled {codex, false}       → ok    (claude-code remains)
SetHarnessEnabled {claude-code, false} → error: cannot disable the last enabled harness
```

## Verification (headless rig, one app instance, no restarts)

Toggled Grok off on the Agents page → engine `harness-prefs.json` updated → clicked Back → opened the model picker via the composer chip → the rail showed Claude Code + Codex only (Grok gone), with the keyboard highlight correctly anchored on the selected model. `cargo test -p comet-ui`: 384 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788855845&installation_model_id=425430&pr_number=32&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F32&signature=82a463f0ae0d6890bf2c3ab4dd76e24c66175d5814466e98b44443448b9fabf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->