### PR TITLE
Traits dropdown: restore the 2px gap between menu rows

### DIFF
--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -2260,6 +2260,10 @@ impl Pickers {
                 div()
                     .flex()
                     .flex_col()
+                    // 2px row gap — the menu-column rhythm everywhere else
+                    // (model list, device switcher); without it adjacent
+                    // hover/selected washes fuse into one blob (user report).
+                    .gap(px(2.0))
                     .child(popover::menu_heading(&theme, "Reasoning"))
                     .children(levels.into_iter().enumerate().map(|(ix, level)| {
                         let is_active = current == Some(level);
@@ -2297,6 +2301,7 @@ impl Pickers {
                 div()
                     .flex()
                     .flex_col()
+                    .gap(px(2.0)) // same rhythm as the Reasoning section above
                     .child(popover::menu_heading(&theme, &option.label))
                     .children(
                         option


### PR DESCRIPTION
The Reasoning/options section columns in the Traits dropdown were missing the `.gap(px(2.0))` every other menu column carries (model list, device switchers, harness rail), so an adjacent selected row and hovered row rendered as one fused wash (screenshot report).

Verified in the headless rig: with "High" selected and "X-High" hovered, the two washes now separate with the standard 2px rhythm. `cargo test -p comet-ui`: 384 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788888733&installation_model_id=425430&pr_number=33&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F33&signature=cc94606fb37557920a9e85c23479e1ec0054e6193d3de4f9aad955e8627b66f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->