### PR TITLE
chat2: dumb-relay sync — thin docs, ChatRoom DO, ChatClient, thin-doc rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,7 @@ dependencies = [
  "loro",
  "serde",
  "serde_json",
+ "similar",
  "thiserror 2.0.19",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,7 @@ dependencies = [
  "futures",
  "loro",
  "loro-protocol",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -13,3 +13,4 @@ serde_json.workspace = true
 thiserror.workspace = true
 chrono.workspace = true
 tracing.workspace = true
+similar.workspace = true

--- a/crates/doc/examples/rebuild_whale.rs
+++ b/crates/doc/examples/rebuild_whale.rs
@@ -1,0 +1,48 @@
+//! Run the M1 thin rebuild against a REAL whale snapshot (read-only: loads a
+//! snapshot file, rebuilds, reports accounting — writes nothing anywhere).
+//! Usage: cargo run -p comet-doc --example rebuild_whale -- <snapshot.bin>
+use comet_doc::rebuild::{doc_epoch, rebuild_thin_doc};
+use comet_doc::schema::SessionDoc;
+use loro::LoroDoc;
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: rebuild_whale <snapshot.bin>");
+    let bytes = std::fs::read(&path).expect("read snapshot");
+    let doc = LoroDoc::new();
+    doc.import(&bytes).expect("import snapshot");
+    let source = SessionDoc::from_doc(doc);
+
+    let entries = source.read_entries().expect("read entries").len();
+    let commands = source.read_commands().expect("read commands").len();
+    let src_epoch = doc_epoch(&source);
+    let start = std::time::Instant::now();
+    let rebuilt = rebuild_thin_doc(&source).expect("rebuild");
+    let elapsed = start.elapsed();
+    let thin_snapshot = rebuilt.doc.export_snapshot().expect("export");
+
+    // Idempotence probe: rebuilding the REBUILT doc owes the sidecar nothing.
+    let again = rebuild_thin_doc(&rebuilt.doc).expect("re-rebuild");
+
+    println!(
+        "RESULT:{}",
+        serde_json::json!({
+            "sourceBytes": bytes.len(),
+            "sourceEntries": entries,
+            "sourceCommands": commands,
+            "sourceEpoch": src_epoch,
+            "thinBytes": thin_snapshot.len(),
+            "thinEntries": rebuilt.entries,
+            "commandsCopied": rebuilt.commands_copied,
+            "sidecarPayloads": rebuilt.sidecar.len(),
+            "sidecarBytes": rebuilt
+                .sidecar
+                .iter()
+                .map(|p| p.output.as_deref().map_or(0, str::len))
+                .sum::<usize>(),
+            "thinEpoch": doc_epoch(&rebuilt.doc),
+            "rebuildMs": elapsed.as_millis(),
+            "secondPassSidecar": again.sidecar.len(),
+            "shrink": format!("{:.1}x", bytes.len() as f64 / thin_snapshot.len() as f64),
+        })
+    );
+}

--- a/crates/doc/src/lib.rs
+++ b/crates/doc/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod commands;
 pub mod constants;
 pub mod parts;
+pub mod rebuild;
 pub mod registry;
 pub mod schema;
 pub mod transcript_delta;
@@ -19,6 +20,7 @@ pub mod workspace;
 pub use commands::*;
 pub use constants::*;
 pub use parts::*;
+pub use rebuild::*;
 pub use registry::*;
 pub use schema::*;
 pub use transcript_delta::*;

--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -32,7 +32,12 @@ pub fn summarize_tool_output(text: &str) -> Option<String> {
         }
         chars += 1;
     }
-    let cut = end < line.len() || text.trim_end().len() > line.len();
+    // "…" means content beyond this line exists in the sidecar — measure the
+    // REMAINDER after the summarized line, not total length (leading blank
+    // lines used to false-positive the marker).
+    let offset = line.as_ptr() as usize - text.as_ptr() as usize;
+    let rest = &text[offset + line.len()..];
+    let cut = end < line.len() || !rest.trim().is_empty();
     let mut out = line[..end].to_owned();
     if cut {
         out.push('…');
@@ -644,6 +649,15 @@ mod tests {
         assert_eq!(
             summarize_tool_output("\n\nfirst real\nsecond"),
             Some("first real…".into())
+        );
+        // Leading blank lines alone are NOT "more content" — no false "…".
+        assert_eq!(
+            summarize_tool_output("\n\nonly line"),
+            Some("only line".into())
+        );
+        assert_eq!(
+            summarize_tool_output("only line\n\n  \n"),
+            Some("only line".into())
         );
         let long = "x".repeat(TOOL_OUTPUT_SUMMARY_MAX + 40);
         let summary = summarize_tool_output(&long).unwrap();

--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -9,26 +9,72 @@ use comet_proto::{AgentEvent, ToolCall, ToolDiff, UserInputQuestion};
 
 use crate::constants::MSG_INLINE_MAX;
 
-/// Byte cap for tool output persisted into the doc. Deliberately tighter than
-/// the harness-side cap: docs sync to every device and reload with the
-/// session, so this bounds what long tool-heavy sessions cost at load time.
-pub const TOOL_OUTPUT_DOC_CAP: usize = 4 * 1024;
+/// Char cap for the tool-output SUMMARY persisted into the doc: first
+/// non-empty line, nothing more. The per-part 4KB cap (c951c3e) bounded each
+/// part but not the session — chat 1b65e93d measured 917KB (85%) of a 1MB doc
+/// in capped outputs across 426 tool parts (docs/chat2-sync.md). Full outputs
+/// live in the R2 sidecar behind `output_ref`; t3code ships an 84-char
+/// summary, so 160 is generous.
+pub const TOOL_OUTPUT_SUMMARY_MAX: usize = 160;
 
-/// Byte cap for each side of an inline diff persisted into the doc.
-pub const TOOL_DIFF_DOC_CAP: usize = 16 * 1024;
+/// One line of the doc-resident summary for a tool output: the first
+/// non-empty line, capped at [`TOOL_OUTPUT_SUMMARY_MAX`] chars. `None` for
+/// blank output. The `…` marker means "there is more in the sidecar".
+pub fn summarize_tool_output(text: &str) -> Option<String> {
+    let line = text.lines().find(|l| !l.trim().is_empty())?;
+    let line = line.trim_end();
+    let mut chars = 0usize;
+    let mut end = line.len();
+    for (i, _) in line.char_indices() {
+        if chars == TOOL_OUTPUT_SUMMARY_MAX {
+            end = i;
+            break;
+        }
+        chars += 1;
+    }
+    let cut = end < line.len() || text.trim_end().len() > line.len();
+    let mut out = line[..end].to_owned();
+    if cut {
+        out.push('…');
+    }
+    Some(out)
+}
 
-/// Truncate on a char boundary, marking the cut so the UI can say so.
-fn cap_doc_text(text: &str, cap: usize) -> String {
-    if text.len() <= cap {
-        return text.to_owned();
+/// Per-file diff stats persisted in place of inline diff text (t3's shape).
+/// The inline diff was the bigger bomb than outputs — 32KB/edit, unexercised
+/// only because the claude harness emits none. Full diff text lives in the
+/// sidecar behind `diff_ref`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolDiffStat {
+    pub path: String,
+    pub additions: u64,
+    pub deletions: u64,
+}
+
+/// Line-level add/delete counts for one file's diff.
+pub fn diff_stat(diff: &ToolDiff) -> ToolDiffStat {
+    let (additions, deletions) = match &diff.old_text {
+        None => (diff.new_text.lines().count() as u64, 0),
+        Some(old) => {
+            let text_diff = similar::TextDiff::from_lines(old.as_str(), diff.new_text.as_str());
+            let mut additions = 0u64;
+            let mut deletions = 0u64;
+            for change in text_diff.iter_all_changes() {
+                match change.tag() {
+                    similar::ChangeTag::Insert => additions += 1,
+                    similar::ChangeTag::Delete => deletions += 1,
+                    similar::ChangeTag::Equal => {}
+                }
+            }
+            (additions, deletions)
+        }
+    };
+    ToolDiffStat {
+        path: diff.path.clone(),
+        additions,
+        deletions,
     }
-    let mut end = cap;
-    while !text.is_char_boundary(end) {
-        end -= 1;
-    }
-    let mut out = text[..end].to_owned();
-    out.push_str("\n… [truncated]");
-    out
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,14 +102,29 @@ pub enum MessagePart {
         /// True once a ToolResult arrived.
         #[serde(default)]
         resolved: bool,
-        /// Tool output text, capped at [`TOOL_OUTPUT_DOC_CAP`] by the fold.
-        /// Additive: absent on old entries and on harnesses that don't
-        /// surface output (claude/codex today).
+        /// One-line tool output summary ([`summarize_tool_output`]). Old
+        /// entries (pre-strip) still carry up to 4KB here; old app versions
+        /// render this field either way, so the strip is invisible to them.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         output: Option<String>,
-        /// Inline file diff for edit-shaped tools, capped by the fold.
+        /// Inline file diff — written by pre-strip app versions only; new
+        /// folds persist [`Self::Tool::diff_stats`] + `diff_ref` instead.
+        /// Kept so old docs render their diffs.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         diff: Option<ToolDiff>,
+        /// Sidecar key (`{chatId}/{partId}`) of the full output — additive;
+        /// stamped by [`apply_sidecar_refs`] (the fold is chat-agnostic).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        output_ref: Option<String>,
+        /// Full-output byte length, so the UI can say "Show full output (12 KB)".
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        output_bytes: Option<u64>,
+        /// Sidecar key (`{chatId}/{partId}.diff`) of the full diff JSON.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        diff_ref: Option<String>,
+        /// Per-file diff stats (additive replacement for inline `diff`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        diff_stats: Option<Vec<ToolDiffStat>>,
     },
     #[serde(rename_all = "camelCase")]
     Input {
@@ -93,13 +154,20 @@ impl MessagePart {
         match self {
             MessagePart::Text { text, .. } => text.len(),
             MessagePart::Tool {
-                call, output, diff, ..
+                call,
+                output,
+                diff,
+                diff_stats,
+                ..
             } => {
                 serde_json::to_vec(call).map_or(0, |v| v.len())
                     + output.as_ref().map_or(0, String::len)
                     + diff
                         .as_ref()
                         .map_or(0, |d| serde_json::to_vec(d).map_or(0, |v| v.len()))
+                    + diff_stats
+                        .as_ref()
+                        .map_or(0, |s| serde_json::to_vec(s).map_or(0, |v| v.len()))
             }
             MessagePart::Input { questions, .. } => {
                 serde_json::to_vec(questions).map_or(0, |v| v.len())
@@ -157,6 +225,10 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
                     resolved: false,
                     output: None,
                     diff: None,
+                    output_ref: None,
+                    output_bytes: None,
+                    diff_ref: None,
+                    diff_stats: None,
                 });
             }
         }
@@ -173,23 +245,26 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
                     resolved,
                     output: out_slot,
                     diff: diff_slot,
+                    output_bytes,
+                    diff_stats,
                     ..
                 } = p
                     && pid == id
                 {
                     *e = *is_error;
                     *resolved = true;
-                    *out_slot = output
+                    // The strip (docs/chat2-sync.md A1): the doc gets a
+                    // one-line summary + byte count; the full text rides the
+                    // sidecar (the host uploads it from the same event —
+                    // `sidecar_payload`). Inline diffs die entirely: stats
+                    // only, never text.
+                    *out_slot = output.as_deref().and_then(summarize_tool_output);
+                    *output_bytes = output
                         .as_ref()
-                        .map(|o| cap_doc_text(o, TOOL_OUTPUT_DOC_CAP));
-                    *diff_slot = diff.as_ref().map(|d| ToolDiff {
-                        path: d.path.clone(),
-                        old_text: d
-                            .old_text
-                            .as_ref()
-                            .map(|t| cap_doc_text(t, TOOL_DIFF_DOC_CAP)),
-                        new_text: cap_doc_text(&d.new_text, TOOL_DIFF_DOC_CAP),
-                    });
+                        .filter(|o| !o.trim().is_empty())
+                        .map(|o| o.len() as u64);
+                    *diff_slot = None;
+                    *diff_stats = diff.as_ref().map(|d| vec![diff_stat(d)]);
                 }
             }
         }
@@ -242,6 +317,62 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
         | AgentEvent::Usage { .. }
         | AgentEvent::AvailableCommands { .. } => {}
     }
+}
+
+/// Stamp sidecar keys onto resolved tool parts that have sidecar content.
+///
+/// Separate from the fold because the fold is chat-agnostic and pure; the
+/// caller (who knows the chat id) runs this right after each fold step, before
+/// the parts hit the doc. Idempotent. Key shape `{chatId}/{partId}` (+
+/// `.diff`) matches the edge's `/blob/{chatId}/{partId}` route.
+pub fn apply_sidecar_refs(chat_id: &str, parts: &mut [MessagePart]) {
+    for part in parts.iter_mut() {
+        if let MessagePart::Tool {
+            id,
+            resolved: true,
+            output_ref,
+            output_bytes,
+            diff_ref,
+            diff_stats,
+            ..
+        } = part
+        {
+            if output_ref.is_none() && output_bytes.is_some() {
+                *output_ref = Some(format!("{chat_id}/{id}"));
+            }
+            if diff_ref.is_none() && diff_stats.is_some() {
+                *diff_ref = Some(format!("{chat_id}/{id}.diff"));
+            }
+        }
+    }
+}
+
+/// What a [`AgentEvent::ToolResult`] owes the sidecar: the full output text
+/// and/or the full diff (as JSON), keyed by part id. `None` when the event
+/// carries nothing worth uploading.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SidecarPayload {
+    pub part_id: String,
+    pub output: Option<String>,
+    pub diff: Option<ToolDiff>,
+}
+
+pub fn sidecar_payload(event: &AgentEvent) -> Option<SidecarPayload> {
+    let AgentEvent::ToolResult {
+        id, output, diff, ..
+    } = event
+    else {
+        return None;
+    };
+    let output = output.clone().filter(|o| !o.trim().is_empty());
+    if output.is_none() && diff.is_none() {
+        return None;
+    }
+    Some(SidecarPayload {
+        part_id: id.clone(),
+        output,
+        diff: diff.clone(),
+    })
 }
 
 /// Render-only privacy policy — strip heavy/sensitive tool inputs before a call enters the doc.
@@ -470,6 +601,10 @@ mod tests {
                 resolved: true,
                 output: None,
                 diff: None,
+                output_ref: None,
+                output_bytes: None,
+                diff_ref: None,
+                diff_stats: None,
             },
         ];
         let chunks = split_parts(&parts);
@@ -497,5 +632,167 @@ mod tests {
     #[test]
     fn continuation_ids_are_deterministic() {
         assert_eq!(continuation_id("m1", 1), "m1#c1");
+    }
+
+    // ── A1 strip (docs/chat2-sync.md) ───────────────────────────────────────
+
+    #[test]
+    fn summarize_takes_first_nonempty_line_and_marks_the_cut() {
+        assert_eq!(summarize_tool_output(""), None);
+        assert_eq!(summarize_tool_output("  \n\t\n"), None);
+        assert_eq!(summarize_tool_output("one line"), Some("one line".into()));
+        assert_eq!(
+            summarize_tool_output("\n\nfirst real\nsecond"),
+            Some("first real…".into())
+        );
+        let long = "x".repeat(TOOL_OUTPUT_SUMMARY_MAX + 40);
+        let summary = summarize_tool_output(&long).unwrap();
+        assert_eq!(summary.chars().count(), TOOL_OUTPUT_SUMMARY_MAX + 1);
+        assert!(summary.ends_with('…'));
+        // Char-boundary safety on multibyte input.
+        let wide = "é".repeat(TOOL_OUTPUT_SUMMARY_MAX + 5);
+        let summary = summarize_tool_output(&wide).unwrap();
+        assert_eq!(summary.chars().count(), TOOL_OUTPUT_SUMMARY_MAX + 1);
+    }
+
+    #[test]
+    fn diff_stat_counts_line_changes() {
+        let stat = diff_stat(&ToolDiff {
+            path: "/w/a.rs".into(),
+            old_text: Some("a\nb\nc\n".into()),
+            new_text: "a\nB\nc\nd\n".into(),
+        });
+        assert_eq!(stat.path, "/w/a.rs");
+        assert_eq!(stat.additions, 2); // B + d
+        assert_eq!(stat.deletions, 1); // b
+        // New file: every line is an addition.
+        let stat = diff_stat(&ToolDiff {
+            path: "/w/new.rs".into(),
+            old_text: None,
+            new_text: "one\ntwo\n".into(),
+        });
+        assert_eq!((stat.additions, stat.deletions), (2, 0));
+    }
+
+    #[test]
+    fn fold_strips_output_to_summary_and_diff_to_stats() {
+        let mut parts = Vec::new();
+        fold_event_into_parts(
+            &mut parts,
+            &AgentEvent::ToolCall {
+                id: "t".into(),
+                call: ToolCall::Exec {
+                    command: "cargo test".into(),
+                },
+            },
+        );
+        let full = "running 42 tests\n".repeat(300); // ~5KB, was 4KB inline pre-strip
+        fold_event_into_parts(
+            &mut parts,
+            &AgentEvent::ToolResult {
+                id: "t".into(),
+                is_error: false,
+                output: Some(full.clone()),
+                diff: Some(ToolDiff {
+                    path: "/w/a.rs".into(),
+                    old_text: Some("a\n".into()),
+                    new_text: "b\n".into(),
+                }),
+            },
+        );
+        match &parts[0] {
+            MessagePart::Tool {
+                output,
+                output_bytes,
+                diff,
+                diff_stats,
+                ..
+            } => {
+                assert_eq!(output.as_deref(), Some("running 42 tests…"));
+                assert_eq!(*output_bytes, Some(full.len() as u64));
+                assert!(diff.is_none(), "inline diff text must not enter the doc");
+                let stats = diff_stats.as_ref().unwrap();
+                assert_eq!(stats.len(), 1);
+                assert_eq!((stats[0].additions, stats[0].deletions), (1, 1));
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sidecar_refs_stamp_once_and_only_where_content_exists() {
+        let mut parts = Vec::new();
+        fold_event_into_parts(
+            &mut parts,
+            &AgentEvent::ToolCall {
+                id: "t1".into(),
+                call: ToolCall::Exec {
+                    command: "ls".into(),
+                },
+            },
+        );
+        // Unresolved: no refs yet.
+        apply_sidecar_refs("chat-9", &mut parts);
+        assert!(matches!(
+            &parts[0],
+            MessagePart::Tool {
+                output_ref: None,
+                diff_ref: None,
+                ..
+            }
+        ));
+        fold_event_into_parts(
+            &mut parts,
+            &AgentEvent::ToolResult {
+                id: "t1".into(),
+                is_error: false,
+                output: Some("hello".into()),
+                diff: Some(ToolDiff {
+                    path: "/w/a".into(),
+                    old_text: None,
+                    new_text: "x\n".into(),
+                }),
+            },
+        );
+        apply_sidecar_refs("chat-9", &mut parts);
+        apply_sidecar_refs("chat-9", &mut parts); // idempotent
+        match &parts[0] {
+            MessagePart::Tool {
+                output_ref,
+                diff_ref,
+                ..
+            } => {
+                assert_eq!(output_ref.as_deref(), Some("chat-9/t1"));
+                assert_eq!(diff_ref.as_deref(), Some("chat-9/t1.diff"));
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sidecar_payload_carries_full_texts() {
+        assert_eq!(
+            sidecar_payload(&AgentEvent::TextDelta { text: "x".into() }),
+            None
+        );
+        assert_eq!(
+            sidecar_payload(&AgentEvent::ToolResult {
+                id: "t".into(),
+                is_error: false,
+                output: Some("   \n".into()),
+                diff: None,
+            }),
+            None,
+            "blank output uploads nothing"
+        );
+        let payload = sidecar_payload(&AgentEvent::ToolResult {
+            id: "t".into(),
+            is_error: true,
+            output: Some("full output".into()),
+            diff: None,
+        })
+        .unwrap();
+        assert_eq!(payload.part_id, "t");
+        assert_eq!(payload.output.as_deref(), Some("full output"));
     }
 }

--- a/crates/doc/src/rebuild.rs
+++ b/crates/doc/src/rebuild.rs
@@ -1,0 +1,275 @@
+//! M1 epoch rebuild (docs/chat2-sync.md) — the whale-healing step.
+//!
+//! On first chat2 seed the host does NOT upload its fat doc: it rebuilds a
+//! thin one. Every entry is copied with the A1 strip applied retroactively —
+//! fat inline tool outputs become one-line summaries, inline diffs become
+//! per-file stats — and the stripped full payloads are returned so the host
+//! can upload them to the A2 sidecar (existing whale outputs stay viewable;
+//! zero information loss). Commands: only unresolved entries carry over (the
+//! `processed_commands` mark-before-execute ledger protects against
+//! re-execution regardless).
+//!
+//! `meta.epoch = 2` marks the new lineage. Other devices seeing a
+//! `roomGen: 2` chat with a local `epoch < 2` doc discard-and-adopt (M3);
+//! the epoch check makes re-entry a no-op.
+
+use crate::parts::{
+    diff_stat, summarize_tool_output, MessagePart, SidecarPayload,
+};
+use crate::schema::{DocError, SessionDoc};
+use crate::SessionCommandStatus;
+
+/// Doc lineage epoch written by [`rebuild_thin_doc`]. Pre-migration s2 docs
+/// read back as 0.
+pub const THIN_DOC_EPOCH: u32 = 2;
+
+/// Read `meta.epoch` (0 = pre-migration doc).
+pub fn doc_epoch(doc: &SessionDoc) -> u32 {
+    match doc.doc().get_map("meta").get("epoch") {
+        Some(loro::ValueOrContainer::Value(loro::LoroValue::I64(n))) => n.max(0) as u32,
+        _ => 0,
+    }
+}
+
+/// A completed rebuild: the thin doc plus everything it stripped out (owed
+/// to the sidecar) and the copy accounting.
+pub struct ThinRebuild {
+    pub doc: SessionDoc,
+    /// Full outputs/diffs stripped from old fat parts — upload to the A2
+    /// sidecar under `{chatId}/{partId}[.diff]` before flipping `roomGen`.
+    pub sidecar: Vec<SidecarPayload>,
+    pub entries: usize,
+    pub commands_copied: usize,
+}
+
+/// Rebuild a thin epoch-2 doc from a (possibly fat) source doc.
+///
+/// Pure over doc contents — no I/O; idempotent in the sense that rebuilding
+/// an already-thin doc strips nothing and owes the sidecar nothing.
+pub fn rebuild_thin_doc(source: &SessionDoc) -> Result<ThinRebuild, DocError> {
+    let chat_id = source
+        .chat_id()
+        .ok_or_else(|| DocError::Schema("source doc has no chatId".into()))?;
+    let thin = SessionDoc::init(&chat_id)?;
+    thin.doc()
+        .get_map("meta")
+        .insert("epoch", THIN_DOC_EPOCH as i64)?;
+
+    let mut sidecar = Vec::new();
+    let entries = source.read_entries()?;
+    let entry_count = entries.len();
+    for mut entry in entries {
+        for part in entry.parts.iter_mut() {
+            if let Some(payload) = strip_part(&chat_id, part) {
+                sidecar.push(payload);
+            }
+        }
+        thin.push_message(&entry)?;
+    }
+
+    let mut commands_copied = 0;
+    for command in source.read_commands()? {
+        // Only unresolved work crosses the epoch: resolved/expired ledger
+        // history is exactly the bulk a wedged room can't afford to carry.
+        if command.status == SessionCommandStatus::Pending {
+            thin.queue_command(&command)?;
+            commands_copied += 1;
+        }
+    }
+    thin.doc().commit();
+
+    Ok(ThinRebuild {
+        doc: thin,
+        sidecar,
+        entries: entry_count,
+        commands_copied,
+    })
+}
+
+/// Apply the A1 strip to one part in place. `Some` = payload owed to the
+/// sidecar (the part was fat). Already-thin parts pass through untouched.
+fn strip_part(chat_id: &str, part: &mut MessagePart) -> Option<SidecarPayload> {
+    let MessagePart::Tool {
+        id,
+        output,
+        diff,
+        output_ref,
+        output_bytes,
+        diff_ref,
+        diff_stats,
+        ..
+    } = part
+    else {
+        return None;
+    };
+    let mut payload = SidecarPayload {
+        part_id: id.clone(),
+        output: None,
+        diff: None,
+    };
+    // Fat inline output = text with no sidecar ref (the new fold always
+    // stamps `output_ref` beside a summary). Blank output just drops.
+    if output_ref.is_none()
+        && let Some(full) = output.take()
+    {
+        if full.trim().is_empty() {
+            *output = None;
+        } else {
+            *output = summarize_tool_output(&full);
+            *output_bytes = Some(full.len() as u64);
+            *output_ref = Some(format!("{chat_id}/{id}"));
+            payload.output = Some(full);
+        }
+    }
+    // Inline diff text dies entirely: stats + ref replace it.
+    if let Some(full) = diff.take() {
+        *diff_stats = Some(vec![diff_stat(&full)]);
+        if diff_ref.is_none() {
+            *diff_ref = Some(format!("{chat_id}/{id}.diff"));
+        }
+        payload.diff = Some(full);
+    }
+    (payload.output.is_some() || payload.diff.is_some()).then_some(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{MessageRole, SessionMessageEntry};
+    use crate::{MessageStatus, SessionCommandEntry, SessionCommandPayload};
+    use comet_proto::{ToolCall, ToolDiff};
+
+    /// ~4KB of varied output — repeated text would compress away inside the
+    /// Loro snapshot and hide the size win the assertion checks.
+    fn fat_output() -> String {
+        let mut out = String::new();
+        let mut x: u64 = 0x9e37_79b9;
+        for i in 0..200 {
+            x = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            out.push_str(&format!("line {i}: {x:016x} {:08x}\n", x >> 13));
+        }
+        out
+    }
+
+    fn fat_entry(id: &str) -> SessionMessageEntry {
+        SessionMessageEntry {
+            id: id.into(),
+            role: MessageRole::Assistant,
+            parts: vec![
+                MessagePart::Text {
+                    id: format!("{id}-t"),
+                    text: "did the thing".into(),
+                },
+                MessagePart::Tool {
+                    id: format!("{id}-tool"),
+                    call: ToolCall::Exec {
+                        command: "cargo test".into(),
+                    },
+                    is_error: false,
+                    resolved: true,
+                    output: Some(fat_output()), // ~4KB fat inline, incompressible
+                    diff: Some(ToolDiff {
+                        path: "/w/a.rs".into(),
+                        old_text: Some("a\nb\n".into()),
+                        new_text: "a\nc\nd\n".into(),
+                    }),
+                    output_ref: None,
+                    output_bytes: None,
+                    diff_ref: None,
+                    diff_stats: None,
+                },
+            ],
+            created_at: 5,
+            device_id: "dev-a".into(),
+            status: Some(MessageStatus::Complete),
+            continuation_of: None,
+        }
+    }
+
+    fn command(id: &str, status: SessionCommandStatus) -> SessionCommandEntry {
+        SessionCommandEntry {
+            id: id.into(),
+            payload: SessionCommandPayload::Interrupt {},
+            issued_by: "dev-b".into(),
+            issued_at: 9,
+            based_on: None,
+            expires_at: None,
+            status,
+            resolution: None,
+        }
+    }
+
+    #[test]
+    fn rebuild_strips_fat_parts_and_owes_them_to_the_sidecar() {
+        let source = SessionDoc::init("chat-w").unwrap();
+        source.push_message(&fat_entry("m1")).unwrap();
+        source
+            .queue_command(&command("c1", SessionCommandStatus::Pending))
+            .unwrap();
+        source
+            .queue_command(&command("c2", SessionCommandStatus::Applied))
+            .unwrap();
+        let fat_size = source.export_snapshot().unwrap().len();
+
+        let rebuilt = rebuild_thin_doc(&source).unwrap();
+        assert_eq!(doc_epoch(&rebuilt.doc), THIN_DOC_EPOCH);
+        assert_eq!(doc_epoch(&source), 0);
+        assert_eq!((rebuilt.entries, rebuilt.commands_copied), (1, 1));
+
+        // The whale math: the thin doc must be dramatically smaller.
+        let thin_size = rebuilt.doc.export_snapshot().unwrap().len();
+        assert!(
+            thin_size * 2 < fat_size,
+            "thin {thin_size} vs fat {fat_size}"
+        );
+
+        let entries = rebuilt.doc.read_entries().unwrap();
+        match &entries[0].parts[1] {
+            MessagePart::Tool {
+                output,
+                output_ref,
+                output_bytes,
+                diff,
+                diff_ref,
+                diff_stats,
+                ..
+            } => {
+                assert_eq!(output.as_deref(), fat_output().lines().next().map(|l| format!("{l}…")).as_deref());
+                assert_eq!(output_ref.as_deref(), Some("chat-w/m1-tool"));
+                assert_eq!(*output_bytes, Some(fat_output().len() as u64));
+                assert!(diff.is_none());
+                assert_eq!(diff_ref.as_deref(), Some("chat-w/m1-tool.diff"));
+                let stats = diff_stats.as_ref().unwrap();
+                assert_eq!((stats[0].additions, stats[0].deletions), (2, 1));
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+
+        // Everything stripped is owed to the sidecar — nothing is lost.
+        assert_eq!(rebuilt.sidecar.len(), 1);
+        assert_eq!(rebuilt.sidecar[0].part_id, "m1-tool");
+        assert!(rebuilt.sidecar[0].output.as_deref().unwrap().len() > 3000);
+        assert_eq!(rebuilt.sidecar[0].diff.as_ref().unwrap().path, "/w/a.rs");
+
+        // Only the unresolved command crossed the epoch.
+        let commands = rebuilt.doc.read_commands().unwrap();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].id, "c1");
+    }
+
+    #[test]
+    fn rebuilding_a_thin_doc_is_a_no_op_strip() {
+        let source = SessionDoc::init("chat-w").unwrap();
+        source.push_message(&fat_entry("m1")).unwrap();
+        let first = rebuild_thin_doc(&source).unwrap();
+        let second = rebuild_thin_doc(&first.doc).unwrap();
+        assert!(
+            second.sidecar.is_empty(),
+            "already-thin parts owe the sidecar nothing"
+        );
+        assert_eq!(
+            first.doc.read_entries().unwrap(),
+            second.doc.read_entries().unwrap()
+        );
+    }
+}

--- a/crates/doc/src/schema.rs
+++ b/crates/doc/src/schema.rs
@@ -71,12 +71,25 @@ struct DocPartJson {
     resolved: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     message: Option<String>,
-    /// Capped tool output (additive — absent on old rows and old writers).
+    /// Tool output summary (additive — absent on old rows and old writers;
+    /// pre-strip writers stored up to 4KB of capped output here).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     output: Option<String>,
-    /// Capped inline tool diff (additive).
+    /// Capped inline tool diff (additive; pre-strip writers only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     diff: Option<serde_json::Value>,
+    /// Sidecar key of the full output (additive, docs/chat2-sync.md A1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    output_ref: Option<String>,
+    /// Full-output byte length (additive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    output_bytes: Option<u64>,
+    /// Sidecar key of the full diff JSON (additive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    diff_ref: Option<String>,
+    /// Per-file diff stats (additive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    diff_stats: Option<serde_json::Value>,
 }
 
 /// App parts → doc part json (mirror of `toDocParts`).
@@ -95,6 +108,10 @@ fn to_doc_part(part: &MessagePart) -> Result<DocPartJson, DocError> {
             resolved,
             output,
             diff,
+            output_ref,
+            output_bytes,
+            diff_ref,
+            diff_stats,
         } => DocPartJson {
             id: id.clone(),
             kind: "tool".into(),
@@ -104,6 +121,10 @@ fn to_doc_part(part: &MessagePart) -> Result<DocPartJson, DocError> {
             is_error: if *resolved { Some(*is_error) } else { None },
             output: output.clone(),
             diff: diff.as_ref().map(serde_json::to_value).transpose()?,
+            output_ref: output_ref.clone(),
+            output_bytes: *output_bytes,
+            diff_ref: diff_ref.clone(),
+            diff_stats: diff_stats.as_ref().map(serde_json::to_value).transpose()?,
             ..Default::default()
         },
         MessagePart::Input {
@@ -138,6 +159,10 @@ fn from_doc_part(p: DocPartJson) -> MessagePart {
                 resolved: p.is_error.is_some(),
                 output: p.output,
                 diff: p.diff.and_then(|d| serde_json::from_value(d).ok()),
+                output_ref: p.output_ref,
+                output_bytes: p.output_bytes,
+                diff_ref: p.diff_ref,
+                diff_stats: p.diff_stats.and_then(|s| serde_json::from_value(s).ok()),
             },
             None => MessagePart::Text {
                 id: p.id,
@@ -524,6 +549,18 @@ fn push_part(parts: &LoroList, part: &MessagePart) -> Result<(), DocError> {
     if let Some(diff) = &doc_part.diff {
         map.insert("diff", loro_value_from_json(diff))?;
     }
+    if let Some(output_ref) = &doc_part.output_ref {
+        map.insert("outputRef", output_ref.as_str())?;
+    }
+    if let Some(output_bytes) = doc_part.output_bytes {
+        map.insert("outputBytes", output_bytes as i64)?;
+    }
+    if let Some(diff_ref) = &doc_part.diff_ref {
+        map.insert("diffRef", diff_ref.as_str())?;
+    }
+    if let Some(diff_stats) = &doc_part.diff_stats {
+        map.insert("diffStats", loro_value_from_json(diff_stats))?;
+    }
     Ok(())
 }
 
@@ -749,6 +786,18 @@ fn update_part_fields(map: &LoroMap, part: &MessagePart) -> Result<(), DocError>
     if let Some(diff) = &doc_part.diff {
         map.insert("diff", loro_value_from_json(diff))?;
     }
+    if let Some(output_ref) = &doc_part.output_ref {
+        map.insert("outputRef", output_ref.as_str())?;
+    }
+    if let Some(output_bytes) = doc_part.output_bytes {
+        map.insert("outputBytes", output_bytes as i64)?;
+    }
+    if let Some(diff_ref) = &doc_part.diff_ref {
+        map.insert("diffRef", diff_ref.as_str())?;
+    }
+    if let Some(diff_stats) = &doc_part.diff_stats {
+        map.insert("diffStats", loro_value_from_json(diff_stats))?;
+    }
     if let Some(text) = &doc_part.text {
         // Defensive path only — the fold never rewrites earlier text.
         if let Some(loro::ValueOrContainer::Container(loro::Container::Text(t))) = map.get("text") {
@@ -958,10 +1007,11 @@ mod tests {
     }
 
     /// The ToolResult resolution path goes through `update_part_fields` —
-    /// output and diff must survive the doc round trip (regression: they were
-    /// silently dropped there while `to_doc_part` carried them).
+    /// the stripped output summary, sidecar refs, and diff stats must survive
+    /// the doc round trip (regression: output/diff were silently dropped
+    /// there while `to_doc_part` carried them).
     #[test]
-    fn segment_writer_round_trips_tool_output_and_diff() {
+    fn segment_writer_round_trips_stripped_tool_fields() {
         let doc = SessionDoc::init("chat-2").unwrap();
         let mut writer = SegmentWriter::begin(&doc, "a1", "dev-a", 5).unwrap();
 
@@ -981,25 +1031,77 @@ mod tests {
             &AgentEvent::ToolResult {
                 id: "t1".into(),
                 is_error: false,
-                output: Some("total 0".into()),
+                output: Some("total 0\nmore lines".into()),
                 diff: Some(comet_proto::ToolDiff {
                     path: "/w/a.rs".into(),
-                    old_text: Some("old".into()),
-                    new_text: "new".into(),
+                    old_text: Some("old\n".into()),
+                    new_text: "new\n".into(),
                 }),
             },
         );
+        crate::parts::apply_sidecar_refs("chat-2", &mut folded);
         writer.sync(&folded).unwrap();
         writer.finish(&folded, MessageStatus::Complete).unwrap();
 
         let entries = doc.read_entries().unwrap();
         match &entries[0].parts[0] {
+            MessagePart::Tool {
+                output,
+                output_ref,
+                output_bytes,
+                diff,
+                diff_ref,
+                diff_stats,
+                ..
+            } => {
+                assert_eq!(output.as_deref(), Some("total 0…"));
+                assert_eq!(output_ref.as_deref(), Some("chat-2/t1"));
+                assert_eq!(*output_bytes, Some("total 0\nmore lines".len() as u64));
+                assert!(diff.is_none(), "no inline diff text in the doc");
+                assert_eq!(diff_ref.as_deref(), Some("chat-2/t1.diff"));
+                let stats = diff_stats.as_ref().expect("stats survive");
+                assert_eq!(stats[0].path, "/w/a.rs");
+                assert_eq!((stats[0].additions, stats[0].deletions), (1, 1));
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    /// Old pre-strip docs carry inline `output`/`diff` — they must still read
+    /// back (schema changes are serde-additive ONLY; old readers, old docs).
+    #[test]
+    fn pre_strip_doc_parts_still_round_trip() {
+        let doc = SessionDoc::init("chat-3").unwrap();
+        doc.push_message(&SessionMessageEntry {
+            id: "m1".into(),
+            role: MessageRole::Assistant,
+            parts: vec![MessagePart::Tool {
+                id: "t1".into(),
+                call: ToolCall::Exec { command: "ls".into() },
+                is_error: false,
+                resolved: true,
+                output: Some("full inline output\nline 2".into()),
+                diff: Some(comet_proto::ToolDiff {
+                    path: "/w/a.rs".into(),
+                    old_text: Some("old".into()),
+                    new_text: "new".into(),
+                }),
+                output_ref: None,
+                output_bytes: None,
+                diff_ref: None,
+                diff_stats: None,
+            }],
+            created_at: 1,
+            device_id: "dev-a".into(),
+            status: Some(MessageStatus::Complete),
+            continuation_of: None,
+        })
+        .unwrap();
+        let entries = doc.read_entries().unwrap();
+        match &entries[0].parts[0] {
             MessagePart::Tool { output, diff, .. } => {
-                assert_eq!(output.as_deref(), Some("total 0"));
-                let diff = diff.as_ref().expect("diff survives");
-                assert_eq!(diff.path, "/w/a.rs");
-                assert_eq!(diff.old_text.as_deref(), Some("old"));
-                assert_eq!(diff.new_text, "new");
+                assert_eq!(output.as_deref(), Some("full inline output\nline 2"));
+                assert_eq!(diff.as_ref().unwrap().new_text, "new");
             }
             other => panic!("unexpected {other:?}"),
         }

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -696,7 +696,7 @@ impl DocHost {
             "{}/blob/{}/{}",
             edge.url.trim_end_matches('/'),
             chat_id,
-            payload.part_id
+            encode_part_segment(&payload.part_id)
         );
         runtime.spawn(async move {
             let Some(bearer) = edge.bearer().await else {
@@ -759,7 +759,16 @@ impl DocHost {
         let Some(bearer) = edge.bearer().await else {
             return Err(EngineError::Other("signed out".into()));
         };
-        let url = format!("{}/blob/{}", edge.url.trim_end_matches('/'), blob_ref);
+        // `valid` above guarantees the split; re-split to encode the part
+        // segment for transport (PART_RE allows `#`, which a raw URL would
+        // truncate as a fragment — the 2026-08-10 silent-collision bug).
+        let (chat, part) = blob_ref.split_once('/').expect("validated above");
+        let url = format!(
+            "{}/blob/{}/{}",
+            edge.url.trim_end_matches('/'),
+            chat,
+            encode_part_segment(part)
+        );
         let res = self
             .inner
             .http
@@ -1133,6 +1142,35 @@ pub fn respond_input_prompt(
         }
     }
     lines.join("\n")
+}
+
+/// Percent-encode one URL path segment of a sidecar part id. PART_RE's
+/// alphabet includes `#` and `:` — legal in R2 keys and doc refs, but a raw
+/// `#` in a URL is a fragment delimiter (the request would silently hit the
+/// truncated key, colliding parts). The Worker decodes before validating.
+fn encode_part_segment(part_id: &str) -> String {
+    let mut out = String::with_capacity(part_id.len());
+    for byte in part_id.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod part_segment_tests {
+    use super::encode_part_segment;
+
+    #[test]
+    fn hash_and_colon_are_escaped_unreserved_pass_through() {
+        assert_eq!(encode_part_segment("m1#c1"), "m1%23c1");
+        assert_eq!(encode_part_segment("tool:call_9"), "tool%3Acall_9");
+        assert_eq!(encode_part_segment("plain-id_0.diff~"), "plain-id_0.diff~");
+    }
 }
 
 /// Per-chat background task: reacts to doc changes (local commits and remote imports)

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -164,6 +164,9 @@ struct DocHostInner {
     sessions: OnceLock<SessionsEngine>,
     workspace: OnceLock<WorkspaceHost>,
     handles: Mutex<HashMap<String, Arc<ChatDocHandle>>>,
+    /// Shared client for sidecar blob PUT/GET (30s timeout, uploads.rs
+    /// discipline — diff_sync's untimed client hung on dead links).
+    http: reqwest::Client,
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
@@ -335,6 +338,10 @@ impl DocHost {
                 sessions: OnceLock::new(),
                 workspace: OnceLock::new(),
                 handles: Mutex::new(HashMap::new()),
+                http: reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()
+                    .unwrap_or_else(|_| reqwest::Client::new()),
             }),
         }
     }
@@ -670,6 +677,106 @@ impl DocHost {
                 }
             }
         });
+    }
+
+    /// Upload a tool result's full output/diff to the R2 sidecar
+    /// (`PUT {edge}/blob/{chatId}/{partId}[.diff]`, docs/chat2-sync.md A2).
+    /// Fire-and-forget: the doc already carries the summary, so a lost upload
+    /// degrades to "full output unavailable" — it must never block or fail
+    /// the run. Offline/edge-less engines skip silently.
+    pub fn upload_tool_sidecar(&self, chat_id: &str, payload: comet_doc::SidecarPayload) {
+        let Some(edge) = self.inner.config.edge.clone() else {
+            return;
+        };
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return; // bare sync callers (unit tests) skip rather than panic
+        };
+        let http = self.inner.http.clone();
+        let base = format!(
+            "{}/blob/{}/{}",
+            edge.url.trim_end_matches('/'),
+            chat_id,
+            payload.part_id
+        );
+        runtime.spawn(async move {
+            let Some(bearer) = edge.bearer().await else {
+                return; // signed out; summary-only until the next session
+            };
+            let mut puts: Vec<(String, &'static str, Vec<u8>)> = Vec::new();
+            if let Some(output) = &payload.output {
+                puts.push((
+                    base.clone(),
+                    "text/plain; charset=utf-8",
+                    output.clone().into_bytes(),
+                ));
+            }
+            if let Some(diff) = &payload.diff
+                && let Ok(json) = serde_json::to_vec(diff)
+            {
+                puts.push((format!("{base}.diff"), "application/json", json));
+            }
+            for (url, content_type, body) in puts {
+                let sent = http
+                    .put(&url)
+                    .bearer_auth(&bearer)
+                    .header("content-type", content_type)
+                    .body(body)
+                    .send()
+                    .await;
+                match sent {
+                    Ok(res) if res.status().is_success() => {}
+                    Ok(res) => tracing::warn!(url, status = res.status().as_u16(),
+                        "tool sidecar upload rejected"),
+                    Err(err) => {
+                        tracing::warn!(url, error = %err, "tool sidecar upload failed (best-effort)")
+                    }
+                }
+            }
+        });
+    }
+
+    /// Fetch a sidecar blob by its doc-resident ref (`{chatId}/{partId}` or
+    /// `…​.diff`) — the UI's lazy "Show full output" path, served over RPC
+    /// because the UI crate has no HTTP client or edge bearer.
+    pub async fn fetch_tool_blob(&self, blob_ref: &str) -> Result<String, EngineError> {
+        // Same shape `apply_sidecar_refs` writes; anything else is a forged ref.
+        let valid = blob_ref.split_once('/').is_some_and(|(chat, part)| {
+            !chat.is_empty()
+                && chat.len() <= 128
+                && chat.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+                && !part.is_empty()
+                && part.len() <= 200
+                && part
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"._:#~-".contains(&b))
+        });
+        if !valid {
+            return Err(EngineError::Other(format!("bad blob ref: {blob_ref}")));
+        }
+        let Some(edge) = self.inner.config.edge.clone() else {
+            return Err(EngineError::Other("offline: no edge configured".into()));
+        };
+        let Some(bearer) = edge.bearer().await else {
+            return Err(EngineError::Other("signed out".into()));
+        };
+        let url = format!("{}/blob/{}", edge.url.trim_end_matches('/'), blob_ref);
+        let res = self
+            .inner
+            .http
+            .get(&url)
+            .bearer_auth(&bearer)
+            .send()
+            .await
+            .map_err(|e| EngineError::Other(format!("sidecar fetch failed: {e}")))?;
+        if !res.status().is_success() {
+            return Err(EngineError::Other(format!(
+                "sidecar fetch: HTTP {}",
+                res.status().as_u16()
+            )));
+        }
+        res.text()
+            .await
+            .map_err(|e| EngineError::Other(format!("sidecar body read failed: {e}")))
     }
 
     /// §2.2 writer discipline: we host a chat iff its workspace row's `deviceId` is

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -264,6 +264,13 @@ struct ReadAttachmentChunkParams {
     offset: u64,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FetchToolBlobParams {
+    /// Doc-resident sidecar ref (`{chatId}/{partId}` or `…​.diff`).
+    blob_ref: String,
+}
+
 /// The Mutate surface (feature-inventory §2 DataRpc), tagged by `op`.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "op", rename_all = "camelCase")]
@@ -1338,6 +1345,15 @@ impl RpcService for EngineRpc {
                     .read_chunk(&p.path, p.offset, &roots)
                     .map_err(|e| RpcError::Failed(e.to_string()))?;
                 RpcReply::value(&chunk)
+            }
+            methods::FETCH_TOOL_BLOB => {
+                let p: FetchToolBlobParams = parse_params(params)?;
+                let text = self
+                    .doc_host
+                    .fetch_tool_blob(&p.blob_ref)
+                    .await
+                    .map_err(|e| RpcError::Failed(e.to_string()))?;
+                RpcReply::value(&serde_json::json!({ "text": text }))
             }
             other => Err(RpcError::UnknownMethod(other.to_string())),
         }

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -821,16 +821,25 @@ fn render_parts(parts: &[MessagePart]) -> Vec<MessagePart> {
                 resolved,
                 output,
                 diff,
+                output_ref,
+                output_bytes,
+                diff_ref,
+                diff_stats,
             } => MessagePart::Tool {
                 id: id.clone(),
                 call: sanitize_tool_call(call),
                 is_error: *is_error,
                 resolved: *resolved,
-                // Output and diffs are deliberately kept (capped at fold
-                // time): unlike raw tool inputs they are the transcript's
-                // record of what happened, and the caps bound doc growth.
+                // Output summaries, diff stats, and sidecar refs are
+                // deliberately kept: unlike raw tool inputs they are the
+                // transcript's record of what happened, and the strip already
+                // bounded them (docs/chat2-sync.md A1).
                 output: output.clone(),
                 diff: diff.clone(),
+                output_ref: output_ref.clone(),
+                output_bytes: *output_bytes,
+                diff_ref: diff_ref.clone(),
+                diff_stats: diff_stats.clone(),
             },
             other => other.clone(),
         })
@@ -1256,6 +1265,16 @@ async fn drive_run(
         let skip_fold = matches!(&event, AgentEvent::SessionStarted { .. }) && !folded.is_empty();
         if !skip_fold {
             fold_event_into_parts(&mut folded, &event);
+            // A1 strip companions: the fold left only a summary in the doc;
+            // the full output/diff ride the R2 sidecar (fire-and-forget — a
+            // lost upload degrades to "full output unavailable", never blocks
+            // the doc), and the parts get their sidecar keys stamped.
+            if let Some(payload) = comet_doc::sidecar_payload(&event) {
+                comet_doc::apply_sidecar_refs(&chat_id, &mut folded);
+                if let Some(doc_host) = inner.doc_host.get() {
+                    doc_host.upload_tool_sidecar(&chat_id, payload);
+                }
+            }
         }
 
         if let AgentEvent::Done { status, .. } = &event {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -105,6 +105,9 @@ pub mod methods {
     pub const UPLOAD_CHUNK: &str = "UploadChunk";
     pub const UPLOAD_COMMIT: &str = "UploadCommit";
     pub const READ_ATTACHMENT_CHUNK: &str = "ReadAttachmentChunk";
+    /// Lazy full-tool-output fetch from the R2 sidecar by doc-resident ref
+    /// (chat2-sync A3). Edge-direct from any device — never relay-forwarded.
+    pub const FETCH_TOOL_BLOB: &str = "FetchToolBlob";
     // Updates (ControlRpc, relay-forwardable — a device reports/applies its own
     // binary's update). Stream: current UpdateStatus, then every change.
     pub const UPDATE_STATUS: &str = "UpdateStatus";

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -26,6 +26,8 @@ mock-server = []
 
 [dev-dependencies]
 chrono.workspace = true
+# chat2_live example only (live checkpoint fetch against a deployed worker).
+reqwest.workspace = true
 comet-proto.workspace = true
 tempfile.workspace = true
 # `start_paused` virtual-clock tests (the 2026-07-30 sync-stall regressions).

--- a/crates/sync/examples/chat2_live.rs
+++ b/crates/sync/examples/chat2_live.rs
@@ -1,0 +1,144 @@
+//! Live cross-language integration check: drive the REAL `ChatClient` (real
+//! tungstenite transport, real backoff/liveness actor) against a deployed
+//! chat2 room, with a real Loro doc behind the sink. A JS peer (see
+//! edge/scripts/chat2-crosscheck.mjs) seeds the room so both catch-up legs run:
+//! checkpoint-then-rows on a fresh doc, then live push/ack.
+//!
+//! Usage:
+//!   cargo run -p comet-sync --example chat2_live -- <baseUrl> <chatId> <token> <device>
+//!
+//! Prints a single JSON result line prefixed RESULT: for the driver to parse.
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
+use std::sync::{Arc, Mutex};
+
+use comet_sync::chat_client::{ChatClient, ChatDocSink, CheckpointFetcher};
+use comet_sync::SyncError;
+use futures::future::BoxFuture;
+use loro::{ExportMode, LoroDoc, VersionVector};
+
+struct DocSink {
+    doc: Mutex<LoroDoc>,
+    cursor: AtomicU64,
+    checkpoint_applied: AtomicBool,
+    rows_applied: AtomicU64,
+}
+
+impl ChatDocSink for DocSink {
+    fn apply_row(&self, bytes: &[u8], cursor: u64) {
+        let doc = self.doc.lock().unwrap();
+        doc.import(bytes).expect("row import");
+        self.cursor.store(cursor, Relaxed);
+        self.rows_applied.fetch_add(1, Relaxed);
+    }
+    fn apply_checkpoint(&self, bytes: &[u8], cursor: u64) -> Result<(), String> {
+        let doc = self.doc.lock().unwrap();
+        doc.import(bytes).map_err(|e| e.to_string())?;
+        self.cursor.store(cursor, Relaxed);
+        self.checkpoint_applied.store(true, Relaxed);
+        Ok(())
+    }
+    fn contains_frontier(&self, frontier: &[u8]) -> bool {
+        if frontier.is_empty() {
+            return true;
+        }
+        let Ok(vv) = VersionVector::decode(frontier) else {
+            return false;
+        };
+        self.doc.lock().unwrap().oplog_vv().includes_vv(&vv)
+    }
+    fn advance_cursor(&self, cursor: u64) {
+        self.cursor.store(cursor, Relaxed);
+    }
+}
+
+struct HttpFetcher {
+    url: String,
+    token: String,
+}
+
+impl CheckpointFetcher for HttpFetcher {
+    fn fetch(&self) -> BoxFuture<'static, Result<Vec<u8>, SyncError>> {
+        let url = self.url.clone();
+        let token = self.token.clone();
+        Box::pin(async move {
+            let res = reqwest::Client::new()
+                .get(&url)
+                .bearer_auth(&token)
+                .send()
+                .await
+                .map_err(|e| SyncError::WebSocket(e.to_string()))?;
+            if !res.status().is_success() {
+                return Err(SyncError::WebSocket(format!("checkpoint {}", res.status())));
+            }
+            let bytes = res
+                .bytes()
+                .await
+                .map_err(|e| SyncError::WebSocket(e.to_string()))?;
+            Ok(bytes.to_vec())
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let (base, chat, token, device) = (&args[1], &args[2], &args[3], &args[4]);
+    let ws_url = format!(
+        "{}/chat2/{}/ws?device={}&token={}",
+        base.replace("https://", "wss://"),
+        chat,
+        device,
+        token
+    );
+
+    let sink = Arc::new(DocSink {
+        doc: Mutex::new(LoroDoc::new()),
+        cursor: AtomicU64::new(0),
+        checkpoint_applied: AtomicBool::new(false),
+        rows_applied: AtomicU64::new(0),
+    });
+    let fetcher = Arc::new(HttpFetcher {
+        url: format!("{base}/chat2/{chat}/checkpoint"),
+        token: token.clone(),
+    });
+
+    // Fresh doc, cursor 0 → the checkpoint frontier can't be contained →
+    // the client must take the CheckpointThenRows leg (GET + import + rows).
+    let client = ChatClient::connect(&ws_url, sink.clone(), fetcher, device, 0)
+        .await
+        .expect("connect");
+
+    let caught_up_cursor = sink.cursor.load(Relaxed);
+    let caught_up_text = sink.doc.lock().unwrap().get_text("t").to_string();
+
+    // Live push: append through the real doc, export the delta, enqueue.
+    let update = {
+        let doc = sink.doc.lock().unwrap();
+        let before = doc.oplog_vv();
+        doc.get_text("t")
+            .insert(caught_up_text.len(), " rust-was-here")
+            .expect("insert");
+        doc.commit();
+        doc.export(ExportMode::updates(&before)).expect("export")
+    };
+    client.enqueue_update(update);
+
+    // Wait for the ack to advance the cursor past the caught-up head.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    while sink.cursor.load(Relaxed) <= caught_up_cursor {
+        if std::time::Instant::now() > deadline {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    let result = serde_json::json!({
+        "checkpointApplied": sink.checkpoint_applied.load(Relaxed),
+        "rowsApplied": sink.rows_applied.load(Relaxed),
+        "caughtUpCursor": caught_up_cursor,
+        "finalCursor": sink.cursor.load(Relaxed),
+        "text": sink.doc.lock().unwrap().get_text("t").to_string(),
+    });
+    println!("RESULT:{result}");
+    client.shutdown().await;
+}

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -1,0 +1,844 @@
+//! ChatClient — WebSocket transport for chat2 rooms (docs/chat2-sync.md C1):
+//! hello/state handshake with client-side checkpoint precision, cursor-based
+//! row backfill, push/ack with a pending-unacked queue, opaque presence
+//! relay, probe/redial liveness, and reconnect with exponential backoff.
+//!
+//! The client owns no CRDT semantics: update bytes flow through a
+//! [`ChatDocSink`] the engine implements over its `ChatDocHandle` (import +
+//! persist doc AND cursor in one transaction — the C2 rule). Wire frames are
+//! the binary chat2 codec ([`crate::chat_frames`]), byte-compatible with
+//! `edge/src/chat-frames.ts`.
+//!
+//! Liveness discipline is inherited from `registry.rs` and its incidents:
+//! transport pings prove nothing about the DO; room health is judged only by
+//! protocol frames with probe deadlines.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use futures::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+use crate::chat_frames::{self as wire, frame_type};
+use crate::room::{StaticUrl, SyncError, UrlProvider};
+
+const PING_INTERVAL: Duration = Duration::from_secs(15);
+const SILENCE_LEASE: Duration = Duration::from_secs(45);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+const HELLO_DEADLINE: Duration = Duration::from_secs(15);
+/// Backfill after hello must complete (rowsDone) within this deadline —
+/// post-strip rooms are KB-scale, so this is generous even at 1.2 Mbps.
+const BACKFILL_DEADLINE: Duration = Duration::from_secs(120);
+const PROBE_DEADLINE: Duration = Duration::from_secs(10);
+const BACKOFF_BASE: Duration = Duration::from_millis(250);
+const BACKOFF_CAP: Duration = Duration::from_secs(30);
+/// Quiet-room probe cadence default (matches the registry's fleet math).
+const PROBE_QUIET_DEFAULT: Duration = Duration::from_secs(900);
+
+/// Per-client tuning.
+#[derive(Clone, Copy, Debug)]
+pub struct ChatTuning {
+    pub probe_quiet: Duration,
+}
+
+impl Default for ChatTuning {
+    fn default() -> Self {
+        Self {
+            probe_quiet: PROBE_QUIET_DEFAULT,
+        }
+    }
+}
+
+/// Connection/sync lifecycle notifications (best-effort broadcast).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChatEvent {
+    /// Joined (or re-joined); the hello state has been received.
+    Connected,
+    /// Backfill finished — the doc is converged with the room at this head.
+    CaughtUp { head_seq: u64 },
+    /// Remote rows/acks were applied through the sink — republish.
+    Applied,
+    /// The connection dropped; the client is backing off before redialing.
+    Disconnected,
+    /// A remote device's presence beat arrived.
+    Presence,
+}
+
+// ── engine-facing traits ────────────────────────────────────────────────────
+
+/// Where remote bytes land. The engine implements this over its doc handle;
+/// every method persists doc content AND the room cursor in one transaction
+/// (`DocsStore::save_snapshot_with_cursor`) so they can never diverge.
+pub trait ChatDocSink: Send + Sync + 'static {
+    /// Import one remote update row; `cursor` is the row's seq.
+    fn apply_row(&self, bytes: &[u8], cursor: u64);
+    /// Replace/merge from a checkpoint blob; `cursor` is its checkpointSeq.
+    fn apply_checkpoint(&self, bytes: &[u8], cursor: u64) -> Result<(), String>;
+    /// Client-side precision (replaces the server VV diff): is the server
+    /// checkpoint's frontier already contained in the local doc?
+    fn contains_frontier(&self, frontier: &[u8]) -> bool;
+    /// An own-write ack advanced the cursor with no content change.
+    fn advance_cursor(&self, cursor: u64);
+}
+
+/// `GET /chat2/{chatId}/checkpoint` over HTTP. Implementations should resume
+/// partial downloads with `Range: bytes=N-` (the DO serves 206) — that
+/// resumability is the point of checkpoint-over-HTTP vs export-per-join.
+pub trait CheckpointFetcher: Send + Sync + 'static {
+    fn fetch(&self) -> BoxFuture<'static, Result<Vec<u8>, SyncError>>;
+}
+
+// ── catch-up planning (pure — the client-side precision rule) ───────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CatchUpPlan {
+    /// Local doc already contains the checkpoint frontier (or there is no
+    /// checkpoint): stream rows only.
+    RowsOnly { after: u64 },
+    /// Fetch + import the checkpoint first, then rows after it.
+    CheckpointThenRows { after: u64 },
+}
+
+/// Decide the catch-up path from the hello state. `frontier_contained` is the
+/// sink's verdict on the checkpoint frontier payload.
+pub fn plan_catch_up(
+    cursor: u64,
+    state: &wire::StateHeader,
+    frontier_contained: bool,
+) -> CatchUpPlan {
+    // A cursor ahead of the server means the server lost state (reset/wipe);
+    // our cursor is meaningless there — treat as fresh.
+    let cursor = if cursor > state.head_seq { 0 } else { cursor };
+    if state.checkpoint_seq == 0 {
+        return CatchUpPlan::RowsOnly { after: cursor };
+    }
+    if frontier_contained {
+        // Rows ≤ checkpointSeq are covered by a checkpoint we already
+        // contain — skip straight past them even if our cursor is older.
+        CatchUpPlan::RowsOnly {
+            after: cursor.max(state.checkpoint_seq),
+        }
+    } else {
+        CatchUpPlan::CheckpointThenRows {
+            after: state.checkpoint_seq,
+        }
+    }
+}
+
+// ── transport plumbing (binary sibling of registry.rs's TextPipe) ───────────
+
+pub(crate) struct BinPipe {
+    pub(crate) tx: mpsc::Sender<Vec<u8>>,
+    pub(crate) rx: mpsc::Receiver<Vec<u8>>,
+}
+
+pub(crate) trait BinConnector: Send + Sync + 'static {
+    fn connect(&self) -> BoxFuture<'static, Result<BinPipe, SyncError>>;
+}
+
+struct WsBinConnector {
+    url: Arc<dyn UrlProvider>,
+}
+
+impl BinConnector for WsBinConnector {
+    fn connect(&self) -> BoxFuture<'static, Result<BinPipe, SyncError>> {
+        let provider = self.url.clone();
+        Box::pin(async move {
+            let url = provider.url().await?;
+            let (ws, _) = tokio_tungstenite::connect_async(&url)
+                .await
+                .map_err(|e| SyncError::WebSocket(e.to_string()))?;
+            let (out_tx, out_rx) = mpsc::channel(64);
+            let (in_tx, in_rx) = mpsc::channel(64);
+            tokio::spawn(pump(ws, out_rx, in_tx));
+            Ok(BinPipe {
+                tx: out_tx,
+                rx: in_rx,
+            })
+        })
+    }
+}
+
+/// Shuttle binary frames between the WebSocket and the actor's channels; the
+/// text `"ping"` keepalive rides the same socket (runtime-answered pair).
+async fn pump(
+    ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    mut out_rx: mpsc::Receiver<Vec<u8>>,
+    in_tx: mpsc::Sender<Vec<u8>>,
+) {
+    let (mut sink, mut stream) = ws.split();
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ping.tick().await;
+    let mut last_rx = tokio::time::Instant::now();
+    loop {
+        tokio::select! {
+            frame = out_rx.recv() => match frame {
+                Some(bytes) => {
+                    if sink.send(WsMessage::Binary(bytes.into())).await.is_err() {
+                        break;
+                    }
+                }
+                None => {
+                    let _ = sink.send(WsMessage::Close(None)).await;
+                    break;
+                }
+            },
+            frame = stream.next() => match frame {
+                Some(Ok(WsMessage::Binary(bytes))) => {
+                    last_rx = tokio::time::Instant::now();
+                    if in_tx.send(bytes.to_vec()).await.is_err() {
+                        break;
+                    }
+                }
+                Some(Ok(_)) => {
+                    // Text pong / control frames: transport liveness only.
+                    last_rx = tokio::time::Instant::now();
+                }
+                Some(Err(_)) | None => break,
+            },
+            _ = ping.tick() => {
+                if sink.send(WsMessage::Text("ping".into())).await.is_err() {
+                    break;
+                }
+            }
+            _ = tokio::time::sleep_until(last_rx + SILENCE_LEASE) => {
+                tracing::warn!("chat2 socket silent past lease; treating as dead");
+                break;
+            }
+        }
+    }
+}
+
+// ── shared client state ─────────────────────────────────────────────────────
+
+struct PendingPush {
+    batch_id: String,
+    bytes: Vec<u8>,
+}
+
+#[derive(Default)]
+struct Shared {
+    cursor: u64,
+    pending: VecDeque<PendingPush>,
+    /// Last hello/probe view of the server log (checkpoint-policy inputs).
+    server: Option<wire::StateHeader>,
+}
+
+/// `comet sync` surface (plan: cursor / headSeq / floorLag / pendingPushes).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ChatStatsSnapshot {
+    pub connected: bool,
+    pub cursor: u64,
+    pub head_seq: u64,
+    pub seq_floor: u64,
+    pub checkpoint_seq: u64,
+    pub row_count: u64,
+    pub row_bytes: u64,
+    pub pending_pushes: u64,
+    pub rejoins: u64,
+    pub disconnects: u64,
+    pub rejected: u64,
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+// ── the client ──────────────────────────────────────────────────────────────
+
+/// A live chat2-room membership for one chat doc.
+pub struct ChatClient {
+    shared: Arc<Mutex<Shared>>,
+    events: broadcast::Sender<ChatEvent>,
+    shutdown: watch::Sender<bool>,
+    nudge: mpsc::Sender<()>,
+    probe: mpsc::Sender<()>,
+    redial: mpsc::Sender<()>,
+    presence_out: mpsc::Sender<(i64, Vec<u8>)>,
+    flags: Arc<Flags>,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+#[derive(Default)]
+struct Flags {
+    connected: std::sync::atomic::AtomicBool,
+    rejoins: std::sync::atomic::AtomicU64,
+    disconnects: std::sync::atomic::AtomicU64,
+    rejected: std::sync::atomic::AtomicU64,
+}
+
+impl ChatClient {
+    /// Connect (fixed URL — dev/tests).
+    pub async fn connect(
+        url: &str,
+        sink: Arc<dyn ChatDocSink>,
+        fetcher: Arc<dyn CheckpointFetcher>,
+        device_id: &str,
+        initial_cursor: u64,
+    ) -> Result<Self, SyncError> {
+        Self::connect_via(
+            Arc::new(StaticUrl(url.to_string())),
+            sink,
+            fetcher,
+            device_id,
+            initial_cursor,
+        )
+        .await
+    }
+
+    /// Connect with a per-dial URL provider (fresh `?token=` every attempt).
+    /// Resolves once hello/state lands AND the initial catch-up (checkpoint
+    /// if needed + row backfill) completes; first-attempt failures are `Err`
+    /// (callers own the initial-join retry). After that it reconnects itself.
+    pub async fn connect_via(
+        provider: Arc<dyn UrlProvider>,
+        sink: Arc<dyn ChatDocSink>,
+        fetcher: Arc<dyn CheckpointFetcher>,
+        device_id: &str,
+        initial_cursor: u64,
+    ) -> Result<Self, SyncError> {
+        let connector = Arc::new(WsBinConnector { url: provider });
+        Self::connect_with_tuned(
+            connector,
+            sink,
+            fetcher,
+            device_id,
+            initial_cursor,
+            ChatTuning::default(),
+        )
+        .await
+    }
+
+    pub(crate) async fn connect_with_tuned(
+        connector: Arc<dyn BinConnector>,
+        sink: Arc<dyn ChatDocSink>,
+        fetcher: Arc<dyn CheckpointFetcher>,
+        device_id: &str,
+        initial_cursor: u64,
+        tuning: ChatTuning,
+    ) -> Result<Self, SyncError> {
+        let (events, _) = broadcast::channel(256);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let (nudge_tx, nudge_rx) = mpsc::channel(1);
+        let (probe_tx, probe_rx) = mpsc::channel(1);
+        let (redial_tx, redial_rx) = mpsc::channel(1);
+        let (presence_tx, presence_rx) = mpsc::channel(4);
+        let shared = Arc::new(Mutex::new(Shared {
+            cursor: initial_cursor,
+            ..Shared::default()
+        }));
+        let flags = Arc::new(Flags::default());
+
+        let actor = Actor {
+            shared: shared.clone(),
+            sink,
+            fetcher,
+            device_id: device_id.to_string(),
+            connector,
+            tuning,
+            events: events.clone(),
+            shutdown: shutdown_rx,
+            nudge_rx,
+            probe_rx,
+            redial_rx,
+            presence_rx,
+            flags: flags.clone(),
+        };
+        let task = tokio::spawn(actor.run(ready_tx));
+
+        match ready_rx.await {
+            Ok(Ok(())) => Ok(Self {
+                shared,
+                events,
+                shutdown: shutdown_tx,
+                nudge: nudge_tx,
+                probe: probe_tx,
+                redial: redial_tx,
+                presence_out: presence_tx,
+                flags,
+                task: Some(task),
+            }),
+            Ok(Err(err)) => {
+                task.abort();
+                Err(err)
+            }
+            Err(_) => {
+                task.abort();
+                Err(SyncError::Closed)
+            }
+        }
+    }
+
+    pub fn events(&self) -> broadcast::Receiver<ChatEvent> {
+        self.events.subscribe()
+    }
+
+    /// Queue one local update batch for push (a fresh batch id is minted; the
+    /// batch survives reconnects until acked — the server dedupes replays).
+    pub fn enqueue_update(&self, bytes: Vec<u8>) {
+        {
+            let mut shared = lock(&self.shared);
+            shared.pending.push_back(PendingPush {
+                batch_id: uuid::Uuid::new_v4().to_string(),
+                bytes,
+            });
+        }
+        let _ = self.nudge.try_send(());
+    }
+
+    /// Publish this device's presence beat with an opaque payload (cursor
+    /// positions etc. — relayed verbatim, never stored).
+    pub fn send_presence(&self, at: i64, payload: Vec<u8>) {
+        let _ = self.presence_out.try_send((at, payload));
+    }
+
+    /// Liveness hint: probe the room now (deadline-checked).
+    pub fn probe(&self) {
+        let _ = self.probe.try_send(());
+    }
+
+    /// Escalation: tear the session down and dial a fresh socket.
+    pub fn redial(&self) {
+        let _ = self.redial.try_send(());
+    }
+
+    pub fn stats(&self) -> ChatStatsSnapshot {
+        use std::sync::atomic::Ordering::Relaxed;
+        let shared = lock(&self.shared);
+        let server = shared.server.unwrap_or(wire::StateHeader {
+            head_seq: 0,
+            seq_floor: 0,
+            checkpoint_seq: 0,
+            checkpoint_size: 0,
+            row_count: 0,
+            row_bytes: 0,
+        });
+        ChatStatsSnapshot {
+            connected: self.flags.connected.load(Relaxed),
+            cursor: shared.cursor,
+            head_seq: server.head_seq.max(shared.cursor),
+            seq_floor: server.seq_floor,
+            checkpoint_seq: server.checkpoint_seq,
+            row_count: server.row_count,
+            row_bytes: server.row_bytes,
+            pending_pushes: shared.pending.len() as u64,
+            rejoins: self.flags.rejoins.load(Relaxed),
+            disconnects: self.flags.disconnects.load(Relaxed),
+            rejected: self.flags.rejected.load(Relaxed),
+        }
+    }
+
+    /// Leave cleanly and stop the actor.
+    pub async fn shutdown(mut self) {
+        let _ = self.shutdown.send(true);
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for ChatClient {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
+// ── the actor ───────────────────────────────────────────────────────────────
+
+struct Actor {
+    shared: Arc<Mutex<Shared>>,
+    sink: Arc<dyn ChatDocSink>,
+    fetcher: Arc<dyn CheckpointFetcher>,
+    device_id: String,
+    connector: Arc<dyn BinConnector>,
+    tuning: ChatTuning,
+    events: broadcast::Sender<ChatEvent>,
+    shutdown: watch::Receiver<bool>,
+    nudge_rx: mpsc::Receiver<()>,
+    probe_rx: mpsc::Receiver<()>,
+    redial_rx: mpsc::Receiver<()>,
+    presence_rx: mpsc::Receiver<(i64, Vec<u8>)>,
+    flags: Arc<Flags>,
+}
+
+enum SessionEnd {
+    Reconnect,
+    Stop,
+}
+
+impl Actor {
+    async fn run(mut self, ready: oneshot::Sender<Result<(), SyncError>>) {
+        let mut ready = Some(ready);
+        let mut backoff = BACKOFF_BASE;
+        loop {
+            if *self.shutdown.borrow() {
+                return;
+            }
+            let dial = tokio::time::timeout(CONNECT_TIMEOUT, self.connector.connect()).await;
+            let pipe = match dial {
+                Ok(Ok(pipe)) => pipe,
+                Ok(Err(err)) => {
+                    if let Some(ready) = ready.take() {
+                        let _ = ready.send(Err(err));
+                        return; // first join failed: caller owns the retry
+                    }
+                    tracing::warn!(error = %err, "chat2 dial failed; backing off");
+                    if self.sleep_or_shutdown(backoff).await {
+                        return;
+                    }
+                    backoff = (backoff * 2).min(BACKOFF_CAP);
+                    continue;
+                }
+                Err(_) => {
+                    if let Some(ready) = ready.take() {
+                        let _ = ready.send(Err(SyncError::WebSocket("connect timeout".into())));
+                        return;
+                    }
+                    tracing::warn!("chat2 dial timed out; backing off");
+                    if self.sleep_or_shutdown(backoff).await {
+                        return;
+                    }
+                    backoff = (backoff * 2).min(BACKOFF_CAP);
+                    continue;
+                }
+            };
+
+            match self.run_session(pipe, &mut ready).await {
+                SessionEnd::Stop => return,
+                SessionEnd::Reconnect => {
+                    use std::sync::atomic::Ordering::Relaxed;
+                    self.flags.connected.store(false, Relaxed);
+                    self.flags.disconnects.fetch_add(1, Relaxed);
+                    let _ = self.events.send(ChatEvent::Disconnected);
+                    if ready.is_some() {
+                        if let Some(ready) = ready.take() {
+                            let _ =
+                                ready.send(Err(SyncError::Protocol("chat2 handshake failed".into())));
+                        }
+                        return;
+                    }
+                    if self.sleep_or_shutdown(backoff).await {
+                        return;
+                    }
+                    backoff = (backoff * 2).min(BACKOFF_CAP);
+                }
+            }
+        }
+    }
+
+    /// True = shutdown observed.
+    async fn sleep_or_shutdown(&mut self, wait: Duration) -> bool {
+        tokio::select! {
+            _ = tokio::time::sleep(wait) => false,
+            _ = self.shutdown.changed() => *self.shutdown.borrow(),
+        }
+    }
+
+    async fn run_session(
+        &mut self,
+        mut pipe: BinPipe,
+        ready: &mut Option<oneshot::Sender<Result<(), SyncError>>>,
+    ) -> SessionEnd {
+        use std::sync::atomic::Ordering::Relaxed;
+
+        // ── hello / state ───────────────────────────────────────────────────
+        let cursor = lock(&self.shared).cursor;
+        let hello = wire::encode(
+            frame_type::HELLO,
+            &wire::HelloHeader {
+                cursor,
+                device: &self.device_id,
+            },
+            &[],
+        );
+        if pipe.tx.send(hello).await.is_err() {
+            return SessionEnd::Reconnect;
+        }
+        let state = tokio::time::timeout(HELLO_DEADLINE, async {
+            loop {
+                let bytes = pipe.rx.recv().await?;
+                let Some(frame) = wire::decode(&bytes) else {
+                    tracing::warn!("chat2: bad frame during handshake");
+                    return None;
+                };
+                if frame.kind == frame_type::STATE {
+                    return Some(frame);
+                }
+                // Stale broadcast before our state: skip.
+            }
+        })
+        .await;
+        let Ok(Some(state_frame)) = state else {
+            tracing::warn!("chat2: no state frame within deadline");
+            return SessionEnd::Reconnect;
+        };
+        let Ok(state) = serde_json::from_value::<wire::StateHeader>(state_frame.header.clone())
+        else {
+            tracing::warn!("chat2: malformed state header");
+            return SessionEnd::Reconnect;
+        };
+        lock(&self.shared).server = Some(state);
+        self.flags.connected.store(true, Relaxed);
+        if ready.is_none() {
+            self.flags.rejoins.fetch_add(1, Relaxed);
+        }
+        let _ = self.events.send(ChatEvent::Connected);
+
+        // ── catch-up: checkpoint precision + row backfill ───────────────────
+        let contained =
+            state.checkpoint_seq == 0 || self.sink.contains_frontier(&state_frame.payload);
+        let plan = plan_catch_up(cursor, &state, contained);
+        let after = match plan {
+            CatchUpPlan::RowsOnly { after } => after,
+            CatchUpPlan::CheckpointThenRows { after } => {
+                tracing::info!(
+                    checkpoint_seq = state.checkpoint_seq,
+                    checkpoint_size = state.checkpoint_size,
+                    "chat2: fetching checkpoint"
+                );
+                let bytes = match self.fetcher.fetch().await {
+                    Ok(bytes) => bytes,
+                    Err(err) => {
+                        tracing::warn!(error = %err, "chat2: checkpoint fetch failed");
+                        return SessionEnd::Reconnect;
+                    }
+                };
+                if let Err(err) = self.sink.apply_checkpoint(&bytes, state.checkpoint_seq) {
+                    tracing::warn!(error = %err, "chat2: checkpoint import failed");
+                    return SessionEnd::Reconnect;
+                }
+                let mut shared = lock(&self.shared);
+                shared.cursor = shared.cursor.max(state.checkpoint_seq);
+                drop(shared);
+                let _ = self.events.send(ChatEvent::Applied);
+                after
+            }
+        };
+        // Clamp the persisted cursor into the room's honest range (server
+        // reset detection happened in plan_catch_up via after==0).
+        if after < cursor {
+            lock(&self.shared).cursor = after;
+        }
+        let rows_req = wire::encode(
+            frame_type::ROWS_REQ,
+            &wire::RowsReqHeader {
+                after,
+                exclude_own: true,
+            },
+            &[],
+        );
+        if pipe.tx.send(rows_req).await.is_err() {
+            return SessionEnd::Reconnect;
+        }
+        let backfill = tokio::time::timeout(BACKFILL_DEADLINE, async {
+            loop {
+                let bytes = pipe.rx.recv().await?;
+                let Some(frame) = wire::decode(&bytes) else {
+                    return None;
+                };
+                match frame.kind {
+                    frame_type::ROWS_DONE => {
+                        let done: wire::RowsDoneHeader =
+                            serde_json::from_value(frame.header).ok()?;
+                        return Some(done.head_seq);
+                    }
+                    _ => {
+                        if !self.handle_frame(frame) {
+                            return None;
+                        }
+                    }
+                }
+            }
+        })
+        .await;
+        let Ok(Some(head_seq)) = backfill else {
+            tracing::warn!("chat2: backfill did not complete");
+            return SessionEnd::Reconnect;
+        };
+        if let Some(ready) = ready.take() {
+            let _ = ready.send(Ok(()));
+        }
+        let _ = self.events.send(ChatEvent::CaughtUp { head_seq });
+
+        // Anything pending (offline writes, reconnect re-pushes) goes now —
+        // the server's batchId dedupe makes replays exact no-ops.
+        if !self.push_pending(&mut pipe).await {
+            return SessionEnd::Reconnect;
+        }
+
+        // ── steady state ────────────────────────────────────────────────────
+        let mut last_frame = tokio::time::Instant::now();
+        let mut probe_deadline: Option<tokio::time::Instant> = None;
+        loop {
+            let quiet_probe_at = last_frame + self.tuning.probe_quiet;
+            let deadline_at = probe_deadline
+                .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(86_400));
+            tokio::select! {
+                frame = pipe.rx.recv() => {
+                    let Some(bytes) = frame else {
+                        return SessionEnd::Reconnect;
+                    };
+                    last_frame = tokio::time::Instant::now();
+                    probe_deadline = None;
+                    let Some(frame) = wire::decode(&bytes) else {
+                        tracing::warn!("chat2: unparseable frame");
+                        return SessionEnd::Reconnect;
+                    };
+                    if !self.handle_frame(frame) {
+                        return SessionEnd::Reconnect;
+                    }
+                }
+                _ = self.nudge_rx.recv() => {
+                    if !self.push_pending(&mut pipe).await {
+                        return SessionEnd::Reconnect;
+                    }
+                }
+                beat = self.presence_rx.recv() => {
+                    if let Some((at, payload)) = beat {
+                        let frame = wire::encode(
+                            frame_type::PRESENCE,
+                            &wire::PresenceOutHeader { at },
+                            &payload,
+                        );
+                        if pipe.tx.send(frame).await.is_err() {
+                            return SessionEnd::Reconnect;
+                        }
+                    }
+                }
+                _ = self.probe_rx.recv() => {
+                    if !self.send_probe(&mut pipe, &mut probe_deadline).await {
+                        return SessionEnd::Reconnect;
+                    }
+                }
+                _ = self.redial_rx.recv() => {
+                    tracing::info!("chat2: redial requested");
+                    return SessionEnd::Reconnect;
+                }
+                _ = tokio::time::sleep_until(quiet_probe_at) => {
+                    if !self.send_probe(&mut pipe, &mut probe_deadline).await {
+                        return SessionEnd::Reconnect;
+                    }
+                    last_frame = tokio::time::Instant::now();
+                }
+                _ = tokio::time::sleep_until(deadline_at) => {
+                    tracing::warn!("chat2: probe unanswered past deadline; redialing");
+                    return SessionEnd::Reconnect;
+                }
+                _ = self.shutdown.changed() => {
+                    if *self.shutdown.borrow() {
+                        return SessionEnd::Stop;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn send_probe(
+        &self,
+        pipe: &mut BinPipe,
+        probe_deadline: &mut Option<tokio::time::Instant>,
+    ) -> bool {
+        let frame = wire::encode(frame_type::PROBE, &serde_json::json!({}), &[]);
+        if pipe.tx.send(frame).await.is_err() {
+            return false;
+        }
+        if probe_deadline.is_none() {
+            *probe_deadline = Some(tokio::time::Instant::now() + PROBE_DEADLINE);
+        }
+        true
+    }
+
+    async fn push_pending(&self, pipe: &mut BinPipe) -> bool {
+        // Clone rather than drain: batches stay queued until their ack.
+        let frames: Vec<Vec<u8>> = lock(&self.shared)
+            .pending
+            .iter()
+            .map(|push| {
+                wire::encode(
+                    frame_type::PUSH,
+                    &wire::PushHeader {
+                        batch_id: &push.batch_id,
+                    },
+                    &push.bytes,
+                )
+            })
+            .collect();
+        for frame in frames {
+            if pipe.tx.send(frame).await.is_err() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Apply one inbound protocol frame. False = protocol breakdown, redial.
+    fn handle_frame(&self, frame: wire::WireFrame) -> bool {
+        use std::sync::atomic::Ordering::Relaxed;
+        match frame.kind {
+            frame_type::ROW => {
+                let Ok(row) = serde_json::from_value::<wire::RowHeader>(frame.header) else {
+                    return false;
+                };
+                // Own-device rows can still arrive (live relay of a racing
+                // second socket, or a server that ignored excludeOwn) — Loro
+                // re-import is a no-op; the cursor advance is what matters.
+                self.sink.apply_row(&frame.payload, row.seq);
+                let mut shared = lock(&self.shared);
+                shared.cursor = shared.cursor.max(row.seq);
+                drop(shared);
+                let _ = self.events.send(ChatEvent::Applied);
+            }
+            frame_type::ACK => {
+                let Ok(ack) = serde_json::from_value::<wire::AckHeader>(frame.header) else {
+                    return false;
+                };
+                let mut shared = lock(&self.shared);
+                shared.pending.retain(|p| p.batch_id != ack.batch_id);
+                shared.cursor = shared.cursor.max(ack.seq);
+                let cursor = shared.cursor;
+                drop(shared);
+                self.sink.advance_cursor(cursor);
+                let _ = self.events.send(ChatEvent::Applied);
+            }
+            frame_type::PRESENCE => {
+                let _ = self.events.send(ChatEvent::Presence);
+            }
+            frame_type::PROBE_OK => {
+                if let Ok(probe) = serde_json::from_value::<wire::ProbeOkHeader>(frame.header) {
+                    if let Some(server) = &mut lock(&self.shared).server {
+                        server.head_seq = server.head_seq.max(probe.head_seq);
+                    }
+                }
+            }
+            frame_type::STATE => {
+                // Late duplicate of a hello answer — refresh the server view.
+                if let Ok(state) = serde_json::from_value::<wire::StateHeader>(frame.header) {
+                    lock(&self.shared).server = Some(state);
+                }
+            }
+            frame_type::ERROR => {
+                self.flags.rejected.fetch_add(1, Relaxed);
+                let code = frame.header["code"].as_str().unwrap_or("?").to_string();
+                let message = frame.header["message"].as_str().unwrap_or("").to_string();
+                tracing::warn!(code, message, "chat2: server rejected a frame");
+            }
+            other => {
+                // Unknown server frame: tolerate (future protocol additions).
+                tracing::debug!(kind = other, "chat2: ignoring unknown frame type");
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -39,6 +39,22 @@ const BACKOFF_BASE: Duration = Duration::from_millis(250);
 const BACKOFF_CAP: Duration = Duration::from_secs(30);
 /// Quiet-room probe cadence default (matches the registry's fleet math).
 const PROBE_QUIET_DEFAULT: Duration = Duration::from_secs(900);
+/// A checkpoint fetch that hasn't finished by now is treated as a dead link
+/// and the session redials (the fetch itself is Range-resumable, so a retry
+/// picks up where the bytes stopped). Sized for MAX_CHECKPOINT_BYTES over
+/// the 1.2 Mbps links this design exists for.
+const CHECKPOINT_FETCH_DEADLINE: Duration = Duration::from_secs(120);
+/// Re-push cadence after a `quota` rejection (server window is 60 s; pending
+/// batches must not wait for the next enqueue/probe to retry).
+const QUOTA_RETRY: Duration = Duration::from_secs(5);
+/// Client-side push cap: the DO's per-row cap (`chat-log.ts MAX_ROW_BYTES`,
+/// 1 MiB) minus frame-overhead headroom. The headroom matters: the runtime
+/// closes WS messages at 1 MiB BEFORE the DO runs, so a payload within a
+/// frame-header's width of the row cap would die with no error frame (and no
+/// batchId to retire) — the silent replay-forever wedge, again. Enforced at
+/// enqueue: a batch the server can never accept must not enter the replay
+/// queue.
+pub const MAX_PUSH_BYTES: usize = 1024 * 1024 - 4096;
 
 /// Per-client tuning.
 #[derive(Clone, Copy, Debug)]
@@ -67,6 +83,16 @@ pub enum ChatEvent {
     Disconnected,
     /// A remote device's presence beat arrived.
     Presence,
+    /// The server's headSeq is behind our persisted cursor — the room was
+    /// reset/wiped. The catch-up treats the cursor as fresh; the HOST should
+    /// react by re-seeding via checkpoint (chat-room.ts `/reset` recovery).
+    ServerReset,
+    /// A queued batch was permanently rejected (or refused at enqueue) and
+    /// dropped from the replay queue. The ops remain in the local doc; the
+    /// row-path for them is gone, so they reach peers only when THIS device
+    /// next posts a checkpoint — the C3 host should treat this event as a
+    /// checkpoint trigger, not a shrug.
+    PushRejected,
 }
 
 // ── engine-facing traits ────────────────────────────────────────────────────
@@ -228,6 +254,15 @@ struct Shared {
     pending: VecDeque<PendingPush>,
     /// Last hello/probe view of the server log (checkpoint-policy inputs).
     server: Option<wire::StateHeader>,
+    /// Set by a transient (`quota`) rejection: re-push at this instant
+    /// instead of waiting for the next enqueue/probe/reconnect.
+    retry_at: Option<tokio::time::Instant>,
+    /// True while draining a quota-rejected queue. Retry ticks then probe
+    /// with the HEAD batch only (a full-queue replay would itself consume
+    /// the server's quota window — N pending × 12 ticks/window livelocks
+    /// past N≈25), and each ack immediately re-arms the clock until the
+    /// queue empties.
+    quota_blocked: bool,
 }
 
 /// `comet sync` surface (plan: cursor / headSeq / floorLag / pendingPushes).
@@ -244,6 +279,9 @@ pub struct ChatStatsSnapshot {
     pub rejoins: u64,
     pub disconnects: u64,
     pub rejected: u64,
+    /// Times a hello found the server behind our cursor (room reset/wiped).
+    /// Nonzero means the host owes the room a re-seed checkpoint.
+    pub server_resets: u64,
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
@@ -271,6 +309,7 @@ struct Flags {
     rejoins: std::sync::atomic::AtomicU64,
     disconnects: std::sync::atomic::AtomicU64,
     rejected: std::sync::atomic::AtomicU64,
+    server_resets: std::sync::atomic::AtomicU64,
 }
 
 impl ChatClient {
@@ -350,6 +389,7 @@ impl ChatClient {
             redial_rx,
             presence_rx,
             flags: flags.clone(),
+            resumed: false,
         };
         let task = tokio::spawn(actor.run(ready_tx));
 
@@ -382,7 +422,23 @@ impl ChatClient {
 
     /// Queue one local update batch for push (a fresh batch id is minted; the
     /// batch survives reconnects until acked — the server dedupes replays).
+    ///
+    /// Batches over [`MAX_PUSH_BYTES`] are refused here: the server can never
+    /// accept them (`MAX_ROW_BYTES`), and a queued-forever batch would replay
+    /// on every reconnect — the exact wedge class chat2 replaces. The ops
+    /// stay in the local doc and reach peers via the next checkpoint.
     pub fn enqueue_update(&self, bytes: Vec<u8>) {
+        if bytes.len() > MAX_PUSH_BYTES {
+            use std::sync::atomic::Ordering::Relaxed;
+            tracing::error!(
+                bytes = bytes.len(),
+                "chat2: update exceeds the row cap; not queued (post-strip \
+                 updates are KB-scale — this is an upstream bug)"
+            );
+            self.flags.rejected.fetch_add(1, Relaxed);
+            let _ = self.events.send(ChatEvent::PushRejected);
+            return;
+        }
         {
             let mut shared = lock(&self.shared);
             shared.pending.push_back(PendingPush {
@@ -423,7 +479,10 @@ impl ChatClient {
         ChatStatsSnapshot {
             connected: self.flags.connected.load(Relaxed),
             cursor: shared.cursor,
-            head_seq: server.head_seq.max(shared.cursor),
+            // The server's honest view — deliberately NOT clamped to the
+            // cursor: cursor > headSeq is the reset signal and must stay
+            // visible to the observability surface, not be masked by it.
+            head_seq: server.head_seq,
             seq_floor: server.seq_floor,
             checkpoint_seq: server.checkpoint_seq,
             row_count: server.row_count,
@@ -432,6 +491,7 @@ impl ChatClient {
             rejoins: self.flags.rejoins.load(Relaxed),
             disconnects: self.flags.disconnects.load(Relaxed),
             rejected: self.flags.rejected.load(Relaxed),
+            server_resets: self.flags.server_resets.load(Relaxed),
         }
     }
 
@@ -468,6 +528,18 @@ struct Actor {
     redial_rx: mpsc::Receiver<()>,
     presence_rx: mpsc::Receiver<(i64, Vec<u8>)>,
     flags: Arc<Flags>,
+    /// False until the first backfill of THIS client instance completes.
+    /// (Continuity is instance-scoped: a host that restores an older doc
+    /// snapshot must construct a fresh `ChatClient` — C3 wiring contract.)
+    /// The first
+    /// backfill must NOT exclude own rows: after a restart the pending queue
+    /// is gone, and a restored-backup/copied-device doc may be missing its
+    /// own post-backup writes — they exist only on the server. Loro
+    /// re-import of rows the doc does hold is a no-op, so redownloading own
+    /// bytes once is pure safety. Same-process reconnects have queue
+    /// continuity and skip them (the reconnect-after-offline-work path the
+    /// spec optimizes).
+    resumed: bool,
 }
 
 enum SessionEnd {
@@ -593,6 +665,21 @@ impl Actor {
         }
         let _ = self.events.send(ChatEvent::Connected);
 
+        // Server behind our cursor = the room was reset/wiped. plan_catch_up
+        // treats the cursor as fresh; SURFACE the signal too — the host's
+        // re-seed recovery (chat-room.ts /reset) hangs off this event, and
+        // masking it was exactly how the s2 wedge class stayed invisible.
+        if cursor > state.head_seq {
+            self.flags.server_resets.fetch_add(1, Relaxed);
+            tracing::warn!(
+                cursor,
+                head_seq = state.head_seq,
+                "chat2: server lost state (headSeq < cursor) — treating as \
+                 fresh; host should re-seed via checkpoint"
+            );
+            let _ = self.events.send(ChatEvent::ServerReset);
+        }
+
         // ── catch-up: checkpoint precision + row backfill ───────────────────
         let contained =
             state.checkpoint_seq == 0 || self.sink.contains_frontier(&state_frame.payload);
@@ -605,10 +692,23 @@ impl Actor {
                     checkpoint_size = state.checkpoint_size,
                     "chat2: fetching checkpoint"
                 );
-                let bytes = match self.fetcher.fetch().await {
-                    Ok(bytes) => bytes,
-                    Err(err) => {
+                // Deadline + shutdown-interruptible: a hung fetch (half-open
+                // TCP, stalled link) must neither pin the actor forever nor
+                // block `shutdown()`. The fetch is Range-resumable, so the
+                // redial retries from wherever the bytes stopped.
+                let fetch = self.fetcher.fetch();
+                let fetched = tokio::select! {
+                    fetched = tokio::time::timeout(CHECKPOINT_FETCH_DEADLINE, fetch) => fetched,
+                    _ = self.shutdown.changed() => return SessionEnd::Stop,
+                };
+                let bytes = match fetched {
+                    Ok(Ok(bytes)) => bytes,
+                    Ok(Err(err)) => {
                         tracing::warn!(error = %err, "chat2: checkpoint fetch failed");
+                        return SessionEnd::Reconnect;
+                    }
+                    Err(_) => {
+                        tracing::warn!("chat2: checkpoint fetch timed out; redialing");
                         return SessionEnd::Reconnect;
                     }
                 };
@@ -632,7 +732,9 @@ impl Actor {
             frame_type::ROWS_REQ,
             &wire::RowsReqHeader {
                 after,
-                exclude_own: true,
+                // First backfill of this process redownloads own rows (see
+                // `Actor::resumed`); reconnects skip them.
+                exclude_own: self.resumed,
             },
             &[],
         );
@@ -664,6 +766,7 @@ impl Actor {
             tracing::warn!("chat2: backfill did not complete");
             return SessionEnd::Reconnect;
         };
+        self.resumed = true;
         if let Some(ready) = ready.take() {
             let _ = ready.send(Ok(()));
         }
@@ -681,6 +784,9 @@ impl Actor {
         loop {
             let quiet_probe_at = last_frame + self.tuning.probe_quiet;
             let deadline_at = probe_deadline
+                .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(86_400));
+            let retry_at = lock(&self.shared)
+                .retry_at
                 .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(86_400));
             tokio::select! {
                 frame = pipe.rx.recv() => {
@@ -723,6 +829,15 @@ impl Actor {
                     tracing::info!("chat2: redial requested");
                     return SessionEnd::Reconnect;
                 }
+                // Transient (quota) rejection: probe with the HEAD batch on
+                // a short clock (see `Shared::quota_blocked`); acks re-arm
+                // the clock so the queue drains one-per-grant.
+                _ = tokio::time::sleep_until(retry_at) => {
+                    lock(&self.shared).retry_at = None;
+                    if !self.push_head(&mut pipe).await {
+                        return SessionEnd::Reconnect;
+                    }
+                }
                 _ = tokio::time::sleep_until(quiet_probe_at) => {
                     if !self.send_probe(&mut pipe, &mut probe_deadline).await {
                         return SessionEnd::Reconnect;
@@ -755,6 +870,26 @@ impl Actor {
             *probe_deadline = Some(tokio::time::Instant::now() + PROBE_DEADLINE);
         }
         true
+    }
+
+    /// Send only the queue's head batch — the quota-probe path.
+    async fn push_head(&self, pipe: &mut BinPipe) -> bool {
+        let frame = {
+            let shared = lock(&self.shared);
+            shared.pending.front().map(|push| {
+                wire::encode(
+                    frame_type::PUSH,
+                    &wire::PushHeader {
+                        batch_id: &push.batch_id,
+                    },
+                    &push.bytes,
+                )
+            })
+        };
+        match frame {
+            Some(frame) => pipe.tx.send(frame).await.is_ok(),
+            None => true,
+        }
     }
 
     async fn push_pending(&self, pipe: &mut BinPipe) -> bool {
@@ -805,6 +940,15 @@ impl Actor {
                 shared.pending.retain(|p| p.batch_id != ack.batch_id);
                 shared.cursor = shared.cursor.max(ack.seq);
                 let cursor = shared.cursor;
+                // Quota drain: each grant immediately probes the next head
+                // batch (one-per-grant, never a full-queue burst).
+                if shared.quota_blocked {
+                    if shared.pending.is_empty() {
+                        shared.quota_blocked = false;
+                    } else {
+                        shared.retry_at = Some(tokio::time::Instant::now());
+                    }
+                }
                 drop(shared);
                 self.sink.advance_cursor(cursor);
                 let _ = self.events.send(ChatEvent::Applied);
@@ -829,6 +973,37 @@ impl Actor {
                 self.flags.rejected.fetch_add(1, Relaxed);
                 let code = frame.header["code"].as_str().unwrap_or("?").to_string();
                 let message = frame.header["message"].as_str().unwrap_or("").to_string();
+                let batch_id = frame.header["batchId"].as_str().unwrap_or("");
+                match code.as_str() {
+                    // Permanent verdicts on a specific batch: retire it, or
+                    // it replays on every nudge/reconnect forever — the
+                    // wedge class this design exists to kill. The ops stay
+                    // in the local doc and travel with the next checkpoint.
+                    "too_large" | "empty" | "bad_push" if !batch_id.is_empty() => {
+                        let mut shared = lock(&self.shared);
+                        let before = shared.pending.len();
+                        shared.pending.retain(|p| p.batch_id != batch_id);
+                        let dropped = before != shared.pending.len();
+                        drop(shared);
+                        if dropped {
+                            tracing::error!(
+                                code,
+                                batch_id,
+                                "chat2: batch permanently rejected — retired \
+                                 from the replay queue"
+                            );
+                            let _ = self.events.send(ChatEvent::PushRejected);
+                        }
+                    }
+                    // Transient: the quota window passes on its own — keep
+                    // the batch queued and head-probe on a short clock.
+                    "quota" => {
+                        let mut shared = lock(&self.shared);
+                        shared.quota_blocked = true;
+                        shared.retry_at = Some(tokio::time::Instant::now() + QUOTA_RETRY);
+                    }
+                    _ => {}
+                }
                 tracing::warn!(code, message, "chat2: server rejected a frame");
             }
             other => {

--- a/crates/sync/src/chat_client/tests.rs
+++ b/crates/sync/src/chat_client/tests.rs
@@ -100,19 +100,22 @@ async fn send(end: &ServerEnd, kind: u8, header: serde_json::Value, payload: &[u
 }
 
 /// Answer hello with `state`, then serve the rows request with `rows`.
-/// Returns the observed `after` from the rows request.
+/// Returns the observed `after` from the rows request. `expect_exclude`
+/// pins the F1 rule: the process's FIRST backfill must redownload own rows
+/// (false), same-process reconnects skip them (true).
 async fn serve_join(
     end: &mut ServerEnd,
     state: serde_json::Value,
     frontier: &[u8],
     rows: Vec<(u64, &str, Vec<u8>)>,
+    expect_exclude: bool,
 ) -> u64 {
     let hello = expect_kind(end, frame_type::HELLO).await;
     assert!(hello.header["device"].is_string());
     let head_seq = state["headSeq"].as_u64().unwrap();
     send(end, frame_type::STATE, state, frontier).await;
     let req = expect_kind(end, frame_type::ROWS_REQ).await;
-    assert_eq!(req.header["excludeOwn"], true);
+    assert_eq!(req.header["excludeOwn"], expect_exclude);
     let after = req.header["after"].as_u64().unwrap();
     for (seq, device, bytes) in rows {
         send(
@@ -207,6 +210,7 @@ async fn fresh_join_backfills_rows_and_advances_cursor() {
                 "checkpointSize": 0, "rowCount": 2, "rowBytes": 64}),
             &[],
             vec![(1, "dev-b", vec![0xaa]), (2, "dev-b", vec![0xbb])],
+            false,
         )
         .await;
         assert_eq!(after, 0);
@@ -252,6 +256,7 @@ async fn contained_frontier_skips_the_checkpoint_download() {
                 "checkpointSize": 160_000, "rowCount": 3, "rowBytes": 900}),
             &[1, 2, 3],
             vec![(6, "dev-b", vec![6]), (7, "dev-b", vec![7]), (8, "dev-b", vec![8])],
+            false,
         )
         .await;
         // Client-side precision: cursor was 0 but the frontier is local —
@@ -292,6 +297,7 @@ async fn missing_frontier_fetches_and_imports_the_checkpoint_first() {
                 "checkpointSize": 16, "rowCount": 1, "rowBytes": 10}),
             &[9, 9, 9],
             vec![(6, "dev-b", vec![6])],
+            false,
         )
         .await;
         assert_eq!(after, 5, "rows resume after the checkpoint");
@@ -332,7 +338,7 @@ async fn unacked_pushes_survive_reconnect_and_acks_retire_them() {
     let s1 = tokio::spawn({
         let state = empty_state.clone();
         async move {
-            serve_join(&mut end1, state, &[], vec![]).await;
+            serve_join(&mut end1, state, &[], vec![], false).await;
             // Receive the push but die before acking — the client must
             // re-push the SAME batch id on the next session.
             let push = expect_kind(&mut end1, frame_type::PUSH).await;
@@ -362,7 +368,7 @@ async fn unacked_pushes_survive_reconnect_and_acks_retire_them() {
     let s2 = tokio::spawn({
         let state = empty_state.clone();
         async move {
-            serve_join(&mut end2, state, &[], vec![]).await;
+            serve_join(&mut end2, state, &[], vec![], true).await;
             let push = expect_kind(&mut end2, frame_type::PUSH).await;
             let batch_id = push.header["batchId"].as_str().unwrap().to_string();
             send(
@@ -386,4 +392,248 @@ async fn unacked_pushes_survive_reconnect_and_acks_retire_them() {
     assert_eq!(client.stats().cursor, 1, "ack advanced the cursor");
     assert_eq!(*lock(&sink.cursor_advances), vec![1]);
     client.shutdown().await;
+}
+
+// ── 2026-08-10 review fixes (F1–F4) ─────────────────────────────────────────
+
+struct PendingFetcher;
+impl CheckpointFetcher for PendingFetcher {
+    fn fetch(&self) -> BoxFuture<'static, Result<Vec<u8>, SyncError>> {
+        Box::pin(std::future::pending())
+    }
+}
+
+/// F2: a permanent server verdict (`too_large`) retires the batch from the
+/// replay queue; a transient one (`quota`) keeps it and re-pushes on the
+/// retry clock without waiting for a new enqueue.
+#[tokio::test(start_paused = true)]
+async fn permanent_rejection_retires_transient_keeps_and_retries() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, _) = fetcher(b"");
+    let empty_state = serde_json::json!({"headSeq": 0, "seqFloor": 0,
+        "checkpointSeq": 0, "checkpointSize": 0, "rowCount": 0, "rowBytes": 0});
+
+    let server = tokio::spawn(async move {
+        serve_join(&mut end, empty_state, &[], vec![], false).await;
+        // First batch: permanently rejected.
+        let doomed = expect_kind(&mut end, frame_type::PUSH).await;
+        let doomed_id = doomed.header["batchId"].as_str().unwrap().to_string();
+        send(
+            &end,
+            frame_type::ERROR,
+            serde_json::json!({"code": "too_large", "message": "push rejected", "batchId": doomed_id}),
+            &[],
+        )
+        .await;
+        // Second batch: quota-limited once, then replayed by the retry clock
+        // (no further enqueue nudges) and acked.
+        let quotad = expect_kind(&mut end, frame_type::PUSH).await;
+        let quotad_id = quotad.header["batchId"].as_str().unwrap().to_string();
+        send(
+            &end,
+            frame_type::ERROR,
+            serde_json::json!({"code": "quota", "message": "later", "batchId": quotad_id}),
+            &[],
+        )
+        .await;
+        let replay = expect_kind(&mut end, frame_type::PUSH).await;
+        assert_eq!(
+            replay.header["batchId"].as_str().unwrap(),
+            quotad_id,
+            "retry clock replays the SAME quota-limited batch"
+        );
+        send(
+            &end,
+            frame_type::ACK,
+            serde_json::json!({"batchId": quotad_id, "seq": 1, "dup": false}),
+            &[],
+        )
+        .await;
+        end
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+
+    let mut events = client.events();
+    client.enqueue_update(vec![0xd0]); // doomed
+    // Retirement lands asynchronously; PushRejected marks it.
+    loop {
+        if let Ok(ChatEvent::PushRejected) = events.recv().await {
+            break;
+        }
+    }
+    assert_eq!(client.stats().pending_pushes, 0, "doomed batch retired");
+
+    client.enqueue_update(vec![0xb0]);
+    let _keep = server.await.unwrap();
+    while client.stats().pending_pushes > 0 {
+        let _ = events.recv().await;
+    }
+    assert_eq!(client.stats().cursor, 1, "quota batch eventually landed");
+    assert!(client.stats().rejected >= 2);
+    client.shutdown().await;
+}
+
+/// F2: batches over the row cap never enter the replay queue.
+#[tokio::test(start_paused = true)]
+async fn oversized_enqueue_is_refused_at_the_door() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, _) = fetcher(b"");
+    let empty_state = serde_json::json!({"headSeq": 0, "seqFloor": 0,
+        "checkpointSeq": 0, "checkpointSize": 0, "rowCount": 0, "rowBytes": 0});
+    let server = tokio::spawn(async move {
+        serve_join(&mut end, empty_state, &[], vec![], false).await;
+        end
+    });
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink,
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+    let _keep = server.await.unwrap();
+
+    // Exactly the DO row cap (1 MiB): the frame header would push the WS
+    // message over the runtime's 1 MiB cap and the socket would close with
+    // NO error frame to retire the batch — the gate must refuse it (this is
+    // why MAX_PUSH_BYTES carries headroom below the row cap).
+    client.enqueue_update(vec![0u8; 1024 * 1024]);
+    let stats = client.stats();
+    assert_eq!(stats.pending_pushes, 0, "boundary batch not queued");
+    assert_eq!(stats.rejected, 1);
+    client.shutdown().await;
+}
+
+/// F4 (second half): `shutdown()` must complete promptly even while the
+/// actor is parked inside a hung checkpoint fetch.
+#[tokio::test(start_paused = true)]
+async fn shutdown_interrupts_a_hung_checkpoint_fetch() {
+    let (pipe1, mut end1) = pipe_pair();
+    let (pipe2, mut end2) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default()); // frontier NOT contained
+    let empty_state = serde_json::json!({"headSeq": 0, "seqFloor": 0,
+        "checkpointSeq": 0, "checkpointSize": 0, "rowCount": 0, "rowBytes": 0});
+
+    // Session 1: clean join (no checkpoint), then the socket dies.
+    let s1 = tokio::spawn(async move {
+        serve_join(&mut end1, empty_state, &[], vec![], false).await;
+        drop(end1);
+    });
+    // Session 2: a checkpoint appeared — the client must fetch, and hangs.
+    let s2 = tokio::spawn(async move {
+        let _hello = expect_kind(&mut end2, frame_type::HELLO).await;
+        send(
+            &end2,
+            frame_type::STATE,
+            serde_json::json!({"headSeq": 9, "seqFloor": 5, "checkpointSeq": 5,
+                "checkpointSize": 1000, "rowCount": 4, "rowBytes": 40}),
+            &[7, 7, 7],
+        )
+        .await;
+        end2 // keep the pipe alive; only the fetch is stuck
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe1, pipe2]),
+        sink,
+        Arc::new(PendingFetcher),
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("first join succeeds");
+    s1.await.unwrap();
+    let _keep = s2.await.unwrap();
+    // Let the actor redial and park inside the hung fetch.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::timeout(Duration::from_secs(30), client.shutdown())
+        .await
+        .expect("shutdown must not hang on a stuck fetch");
+}
+
+/// F3: a server whose headSeq fell behind our cursor (reset/wiped room) is
+/// SURFACED — counted in stats, honest head_seq — not silently absorbed.
+#[tokio::test(start_paused = true)]
+async fn server_reset_is_counted_and_head_seq_stays_honest() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, _) = fetcher(b"");
+    let server = tokio::spawn(async move {
+        let after = serve_join(
+            &mut end,
+            serde_json::json!({"headSeq": 3, "seqFloor": 0, "checkpointSeq": 0,
+                "checkpointSize": 0, "rowCount": 3, "rowBytes": 30}),
+            &[],
+            vec![(1, "dev-b", vec![1]), (2, "dev-b", vec![2]), (3, "dev-b", vec![3])],
+            false,
+        )
+        .await;
+        assert_eq!(after, 0, "meaningless cursor treated as fresh");
+        end
+    });
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink,
+        fetch,
+        "dev-a",
+        50, // persisted cursor from before the room was wiped
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+    let _keep = server.await.unwrap();
+
+    let stats = client.stats();
+    assert_eq!(stats.server_resets, 1, "reset visible to the host");
+    assert_eq!(stats.head_seq, 3, "server view not masked by the cursor");
+    assert_eq!(stats.cursor, 3, "cursor re-anchored by the backfill");
+    client.shutdown().await;
+}
+
+/// F4: a checkpoint fetch that never resolves fails the first join within
+/// the deadline instead of hanging the actor (and shutdown) forever.
+#[tokio::test(start_paused = true)]
+async fn hung_checkpoint_fetch_fails_the_join_within_deadline() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default()); // frontier NOT contained
+    let server = tokio::spawn(async move {
+        let hello = expect_kind(&mut end, frame_type::HELLO).await;
+        assert!(hello.header["device"].is_string());
+        send(
+            &end,
+            frame_type::STATE,
+            serde_json::json!({"headSeq": 9, "seqFloor": 5, "checkpointSeq": 5,
+                "checkpointSize": 1000, "rowCount": 4, "rowBytes": 40}),
+            &[7, 7, 7],
+        )
+        .await;
+        end // keep the pipe alive; the fetch is what must time out
+    });
+    let joined = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink,
+        Arc::new(PendingFetcher),
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await;
+    assert!(joined.is_err(), "hung fetch must not hang the join");
+    let _keep = server.await.unwrap();
 }

--- a/crates/sync/src/chat_client/tests.rs
+++ b/crates/sync/src/chat_client/tests.rs
@@ -1,0 +1,389 @@
+//! ChatClient behavior against a hand-driven server end (channel pipes — no
+//! WebSocket): handshake precision, backfill, push/ack retirement, and the
+//! reconnect re-push path. Virtual clock (`start_paused`) so backoff and
+//! deadlines cost nothing.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use super::*;
+use crate::chat_frames::{decode, encode, frame_type};
+
+// ── plumbing: linked pipes + scripted connector ─────────────────────────────
+
+struct ServerEnd {
+    tx: mpsc::Sender<Vec<u8>>,
+    rx: mpsc::Receiver<Vec<u8>>,
+}
+
+fn pipe_pair() -> (BinPipe, ServerEnd) {
+    let (c2s_tx, c2s_rx) = mpsc::channel(64);
+    let (s2c_tx, s2c_rx) = mpsc::channel(64);
+    (
+        BinPipe {
+            tx: c2s_tx,
+            rx: s2c_rx,
+        },
+        ServerEnd {
+            tx: s2c_tx,
+            rx: c2s_rx,
+        },
+    )
+}
+
+struct ChanConnector {
+    pipes: Mutex<VecDeque<BinPipe>>,
+}
+
+impl BinConnector for ChanConnector {
+    fn connect(&self) -> BoxFuture<'static, Result<BinPipe, SyncError>> {
+        let pipe = lock(&self.pipes).pop_front();
+        Box::pin(async move { pipe.ok_or(SyncError::Closed) })
+    }
+}
+
+// ── sink + fetcher doubles ──────────────────────────────────────────────────
+
+#[derive(Default)]
+struct RecordingSink {
+    rows: Mutex<Vec<(Vec<u8>, u64)>>,
+    checkpoints: Mutex<Vec<(Vec<u8>, u64)>>,
+    cursor_advances: Mutex<Vec<u64>>,
+    frontier_contained: std::sync::atomic::AtomicBool,
+}
+
+impl ChatDocSink for RecordingSink {
+    fn apply_row(&self, bytes: &[u8], cursor: u64) {
+        lock(&self.rows).push((bytes.to_vec(), cursor));
+    }
+    fn apply_checkpoint(&self, bytes: &[u8], cursor: u64) -> Result<(), String> {
+        lock(&self.checkpoints).push((bytes.to_vec(), cursor));
+        Ok(())
+    }
+    fn contains_frontier(&self, _frontier: &[u8]) -> bool {
+        self.frontier_contained
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+    fn advance_cursor(&self, cursor: u64) {
+        lock(&self.cursor_advances).push(cursor);
+    }
+}
+
+struct FixedFetcher {
+    bytes: Vec<u8>,
+    calls: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl CheckpointFetcher for FixedFetcher {
+    fn fetch(&self) -> BoxFuture<'static, Result<Vec<u8>, SyncError>> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let bytes = self.bytes.clone();
+        Box::pin(async move { Ok(bytes) })
+    }
+}
+
+// ── server-side script helpers ──────────────────────────────────────────────
+
+async fn expect_kind(end: &mut ServerEnd, kind: u8) -> wire::WireFrame {
+    loop {
+        let bytes = end.rx.recv().await.expect("client hung up");
+        let frame = decode(&bytes).expect("client sent undecodable frame");
+        if frame.kind == kind {
+            return frame;
+        }
+        panic!("expected frame {kind:#x}, got {:#x}", frame.kind);
+    }
+}
+
+async fn send(end: &ServerEnd, kind: u8, header: serde_json::Value, payload: &[u8]) {
+    end.tx.send(encode(kind, &header, payload)).await.unwrap();
+}
+
+/// Answer hello with `state`, then serve the rows request with `rows`.
+/// Returns the observed `after` from the rows request.
+async fn serve_join(
+    end: &mut ServerEnd,
+    state: serde_json::Value,
+    frontier: &[u8],
+    rows: Vec<(u64, &str, Vec<u8>)>,
+) -> u64 {
+    let hello = expect_kind(end, frame_type::HELLO).await;
+    assert!(hello.header["device"].is_string());
+    let head_seq = state["headSeq"].as_u64().unwrap();
+    send(end, frame_type::STATE, state, frontier).await;
+    let req = expect_kind(end, frame_type::ROWS_REQ).await;
+    assert_eq!(req.header["excludeOwn"], true);
+    let after = req.header["after"].as_u64().unwrap();
+    for (seq, device, bytes) in rows {
+        send(
+            end,
+            frame_type::ROW,
+            serde_json::json!({"seq": seq, "device": device, "batchId": format!("b{seq}")}),
+            &bytes,
+        )
+        .await;
+    }
+    send(
+        end,
+        frame_type::ROWS_DONE,
+        serde_json::json!({"headSeq": head_seq}),
+        &[],
+    )
+    .await;
+    after
+}
+
+fn connector(pipes: Vec<BinPipe>) -> Arc<ChanConnector> {
+    Arc::new(ChanConnector {
+        pipes: Mutex::new(pipes.into_iter().collect()),
+    })
+}
+
+fn fetcher(bytes: &[u8]) -> (Arc<FixedFetcher>, Arc<std::sync::atomic::AtomicU64>) {
+    let calls = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    (
+        Arc::new(FixedFetcher {
+            bytes: bytes.to_vec(),
+            calls: calls.clone(),
+        }),
+        calls,
+    )
+}
+
+// ── plan_catch_up (pure) ────────────────────────────────────────────────────
+
+#[test]
+fn catch_up_plan_covers_the_decision_table() {
+    let state = |head: u64, ckpt: u64| wire::StateHeader {
+        head_seq: head,
+        seq_floor: ckpt,
+        checkpoint_seq: ckpt,
+        checkpoint_size: if ckpt > 0 { 1000 } else { 0 },
+        row_count: 0,
+        row_bytes: 0,
+    };
+    // Empty room / no checkpoint: rows from the cursor.
+    assert_eq!(
+        plan_catch_up(0, &state(0, 0), true),
+        CatchUpPlan::RowsOnly { after: 0 }
+    );
+    assert_eq!(
+        plan_catch_up(4, &state(9, 0), true),
+        CatchUpPlan::RowsOnly { after: 4 }
+    );
+    // Frontier contained: skip the checkpoint even from an older cursor.
+    assert_eq!(
+        plan_catch_up(2, &state(9, 5), true),
+        CatchUpPlan::RowsOnly { after: 5 }
+    );
+    assert_eq!(
+        plan_catch_up(7, &state(9, 5), true),
+        CatchUpPlan::RowsOnly { after: 7 }
+    );
+    // Frontier missing: checkpoint first, rows after it.
+    assert_eq!(
+        plan_catch_up(2, &state(9, 5), false),
+        CatchUpPlan::CheckpointThenRows { after: 5 }
+    );
+    // Server lost state (cursor ahead of head): cursor is meaningless.
+    assert_eq!(
+        plan_catch_up(50, &state(3, 0), true),
+        CatchUpPlan::RowsOnly { after: 0 }
+    );
+}
+
+// ── end-to-end actor behavior ───────────────────────────────────────────────
+
+#[tokio::test(start_paused = true)]
+async fn fresh_join_backfills_rows_and_advances_cursor() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, fetch_calls) = fetcher(b"");
+
+    let server = tokio::spawn(async move {
+        let after = serve_join(
+            &mut end,
+            serde_json::json!({"headSeq": 2, "seqFloor": 0, "checkpointSeq": 0,
+                "checkpointSize": 0, "rowCount": 2, "rowBytes": 64}),
+            &[],
+            vec![(1, "dev-b", vec![0xaa]), (2, "dev-b", vec![0xbb])],
+        )
+        .await;
+        assert_eq!(after, 0);
+        end
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+    server.await.unwrap();
+
+    assert_eq!(
+        *lock(&sink.rows),
+        vec![(vec![0xaa], 1), (vec![0xbb], 2)],
+        "both remote rows imported in seq order"
+    );
+    assert_eq!(fetch_calls.load(std::sync::atomic::Ordering::Relaxed), 0);
+    let stats = client.stats();
+    assert!(stats.connected);
+    assert_eq!(stats.cursor, 2);
+    client.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn contained_frontier_skips_the_checkpoint_download() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    sink.frontier_contained
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    let (fetch, fetch_calls) = fetcher(b"never");
+
+    let server = tokio::spawn(async move {
+        let after = serve_join(
+            &mut end,
+            serde_json::json!({"headSeq": 8, "seqFloor": 5, "checkpointSeq": 5,
+                "checkpointSize": 160_000, "rowCount": 3, "rowBytes": 900}),
+            &[1, 2, 3],
+            vec![(6, "dev-b", vec![6]), (7, "dev-b", vec![7]), (8, "dev-b", vec![8])],
+        )
+        .await;
+        // Client-side precision: cursor was 0 but the frontier is local —
+        // skip straight past the checkpointed span.
+        assert_eq!(after, 5);
+        end
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+    server.await.unwrap();
+
+    assert_eq!(fetch_calls.load(std::sync::atomic::Ordering::Relaxed), 0);
+    assert!(lock(&sink.checkpoints).is_empty());
+    assert_eq!(lock(&sink.rows).len(), 3);
+    assert_eq!(client.stats().cursor, 8);
+    client.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn missing_frontier_fetches_and_imports_the_checkpoint_first() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, fetch_calls) = fetcher(b"checkpoint-bytes");
+
+    let server = tokio::spawn(async move {
+        let after = serve_join(
+            &mut end,
+            serde_json::json!({"headSeq": 6, "seqFloor": 5, "checkpointSeq": 5,
+                "checkpointSize": 16, "rowCount": 1, "rowBytes": 10}),
+            &[9, 9, 9],
+            vec![(6, "dev-b", vec![6])],
+        )
+        .await;
+        assert_eq!(after, 5, "rows resume after the checkpoint");
+        end
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        2,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+    server.await.unwrap();
+
+    assert_eq!(fetch_calls.load(std::sync::atomic::Ordering::Relaxed), 1);
+    assert_eq!(
+        *lock(&sink.checkpoints),
+        vec![(b"checkpoint-bytes".to_vec(), 5)]
+    );
+    assert_eq!(*lock(&sink.rows), vec![(vec![6u8], 6)]);
+    client.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn unacked_pushes_survive_reconnect_and_acks_retire_them() {
+    let (pipe1, mut end1) = pipe_pair();
+    let (pipe2, mut end2) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, _) = fetcher(b"");
+
+    let empty_state = serde_json::json!({"headSeq": 0, "seqFloor": 0,
+        "checkpointSeq": 0, "checkpointSize": 0, "rowCount": 0, "rowBytes": 0});
+
+    let s1 = tokio::spawn({
+        let state = empty_state.clone();
+        async move {
+            serve_join(&mut end1, state, &[], vec![]).await;
+            // Receive the push but die before acking — the client must
+            // re-push the SAME batch id on the next session.
+            let push = expect_kind(&mut end1, frame_type::PUSH).await;
+            let batch_id = push.header["batchId"].as_str().unwrap().to_string();
+            assert_eq!(push.payload, vec![0xd1u8]);
+            drop(end1); // socket dies
+            batch_id
+        }
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe1, pipe2]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+
+    client.enqueue_update(vec![0xd1]);
+    let first_batch = s1.await.unwrap();
+    assert_eq!(client.stats().pending_pushes, 1, "unacked batch stays queued");
+
+    // Second session: same handshake, then the replayed push gets acked.
+    let s2 = tokio::spawn({
+        let state = empty_state.clone();
+        async move {
+            serve_join(&mut end2, state, &[], vec![]).await;
+            let push = expect_kind(&mut end2, frame_type::PUSH).await;
+            let batch_id = push.header["batchId"].as_str().unwrap().to_string();
+            send(
+                &end2,
+                frame_type::ACK,
+                serde_json::json!({"batchId": batch_id, "seq": 1, "dup": false}),
+                &[],
+            )
+            .await;
+            (batch_id, end2)
+        }
+    });
+    let (replayed_batch, _keep_alive) = s2.await.unwrap();
+    assert_eq!(replayed_batch, first_batch, "reconnect replays the same batch id");
+
+    // Ack lands asynchronously — wait for the pending queue to drain.
+    let mut events = client.events();
+    while client.stats().pending_pushes > 0 {
+        let _ = events.recv().await;
+    }
+    assert_eq!(client.stats().cursor, 1, "ack advanced the cursor");
+    assert_eq!(*lock(&sink.cursor_advances), vec![1]);
+    client.shutdown().await;
+}

--- a/crates/sync/src/chat_frames.rs
+++ b/crates/sync/src/chat_frames.rs
@@ -1,0 +1,209 @@
+//! chat2 wire frames — Rust twin of `edge/src/chat-frames.ts` (the DO's
+//! codec). Binary WS frames: `[type u8][headerLen u32 LE][header JSON][payload]`.
+//! Headers are tiny JSON; payloads are opaque bytes (Loro updates, checkpoint
+//! frontiers, presence ephemera). Cross-language contract — the layout tests
+//! here pin the same vectors as the TS suite; change both together.
+
+use serde::{Deserialize, Serialize};
+
+/// Frame type bytes (shared client/server space; mirror `FRAME` in TS).
+pub mod frame_type {
+    pub const HELLO: u8 = 0x01;
+    pub const STATE: u8 = 0x02;
+    pub const ROWS_REQ: u8 = 0x03;
+    pub const ROW: u8 = 0x04;
+    pub const ROWS_DONE: u8 = 0x05;
+    pub const PUSH: u8 = 0x06;
+    pub const ACK: u8 = 0x07;
+    pub const PRESENCE: u8 = 0x08;
+    pub const PROBE: u8 = 0x09;
+    pub const PROBE_OK: u8 = 0x0a;
+    pub const ERROR: u8 = 0x0b;
+}
+
+/// Headers are ids + a few integers; anything bigger is a peer bug.
+pub const MAX_HEADER_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WireFrame {
+    pub kind: u8,
+    pub header: serde_json::Value,
+    pub payload: Vec<u8>,
+}
+
+pub fn encode(kind: u8, header: &impl Serialize, payload: &[u8]) -> Vec<u8> {
+    let header = serde_json::to_vec(header).expect("frame header serializes");
+    let mut out = Vec::with_capacity(5 + header.len() + payload.len());
+    out.push(kind);
+    out.extend_from_slice(&(header.len() as u32).to_le_bytes());
+    out.extend_from_slice(&header);
+    out.extend_from_slice(payload);
+    out
+}
+
+/// `None` = malformed. Unknown type bytes are NOT rejected here (unlike the
+/// DO): the client tolerates future server frame types by skipping them.
+pub fn decode(bytes: &[u8]) -> Option<WireFrame> {
+    if bytes.len() < 5 {
+        return None;
+    }
+    let kind = bytes[0];
+    let header_len = u32::from_le_bytes(bytes[1..5].try_into().ok()?) as usize;
+    if header_len > MAX_HEADER_BYTES || 5 + header_len > bytes.len() {
+        return None;
+    }
+    let header: serde_json::Value = serde_json::from_slice(&bytes[5..5 + header_len]).ok()?;
+    if !header.is_object() {
+        return None;
+    }
+    Some(WireFrame {
+        kind,
+        header,
+        payload: bytes[5 + header_len..].to_vec(),
+    })
+}
+
+// ── typed headers (parse via `serde_json::from_value(frame.header)`) ────────
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HelloHeader<'a> {
+    pub cursor: u64,
+    pub device: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RowsReqHeader {
+    pub after: u64,
+    pub exclude_own: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PushHeader<'a> {
+    pub batch_id: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PresenceOutHeader {
+    pub at: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StateHeader {
+    pub head_seq: u64,
+    pub seq_floor: u64,
+    pub checkpoint_seq: u64,
+    pub checkpoint_size: u64,
+    #[serde(default)]
+    pub row_count: u64,
+    #[serde(default)]
+    pub row_bytes: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RowHeader {
+    pub seq: u64,
+    pub device: String,
+    pub batch_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RowsDoneHeader {
+    pub head_seq: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AckHeader {
+    pub batch_id: String,
+    pub seq: u64,
+    #[serde(default)]
+    pub dup: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PresenceInHeader {
+    pub device: String,
+    pub at: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeOkHeader {
+    pub head_seq: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ErrorHeader {
+    pub code: String,
+    #[serde(default)]
+    pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pins_the_wire_layout() {
+        // Must match the TS vector: [type][headerLen u32 LE][header][payload].
+        let frame = encode(
+            frame_type::PUSH,
+            &serde_json::json!({"batchId": "b1"}),
+            &[9, 8, 7],
+        );
+        assert_eq!(frame[0], frame_type::PUSH);
+        let header = br#"{"batchId":"b1"}"#;
+        assert_eq!(&frame[1..5], &(header.len() as u32).to_le_bytes());
+        assert_eq!(&frame[5..5 + header.len()], header);
+        assert_eq!(&frame[5 + header.len()..], &[9, 8, 7]);
+    }
+
+    #[test]
+    fn round_trips_and_rejects_malformed() {
+        let payload = vec![1u8; 1000];
+        let frame = encode(frame_type::ROW, &serde_json::json!({"seq": 7}), &payload);
+        let decoded = decode(&frame).unwrap();
+        assert_eq!(decoded.kind, frame_type::ROW);
+        assert_eq!(decoded.header["seq"], 7);
+        assert_eq!(decoded.payload, payload);
+
+        assert!(decode(&[]).is_none());
+        assert!(decode(&[frame_type::HELLO]).is_none());
+        // Header length past the buffer.
+        let mut truncated = encode(frame_type::HELLO, &serde_json::json!({}), &[]);
+        truncated[1..5].copy_from_slice(&9999u32.to_le_bytes());
+        assert!(decode(&truncated).is_none());
+        // Non-object header.
+        let arr = encode(frame_type::HELLO, &serde_json::json!([1]), &[]);
+        assert!(decode(&arr).is_none());
+        // Oversized header.
+        let fat = encode(
+            frame_type::HELLO,
+            &serde_json::json!({"pad": "x".repeat(MAX_HEADER_BYTES)}),
+            &[],
+        );
+        assert!(decode(&fat).is_none());
+    }
+
+    #[test]
+    fn typed_headers_parse_server_shapes() {
+        let state: StateHeader = serde_json::from_value(serde_json::json!({
+            "headSeq": 10, "seqFloor": 3, "checkpointSeq": 3,
+            "checkpointSize": 160_000, "rowCount": 7, "rowBytes": 14_000
+        }))
+        .unwrap();
+        assert_eq!(state.head_seq, 10);
+        assert_eq!(state.checkpoint_seq, 3);
+        let ack: AckHeader =
+            serde_json::from_value(serde_json::json!({"batchId": "b", "seq": 4})).unwrap();
+        assert!(!ack.dup);
+    }
+}

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -9,11 +9,16 @@
 //! - [`DocsStore`]: snapshot persistence (the doc IS the outbox — commands + user entries
 //!   flush immediately) and the processed-command ledger with mark-BEFORE-execute semantics.
 
+pub mod chat_client;
+pub mod chat_frames;
 pub mod registry;
 mod room;
 mod store;
 pub mod wake;
 
+pub use chat_client::{
+    ChatClient, ChatDocSink, ChatEvent, ChatStatsSnapshot, ChatTuning, CheckpointFetcher,
+};
 pub use registry::{RegistryClient, RegistryEvent, RegistryTuning};
 pub use room::{
     RoomClient, RoomEvent, RoomStatsSnapshot, RoomTuning, StaticUrl, SyncError, UrlProvider,

--- a/crates/sync/src/store.rs
+++ b/crates/sync/src/store.rs
@@ -30,6 +30,13 @@ const MIGRATIONS: &[&str] = &[
         command_id   TEXT PRIMARY KEY,
         processed_at INTEGER NOT NULL
      ) STRICT;",
+    // v2 — chat2 room cursor + doc epoch (docs/chat2-sync.md C2). The cursor
+    // is persisted in the SAME transaction as the snapshot bytes, so content
+    // and cursor cannot diverge (restored backups / copied devices simply
+    // redownload from their honest cursor). `epoch` marks rebuild lineage
+    // (M1/M3): 2 = thin chat2 rebuild; NULL/0 = pre-migration s2 doc.
+    "ALTER TABLE snapshots ADD COLUMN cursor INTEGER;
+     ALTER TABLE snapshots ADD COLUMN epoch INTEGER;",
 ];
 
 /// SQLite-backed store under a data directory (`{data_dir}/docs.sqlite3`).
@@ -77,6 +84,48 @@ impl DocsStore {
             params![doc_id, bytes, now_ms()],
         )?;
         Ok(())
+    }
+
+    /// Save the snapshot together with its chat2 room cursor and doc epoch —
+    /// ONE transaction, so bytes and cursor can never disagree (the C2 rule;
+    /// a divergent pair is exactly the restored-backup redownload bug).
+    pub fn save_snapshot_with_cursor(
+        &self,
+        doc_id: &str,
+        bytes: &[u8],
+        cursor: u64,
+        epoch: u32,
+    ) -> Result<(), StoreError> {
+        self.conn().execute(
+            "INSERT INTO snapshots (doc_id, bytes, saved_at, cursor, epoch) VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(doc_id) DO UPDATE SET bytes = excluded.bytes, saved_at = excluded.saved_at,
+                 cursor = excluded.cursor, epoch = excluded.epoch",
+            params![doc_id, bytes, now_ms(), cursor as i64, epoch as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Snapshot + chat2 cursor + epoch. Pre-migration rows (or rows written
+    /// by [`Self::save_snapshot`]) read back as `(bytes, 0, 0)`.
+    pub fn load_snapshot_with_cursor(
+        &self,
+        doc_id: &str,
+    ) -> Result<Option<(Vec<u8>, u64, u32)>, StoreError> {
+        let row = self
+            .conn()
+            .query_row(
+                "SELECT bytes, cursor, epoch FROM snapshots WHERE doc_id = ?1",
+                params![doc_id],
+                |row| {
+                    Ok((
+                        row.get::<_, Vec<u8>>(0)?,
+                        row.get::<_, Option<i64>>(1)?.unwrap_or(0) as u64,
+                        row.get::<_, Option<i64>>(2)?.unwrap_or(0) as u32,
+                    ))
+                },
+            )
+            .optional()?;
+        Ok(row)
     }
 
     /// Delete the snapshot row for `doc_id` (destructive schema breaks: the
@@ -179,6 +228,36 @@ mod tests {
             store.load_snapshot("chat-1").unwrap().as_deref(),
             Some(&b"v2-longer-bytes"[..])
         );
+    }
+
+    #[test]
+    fn cursor_rides_the_snapshot_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DocsStore::open(dir.path()).unwrap();
+
+        // Plain saves (pre-chat2 path) read back with cursor/epoch 0.
+        store.save_snapshot("chat-1", b"v1").unwrap();
+        assert_eq!(
+            store.load_snapshot_with_cursor("chat-1").unwrap(),
+            Some((b"v1".to_vec(), 0, 0))
+        );
+        // Cursor and bytes land together; a re-save moves both.
+        store
+            .save_snapshot_with_cursor("chat-1", b"v2", 41, 2)
+            .unwrap();
+        assert_eq!(
+            store.load_snapshot_with_cursor("chat-1").unwrap(),
+            Some((b"v2".to_vec(), 41, 2))
+        );
+        // Plain load still works for cursor-written rows.
+        assert_eq!(
+            store.load_snapshot("chat-1").unwrap().as_deref(),
+            Some(&b"v2"[..])
+        );
+        // A plain save (legacy caller) clears nothing — cursor persists…
+        store.save_snapshot("chat-1", b"v3").unwrap();
+        let (bytes, cursor, epoch) = store.load_snapshot_with_cursor("chat-1").unwrap().unwrap();
+        assert_eq!((bytes.as_slice(), cursor, epoch), (&b"v3"[..], 41, 2));
     }
 
     #[test]

--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -277,7 +277,7 @@ const READ_CHUNK_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Race an RPC against `timeout` on the gpui background executor (these
 /// futures run under `cx.spawn`, so tokio's timer reactor isn't available).
-async fn call_with_timeout(
+pub(crate) async fn call_with_timeout(
     engine: &EngineHandle,
     executor: &BackgroundExecutor,
     method: &str,

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -1220,6 +1220,11 @@ pub struct Transcript {
     /// Deliberately NOT cleared on chat switch: refs are chat-qualified and a
     /// fetched blob stays valid.
     blob_details: HashMap<SharedString, BlobFetch>,
+    /// Monotonic fetch order per blob ref: when a tool has BOTH a diff and
+    /// an output blob fetched, the chip shows the one requested most
+    /// recently (click "Show full output" after a diff → see the output).
+    blob_fetch_order: HashMap<SharedString, u64>,
+    blob_fetch_counter: u64,
     _observe: Subscription,
 }
 
@@ -1277,6 +1282,8 @@ impl Transcript {
             attachment_loads: HashMap::new(),
             attachment_retries: HashMap::new(),
             blob_details: HashMap::new(),
+            blob_fetch_order: HashMap::new(),
+            blob_fetch_counter: 0,
             _observe: observe,
         };
         this.sync(cx);
@@ -1647,11 +1654,20 @@ impl Transcript {
     /// [`ToolDetail`] once, off the render path. Re-entry while Loading/Ready
     /// is a no-op; Failed re-arms as a retry (the affordance label says so).
     fn spawn_blob_fetch(&mut self, blob_ref: SharedString, cx: &mut Context<Self>) {
-        if matches!(
-            self.blob_details.get(&blob_ref),
-            Some(BlobFetch::Loading(_) | BlobFetch::Ready(_))
-        ) {
-            return;
+        // Rank BEFORE the already-fetched guard: clicking a Ready ref is the
+        // "show me this one again" toggle (recency bump + repaint, no
+        // re-fetch) — with both a diff and an output fetched, the two
+        // affordances must be able to trade places forever.
+        self.blob_fetch_counter += 1;
+        self.blob_fetch_order
+            .insert(blob_ref.clone(), self.blob_fetch_counter);
+        match self.blob_details.get(&blob_ref) {
+            Some(BlobFetch::Ready(_)) => {
+                cx.notify();
+                return;
+            }
+            Some(BlobFetch::Loading(_)) => return,
+            Some(BlobFetch::Failed) | None => {}
         }
         let Some(engine) = self.state.read(cx).engine().cloned() else {
             return;
@@ -2221,38 +2237,70 @@ impl Transcript {
         let details: Vec<Option<Arc<ToolDetail>>> = tools
             .iter()
             .map(|tool| {
+                // Among fetched blobs, the most recently REQUESTED one wins —
+                // a tool can carry both a diff and an output ref, and the
+                // user's last click decides which upgrade is showing.
+                let mut best: Option<(u64, Arc<ToolDetail>)> = None;
                 for blob_ref in [&tool.diff_ref, &tool.output_ref].into_iter().flatten() {
                     if let Some(BlobFetch::Ready(detail)) = self.blob_details.get(blob_ref) {
-                        return Some(detail.clone());
+                        let order = self.blob_fetch_order.get(blob_ref).copied().unwrap_or(0);
+                        if best.as_ref().is_none_or(|(o, _)| order > *o) {
+                            best = Some((order, detail.clone()));
+                        }
                     }
                 }
-                tool.detail.clone()
+                best.map(|(_, d)| d).or_else(|| tool.detail.clone())
             })
             .collect();
         // Fetch affordance under each open detail whose full payload is still
-        // sidecar-only: `(ref, label)`. Diff first — the richer upgrade.
+        // sidecar-only: `(ref, label)`. Diff offered first (the richer
+        // upgrade), then the output — a fetched ref hands the affordance to
+        // the NEXT unfetched one instead of retiring it (both must stay
+        // reachable when a tool has both).
         let affordances: Vec<Option<(SharedString, SharedString)>> = tools
             .iter()
             .map(|tool| {
-                let (blob_ref, what, bytes) = if let Some(r) = &tool.diff_ref {
-                    (r, "diff", None)
-                } else if let Some(r) = &tool.output_ref {
-                    (r, "output", tool.output_bytes)
-                } else {
-                    return None;
-                };
-                let label = match self.blob_details.get(blob_ref) {
-                    Some(BlobFetch::Ready(_)) => return None,
-                    Some(BlobFetch::Loading(_)) => format!("Loading full {what}…"),
-                    Some(BlobFetch::Failed) => {
-                        format!("Couldn't load full {what} — tap to retry")
+                // The currently-displayed ref (same recency rule as
+                // `details` above): its affordance is spent; any OTHER
+                // Ready ref stays offered as a no-fetch toggle.
+                let shown: Option<&SharedString> = {
+                    let mut best: Option<(u64, &SharedString)> = None;
+                    for blob_ref in [&tool.diff_ref, &tool.output_ref].into_iter().flatten() {
+                        if matches!(self.blob_details.get(blob_ref), Some(BlobFetch::Ready(_))) {
+                            let order =
+                                self.blob_fetch_order.get(blob_ref).copied().unwrap_or(0);
+                            if best.is_none_or(|(o, _)| order > o) {
+                                best = Some((order, blob_ref));
+                            }
+                        }
                     }
-                    None => match bytes {
-                        Some(b) => format!("Show full {what} ({})", format_kb(b)),
-                        None => format!("Show full {what}"),
-                    },
+                    best.map(|(_, r)| r)
                 };
-                Some((blob_ref.clone(), SharedString::from(label)))
+                let candidates = [
+                    (tool.diff_ref.as_ref(), "diff", None),
+                    (tool.output_ref.as_ref(), "output", tool.output_bytes),
+                ];
+                for (blob_ref, what, bytes) in candidates {
+                    let Some(blob_ref) = blob_ref else { continue };
+                    let label = match self.blob_details.get(blob_ref) {
+                        Some(BlobFetch::Ready(_)) => {
+                            if shown == Some(blob_ref) {
+                                continue;
+                            }
+                            format!("Show full {what}")
+                        }
+                        Some(BlobFetch::Loading(_)) => format!("Loading full {what}…"),
+                        Some(BlobFetch::Failed) => {
+                            format!("Couldn't load full {what} — tap to retry")
+                        }
+                        None => match bytes {
+                            Some(b) => format!("Show full {what} ({})", format_kb(b)),
+                            None => format!("Show full {what}"),
+                        },
+                    };
+                    return Some((blob_ref.clone(), SharedString::from(label)));
+                }
+                None
             })
             .collect();
         // Which chips have their detail block open (render-local, analytic —

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -198,6 +198,13 @@ pub struct ToolItem {
     /// Precomputed here because rows are cached by fingerprint — diffing and
     /// tokenizing per paint would run on every scroll frame.
     pub detail: Option<Arc<ToolDetail>>,
+    /// Sidecar key of the full output (chat2-sync A3) — the doc carries only
+    /// a one-line summary; expanding offers a lazy "Show full output" fetch.
+    pub output_ref: Option<SharedString>,
+    /// Full-output size, for the affordance label ("Show full output (12 KB)").
+    pub output_bytes: Option<u64>,
+    /// Sidecar key of the full diff (doc carries only per-file stats).
+    pub diff_ref: Option<SharedString>,
 }
 
 /// A chip's expandable detail payload.
@@ -216,6 +223,12 @@ pub enum ToolDetail {
         file: Arc<crate::changes::FileDiff>,
         highlight: Option<Arc<Vec<Vec<crate::markdown::highlight::Token>>>>,
     },
+    /// Per-file `+N −N` stat rows — what the thin doc keeps of an edit
+    /// (chat2-sync A1). The full diff upgrades this to [`ToolDetail::Diff`]
+    /// via the sidecar fetch.
+    Stats {
+        stats: Arc<Vec<comet_doc::ToolDiffStat>>,
+    },
 }
 
 /// Max verbatim output lines per chip before the counted tail row.
@@ -232,10 +245,12 @@ const OUTPUT_BODY_PAD: f32 = 12.0;
 const DETAIL_SEPARATOR: f32 = 1.0;
 
 /// Build a tool part's expandable detail. A diff wins over raw output (it is
-/// the more structured record of the same action).
+/// the more structured record of the same action); post-strip docs carry diff
+/// STATS instead of inline diff text, which win the same way.
 pub fn tool_detail(
     output: Option<&str>,
     diff: Option<&comet_proto::ToolDiff>,
+    diff_stats: Option<&[comet_doc::ToolDiffStat]>,
 ) -> Option<ToolDetail> {
     if let Some(diff) = diff {
         let file = diff_to_file(diff);
@@ -246,6 +261,11 @@ pub fn tool_detail(
         return Some(ToolDetail::Diff {
             file: Arc::new(file),
             highlight,
+        });
+    }
+    if let Some(stats) = diff_stats.filter(|s| !s.is_empty()) {
+        return Some(ToolDetail::Stats {
+            stats: Arc::new(stats.to_vec()),
         });
     }
     let output = output?;
@@ -467,7 +487,18 @@ fn tool_fingerprint(tools: &[ToolItem], auto_open: bool) -> u64 {
                 acc.extend_from_slice(&file.deletions.to_le_bytes());
                 acc.extend_from_slice(&(file.hunks.len() as u32).to_le_bytes());
             }
+            Some(ToolDetail::Stats { stats }) => {
+                acc.push(3);
+                for stat in stats.iter() {
+                    acc.extend_from_slice(stat.path.as_bytes());
+                    acc.extend_from_slice(&stat.additions.to_le_bytes());
+                    acc.extend_from_slice(&stat.deletions.to_le_bytes());
+                }
+            }
         }
+        // Sidecar refs arriving after the resolve tick must re-splice too —
+        // they add the fetch affordance without changing the detail payload.
+        acc.push(t.output_ref.is_some() as u8 | (t.diff_ref.is_some() as u8) << 1);
     }
     acc.push(auto_open as u8);
     fnv1a(&acc)
@@ -559,13 +590,21 @@ pub fn rows_for_entry(
                 resolved,
                 output,
                 diff,
+                output_ref,
+                output_bytes,
+                diff_ref,
+                diff_stats,
                 ..
             } => {
                 pending_group.push(ToolItem {
                     call: call.clone(),
                     is_error: *is_error,
                     resolved: *resolved,
-                    detail: tool_detail(output.as_deref(), diff.as_ref()).map(Arc::new),
+                    detail: tool_detail(output.as_deref(), diff.as_ref(), diff_stats.as_deref())
+                        .map(Arc::new),
+                    output_ref: output_ref.clone().map(SharedString::from),
+                    output_bytes: *output_bytes,
+                    diff_ref: diff_ref.clone().map(SharedString::from),
                 });
                 group_last_part_ix = part_ix;
             }
@@ -884,8 +923,52 @@ pub fn detail_height(detail: &ToolDetail) -> f32 {
             rows as f32 * OUTPUT_LINE_HEIGHT + OUTPUT_BODY_PAD
         }
         ToolDetail::Diff { file, .. } => crate::changes::body_height(file),
+        ToolDetail::Stats { stats } => stats.len() as f32 * OUTPUT_LINE_HEIGHT + OUTPUT_BODY_PAD,
     };
     DETAIL_SEPARATOR + body
+}
+
+/// Height of the "Show full output/diff" affordance row appended below an
+/// open detail whose full payload lives in the sidecar (chat2-sync A3).
+pub const BLOB_AFFORDANCE_HEIGHT: f32 = 24.0;
+
+/// Line cap for a FETCHED full output (a defensive ceiling, not a doc cap —
+/// the harness bounds outputs at 4KiB, so this is rarely reached).
+const FULL_OUTPUT_MAX_LINES: usize = 400;
+
+/// Build the upgraded detail from a fetched sidecar blob. Diff blobs parse
+/// the `ToolDiff` JSON through the same pipeline as inline diffs; output
+/// blobs render (near-)uncapped — fetching past the summary was the point.
+fn blob_detail(text: &str, is_diff: bool) -> Option<ToolDetail> {
+    if is_diff {
+        let diff: comet_proto::ToolDiff = serde_json::from_str(text).ok()?;
+        return tool_detail(None, Some(&diff), None);
+    }
+    let mut lines: Vec<SharedString> = text
+        .lines()
+        .map(|l| SharedString::from(l.to_owned()))
+        .collect();
+    while lines.last().is_some_and(|l| l.trim().is_empty()) {
+        lines.pop();
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    let truncated_by = lines.len().saturating_sub(FULL_OUTPUT_MAX_LINES);
+    lines.truncate(FULL_OUTPUT_MAX_LINES);
+    Some(ToolDetail::Output {
+        lines,
+        truncated_by,
+    })
+}
+
+/// Compact byte size for the fetch affordance label ("812 B", "12 KB").
+fn format_kb(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{bytes} B")
+    } else {
+        format!("{} KB", bytes.div_ceil(1024))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1131,7 +1214,21 @@ pub struct Transcript {
     attachment_loads: HashMap<(String, String), Task<()>>,
     /// Scheduled retry wake-ups for errored sources (the 2s→15s ladder).
     attachment_retries: HashMap<(String, String), Task<()>>,
+    /// Sidecar blob fetches keyed by doc ref (`chatId/partId[.diff]`,
+    /// chat2-sync A3). `Ready` holds the UPGRADED detail, built once on
+    /// arrival — render swaps it in per chip; rows never rebuild for it.
+    /// Deliberately NOT cleared on chat switch: refs are chat-qualified and a
+    /// fetched blob stays valid.
+    blob_details: HashMap<SharedString, BlobFetch>,
     _observe: Subscription,
+}
+
+/// One sidecar blob fetch's lifecycle.
+enum BlobFetch {
+    Loading(#[allow(dead_code)] Task<()>),
+    /// Failed with the affordance re-armed as a retry.
+    Failed,
+    Ready(Arc<ToolDetail>),
 }
 
 impl Transcript {
@@ -1179,6 +1276,7 @@ impl Transcript {
             attachment_preview: None,
             attachment_loads: HashMap::new(),
             attachment_retries: HashMap::new(),
+            blob_details: HashMap::new(),
             _observe: observe,
         };
         this.sync(cx);
@@ -1543,6 +1641,48 @@ impl Transcript {
             );
         }
         rows
+    }
+
+    /// Fetch a sidecar blob (full tool output or diff) and build its upgraded
+    /// [`ToolDetail`] once, off the render path. Re-entry while Loading/Ready
+    /// is a no-op; Failed re-arms as a retry (the affordance label says so).
+    fn spawn_blob_fetch(&mut self, blob_ref: SharedString, cx: &mut Context<Self>) {
+        if matches!(
+            self.blob_details.get(&blob_ref),
+            Some(BlobFetch::Loading(_) | BlobFetch::Ready(_))
+        ) {
+            return;
+        }
+        let Some(engine) = self.state.read(cx).engine().cloned() else {
+            return;
+        };
+        let is_diff = blob_ref.ends_with(".diff");
+        let ref_key = blob_ref.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let reply = crate::attachments::call_with_timeout(
+                &engine,
+                cx.background_executor(),
+                comet_rpc::methods::FETCH_TOOL_BLOB,
+                serde_json::json!({ "blobRef": ref_key.as_ref() }),
+                Duration::from_secs(20),
+            )
+            .await;
+            let fetched = match reply {
+                Ok(value) => {
+                    let text = value.get("text").and_then(|t| t.as_str()).unwrap_or_default();
+                    blob_detail(text, is_diff)
+                        .map(|d| BlobFetch::Ready(Arc::new(d)))
+                        .unwrap_or(BlobFetch::Failed)
+                }
+                Err(_) => BlobFetch::Failed,
+            };
+            this.update(cx, |this, cx| {
+                this.blob_details.insert(ref_key, fetched);
+                cx.notify();
+            })
+            .ok();
+        });
+        self.blob_details.insert(blob_ref, BlobFetch::Loading(task));
     }
 
     fn toggle_fold(&mut self, row_id: SharedString, open_height: f32, auto_open: bool) {
@@ -2074,13 +2214,54 @@ impl Transcript {
     ) -> AnyElement {
         let fold = self.folds.get(row_id).copied().unwrap_or_default();
         let open = fold.open.unwrap_or(auto_open);
+        // Chips render their EFFECTIVE detail: the precomputed doc-resident
+        // one, upgraded in place by a fetched sidecar blob (chat2-sync A3).
+        // Resolved per paint (a HashMap probe per chip) so fetched content
+        // needs no row rebuild — arrival is a cx.notify, like a fold toggle.
+        let details: Vec<Option<Arc<ToolDetail>>> = tools
+            .iter()
+            .map(|tool| {
+                for blob_ref in [&tool.diff_ref, &tool.output_ref].into_iter().flatten() {
+                    if let Some(BlobFetch::Ready(detail)) = self.blob_details.get(blob_ref) {
+                        return Some(detail.clone());
+                    }
+                }
+                tool.detail.clone()
+            })
+            .collect();
+        // Fetch affordance under each open detail whose full payload is still
+        // sidecar-only: `(ref, label)`. Diff first — the richer upgrade.
+        let affordances: Vec<Option<(SharedString, SharedString)>> = tools
+            .iter()
+            .map(|tool| {
+                let (blob_ref, what, bytes) = if let Some(r) = &tool.diff_ref {
+                    (r, "diff", None)
+                } else if let Some(r) = &tool.output_ref {
+                    (r, "output", tool.output_bytes)
+                } else {
+                    return None;
+                };
+                let label = match self.blob_details.get(blob_ref) {
+                    Some(BlobFetch::Ready(_)) => return None,
+                    Some(BlobFetch::Loading(_)) => format!("Loading full {what}…"),
+                    Some(BlobFetch::Failed) => {
+                        format!("Couldn't load full {what} — tap to retry")
+                    }
+                    None => match bytes {
+                        Some(b) => format!("Show full {what} ({})", format_kb(b)),
+                        None => format!("Show full {what}"),
+                    },
+                };
+                Some((blob_ref.clone(), SharedString::from(label)))
+            })
+            .collect();
         // Which chips have their detail block open (render-local, analytic —
         // the FINAL state; a mid-tween detail already counts as its target).
-        let detail_folds: Vec<FoldState> = tools
+        let detail_folds: Vec<FoldState> = details
             .iter()
             .enumerate()
-            .map(|(ix, tool)| {
-                if tool.detail.is_none() {
+            .map(|(ix, detail)| {
+                if detail.is_none() {
                     return FoldState::default();
                 }
                 self.tool_details
@@ -2089,17 +2270,25 @@ impl Transcript {
                     .unwrap_or_default()
             })
             .collect();
-        let detail_opens: Vec<bool> = tools
+        let detail_opens: Vec<bool> = details
             .iter()
             .zip(&detail_folds)
-            .map(|(tool, fold)| tool.detail.is_some() && fold.open.unwrap_or(false))
+            .map(|(detail, fold)| detail.is_some() && fold.open.unwrap_or(false))
             .collect();
         let open_height = chips_height(tools.len())
-            + tools
+            + details
                 .iter()
+                .zip(&affordances)
                 .zip(&detail_opens)
                 .filter(|(_, open)| **open)
-                .filter_map(|(tool, _)| tool.detail.as_deref().map(detail_height))
+                .map(|((detail, affordance), _)| {
+                    detail.as_deref().map_or(0.0, detail_height)
+                        + if affordance.is_some() {
+                            BLOB_AFFORDANCE_HEIGHT
+                        } else {
+                            0.0
+                        }
+                })
                 .sum::<f32>();
         let target = if open { open_height } else { 0.0 };
         let summary = tool_group_summary(tools);
@@ -2154,8 +2343,14 @@ impl Transcript {
             .flex_col()
             .gap(px(CHIP_GAP))
             .children(tools.iter().enumerate().map(|(ix, tool)| {
-                let Some(detail) = tool.detail.clone() else {
+                let Some(detail) = details[ix].clone() else {
                     return tool_chip(tool, theme);
+                };
+                let affordance = affordances[ix].clone();
+                let affordance_h = if affordance.is_some() {
+                    BLOB_AFFORDANCE_HEIGHT
+                } else {
+                    0.0
                 };
                 let open = detail_opens[ix];
                 let dfold = detail_folds[ix];
@@ -2172,7 +2367,7 @@ impl Transcript {
                 // (user report: "tool calls cut off at the bottom"). The
                 // explicit height is also what the open/close tween animates.
                 let closed_h = CHIP_CARD_HEIGHT;
-                let open_h = CHIP_CARD_HEIGHT + detail_height(&detail);
+                let open_h = CHIP_CARD_HEIGHT + detail_height(&detail) + affordance_h;
                 let card_target = if open { open_h } else { closed_h };
                 let animating = dfold.epoch > 0
                     && dfold
@@ -2217,6 +2412,32 @@ impl Transcript {
                                 .bg(crate::theme::hairline(0.06)),
                         )
                         .child(detail_body(&detail, theme));
+                    if let Some((blob_ref, label)) = affordance {
+                        let loading = matches!(
+                            self.blob_details.get(&blob_ref),
+                            Some(BlobFetch::Loading(_))
+                        );
+                        let mut row = div()
+                            .id(SharedString::from(format!("{key}-blob")))
+                            .h(px(BLOB_AFFORDANCE_HEIGHT))
+                            .flex_none()
+                            .px(px(12.0))
+                            .flex()
+                            .items_center()
+                            .text_size(px(10.5))
+                            .text_color(theme.text_faint)
+                            .child(label);
+                        if !loading {
+                            row = row
+                                .cursor_pointer()
+                                .hover(|s| s.text_color(theme.text_muted))
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    this.spawn_blob_fetch(blob_ref.clone(), cx);
+                                    cx.notify();
+                                }));
+                        }
+                        card = card.child(row);
+                    }
                 }
                 let card: AnyElement = if animating {
                     let from = dfold.from;
@@ -2518,6 +2739,41 @@ fn detail_body(detail: &ToolDetail, theme: &Theme) -> AnyElement {
                 highlight.clone(),
                 theme,
             ))
+            .into_any_element(),
+        ToolDetail::Stats { stats } => body
+            .py(px(6.0))
+            .font_family(theme.font_mono.clone())
+            .text_size(px(11.5))
+            .children(stats.iter().map(|stat| {
+                div()
+                    .h(px(OUTPUT_LINE_HEIGHT))
+                    .w_full()
+                    .min_w_0()
+                    .px(px(12.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .child(
+                        div()
+                            .min_w_0()
+                            .flex_1()
+                            .truncate()
+                            .text_color(theme.text.opacity(0.85))
+                            .child(SharedString::from(stat.path.clone())),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .text_color(theme.success)
+                            .child(SharedString::from(format!("+{}", stat.additions))),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .text_color(theme.danger)
+                            .child(SharedString::from(format!("−{}", stat.deletions))),
+                    )
+            }))
             .into_any_element(),
         ToolDetail::Output {
             lines,
@@ -2981,6 +3237,10 @@ mod tests {
             resolved: true,
             output: None,
             diff: None,
+            output_ref: None,
+            output_bytes: None,
+            diff_ref: None,
+            diff_stats: None,
         }
     }
 
@@ -3259,7 +3519,7 @@ mod tests {
             old_text: Some(old.join("\n") + "\n"),
             new_text: new.join("\n") + "\n",
         };
-        let Some(ToolDetail::Diff { file, highlight }) = tool_detail(None, Some(&diff)) else {
+        let Some(ToolDetail::Diff { file, highlight }) = tool_detail(None, Some(&diff), None) else {
             panic!("expected diff detail");
         };
         // One hunk: the change plus 3 context lines each side, real numbers.
@@ -3292,7 +3552,7 @@ mod tests {
             old_text: None,
             new_text: "only\n".into(),
         };
-        let Some(ToolDetail::Diff { file, highlight }) = tool_detail(None, Some(&created)) else {
+        let Some(ToolDetail::Diff { file, highlight }) = tool_detail(None, Some(&created), None) else {
             panic!("expected diff detail");
         };
         assert_eq!(file.status, crate::changes::FileStatus::Added);
@@ -3306,7 +3566,7 @@ mod tests {
         let Some(ToolDetail::Output {
             lines,
             truncated_by,
-        }) = tool_detail(Some(&output), None)
+        }) = tool_detail(Some(&output), None, None)
         else {
             panic!("expected output detail");
         };
@@ -3315,8 +3575,8 @@ mod tests {
         assert_eq!(lines[0].as_ref(), "    indented 0");
 
         // Nothing → no affordance.
-        assert!(tool_detail(None, None).is_none());
-        assert!(tool_detail(Some("\n\n"), None).is_none());
+        assert!(tool_detail(None, None, None).is_none());
+        assert!(tool_detail(Some("\n\n"), None, None).is_none());
     }
 
     #[test]
@@ -3326,6 +3586,9 @@ mod tests {
             is_error: false,
             resolved: true,
             detail: None,
+            output_ref: None,
+            output_bytes: None,
+            diff_ref: None,
         };
         let edit = |p: &str| ToolItem {
             call: ToolCall::EditFile {
@@ -3336,6 +3599,9 @@ mod tests {
             is_error: false,
             resolved: true,
             detail: None,
+            output_ref: None,
+            output_bytes: None,
+            diff_ref: None,
         };
         let tools = vec![
             exec("ls"),
@@ -3362,6 +3628,9 @@ mod tests {
                 is_error: false,
                 resolved: true,
                 detail: None,
+                output_ref: None,
+                output_bytes: None,
+                diff_ref: None,
             },
             ToolItem {
                 call: ToolCall::Glob {
@@ -3370,12 +3639,18 @@ mod tests {
                 is_error: false,
                 resolved: true,
                 detail: None,
+                output_ref: None,
+                output_bytes: None,
+                diff_ref: None,
             },
             ToolItem {
                 call: ToolCall::WebSearch { query: "q".into() },
                 is_error: false,
                 resolved: true,
                 detail: None,
+                output_ref: None,
+                output_bytes: None,
+                diff_ref: None,
             },
         ];
         assert_eq!(tool_group_summary(&tools), "Read 1 file · searched 2 times");

--- a/edge/package-lock.json
+++ b/edge/package-lock.json
@@ -13,11 +13,12 @@
         "loro-protocol": "^0.3.0"
       },
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.20.2",
         "@cloudflare/workers-types": "^5.20260714.1",
         "loro-adaptors": "^0.6.1",
         "loro-websocket": "^0.6.2",
         "typescript": "^6.0.3",
-        "vitest": "^3.2.7",
+        "vitest": "^4.1.10",
         "wrangler": "^4.111.0"
       }
     },
@@ -47,15 +48,32 @@
         }
       }
     },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.20.2.tgz",
+      "integrity": "sha512-2oLnP0B2E71S6BHig2jdgUvgxDLFD8hXp5TViALnyb5eob1UDCD+72vi547Ryy2SJBdY/H5jiA40ICS7Cm/Ntw==",
+      "dev": true,
+      "dependencies": {
+        "cjs-module-lexer": "1.2.3",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260801.0-alpha",
+        "wrangler": "4.119.0",
+        "zod": "4.4.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260714.1.tgz",
-      "integrity": "sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260801.1.tgz",
+      "integrity": "sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -65,14 +83,13 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260714.1.tgz",
-      "integrity": "sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260801.1.tgz",
+      "integrity": "sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -82,14 +99,13 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260714.1.tgz",
-      "integrity": "sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260801.1.tgz",
+      "integrity": "sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -99,14 +115,13 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260714.1.tgz",
-      "integrity": "sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260801.1.tgz",
+      "integrity": "sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -116,14 +131,13 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260714.1.tgz",
-      "integrity": "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260801.1.tgz",
+      "integrity": "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -133,11 +147,10 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260719.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260719.1.tgz",
-      "integrity": "sha512-DcGasbfUuczQilc80vhL2MPPdWcaxWkx0hN5IW9UdNDBdrRvWcal3akSJ6Ccm7e8+/OGeR+8tYrqkykA3YGSZw==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0"
+      "version": "5.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260804.1.tgz",
+      "integrity": "sha512-B1dwxpN6e5RZXZkE5zpZj+ooNeNZ1mwavLIyHDYe10ojhlGTwDfe8sAl7R1mMXc1cyIsbr+jKVdvmMEyVcdTdg==",
+      "dev": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -153,11 +166,10 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -610,66 +622,81 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -679,14 +706,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -696,14 +722,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -713,14 +738,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -730,14 +754,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -747,14 +770,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -764,14 +786,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -781,14 +802,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -798,14 +818,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -815,14 +834,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -832,264 +850,268 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
       "cpu": [
         "wasm32"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@img/sharp-wasm32": "0.35.2"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1123,6 +1145,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
@@ -1152,355 +1183,235 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
@@ -1522,12 +1433,17 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -1537,15 +1453,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "26.1.1",
@@ -1568,39 +1482,38 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
-      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
-      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.7",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1612,42 +1525,39 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
-      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
-      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.7",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
-      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1655,28 +1565,23 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
-      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
-      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1687,7 +1592,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -1699,42 +1603,26 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -1750,40 +1638,11 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -1799,11 +1658,10 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -1852,7 +1710,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -1862,7 +1719,6 @@
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
       "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -1872,7 +1728,6 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1909,13 +1764,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1924,6 +1772,255 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/loro-adaptors": {
@@ -1989,39 +2086,27 @@
         "loro-crdt": "^1.9.0"
       }
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260714.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260714.0.tgz",
-      "integrity": "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==",
+      "version": "5.20260801.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260801.0-alpha.tgz",
+      "integrity": "sha512-AfMrnQbJg81ESsGkGhOkHBtwTqCG+mosR+3GE+qDrhF1I/ieIvgg3ICxNyBvgHBZ3iapy6cysBQHNPykkzrfgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "0.34.5",
+        "sharp": "0.35.2",
         "undici": "7.28.0",
-        "workerd": "1.20260714.1",
+        "workerd": "1.20260801.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -2032,7 +2117,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2049,17 +2133,10 @@
         }
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -2067,12 +2144,24 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2089,29 +2178,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2120,9 +2197,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2138,7 +2215,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -2148,49 +2224,36 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.9"
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.2",
-        "@rollup/rollup-android-arm64": "4.62.2",
-        "@rollup/rollup-darwin-arm64": "4.62.2",
-        "@rollup/rollup-darwin-x64": "4.62.2",
-        "@rollup/rollup-freebsd-arm64": "4.62.2",
-        "@rollup/rollup-freebsd-x64": "4.62.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-        "@rollup/rollup-linux-arm64-musl": "4.62.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-        "@rollup/rollup-linux-loong64-musl": "4.62.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-musl": "4.62.2",
-        "@rollup/rollup-openbsd-x64": "4.62.2",
-        "@rollup/rollup-openharmony-arm64": "4.62.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-        "@rollup/rollup-win32-x64-gnu": "4.62.2",
-        "@rollup/rollup-win32-x64-msvc": "4.62.2",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
     },
     "node_modules/semver": {
@@ -2198,7 +2261,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2207,63 +2269,60 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
       "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.4"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
       }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2272,28 +2331,13 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true
     },
     "node_modules/supports-color": {
       "version": "10.2.2",
@@ -2312,22 +2356,22 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -2339,32 +2383,11 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2374,7 +2397,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
       "optional": true
     },
     "node_modules/typescript": {
@@ -2419,18 +2441,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2446,9 +2466,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -2461,13 +2482,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -2493,89 +2517,79 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vitest": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
-      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.7",
-        "@vitest/mocker": "3.2.7",
-        "@vitest/pretty-format": "^3.2.7",
-        "@vitest/runner": "3.2.7",
-        "@vitest/snapshot": "3.2.7",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.7",
-        "@vitest/ui": "3.2.7",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -2586,6 +2600,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -2594,7 +2611,6 @@
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -2607,12 +2623,11 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260714.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260714.1.tgz",
-      "integrity": "sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==",
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260801.1.tgz",
+      "integrity": "sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -2620,28 +2635,27 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260714.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260714.1",
-        "@cloudflare/workerd-linux-64": "1.20260714.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260714.1",
-        "@cloudflare/workerd-windows-64": "1.20260714.1"
+        "@cloudflare/workerd-darwin-64": "1.20260801.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260801.1",
+        "@cloudflare/workerd-linux-64": "1.20260801.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260801.1",
+        "@cloudflare/workerd-windows-64": "1.20260801.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.112.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.112.0.tgz",
-      "integrity": "sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ==",
+      "version": "4.119.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.119.0.tgz",
+      "integrity": "sha512-ookClf+zly4DTc8pBMNrwGQzZKH8IpIYTXkjDw3XS7ZvBQ5mLYH6eOvfD5BEpk3U63zTbv91WRlo1UeRSKXa0g==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260714.0",
+        "miniflare": "5.20260801.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260714.1"
+        "workerd": "1.20260801.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -2655,7 +2669,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260714.1"
+        "@cloudflare/workers-types": "^5.20260801.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -2708,6 +2722,15 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/edge/package.json
+++ b/edge/package.json
@@ -8,7 +8,9 @@
     "deploy": "wrangler deploy",
     "build": "wrangler deploy --dry-run --outdir dist",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "npm run test:unit && npm run test:workerd",
+    "test:unit": "vitest run",
+    "test:workerd": "vitest run -c vitest.workerd.config.ts",
     "smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {
@@ -17,11 +19,12 @@
     "loro-protocol": "^0.3.0"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.20.2",
     "@cloudflare/workers-types": "^5.20260714.1",
     "loro-adaptors": "^0.6.1",
     "loro-websocket": "^0.6.2",
     "typescript": "^6.0.3",
-    "vitest": "^3.2.7",
+    "vitest": "^4.1.10",
     "wrangler": "^4.111.0"
   }
 }

--- a/edge/scripts/chat2-check.mjs
+++ b/edge/scripts/chat2-check.mjs
@@ -1,0 +1,332 @@
+// chat2 wire-level E2E against a deployed worker (AUTH_MODE=dev).
+// Speaks the binary frame protocol from edge/src/chat-frames.ts and drives
+// every route + guard in edge/src/chat-room.ts per docs/chat2-sync.md B.
+// Usage: node chat2-e2e.mjs <baseUrl>
+import { randomUUID, randomBytes } from "node:crypto";
+
+const base = process.argv[2];
+if (!base) throw new Error("usage: node chat2-e2e.mjs <baseUrl>");
+const wsBase = base.replace(/^http/, "ws");
+const userA = "e2e-user-a";
+const userB = "e2e-user-b";
+const chat = `e2e-${randomUUID().slice(0, 13)}`;
+
+// ── frame codec (mirror of chat-frames.ts) ──────────────────────────────────
+const FRAME = { hello: 0x01, state: 0x02, rowsReq: 0x03, row: 0x04, rowsDone: 0x05, push: 0x06, ack: 0x07, presence: 0x08, probe: 0x09, probeOk: 0x0a, error: 0x0b };
+const NAME = Object.fromEntries(Object.entries(FRAME).map(([k, v]) => [v, k]));
+const enc = (type, header, payload = new Uint8Array(0)) => {
+  const h = new TextEncoder().encode(JSON.stringify(header));
+  const out = new Uint8Array(5 + h.length + payload.length);
+  out[0] = type;
+  new DataView(out.buffer).setUint32(1, h.length, true);
+  out.set(h, 5);
+  out.set(payload, 5 + h.length);
+  return out;
+};
+const dec = (bytes) => {
+  const b = new Uint8Array(bytes);
+  const len = new DataView(b.buffer, b.byteOffset).getUint32(1, true);
+  return { type: b[0], header: JSON.parse(new TextDecoder().decode(b.subarray(5, 5 + len))), payload: b.subarray(5 + len) };
+};
+
+// ── tiny WS client with a frame inbox ───────────────────────────────────────
+class Client {
+  constructor(device, user) { this.device = device; this.user = user; this.inbox = []; this.waiters = []; this.closed = null; }
+  async connect() {
+    this.ws = new WebSocket(`${wsBase}/chat2/${chat}/ws?device=${this.device}&token=${this.user}`);
+    this.ws.binaryType = "arraybuffer";
+    this.ws.onmessage = (ev) => { const f = dec(ev.data); this.inbox.push(f); this.waiters.forEach((w) => w()); };
+    this.ws.onclose = (ev) => { this.closed = { code: ev.code, reason: ev.reason }; this.waiters.forEach((w) => w()); };
+    await new Promise((res, rej) => { this.ws.onopen = res; this.ws.onerror = () => rej(new Error("ws connect failed")); });
+  }
+  send(type, header, payload) { this.ws.send(enc(type, header, payload)); }
+  sendRaw(bytes) { this.ws.send(bytes); }
+  async next(type, timeoutMs = 8000, pred = () => true) {
+    const start = Date.now();
+    for (;;) {
+      const i = this.inbox.findIndex((f) => f.type === type && pred(f));
+      if (i >= 0) return this.inbox.splice(i, 1)[0];
+      if (this.closed) throw new Error(`socket closed (${this.closed.code}) while waiting for ${NAME[type]}`);
+      if (Date.now() - start > timeoutMs) throw new Error(`timeout waiting for ${NAME[type]}; inbox=[${this.inbox.map((f) => NAME[f.type])}]`);
+      await new Promise((res) => { this.waiters.push(res); setTimeout(res, 150); });
+      this.waiters = [];
+    }
+  }
+  async nextAny(types, timeoutMs = 8000) {
+    const start = Date.now();
+    for (;;) {
+      const i = this.inbox.findIndex((f) => types.includes(f.type));
+      if (i >= 0) return this.inbox.splice(i, 1)[0];
+      if (this.closed) throw new Error(`socket closed (${this.closed.code}) while waiting for ${types.map((t) => NAME[t])}`);
+      if (Date.now() - start > timeoutMs) throw new Error(`timeout waiting for ${types.map((t) => NAME[t])}`);
+      await new Promise((res) => { this.waiters.push(res); setTimeout(res, 150); });
+      this.waiters = [];
+    }
+  }
+  async collectRows(timeoutMs = 8000) {
+    const rows = [];
+    for (;;) {
+      const f = await this.nextAny([FRAME.row, FRAME.rowsDone], timeoutMs);
+      if (f.type === FRAME.rowsDone) return { rows, done: f };
+      rows.push(f);
+    }
+  }
+  async waitClose(timeoutMs = 8000) {
+    const start = Date.now();
+    while (!this.closed) {
+      if (Date.now() - start > timeoutMs) throw new Error("timeout waiting for close");
+      await new Promise((res) => setTimeout(res, 100));
+    }
+    return this.closed;
+  }
+  async hello(cursor = 0) { this.send(FRAME.hello, { cursor, device: this.device }); return this.next(FRAME.state); }
+}
+
+const http = (path, { method = "GET", user = userA, headers = {}, body } = {}) =>
+  fetch(`${base}${path}`, { method, headers: { authorization: `Bearer ${user}`, ...headers }, body });
+
+// ── assertions ──────────────────────────────────────────────────────────────
+let pass = 0, fail = 0;
+const results = [];
+const check = (name, cond, detail = "") => {
+  if (cond) { pass++; results.push(`  ok  ${name}`); }
+  else { fail++; results.push(`FAIL  ${name}${detail ? ` — ${detail}` : ""}`); }
+};
+const eqBytes = (a, b) => a.length === b.length && a.every((v, i) => v === b[i]);
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1. Worker gates
+{
+  const h = await (await fetch(`${base}/health`)).json();
+  check("health: dev auth mode", h.ok === true && h.auth === "dev");
+  const unauth = await fetch(`${base}/chat2/${chat}/stats`);
+  check("unauthenticated → 401", unauth.status === 401, `got ${unauth.status}`);
+  const preClaim = await http(`/chat2/${chat}/stats`);
+  check("stats before claim → 404", preClaim.status === 404, `got ${preClaim.status}`);
+  const badSub = await http(`/chat2/${chat}/bogus`);
+  check("unknown subroute → 404", badSub.status === 404, `got ${badSub.status}`);
+  const badMethod = await http(`/chat2/${chat}/stats`, { method: "POST" });
+  check("wrong method → 404", badMethod.status === 404, `got ${badMethod.status}`);
+}
+
+// 2. Basic protocol on device A
+const devA = new Client("devA", userA);
+await devA.connect();
+{
+  const state = await devA.hello();
+  check("hello → state on fresh room", state.header.headSeq === 0 && state.header.seqFloor === 0 && state.header.checkpointSeq === 0 && state.header.rowCount === 0, JSON.stringify(state.header));
+  check("fresh room frontier empty", state.payload.length === 0, `${state.payload.length}B`);
+}
+const rows = [randomBytes(1024), randomBytes(32 * 1024), randomBytes(200 * 1024)].map((b) => new Uint8Array(b));
+for (let i = 0; i < rows.length; i++) {
+  devA.send(FRAME.push, { batchId: `batch-${i + 1}` }, rows[i]);
+  const ack = await devA.next(FRAME.ack);
+  check(`push ${i + 1} acked seq=${i + 1}`, ack.header.seq === i + 1 && ack.header.dup === false, JSON.stringify(ack.header));
+}
+{
+  devA.send(FRAME.push, { batchId: "batch-2" }, new Uint8Array(randomBytes(64)));
+  const ack = await devA.next(FRAME.ack);
+  check("dup batchId → dup:true, original seq", ack.header.dup === true && ack.header.seq === 2, JSON.stringify(ack.header));
+  devA.send(FRAME.probe, {});
+  const p = await devA.next(FRAME.probeOk);
+  check("probe → probeOk{headSeq:3} (dup not appended)", p.header.headSeq === 3, JSON.stringify(p.header));
+  devA.send(FRAME.rowsReq, { after: 0 });
+  const { rows: seen, done } = await devA.collectRows();
+  check("rowsReq → rowsDone{headSeq:3}", done.header.headSeq === 3, JSON.stringify(done.header));
+  check("backfill: 3 rows, ordered, bytes intact", seen.length === 3 && seen.every((f, i) => f.header.seq === i + 1 && f.header.device === "devA" && eqBytes(f.payload, rows[i])), `got ${seen.length} rows`);
+}
+
+// 3. Pre-hello + malformed-frame handling on a fresh socket
+{
+  const pre = new Client("devPre", userA);
+  await pre.connect();
+  pre.send(FRAME.rowsReq, { after: 0 });
+  const err = await pre.next(FRAME.error);
+  check("rowsReq before hello → hello_first error", err.header.code === "hello_first", JSON.stringify(err.header));
+  pre.sendRaw(new Uint8Array([0x7f, 1, 0, 0, 0, 123]));
+  const err2 = await pre.next(FRAME.error);
+  check("unknown frame type → bad_frame error (socket open)", err2.header.code === "bad_frame");
+  pre.send(FRAME.probe, {});
+  await pre.next(FRAME.probeOk);
+  check("socket still usable after bad frame", true);
+  pre.ws.send("hello as text");
+  const closed = await pre.waitClose();
+  check("text message → close 1003", closed.code === 1003, `got ${closed.code}`);
+}
+
+// 4. Second device: backfill, live relay, excludeOwn, presence
+const devB = new Client("devB", userA);
+await devB.connect();
+{
+  const state = await devB.hello();
+  check("devB hello sees headSeq=3", state.header.headSeq === 3, JSON.stringify(state.header));
+  const live = new Uint8Array(randomBytes(5 * 1024));
+  devA.send(FRAME.push, { batchId: "batch-live-4" }, live);
+  const [ack, relayed] = await Promise.all([devA.next(FRAME.ack), devB.next(FRAME.row)]);
+  check("live relay: devB got devA's push", relayed.header.seq === 4 && relayed.header.device === "devA" && eqBytes(relayed.payload, live), JSON.stringify(relayed.header));
+  check("sender gets ack only", ack.header.seq === 4 && devA.inbox.every((f) => f.type !== FRAME.row), `inbox=[${devA.inbox.map((f) => NAME[f.type])}]`);
+  const fromB = new Uint8Array(randomBytes(2048));
+  devB.send(FRAME.push, { batchId: "batch-b-5" }, fromB);
+  const [, toA] = await Promise.all([devB.next(FRAME.ack), devA.next(FRAME.row)]);
+  check("relay works both directions", toA.header.seq === 5 && toA.header.device === "devB");
+
+  const devA2 = new Client("devA", userA); // reconnect path
+  await devA2.connect();
+  await devA2.hello(4);
+  devA2.send(FRAME.rowsReq, { after: 0, excludeOwn: true });
+  const { rows: got, done: exDone } = await devA2.collectRows();
+  check("excludeOwn rowsDone still reports true headSeq=5", exDone.header.headSeq === 5, JSON.stringify(exDone.header));
+  check("excludeOwn: only devB's row returned", got.length === 1 && got[0].header.device === "devB" && got[0].header.seq === 5, `got ${got.length}`);
+  devA2.ws.close();
+
+  const beat = new Uint8Array(randomBytes(48));
+  devA.send(FRAME.presence, { at: Date.now() }, beat);
+  const seen = await devB.next(FRAME.presence);
+  check("presence relayed with payload", seen.header.device === "devA" && eqBytes(seen.payload, beat));
+}
+
+// 5. Ownership
+{
+  const asB = await http(`/chat2/${chat}/stats`, { user: userB });
+  check("other user stats → 403", asB.status === 403, `got ${asB.status}`);
+  let wsRejected = false;
+  try { const c = new Client("devX", userB); await c.connect(); await c.waitClose(3000); wsRejected = true; } catch { wsRejected = true; }
+  check("other user WS → rejected", wsRejected);
+  const cpB = await http(`/chat2/${chat}/checkpoint?seqCovered=1`, { method: "POST", user: userB, headers: { "x-chat2-frontier": "" }, body: new Uint8Array([1]) });
+  check("other user checkpoint POST → 403", cpB.status === 403, `got ${cpB.status}`);
+}
+
+// 6. Checkpoint lifecycle
+const frontier = new Uint8Array(randomBytes(32));
+const ckpt = new Uint8Array(randomBytes(300 * 1024));
+{
+  const res = await http(`/chat2/${chat}/checkpoint?seqCovered=5`, { method: "POST", headers: { "x-chat2-frontier": Buffer.from(frontier).toString("base64") }, body: ckpt });
+  const body = await res.json();
+  check("checkpoint commit → pruned 5 rows", res.status === 200 && body.seqFloor === 5 && body.pruned === 5, JSON.stringify(body));
+  const stats = await (await http(`/chat2/${chat}/stats`)).json();
+  check("stats after checkpoint", stats.headSeq === 5 && stats.seqFloor === 5 && stats.rowCount === 0 && stats.checkpointSeq === 5 && stats.checkpointSize === ckpt.length, JSON.stringify(stats));
+  const get = await http(`/chat2/${chat}/checkpoint`);
+  const bytes = new Uint8Array(await get.arrayBuffer());
+  check("GET checkpoint round-trips", get.status === 200 && get.headers.get("x-chat2-checkpoint-seq") === "5" && eqBytes(bytes, ckpt));
+  const part = await http(`/chat2/${chat}/checkpoint`, { headers: { range: "bytes=100000-" } });
+  const partBytes = new Uint8Array(await part.arrayBuffer());
+  check("Range resume → 206 correct slice", part.status === 206 && part.headers.get("content-range") === `bytes 100000-${ckpt.length - 1}/${ckpt.length}` && eqBytes(partBytes, ckpt.subarray(100000)), `${part.status} ${part.headers.get("content-range")}`);
+  const past = await http(`/chat2/${chat}/checkpoint`, { headers: { range: `bytes=${ckpt.length}-` } });
+  check("Range past end → 416", past.status === 416, `got ${past.status}`);
+  const reg = await http(`/chat2/${chat}/checkpoint?seqCovered=4`, { method: "POST", headers: { "x-chat2-frontier": "" }, body: new Uint8Array([1]) });
+  check("floor regression → 409", reg.status === 409 && (await reg.json()).error === "floor_regression");
+  const ahead = await http(`/chat2/${chat}/checkpoint?seqCovered=99`, { method: "POST", headers: { "x-chat2-frontier": "" }, body: new Uint8Array([1]) });
+  check("ahead of head → 409", ahead.status === 409 && (await ahead.json()).error === "ahead_of_head");
+  const empty = await http(`/chat2/${chat}/checkpoint?seqCovered=5`, { method: "POST", headers: { "x-chat2-frontier": "" }, body: new Uint8Array(0) });
+  check("empty checkpoint → 409", empty.status === 409);
+  const badFrontier = await http(`/chat2/${chat}/checkpoint?seqCovered=5`, { method: "POST", headers: { "x-chat2-frontier": "!!!not-base64!!!" }, body: new Uint8Array([1]) });
+  check("malformed frontier → 400", badFrontier.status === 400, `got ${badFrontier.status}`);
+  const fresh = new Client("devC", userA);
+  await fresh.connect();
+  const st = await fresh.hello();
+  check("hello carries checkpoint frontier bytes", eqBytes(st.payload, frontier) && st.header.checkpointSeq === 5);
+  fresh.ws.close();
+  devA.send(FRAME.push, { batchId: "batch-post-ckpt-6" }, new Uint8Array(randomBytes(512)));
+  const ack = await devA.next(FRAME.ack);
+  check("seq continues past checkpoint floor", ack.header.seq === 6, JSON.stringify(ack.header));
+}
+
+// 7. Sidecars
+{
+  const tail = JSON.stringify({ entries: [{ id: 1, text: "hello tail" }] });
+  const put = await http(`/chat2/${chat}/tail`, { method: "PUT", headers: { "content-type": "application/json" }, body: tail });
+  check("PUT tail sidecar", put.status === 200);
+  const get = await http(`/chat2/${chat}/tail`);
+  check("GET tail verbatim + content-type", (await get.text()) === tail && get.headers.get("content-type") === "application/json");
+  const diffBytes = new Uint8Array(randomBytes(10 * 1024));
+  await http(`/chat2/${chat}/diff`, { method: "PUT", headers: { "content-type": "application/octet-stream" }, body: diffBytes });
+  const gd = await http(`/chat2/${chat}/diff`);
+  check("diff sidecar round-trips", eqBytes(new Uint8Array(await gd.arrayBuffer()), diffBytes));
+  const big = await http(`/chat2/${chat}/tail`, { method: "PUT", body: new Uint8Array(4 * 1024 * 1024 + 1) });
+  check("oversized sidecar → 413", big.status === 413, `got ${big.status}`);
+}
+
+// 8. Caps + quota
+{
+  devA.send(FRAME.push, { batchId: "batch-too-big" }, new Uint8Array(1024 * 1024 + 1));
+  const err = await devA.next(FRAME.error);
+  check("row > 1MB → too_large error, socket open", err.header.code === "too_large");
+  check("too_large error carries batchId (F2 retirement)", err.header.batchId === "batch-too-big", JSON.stringify(err.header));
+  devA.send(FRAME.probe, {});
+  await devA.next(FRAME.probeOk);
+  check("socket survives too_large", true);
+
+  const huge = new Client("devHuge", userA);
+  await huge.connect();
+  await huge.hello();
+  huge.send(FRAME.push, { batchId: "b" }, new Uint8Array(1024 * 1024 + 16 * 1024));
+  const closed = await huge.waitClose();
+  check("frame > cap → close 1009", closed.code === 1009, `got ${closed.code}`);
+
+  const q = new Client("devQ", userA);
+  await q.connect();
+  await q.hello();
+  let quotaErr = null, acks = 0;
+  for (let i = 0; i < 305 && !quotaErr; i++) {
+    q.send(FRAME.push, { batchId: `q-${i}` }, new Uint8Array([1, 2, 3]));
+    const f = await Promise.race([q.next(FRAME.ack, 8000).catch(() => null), q.next(FRAME.error, 8000).catch(() => null)]);
+    if (f?.type === FRAME.error) quotaErr = { at: i, code: f.header.code, batchId: f.header.batchId };
+    else if (f?.type === FRAME.ack) acks++;
+  }
+  check("push quota trips at 300/min", quotaErr?.code === "quota" && acks === 300, JSON.stringify({ quotaErr, acks }));
+  check("quota error carries batchId (transient retry)", quotaErr?.batchId === `q-${quotaErr?.at}`, JSON.stringify(quotaErr));
+  q.ws.close();
+  const stats = await (await http(`/chat2/${chat}/stats`)).json();
+  check("stats: pushOutcomes attribution", stats.pushOutcomes?.devQ?.ok === 300 && stats.pushOutcomes?.devQ?.rejected >= 1 && stats.pushOutcomes?.devA?.ok >= 5, JSON.stringify(stats.pushOutcomes ?? {}));
+  check("stats: presence + sockets present", typeof stats.connectedSockets === "number" && typeof stats.presence === "object");
+}
+
+// 9. Blob sidecar routes (workstream A)
+{
+  const text = "full tool output — line one\nline two, much longer than the 160-char summary would allow…";
+  const put = await http(`/blob/${chat}/part-01`, { method: "PUT", headers: { "content-type": "text/plain; charset=utf-8" }, body: text });
+  check("PUT blob", put.status === 200, `got ${put.status}`);
+  const get = await http(`/blob/${chat}/part-01`);
+  check("GET blob round-trips + content-type", (await get.text()) === text && (get.headers.get("content-type") ?? "").startsWith("text/plain"));
+  const crossUser = await http(`/blob/${chat}/part-01`, { user: userB });
+  check("cross-user blob GET → 404 (key isolation)", crossUser.status === 404, `got ${crossUser.status}`);
+  const traversal = await http(`/blob/${chat}/${encodeURIComponent("../escape")}`, { method: "PUT", body: "x" });
+  check("path-traversal partId rejected", traversal.status === 404 || traversal.status === 400, `got ${traversal.status}`);
+  const tooBig = await http(`/blob/${chat}/part-big`, { method: "PUT", body: new Uint8Array(1024 * 1024 + 1) });
+  check("blob > 1MB → 413", tooBig.status === 413, `got ${tooBig.status}`);
+  const diffKey = await http(`/blob/${chat}/part-01.diff`, { method: "PUT", body: "diff body" });
+  check("'.diff'-suffixed part key accepted", diffKey.status === 200);
+  // '#'-bearing part ids travel percent-encoded (the doc_host fix): two ids
+  // that used to silently collide on the truncated key must stay distinct.
+  const hash1 = await http(`/blob/${chat}/${encodeURIComponent("m1#c1")}`, { method: "PUT", body: "payload of m1#c1" });
+  const hash2 = await http(`/blob/${chat}/${encodeURIComponent("m1#c2")}`, { method: "PUT", body: "payload of m1#c2" });
+  check("encoded '#' part ids accepted", hash1.status === 200 && hash2.status === 200, `${hash1.status}/${hash2.status}`);
+  const hashGet1 = await (await http(`/blob/${chat}/${encodeURIComponent("m1#c1")}`)).text();
+  const hashGet2 = await (await http(`/blob/${chat}/${encodeURIComponent("m1#c2")}`)).text();
+  check("'#' part ids resolve distinct keys (no collision)", hashGet1 === "payload of m1#c1" && hashGet2 === "payload of m1#c2", `${hashGet1} / ${hashGet2}`);
+  const truncated = await http(`/blob/${chat}/m1`);
+  check("truncated key 'm1' does NOT exist (old bug shape)", truncated.status === 404, `got ${truncated.status}`);
+  const badEscape = await http(`/blob/${chat}/bad%zzescape`, { method: "PUT", body: "x" });
+  check("malformed %-escape → 400", badEscape.status === 400, `got ${badEscape.status}`);
+}
+
+// 10. Reset (operator wipe)
+{
+  const res = await http(`/chat2/${chat}/reset`, { method: "POST" });
+  check("reset → ok", res.status === 200);
+  const closedA = await devA.waitClose(8000);
+  const closedB = await devB.waitClose(8000);
+  check("reset closes sockets 4410", closedA.code === 4410 && closedB.code === 4410, `${closedA.code}/${closedB.code}`);
+  const stats = await http(`/chat2/${chat}/stats`);
+  check("room unclaimed after reset (stats 404)", stats.status === 404, `got ${stats.status}`);
+  const re = new Client("devA", userA);
+  await re.connect();
+  const st = await re.hello();
+  check("re-claim after reset: fresh log", st.header.headSeq === 0 && st.payload.length === 0, JSON.stringify(st.header));
+  re.ws.close();
+}
+
+console.log(`\nchat2 E2E vs ${base}\nroom: chat2/${chat}\n`);
+console.log(results.join("\n"));
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);

--- a/edge/scripts/chat2-crosscheck.mjs
+++ b/edge/scripts/chat2-crosscheck.mjs
@@ -1,0 +1,122 @@
+// Cross-language convergence: JS Loro peer seeds a chat2 room (rows +
+// checkpoint), the REAL Rust ChatClient joins (checkpoint-then-rows leg),
+// pushes a live edit, and JS verifies byte-level convergence both ways.
+// Run from edge/ so loro-crdt resolves. Usage: node crosscheck.mjs <baseUrl>
+import { LoroDoc } from "loro-crdt";
+import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+
+const base = process.argv[2];
+const wsBase = base.replace(/^http/, "ws");
+const user = "e2e-cross-user";
+const chat = `cross-${randomUUID().slice(0, 12)}`;
+
+const FRAME = { hello: 0x01, rowsReq: 0x03, row: 0x04, rowsDone: 0x05, push: 0x06, ack: 0x07 };
+const enc = (type, header, payload = new Uint8Array(0)) => {
+  const h = new TextEncoder().encode(JSON.stringify(header));
+  const out = new Uint8Array(5 + h.length + payload.length);
+  out[0] = type;
+  new DataView(out.buffer).setUint32(1, h.length, true);
+  out.set(h, 5); out.set(payload, 5 + h.length);
+  return out;
+};
+const dec = (data) => {
+  const b = new Uint8Array(data);
+  const len = new DataView(b.buffer, b.byteOffset).getUint32(1, true);
+  return { type: b[0], header: JSON.parse(new TextDecoder().decode(b.subarray(5, 5 + len))), payload: b.subarray(5 + len) };
+};
+const http = (path, init = {}) => fetch(`${base}${path}`, { ...init, headers: { authorization: `Bearer ${user}`, ...(init.headers ?? {}) } });
+
+const connect = async (device) => {
+  const ws = new WebSocket(`${wsBase}/chat2/${chat}/ws?device=${device}&token=${user}`);
+  ws.binaryType = "arraybuffer";
+  const inbox = [];
+  ws.onmessage = (ev) => inbox.push(dec(ev.data));
+  await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
+  const wait = async (type, timeout = 8000) => {
+    const start = Date.now();
+    for (;;) {
+      const i = inbox.findIndex((f) => f.type === type);
+      if (i >= 0) return inbox.splice(i, 1)[0];
+      if (Date.now() - start > timeout) throw new Error(`timeout ${type}`);
+      await new Promise((r) => setTimeout(r, 80));
+    }
+  };
+  return { ws, inbox, wait, send: (t, h, p) => ws.send(enc(t, h, p)) };
+};
+
+let pass = 0, fail = 0;
+const check = (name, cond, detail = "") => {
+  console.log(`${cond ? "  ok" : "FAIL"}  ${name}${cond ? "" : ` — ${detail}`}`);
+  cond ? pass++ : fail++;
+};
+
+// ── seed: two committed updates, checkpoint covering them, one row on top ──
+const js = new LoroDoc();
+const text = js.getText("t");
+const peer = await connect("js-seeder");
+peer.send(FRAME.hello, { cursor: 0, device: "js-seeder" });
+await peer.wait(0x02);
+
+let from = js.version();
+text.insert(0, "one ");
+js.commit();
+peer.send(FRAME.push, { batchId: "cross-1" }, js.export({ mode: "update", from }));
+await peer.wait(FRAME.ack);
+
+from = js.version();
+text.insert(4, "two ");
+js.commit();
+peer.send(FRAME.push, { batchId: "cross-2" }, js.export({ mode: "update", from }));
+await peer.wait(FRAME.ack);
+
+// checkpoint = full snapshot at vv(two rows); frontier = encoded VV
+const cp = await http(`/chat2/${chat}/checkpoint?seqCovered=2`, {
+  method: "POST",
+  headers: { "x-chat2-frontier": Buffer.from(js.version().encode()).toString("base64") },
+  body: js.export({ mode: "snapshot" })
+});
+check("seed checkpoint committed (rows 1-2 pruned)", cp.status === 200 && (await cp.json()).pruned === 2);
+
+from = js.version();
+text.insert(8, "three ");
+js.commit();
+peer.send(FRAME.push, { batchId: "cross-3" }, js.export({ mode: "update", from }));
+await peer.wait(FRAME.ack);
+
+// ── run the real Rust client ────────────────────────────────────────────────
+const out = execFileSync(
+  "cargo",
+  ["run", "-q", "-p", "comet-sync", "--example", "chat2_live", "--", base, chat, user, "rust-dev"],
+  { cwd: "/home/ubuntu/GitHub/comet", encoding: "utf8", timeout: 120000 }
+);
+const result = JSON.parse(out.split("\n").find((l) => l.startsWith("RESULT:")).slice(7));
+console.log("rust client:", JSON.stringify(result));
+
+check("rust took checkpoint-then-rows leg", result.checkpointApplied === true, out);
+check("rust imported the post-checkpoint row", result.rowsApplied >= 1 && result.caughtUpCursor === 3, JSON.stringify(result));
+check("rust doc converged with JS seed", result.text.startsWith("one two three"), result.text);
+check("rust live push acked (cursor advanced)", result.finalCursor === 4, JSON.stringify(result));
+
+// ── JS side pulls the rust row and verifies convergence ────────────────────
+// (seeder socket also received the live relay; use a FRESH reader instead to
+// prove the row is durable, not just relayed)
+const reader = await connect("js-reader");
+reader.send(FRAME.hello, { cursor: 0, device: "js-reader" });
+const state = await reader.wait(0x02);
+check("state advertises rust's row (headSeq 4)", state.header.headSeq === 4, JSON.stringify(state.header));
+const verify = new LoroDoc();
+verify.import(new Uint8Array(await (await http(`/chat2/${chat}/checkpoint`)).arrayBuffer()));
+reader.send(FRAME.rowsReq, { after: 2 });
+for (;;) {
+  const f = await reader.wait(FRAME.row, 4000).catch(() => null);
+  if (!f) break;
+  verify.import(f.payload);
+  if (f.header.seq === 4) { check("rust row attributed to rust-dev", f.header.device === "rust-dev", f.header.device); break; }
+}
+check("fresh JS reader converges with rust edit", verify.getText("t").toString() === "one two three  rust-was-here".replace("three  ", "three ") || verify.getText("t").toString().includes("rust-was-here"), verify.getText("t").toString());
+check("both docs identical", verify.getText("t").toString() === result.text, `js='${verify.getText("t")}' rust='${result.text}'`);
+
+peer.ws.close(); reader.ws.close();
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);

--- a/edge/scripts/chat2-persist-check.mjs
+++ b/edge/scripts/chat2-persist-check.mjs
@@ -1,0 +1,73 @@
+// Durability across DO eviction: seed rows + checkpoint, then (after the
+// caller redeploys the worker, evicting every DO) verify nothing reverted.
+// The s2 whale bug was exactly "acks Ok live, reverts on hibernation" — this
+// proves chat2 rows/checkpoint/meta survive a cold start from SQLite.
+// Usage: node persist-check.mjs <baseUrl> seed|verify <chatId>
+import { randomBytes, createHash } from "node:crypto";
+
+const [base, mode, chat] = process.argv.slice(2);
+const wsBase = base.replace(/^http/, "ws");
+const user = "e2e-persist-user";
+const FRAME = { hello: 0x01, push: 0x06, ack: 0x07 };
+const enc = (type, header, payload = new Uint8Array(0)) => {
+  const h = new TextEncoder().encode(JSON.stringify(header));
+  const out = new Uint8Array(5 + h.length + payload.length);
+  out[0] = type;
+  new DataView(out.buffer).setUint32(1, h.length, true);
+  out.set(h, 5); out.set(payload, 5 + h.length);
+  return out;
+};
+const dec = (data) => {
+  const b = new Uint8Array(data);
+  const len = new DataView(b.buffer, b.byteOffset).getUint32(1, true);
+  return { type: b[0], header: JSON.parse(new TextDecoder().decode(b.subarray(5, 5 + len))), payload: b.subarray(5 + len) };
+};
+const http = (path, init = {}) => fetch(`${base}${path}`, { ...init, headers: { authorization: `Bearer ${user}`, ...(init.headers ?? {}) } });
+// Deterministic pseudo-random payloads so seed and verify agree byte-for-byte.
+const rowBytes = (i) => { const seed = createHash("sha256").update(`row-${i}`).digest(); const out = new Uint8Array(8192); for (let o = 0; o < out.length; o += 32) out.set(seed, o > out.length - 32 ? out.length - 32 : o); return out; };
+const ckptBytes = () => new Uint8Array(createHash("sha512").update("checkpoint").digest());
+const frontier = () => new Uint8Array(createHash("sha256").update("frontier").digest());
+
+if (mode === "seed") {
+  const ws = new WebSocket(`${wsBase}/chat2/${chat}/ws?device=seeder&token=${user}`);
+  ws.binaryType = "arraybuffer";
+  const inbox = [];
+  ws.onmessage = (ev) => inbox.push(dec(ev.data));
+  await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
+  ws.send(enc(FRAME.hello, { cursor: 0, device: "seeder" }));
+  for (let i = 1; i <= 8; i++) ws.send(enc(FRAME.push, { batchId: `persist-${i}` }, rowBytes(i)));
+  const deadline = Date.now() + 10000;
+  while (inbox.filter((f) => f.type === FRAME.ack).length < 8 && Date.now() < deadline) await new Promise((r) => setTimeout(r, 100));
+  if (inbox.filter((f) => f.type === FRAME.ack).length < 8) throw new Error("seed: missing acks");
+  // checkpoint covering rows 1..4 → floor 4, rows 5..8 remain
+  const cp = await http(`/chat2/${chat}/checkpoint?seqCovered=4`, { method: "POST", headers: { "x-chat2-frontier": Buffer.from(frontier()).toString("base64") }, body: ckptBytes() });
+  if (cp.status !== 200) throw new Error(`seed: checkpoint ${cp.status}`);
+  await http(`/chat2/${chat}/tail`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ marker: "persist-tail" }) });
+  ws.close();
+  const stats = await (await http(`/chat2/${chat}/stats`)).json();
+  console.log("SEEDED", JSON.stringify(stats));
+} else {
+  const stats = await (await http(`/chat2/${chat}/stats`)).json();
+  const expect = { headSeq: 8, seqFloor: 4, rowCount: 4, checkpointSeq: 4 };
+  const statsOk = Object.entries(expect).every(([k, v]) => stats[k] === v);
+  const cp = await http(`/chat2/${chat}/checkpoint`);
+  const cpOk = cp.status === 200 && Buffer.from(await cp.arrayBuffer()).equals(Buffer.from(ckptBytes()));
+  const tail = await (await http(`/chat2/${chat}/tail`)).json();
+  const tailOk = tail.marker === "persist-tail";
+  // rows 5..8 with intact bytes via a fresh reader socket
+  const ws = new WebSocket(`${wsBase}/chat2/${chat}/ws?device=verifier&token=${user}`);
+  ws.binaryType = "arraybuffer";
+  const inbox = [];
+  ws.onmessage = (ev) => inbox.push(dec(ev.data));
+  await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
+  ws.send(enc(FRAME.hello, { cursor: 0, device: "verifier" }));
+  ws.send(enc(0x03, { after: 4 }));
+  const deadline = Date.now() + 10000;
+  while (!inbox.some((f) => f.type === 0x05) && Date.now() < deadline) await new Promise((r) => setTimeout(r, 100));
+  const rows = inbox.filter((f) => f.type === 0x04);
+  const rowsOk = rows.length === 4 && rows.every((f, i) => f.header.seq === 5 + i && Buffer.from(f.payload).equals(Buffer.from(rowBytes(5 + i))));
+  ws.close();
+  console.log(JSON.stringify({ statsOk, cpOk, tailOk, rowsOk, stats }));
+  if (!(statsOk && cpOk && tailOk && rowsOk)) process.exit(1);
+  console.log("PERSISTENCE OK: rows, checkpoint, frontier meta, sidecar all survived eviction");
+}

--- a/edge/scripts/fold-check.mjs
+++ b/edge/scripts/fold-check.mjs
@@ -30,7 +30,7 @@ await client.join({ roomId: room, crdtAdaptor: adaptor });
 const doc = adaptor.getDoc();
 const map = doc.getMap("devices");
 
-// COMPACT_LOG_ROWS = 1500; each commit is its own update row on the DO.
+// COMPACT_LOG_ROWS = 400; each commit is its own update row on the DO.
 const N = 1700;
 let maxRows = 0;
 for (let i = 0; i < N; i++) {

--- a/edge/scripts/whale-check.mjs
+++ b/edge/scripts/whale-check.mjs
@@ -82,6 +82,47 @@ const tailRes = await fetch(`${base}/tail/${chatId}?token=${token}`);
 const tailBody = tailRes.status === 200 ? await tailRes.json() : await tailRes.text();
 log(`tail: ${tailRes.status}${tailRes.status !== 200 ? " " + String(tailBody).slice(0, 200) : ` (${tailBody.totalMessages} messages)`}`);
 
+// ── fold backpressure: a >2MB log crosses COMPACT_LOG_BYTES on the same
+//    flush that wrote its chunked rows, so foldLog must have collapsed the
+//    log into the snapshot (force-trimming shallow via TRIM_FORCE_BYTES on a
+//    chat room) and reset the byte accounting — then the room must keep
+//    accepting, persisting, and serving writes on top of the folded doc. ────
+const EXTRA = 40;
+for (let j = 0; j < EXTRA; j++) {
+  const m = messages.insertContainer(messages.length, new LoroMap());
+  m.set("id", `m${i + j}`);
+  m.set("role", j % 2 ? "assistant" : "user");
+  m.set("createdAt", 1754400000000 + i + j);
+  m.set("deviceId", "whale-dev");
+  const parts = m.setContainer("parts", new LoroList());
+  const part = parts.insertContainer(0, new LoroMap());
+  part.set("id", `p${i + j}`);
+  part.set("kind", "text");
+  part.setContainer("text", new LoroText()).insert(0, `post-fold message ${j}`);
+  hostDoc.commit(); // one update per message: exercises the row path, not another whale
+}
+await sleep(1500); // let the wave relay
+const s3 = await stats(); // /stats flushes, so the wave's rows land durably now
+log(`stats after post-fold wave:  ${s3.status} ${JSON.stringify(s3.body)}`);
+
+// A fresh reader joining AFTER the fold+trim reads the shallow-aware §3.1
+// backfill (the bug-#2 path: force-trimmed whale rooms used to serve fresh
+// readers an EMPTY transcript with zero errors).
+const reader2 = new LoroWebsocketClient({ url: `${wsBase}/session/${chatId}/ws?token=${token}` });
+await reader2.waitConnected();
+const reader2Adaptor = new LoroAdaptor();
+await reader2.join({ roomId: chatId, crdtAdaptor: reader2Adaptor });
+const reader2Doc = reader2Adaptor.getDoc();
+const t1 = Date.now();
+while (Date.now() - t1 < 20000) {
+  if (reader2Doc.getList("messages").length >= i + EXTRA) break;
+  await sleep(100);
+}
+log(`post-fold reader backfill: ${reader2Doc.getList("messages").length}/${i + EXTRA} messages`);
+
+const tail2Res = await fetch(`${base}/tail/${chatId}?token=${token}`);
+const tail2Body = tail2Res.status === 200 ? await tail2Res.json() : await tail2Res.text();
+
 // ── verdict ───────────────────────────────────────────────────────────────
 let failures = 0;
 const check = (name, cond, detail = "") => {
@@ -102,5 +143,40 @@ check(
   "/tail materializes",
   tailRes.status === 200 && tailBody.totalMessages === i,
   `status=${tailRes.status}`
+);
+
+// Fold backpressure. The byte-budget assertions only hold when the payload
+// actually crosses COMPACT_LOG_BYTES (2MB) — the default 3MB does.
+if (payloadMB * 1024 * 1024 > 2 * 1024 * 1024) {
+  check(
+    "fold collapsed the chunked log into the snapshot",
+    s2.status === 200 && s2.body.updateRows === 0 && s2.body.snapshotBytes > 0,
+    s2.status === 200 ? `updateRows=${s2.body.updateRows}, snapshotBytes=${s2.body.snapshotBytes}` : ""
+  );
+  check(
+    "fold reset the log byte accounting",
+    s2.status === 200 && s2.body.updateLogBytes === 0,
+    s2.status === 200 ? `updateLogBytes=${s2.body.updateLogBytes}` : ""
+  );
+  check(
+    "force-trim engaged on the whale room",
+    s2.status === 200 && !!s2.body.lastTrimAt,
+    s2.status === 200 ? `lastTrimAt=${s2.body.lastTrimAt}` : ""
+  );
+}
+check(
+  "post-fold writes persist as fresh log rows",
+  s3.status === 200 && s3.body.updateRows > 0,
+  s3.status === 200 ? `updateRows=${s3.body.updateRows}` : `status=${s3.status}`
+);
+check("first reader stayed live across the fold", readerDoc.getList("messages").length === i + EXTRA);
+check(
+  "fresh post-fold reader gets the full transcript (shallow-aware backfill)",
+  reader2Doc.getList("messages").length === i + EXTRA
+);
+check(
+  "/tail reflects the post-fold wave",
+  tail2Res.status === 200 && tail2Body.totalMessages === i + EXTRA,
+  `status=${tail2Res.status}${tail2Res.status === 200 ? `, totalMessages=${tail2Body.totalMessages}` : ""}`
 );
 process.exit(failures === 0 ? 0 : 1);

--- a/edge/src/chat-frames.test.ts
+++ b/edge/src/chat-frames.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { decodeFrame, encodeFrame, FRAME, MAX_HEADER_BYTES } from "./chat-frames";
+
+/** The chat2 wire codec is a cross-language contract (Rust + Swift clients
+ * re-implement it); these vectors pin the layout, not just round-tripping. */
+
+const bytesOf = (len: number, seed: number): Uint8Array => {
+  const out = new Uint8Array(len);
+  for (let i = 0; i < len; i++) out[i] = (seed + i * 31) & 0xff;
+  return out;
+};
+
+describe("chat2 frame codec", () => {
+  it("pins the wire layout: [type u8][headerLen u32 LE][header][payload]", () => {
+    const frame = encodeFrame(FRAME.push, { batchId: "b1" }, new Uint8Array([9, 8, 7]));
+    expect(frame[0]).toBe(FRAME.push);
+    const headerJson = JSON.stringify({ batchId: "b1" });
+    expect(new DataView(frame.buffer).getUint32(1, true)).toBe(headerJson.length);
+    expect(new TextDecoder().decode(frame.subarray(5, 5 + headerJson.length))).toBe(headerJson);
+    expect([...frame.subarray(5 + headerJson.length)]).toEqual([9, 8, 7]);
+  });
+
+  it("round-trips every frame type, with and without payload", () => {
+    for (const type of Object.values(FRAME)) {
+      const payload = bytesOf(1000, type);
+      const decoded = decodeFrame(encodeFrame(type, { seq: 7, device: "dev-a" }, payload));
+      expect(decoded).toBeDefined();
+      expect(decoded!.type).toBe(type);
+      expect(decoded!.header).toEqual({ seq: 7, device: "dev-a" });
+      expect(decoded!.payload).toEqual(payload);
+
+      const bare = decodeFrame(encodeFrame(type, {}));
+      expect(bare!.payload.length).toBe(0);
+    }
+  });
+
+  it("round-trips a subarray view (offset ≠ 0 — the ws buffer case)", () => {
+    const inner = encodeFrame(FRAME.row, { seq: 1 }, bytesOf(64, 3));
+    const shifted = new Uint8Array(inner.length + 8);
+    shifted.set(inner, 8);
+    const decoded = decodeFrame(shifted.subarray(8));
+    expect(decoded?.header).toEqual({ seq: 1 });
+    expect(decoded?.payload).toEqual(bytesOf(64, 3));
+  });
+
+  it("rejects malformed frames as undefined, never throws", () => {
+    expect(decodeFrame(new Uint8Array(0))).toBeUndefined();
+    expect(decodeFrame(new Uint8Array([FRAME.hello]))).toBeUndefined(); // truncated length
+    expect(decodeFrame(new Uint8Array([0x7f, 0, 0, 0, 0]))).toBeUndefined(); // unknown type
+    // Header length pointing past the buffer.
+    const truncated = encodeFrame(FRAME.hello, { cursor: 5 });
+    new DataView(truncated.buffer).setUint32(1, 9999, true);
+    expect(decodeFrame(truncated)).toBeUndefined();
+    // Junk JSON in the header span.
+    const junk = new Uint8Array([FRAME.hello, 2, 0, 0, 0, 0x7b, 0x7b]);
+    expect(decodeFrame(junk)).toBeUndefined();
+    // Valid JSON but not an object.
+    const arr = new TextEncoder().encode("[1]");
+    const arrFrame = new Uint8Array(5 + arr.length);
+    arrFrame[0] = FRAME.hello;
+    new DataView(arrFrame.buffer).setUint32(1, arr.length, true);
+    arrFrame.set(arr, 5);
+    expect(decodeFrame(arrFrame)).toBeUndefined();
+  });
+
+  it("rejects oversized headers (payloads are unbounded here; the DO caps frames)", () => {
+    const fat = encodeFrame(FRAME.hello, { pad: "x".repeat(MAX_HEADER_BYTES) });
+    expect(decodeFrame(fat)).toBeUndefined();
+  });
+});

--- a/edge/src/chat-frames.ts
+++ b/edge/src/chat-frames.ts
@@ -1,0 +1,101 @@
+/**
+ * chat2 wire frames (docs/chat2-sync.md workstream B).
+ *
+ * Binary WS frames: `[type u8][headerLen u32 LE][header JSON utf8][payload]`.
+ * Headers are tiny JSON (ids, seqs); payloads are opaque byte blobs (Loro
+ * updates, checkpoint frontiers, presence ephemera) that only CLIENTS parse —
+ * the DO relays them untouched. Binary because base64'ing update bytes costs
+ * 33% on the wire, which matters at the 1.2 Mbps links the whale incident
+ * surfaced; no loro-protocol because the server owns no CRDT semantics.
+ *
+ * Shared shape across Rust (crates/sync) and Swift clients — change it only
+ * with cross-language test vectors (registry precedent).
+ */
+
+import { textDecoder, textEncoder } from "./blobs";
+
+/** Frame type bytes. Client→server and server→client share one space. */
+export const FRAME = {
+  // client → server
+  /** `{cursor, device}` — first frame on a socket; answered by `state`. */
+  hello: 0x01,
+  /** `{after, excludeOwn}` — request backfill rows with `seq > after`;
+   * `excludeOwn` skips the sender device's own writes (reconnect path). */
+  rowsReq: 0x03,
+  /** `{batchId}` + payload = one opaque Loro update. */
+  push: 0x06,
+  /** `{at}` + opaque payload — relayed verbatim to live peers, never stored. */
+  presence: 0x08,
+  /** `{}` — liveness probe; answered by `probeOk` from the DO itself (unlike
+   * the runtime-answered ping/pong pair, this proves the DO runs). */
+  probe: 0x09,
+
+  // server → client
+  /** `{headSeq, seqFloor, checkpointSeq, checkpointSize, rowCount, rowBytes}`
+   * + payload = checkpoint frontier bytes (empty when no checkpoint). The
+   * client compares the frontier against its local doc: included → rows-only
+   * catch-up; not included → `GET /checkpoint` first. */
+  state: 0x02,
+  /** `{seq, device, batchId}` + payload = update bytes. Sent during backfill
+   * (after `rowsReq`) and as the live relay of other devices' pushes. */
+  row: 0x04,
+  /** `{headSeq}` — backfill complete; subsequent `row` frames are live. */
+  rowsDone: 0x05,
+  /** `{batchId, seq, dup}` — push accepted (`dup` = batchId replay, no-op). */
+  ack: 0x07,
+  /** `{headSeq}` — probe answer. */
+  probeOk: 0x0a,
+  /** `{code, message}` — recoverable rejection (socket stays open). */
+  error: 0x0b
+} as const;
+
+export type FrameType = (typeof FRAME)[keyof typeof FRAME];
+
+export interface Frame {
+  type: FrameType;
+  header: Record<string, unknown>;
+  payload: Uint8Array;
+}
+
+/** Headers are ids + a few integers; anything bigger is a client bug. */
+export const MAX_HEADER_BYTES = 4096;
+
+const KNOWN_TYPES = new Set<number>(Object.values(FRAME));
+
+export const encodeFrame = (
+  type: FrameType,
+  header: Record<string, unknown>,
+  payload?: Uint8Array
+): Uint8Array => {
+  const headerBytes = textEncoder.encode(JSON.stringify(header));
+  const payloadLen = payload?.length ?? 0;
+  const out = new Uint8Array(5 + headerBytes.length + payloadLen);
+  out[0] = type;
+  new DataView(out.buffer).setUint32(1, headerBytes.length, true);
+  out.set(headerBytes, 5);
+  if (payload) out.set(payload, 5 + headerBytes.length);
+  return out;
+};
+
+/** `undefined` = malformed (unknown type, bad length, junk JSON). The DO
+ * answers malformed frames with an `error` frame, not a close — one corrupt
+ * frame from a flaky link must not cost a reconnect cycle. */
+export const decodeFrame = (bytes: Uint8Array): Frame | undefined => {
+  if (bytes.length < 5) return undefined;
+  const type = bytes[0]!;
+  if (!KNOWN_TYPES.has(type)) return undefined;
+  const headerLen = new DataView(bytes.buffer, bytes.byteOffset).getUint32(1, true);
+  if (headerLen > MAX_HEADER_BYTES || 5 + headerLen > bytes.length) return undefined;
+  let header: unknown;
+  try {
+    header = JSON.parse(textDecoder.decode(bytes.subarray(5, 5 + headerLen)));
+  } catch {
+    return undefined;
+  }
+  if (typeof header !== "object" || header === null || Array.isArray(header)) return undefined;
+  return {
+    type: type as FrameType,
+    header: header as Record<string, unknown>,
+    payload: bytes.subarray(5 + headerLen)
+  };
+};

--- a/edge/src/chat-log.ts
+++ b/edge/src/chat-log.ts
@@ -1,0 +1,180 @@
+/**
+ * chat2 log storage (docs/chat2-sync.md workstream B) — the dumb-relay data
+ * model, pure over a DO's SqlStorage + BlobStore so the workerd test tier
+ * exercises it against real SQLite (the ~2MB value-cap runtime).
+ *
+ * The room is an append-only log of opaque Loro update blobs plus one
+ * client-written checkpoint blob. No wasm, no replay, no materialization:
+ * cold start is a table read, so the s2 wedge class (CPU-limited history
+ * replay in the DO) cannot exist here by construction.
+ */
+
+import type { BlobStore } from "./blobs";
+
+/** Per-row byte cap, rejected at the frame header. Post-strip updates are
+ * KB-scale; a full checkpoint travels over HTTP, never as a row. Well under
+ * the ~2MB SQL value cap, so rows are never chunked (unlike s2's update-log,
+ * whose silent SQLITE_TOOBIG overflow was the 2026-08-05 whale freeze). */
+export const MAX_ROW_BYTES = 1024 * 1024;
+
+/** Blob-store names for the checkpoint payload and its frontier. */
+export const CHECKPOINT_BLOB = "checkpoint";
+export const FRONTIER_BLOB = "checkpoint-frontier";
+
+export interface LogRow {
+  seq: number;
+  device: string;
+  batchId: string;
+  bytes: Uint8Array;
+}
+
+export const ensureChatLog = (sql: SqlStorage): void => {
+  sql.exec(
+    "CREATE TABLE IF NOT EXISTS rows (seq INTEGER PRIMARY KEY, device TEXT NOT NULL, batch_id TEXT NOT NULL UNIQUE, bytes BLOB NOT NULL, received_at INTEGER NOT NULL)"
+  );
+  sql.exec("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+};
+
+export const getMeta = (sql: SqlStorage, key: string): string | undefined => {
+  const rows = [...sql.exec("SELECT value FROM meta WHERE key = ?", key)];
+  return rows[0]?.value as string | undefined;
+};
+
+export const setMeta = (sql: SqlStorage, key: string, value: string): void => {
+  sql.exec(
+    "INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    key,
+    value
+  );
+};
+
+export const headSeq = (sql: SqlStorage): number => Number(getMeta(sql, "headSeq") ?? "0");
+
+/** Rows with `seq <= seqFloor` are gone — covered by the checkpoint. A cursor
+ * below the floor must load the checkpoint before requesting rows. */
+export const seqFloor = (sql: SqlStorage): number => Number(getMeta(sql, "seqFloor") ?? "0");
+
+export type AppendOutcome =
+  | { ok: true; seq: number; dup: boolean }
+  | { ok: false; error: "too_large" | "empty" };
+
+/** Append one update row. `batch_id` UNIQUE dedupes reconnect re-pushes
+ * server-side: a replay acks the ORIGINAL seq and appends nothing (Loro
+ * re-import is a no-op client-side, so duplicates are safe end-to-end — this
+ * just keeps the log tight). */
+export const appendRow = (
+  sql: SqlStorage,
+  device: string,
+  batchId: string,
+  bytes: Uint8Array,
+  receivedAt: number
+): AppendOutcome => {
+  if (bytes.byteLength === 0) return { ok: false, error: "empty" };
+  if (bytes.byteLength > MAX_ROW_BYTES) return { ok: false, error: "too_large" };
+  const existing = [...sql.exec("SELECT seq FROM rows WHERE batch_id = ?", batchId)];
+  if (existing.length > 0) {
+    return { ok: true, seq: existing[0]!.seq as number, dup: true };
+  }
+  const seq = headSeq(sql) + 1;
+  sql.exec(
+    "INSERT INTO rows (seq, device, batch_id, bytes, received_at) VALUES (?, ?, ?, ?, ?)",
+    seq,
+    device,
+    batchId,
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    receivedAt
+  );
+  setMeta(sql, "headSeq", String(seq));
+  return { ok: true, seq, dup: false };
+};
+
+/** Rows `seq > after`, in order, optionally excluding one device's own writes
+ * (the reconnect-after-offline-work path never re-downloads itself). */
+export function* rowsAfter(
+  sql: SqlStorage,
+  after: number,
+  excludeDevice?: string
+): Generator<LogRow> {
+  const cursor = excludeDevice
+    ? sql.exec(
+        "SELECT seq, device, batch_id, bytes FROM rows WHERE seq > ? AND device != ? ORDER BY seq",
+        after,
+        excludeDevice
+      )
+    : sql.exec("SELECT seq, device, batch_id, bytes FROM rows WHERE seq > ? ORDER BY seq", after);
+  for (const raw of cursor) {
+    yield {
+      seq: raw.seq as number,
+      device: raw.device as string,
+      batchId: raw.batch_id as string,
+      bytes: new Uint8Array(raw.bytes as ArrayBuffer)
+    };
+  }
+}
+
+export type CheckpointOutcome =
+  | { ok: true; seqFloor: number; pruned: number }
+  | { ok: false; error: "floor_regression" | "ahead_of_head" | "empty" };
+
+/** Commit a client-built checkpoint covering rows `seq <= seqCovered`.
+ *
+ * The guard is floor-monotonic — the dumb replacement for s2's VV-monotonic
+ * R2 guard: a checkpoint may only move the floor forward, and may not claim
+ * to cover rows that don't exist yet. Within those bounds the SERVER trusts
+ * the payload blindly (owner-only rooms contain semantic garbage per-user;
+ * the next checkpoint erases it). Rows covered by the checkpoint are deleted
+ * in the same event — DO events are single-threaded and commit atomically,
+ * so a crash never leaves the floor and the rows disagreeing. */
+export const commitCheckpoint = (
+  sql: SqlStorage,
+  blobs: BlobStore,
+  seqCovered: number,
+  frontier: Uint8Array,
+  bytes: Uint8Array,
+  committedAt: number
+): CheckpointOutcome => {
+  if (bytes.byteLength === 0) return { ok: false, error: "empty" };
+  if (seqCovered < seqFloor(sql)) return { ok: false, error: "floor_regression" };
+  if (seqCovered > headSeq(sql)) return { ok: false, error: "ahead_of_head" };
+  blobs.put(CHECKPOINT_BLOB, bytes);
+  blobs.put(FRONTIER_BLOB, frontier);
+  const before = rowCount(sql);
+  sql.exec("DELETE FROM rows WHERE seq <= ?", seqCovered);
+  const pruned = before - rowCount(sql);
+  setMeta(sql, "seqFloor", String(seqCovered));
+  setMeta(sql, "checkpointSeq", String(seqCovered));
+  setMeta(sql, "checkpointSize", String(bytes.byteLength));
+  setMeta(sql, "checkpointAt", String(committedAt));
+  return { ok: true, seqFloor: seqCovered, pruned };
+};
+
+const rowCount = (sql: SqlStorage): number =>
+  [...sql.exec("SELECT COUNT(*) AS n FROM rows")][0]?.n as number;
+
+export interface LogStats {
+  headSeq: number;
+  seqFloor: number;
+  rowCount: number;
+  rowBytes: number;
+  checkpointSeq: number;
+  checkpointSize: number;
+  checkpointAt: number;
+}
+
+/** The hello/stats surface — also what the host's checkpoint policy reads
+ * (`rowBytes > 512KB || rowCount > 200` → post a checkpoint) and what the
+ * fleet alert watches (unbounded growth is this design's failure mode). */
+export const logStats = (sql: SqlStorage): LogStats => {
+  const agg = [
+    ...sql.exec("SELECT COUNT(*) AS n, COALESCE(SUM(LENGTH(bytes)), 0) AS b FROM rows")
+  ][0]!;
+  return {
+    headSeq: headSeq(sql),
+    seqFloor: seqFloor(sql),
+    rowCount: agg.n as number,
+    rowBytes: agg.b as number,
+    checkpointSeq: Number(getMeta(sql, "checkpointSeq") ?? "0"),
+    checkpointSize: Number(getMeta(sql, "checkpointSize") ?? "0"),
+    checkpointAt: Number(getMeta(sql, "checkpointAt") ?? "0")
+  };
+};

--- a/edge/src/chat-room.ts
+++ b/edge/src/chat-room.ts
@@ -1,0 +1,496 @@
+/**
+ * ChatRoom — one Durable Object per chat session (`chat2/{chatId}`), the
+ * dumb authenticated log relay replacing SessionRoom's loro-aware s2 rooms
+ * (docs/chat2-sync.md workstream B). Modeled line-for-line on RegistryRoom,
+ * NOT on SessionRoom: no loro-wasm import anywhere in this class.
+ *
+ * The DO's entire job: append opaque update blobs to a seq-ordered log,
+ * relay them to live sockets, store one client-built checkpoint blob, and
+ * serve both back. All CRDT semantics live in the clients. Cold start is a
+ * table read — the s2 wedge class (CPU-limited export/replay in the DO)
+ * cannot exist here by construction.
+ *
+ * Sidecars (`/tail`, `/diff`) are host-PUBLISHED and served verbatim: the DO
+ * never materializes anything.
+ *
+ * Hibernation discipline: ZERO wall-clock timers; ping/pong rides the
+ * auto-response pair; the daily alarm does the nightly R2 backup only.
+ */
+import { createBlobStore, type BlobStore } from "./blobs";
+import {
+  appendRow,
+  CHECKPOINT_BLOB,
+  commitCheckpoint,
+  ensureChatLog,
+  FRONTIER_BLOB,
+  getMeta,
+  headSeq,
+  logStats,
+  MAX_ROW_BYTES,
+  rowsAfter,
+  setMeta
+} from "./chat-log";
+import { decodeFrame, encodeFrame, FRAME } from "./chat-frames";
+import { AUTH_USER_HEADER, type Env } from "./env";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** Inbound frame budget: one pushed row (+ header slack). */
+const MAX_FRAME_BYTES = MAX_ROW_BYTES + 8192;
+/** Host-published sidecar budget (tail JSON / diff payload). */
+const MAX_SIDECAR_BYTES = 4 * 1024 * 1024;
+/** Checkpoint upload budget — a REBUILT thin doc is ~KB-to-100s-of-KB scale;
+ * 16MB is deliberate headroom over any sane doc, not a target. */
+const MAX_CHECKPOINT_BYTES = 16 * 1024 * 1024;
+/** Presence beats older than this are swept before relay/stats. */
+const PRESENCE_TTL_MS = 30_000;
+/** Per-device push quota, rolling window (in-memory; resets on hibernation —
+ * it exists to contain a runaway client loop, not to meter honest traffic). */
+const QUOTA_WINDOW_MS = 60_000;
+const QUOTA_MAX_PUSHES = 300;
+const QUOTA_MAX_BYTES = 8 * 1024 * 1024;
+
+interface SocketState {
+  userId: string;
+  device: string;
+  /** Set once a valid hello established the session. */
+  ready?: boolean;
+}
+
+interface PushOutcome {
+  ok: number;
+  rejected: number;
+  lastOkAt: number;
+}
+
+interface QuotaWindow {
+  since: number;
+  pushes: number;
+  bytes: number;
+}
+
+export class ChatRoom implements DurableObject {
+  private readonly ctx: DurableObjectState;
+  private readonly env: Env;
+  private readonly blobs: BlobStore;
+  /** device → last presence beat (epoch ms). Memory-only by construction. */
+  private readonly presence = new Map<string, number>();
+  /** device → rolling push quota window. Memory-only. */
+  private readonly quotas = new Map<string, QuotaWindow>();
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    this.ctx = ctx;
+    this.env = env;
+    ensureChatLog(ctx.storage.sql);
+    this.blobs = createBlobStore(ctx.storage.sql);
+    // Runtime-answered keepalive; proves nothing about this DO's health.
+    // Clients judge liveness by probe frames (same caveat as RegistryRoom).
+    ctx.setWebSocketAutoResponse(new WebSocketRequestResponsePair("ping", "pong"));
+  }
+
+  // ── HTTP surface (only reachable through the authed Worker) ──────────────
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const userId = request.headers.get(AUTH_USER_HEADER);
+    if (!userId) return json({ error: "unauthenticated" }, 401);
+
+    const sql = this.ctx.storage.sql;
+    const owner = getMeta(sql, "owner");
+
+    if (url.pathname === "/ws") {
+      // Claim-on-first-join ownership, then owner-only forever (the s2
+      // discipline: chat ids are client-minted, the first authed user to
+      // dial one owns it).
+      if (!owner) setMeta(sql, "owner", userId);
+      else if (owner !== userId) return json({ error: "forbidden" }, 403);
+      const device = url.searchParams.get("device") ?? "";
+      const pair = new WebSocketPair();
+      this.ctx.acceptWebSocket(pair[1]);
+      const state: SocketState = { userId, device };
+      pair[1].serializeAttachment(state);
+      return new Response(null, { status: 101, webSocket: pair[0] });
+    }
+
+    if (url.pathname === "/checkpoint" && request.method === "POST") {
+      if (!owner) setMeta(sql, "owner", userId);
+      else if (owner !== userId) return json({ error: "forbidden" }, 403);
+      const seqCovered = Number(url.searchParams.get("seqCovered") ?? "");
+      if (!Number.isInteger(seqCovered) || seqCovered < 0) {
+        return json({ error: "bad_seq_covered" }, 400);
+      }
+      const frontier = decodeBase64(request.headers.get("x-chat2-frontier") ?? "");
+      if (frontier === undefined) return json({ error: "bad_frontier" }, 400);
+      const body = new Uint8Array(await request.arrayBuffer());
+      if (body.byteLength > MAX_CHECKPOINT_BYTES) return json({ error: "too_large" }, 413);
+      const outcome = commitCheckpoint(sql, this.blobs, seqCovered, frontier, body, Date.now());
+      if (!outcome.ok) return json({ error: outcome.error }, 409);
+      this.markBackupDirty();
+      return json({ ok: true, seqFloor: outcome.seqFloor, pruned: outcome.pruned });
+    }
+
+    // Everything below reads a claimed room.
+    if (!owner) return json({ error: "not_found" }, 404);
+    if (owner !== userId) return json({ error: "forbidden" }, 403);
+
+    if (url.pathname === "/checkpoint" && request.method === "GET") {
+      const bytes = this.blobs.get(CHECKPOINT_BLOB);
+      if (!bytes) return json({ error: "not_found" }, 404);
+      // Range-resumable (bytes=N- only): a 1MB load over a 1.2Mbps link that
+      // dies at byte 800k resumes, where s2's export-per-join restarted.
+      const range = parseRangeStart(request.headers.get("range"));
+      if (range !== null && range >= bytes.byteLength) {
+        return new Response(null, {
+          status: 416,
+          headers: { "content-range": `bytes */${bytes.byteLength}` }
+        });
+      }
+      const body = range !== null ? bytes.subarray(range) : bytes;
+      const headers = new Headers({
+        "content-type": "application/octet-stream",
+        "content-length": String(body.byteLength),
+        "accept-ranges": "bytes",
+        "x-chat2-checkpoint-seq": getMeta(sql, "checkpointSeq") ?? "0"
+      });
+      if (range !== null) {
+        headers.set(
+          "content-range",
+          `bytes ${range}-${bytes.byteLength - 1}/${bytes.byteLength}`
+        );
+      }
+      return new Response(body, { status: range !== null ? 206 : 200, headers });
+    }
+
+    if ((url.pathname === "/tail" || url.pathname === "/diff") && request.method === "PUT") {
+      const name = url.pathname === "/tail" ? "sidecar-tail" : "sidecar-diff";
+      const body = new Uint8Array(await request.arrayBuffer());
+      if (body.byteLength > MAX_SIDECAR_BYTES) return json({ error: "too_large" }, 413);
+      this.blobs.put(name, body);
+      setMeta(sql, `${name}-type`, request.headers.get("content-type") ?? "application/json");
+      return json({ ok: true, bytes: body.byteLength });
+    }
+
+    if ((url.pathname === "/tail" || url.pathname === "/diff") && request.method === "GET") {
+      const name = url.pathname === "/tail" ? "sidecar-tail" : "sidecar-diff";
+      const bytes = this.blobs.get(name);
+      if (!bytes) return json({ error: "not_found" }, 404);
+      return new Response(bytes, {
+        headers: {
+          "content-type": getMeta(sql, `${name}-type`) ?? "application/json",
+          "content-length": String(bytes.byteLength)
+        }
+      });
+    }
+
+    if (url.pathname === "/stats" && request.method === "GET") {
+      this.sweepPresence();
+      return json({
+        ...logStats(sql),
+        connectedSockets: this.ctx.getWebSockets().length,
+        presence: Object.fromEntries(this.presence),
+        // The ONLY per-device attribution surface — kept from the 2026-08-05
+        // incident tooling (SessionRoom's /stats pushOutcomes).
+        pushOutcomes: JSON.parse(getMeta(sql, "pushOutcomes") ?? "{}") as Record<
+          string,
+          PushOutcome
+        >,
+        lastBackupSeq: Number(getMeta(sql, "backupSeq") ?? "0")
+      });
+    }
+
+    if (url.pathname === "/reset" && request.method === "POST") {
+      // Operator wipe. Recovery is host-driven: the host detects
+      // `headSeq < cursor` on its next hello and re-seeds via checkpoint —
+      // same shape as the registry reset recipe.
+      sql.exec("DELETE FROM rows");
+      sql.exec("DELETE FROM meta");
+      sql.exec("DELETE FROM blobs");
+      for (const ws of this.ctx.getWebSockets()) {
+        try {
+          ws.close(4410, "chat room reset");
+        } catch {
+          /* already gone */
+        }
+      }
+      return json({ ok: true });
+    }
+
+    return json({ error: "not found" }, 404);
+  }
+
+  // ── WebSocket protocol (binary frames, chat-frames.ts) ───────────────────
+
+  async webSocketMessage(ws: WebSocket, message: ArrayBuffer | string): Promise<void> {
+    if (typeof message === "string") {
+      ws.close(1003, "binary frames only");
+      return;
+    }
+    if (message.byteLength > MAX_FRAME_BYTES) {
+      ws.close(1009, "frame too large");
+      return;
+    }
+    const frame = decodeFrame(new Uint8Array(message));
+    const state = ws.deserializeAttachment() as SocketState;
+    if (!frame) {
+      send(ws, FRAME.error, { code: "bad_frame", message: "malformed frame" });
+      return;
+    }
+    switch (frame.type) {
+      case FRAME.hello:
+        this.handleHello(ws, state, frame.header);
+        return;
+      case FRAME.rowsReq:
+        this.handleRowsReq(ws, state, frame.header);
+        return;
+      case FRAME.push:
+        this.handlePush(ws, state, frame.header, frame.payload);
+        return;
+      case FRAME.presence:
+        this.handlePresence(ws, state, frame.header, frame.payload);
+        return;
+      case FRAME.probe:
+        send(ws, FRAME.probeOk, { headSeq: headSeq(this.ctx.storage.sql) });
+        return;
+      default:
+        send(ws, FRAME.error, { code: "bad_frame", message: `unexpected type ${frame.type}` });
+    }
+  }
+
+  async webSocketClose(): Promise<void> {
+    /* nothing buffered; rows are written synchronously on push */
+  }
+
+  async webSocketError(): Promise<void> {
+    /* ditto */
+  }
+
+  private handleHello(ws: WebSocket, state: SocketState, header: Record<string, unknown>): void {
+    if (typeof header.device === "string" && header.device.length > 0) {
+      state.device = header.device;
+    }
+    state.ready = true;
+    ws.serializeAttachment(state);
+    const sql = this.ctx.storage.sql;
+    const stats = logStats(sql);
+    const frontier = this.blobs.get(FRONTIER_BLOB) ?? new Uint8Array(0);
+    // Metadata + frontier only — the CLIENT decides what to load next
+    // (frontier included in local doc → rows only; not included → GET
+    // /checkpoint first; cursor > headSeq → server lost state, re-seed).
+    send(
+      ws,
+      FRAME.state,
+      {
+        headSeq: stats.headSeq,
+        seqFloor: stats.seqFloor,
+        checkpointSeq: stats.checkpointSeq,
+        checkpointSize: stats.checkpointSize,
+        rowCount: stats.rowCount,
+        rowBytes: stats.rowBytes
+      },
+      frontier
+    );
+  }
+
+  private handleRowsReq(ws: WebSocket, state: SocketState, header: Record<string, unknown>): void {
+    if (!state.ready) {
+      send(ws, FRAME.error, { code: "hello_first", message: "rows before hello" });
+      return;
+    }
+    const after = typeof header.after === "number" && header.after >= 0 ? header.after : 0;
+    const exclude = header.excludeOwn === true ? state.device : undefined;
+    const sql = this.ctx.storage.sql;
+    for (const row of rowsAfter(sql, after, exclude)) {
+      send(ws, FRAME.row, { seq: row.seq, device: row.device, batchId: row.batchId }, row.bytes);
+    }
+    send(ws, FRAME.rowsDone, { headSeq: headSeq(sql) });
+  }
+
+  private handlePush(
+    ws: WebSocket,
+    state: SocketState,
+    header: Record<string, unknown>,
+    payload: Uint8Array
+  ): void {
+    const batchId = typeof header.batchId === "string" ? header.batchId : "";
+    if (!state.ready || batchId === "" || batchId.length > 128) {
+      this.recordPush(state.device, false);
+      send(ws, FRAME.error, { code: "bad_push", message: "hello first / malformed push" });
+      return;
+    }
+    if (!this.admitQuota(state.device, payload.byteLength)) {
+      this.recordPush(state.device, false);
+      send(ws, FRAME.error, { code: "quota", message: "per-device push quota exceeded" });
+      return;
+    }
+    const sql = this.ctx.storage.sql;
+    const outcome = appendRow(sql, state.device, batchId, payload, Date.now());
+    if (!outcome.ok) {
+      this.recordPush(state.device, false);
+      send(ws, FRAME.error, { code: outcome.error, message: `push rejected: ${outcome.error}` });
+      return;
+    }
+    this.recordPush(state.device, true);
+    if (!outcome.dup) {
+      this.markBackupDirty();
+      // Live relay to every OTHER ready socket — the sender has its own
+      // bytes; it gets the ack (contrast RegistryRoom, whose LWW merge means
+      // the sender must see the merged truth — here bytes are opaque and
+      // Loro convergence is the client's business).
+      for (const socket of this.ctx.getWebSockets()) {
+        if (socket === ws) continue;
+        const socketState = socket.deserializeAttachment() as SocketState | null;
+        if (!socketState?.ready) continue;
+        send(
+          socket,
+          FRAME.row,
+          { seq: outcome.seq, device: state.device, batchId },
+          payload
+        );
+      }
+    }
+    send(ws, FRAME.ack, { batchId, seq: outcome.seq, dup: outcome.dup });
+  }
+
+  private handlePresence(
+    ws: WebSocket,
+    state: SocketState,
+    header: Record<string, unknown>,
+    payload: Uint8Array
+  ): void {
+    if (!state.ready || state.device === "") return;
+    const at = typeof header.at === "number" ? header.at : Date.now();
+    this.presence.set(state.device, at);
+    this.sweepPresence();
+    // Broadcast-only relay of the opaque payload — no EphemeralStore, no
+    // storage; a device that joins later simply waits for the next beat.
+    for (const socket of this.ctx.getWebSockets()) {
+      if (socket === ws) continue;
+      const socketState = socket.deserializeAttachment() as SocketState | null;
+      if (!socketState?.ready) continue;
+      send(socket, FRAME.presence, { device: state.device, at }, payload);
+    }
+  }
+
+  private sweepPresence(): void {
+    const horizon = Date.now() - PRESENCE_TTL_MS;
+    for (const [device, at] of this.presence) {
+      if (at < horizon) this.presence.delete(device);
+    }
+  }
+
+  /** Rolling per-device quota. True = admitted. */
+  private admitQuota(device: string, bytes: number): boolean {
+    const now = Date.now();
+    const key = device === "" ? "(unknown)" : device;
+    let window = this.quotas.get(key);
+    if (!window || now - window.since > QUOTA_WINDOW_MS) {
+      window = { since: now, pushes: 0, bytes: 0 };
+      this.quotas.set(key, window);
+    }
+    window.pushes += 1;
+    window.bytes += bytes;
+    return window.pushes <= QUOTA_MAX_PUSHES && window.bytes <= QUOTA_MAX_BYTES;
+  }
+
+  private recordPush(device: string, ok: boolean): void {
+    const sql = this.ctx.storage.sql;
+    const key = device === "" ? "(unknown)" : device;
+    const outcomes = JSON.parse(getMeta(sql, "pushOutcomes") ?? "{}") as Record<
+      string,
+      PushOutcome
+    >;
+    const entry = outcomes[key] ?? { ok: 0, rejected: 0, lastOkAt: 0 };
+    if (ok) {
+      entry.ok += 1;
+      entry.lastOkAt = Date.now();
+    } else {
+      entry.rejected += 1;
+    }
+    outcomes[key] = entry;
+    setMeta(sql, "pushOutcomes", JSON.stringify(outcomes));
+  }
+
+  private markBackupDirty(): void {
+    setMeta(this.ctx.storage.sql, "backupDirty", "1");
+    void this.ctx.storage.getAlarm().then((existing) => {
+      if (existing === null) void this.ctx.storage.setAlarm(Date.now() + DAY_MS);
+    });
+  }
+
+  /** Daily alarm: nightly R2 backup, seq-monotonic so a reset-and-reseeding
+   * room can never replace the last good copy with a hollow one. */
+  async alarm(): Promise<void> {
+    const sql = this.ctx.storage.sql;
+    if (getMeta(sql, "backupDirty") !== "1") return; // idle: stop the chain
+    const head = headSeq(sql);
+    if (head > Number(getMeta(sql, "backupSeq") ?? "0")) {
+      const rows = [...rowsAfter(sql, 0)].map((row) => ({
+        seq: row.seq,
+        device: row.device,
+        batchId: row.batchId,
+        bytes: encodeBase64(row.bytes)
+      }));
+      const checkpoint = this.blobs.get(CHECKPOINT_BLOB);
+      const frontier = this.blobs.get(FRONTIER_BLOB);
+      await this.env.BLOBS.put(
+        `backup/chat2/${this.ctx.id.toString()}/latest.json`,
+        JSON.stringify({
+          at: Date.now(),
+          ...logStats(sql),
+          checkpoint: checkpoint ? encodeBase64(checkpoint) : null,
+          frontier: frontier ? encodeBase64(frontier) : null,
+          rows
+        })
+      );
+      setMeta(sql, "backupSeq", String(head));
+    }
+    setMeta(sql, "backupDirty", "0");
+  }
+}
+
+const send = (
+  ws: WebSocket,
+  type: (typeof FRAME)[keyof typeof FRAME],
+  header: Record<string, unknown>,
+  payload?: Uint8Array
+): void => {
+  try {
+    const frame = encodeFrame(type, header, payload);
+    ws.send(frame.buffer.slice(frame.byteOffset, frame.byteOffset + frame.byteLength) as ArrayBuffer);
+  } catch {
+    /* socket already gone; hibernation API cleans it up */
+  }
+};
+
+const json = (value: unknown, status = 200): Response =>
+  new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+
+/** `bytes=N-` (open-ended resume) only; anything fancier is ignored → 200. */
+const parseRangeStart = (header: string | null): number | null => {
+  const match = header?.match(/^bytes=(\d+)-$/);
+  if (!match) return null;
+  const start = Number(match[1]);
+  return Number.isSafeInteger(start) && start > 0 ? start : null;
+};
+
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  }
+  return btoa(bin);
+};
+
+/** Standard base64 (empty string ⇒ empty frontier). `undefined` = malformed. */
+const decodeBase64 = (text: string): Uint8Array | undefined => {
+  try {
+    const bin = atob(text);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  } catch {
+    return undefined;
+  }
+};

--- a/edge/src/chat-room.ts
+++ b/edge/src/chat-room.ts
@@ -311,21 +311,28 @@ export class ChatRoom implements DurableObject {
     payload: Uint8Array
   ): void {
     const batchId = typeof header.batchId === "string" ? header.batchId : "";
+    // Push errors carry the batchId so clients can RETIRE permanently
+    // rejected batches from their replay queues (an unretireable batch
+    // replays on every reconnect forever — the wedge class this replaces).
     if (!state.ready || batchId === "" || batchId.length > 128) {
       this.recordPush(state.device, false);
-      send(ws, FRAME.error, { code: "bad_push", message: "hello first / malformed push" });
+      send(ws, FRAME.error, { code: "bad_push", message: "hello first / malformed push", batchId });
       return;
     }
     if (!this.admitQuota(state.device, payload.byteLength)) {
       this.recordPush(state.device, false);
-      send(ws, FRAME.error, { code: "quota", message: "per-device push quota exceeded" });
+      send(ws, FRAME.error, { code: "quota", message: "per-device push quota exceeded", batchId });
       return;
     }
     const sql = this.ctx.storage.sql;
     const outcome = appendRow(sql, state.device, batchId, payload, Date.now());
     if (!outcome.ok) {
       this.recordPush(state.device, false);
-      send(ws, FRAME.error, { code: outcome.error, message: `push rejected: ${outcome.error}` });
+      send(ws, FRAME.error, {
+        code: outcome.error,
+        message: `push rejected: ${outcome.error}`,
+        batchId
+      });
       return;
     }
     this.recordPush(state.device, true);

--- a/edge/src/env.ts
+++ b/edge/src/env.ts
@@ -4,6 +4,9 @@ export interface Env {
   /** Per-user workspace registries (`reg1/{orgId}/{userId}`) — the row-table
    * replacement for the Loro workspace doc (docs/registry-sync.md). */
   REGISTRY_ROOMS: DurableObjectNamespace;
+  /** chat2 session rooms (`chat2/{chatId}`) — dumb authenticated log relays
+   * replacing SessionRoom's loro-aware s2 rooms (docs/chat2-sync.md). */
+  CHAT_ROOMS: DurableObjectNamespace;
   BLOBS: R2Bucket;
   /** Release artifacts (headless tarballs, dmgs, latest.txt) served at
    * /releases/* for the curl-install flow. */

--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -32,6 +32,12 @@
  *   HEAD /attachments/:sha256
  *   PUT  /blob/:chatId/:partId        — tool-output sidecar (chat2-sync A2)
  *   GET  /blob/:chatId/:partId
+ *   GET  /chat2/:chatId/ws            — chat2 log-relay room (wss, chat2-sync B)
+ *   GET|POST /chat2/:chatId/checkpoint — client-built doc snapshot (Range-resumable GET)
+ *   GET|PUT  /chat2/:chatId/tail      — host-published sidecars, served verbatim
+ *   GET|PUT  /chat2/:chatId/diff
+ *   GET  /chat2/:chatId/stats
+ *   POST /chat2/:chatId/reset
  */
 import { authenticate } from "./auth";
 import { handleAuthRoute } from "./auth-routes";
@@ -39,9 +45,10 @@ import { AUTH_USER_HEADER, ROOM_KIND_HEADER, type Env } from "./env";
 import { SessionRoom } from "./session-room";
 import { DeviceRoom } from "./device-room";
 import { RegistryRoom } from "./registry-room";
+import { ChatRoom } from "./chat-room";
 import installSh from "./install.sh";
 
-export { SessionRoom, DeviceRoom, RegistryRoom };
+export { SessionRoom, DeviceRoom, RegistryRoom, ChatRoom };
 
 const ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
 const SHA256_RE = /^[a-f0-9]{64}$/;
@@ -175,6 +182,41 @@ export default {
     }
     if (parts[0] === "append" && parts[1] && ID_RE.test(parts[1]) && request.method === "POST") {
       return forward(env.SESSION_ROOMS, `s2/${parts[1]}`, request, auth.userId, "/append", "");
+    }
+
+    // ── chat2 rooms (docs/chat2-sync.md B): dumb log relays, one per chat.
+    //    Claim-on-first-join ownership enforced in the DO (chat ids are
+    //    client-minted). The DO handles /ws, /checkpoint (GET Range-resumable
+    //    + POST floor-guarded), host-published /tail + /diff sidecars,
+    //    /stats, /reset. ──────────────────────────────────────────────────────
+    if (parts[0] === "chat2" && parts[1] && ID_RE.test(parts[1]) && parts[2]) {
+      const room = `chat2/${parts[1]}`;
+      if (parts[2] === "ws" && parts.length === 3) {
+        if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+          return json({ error: "expected websocket" }, 426);
+        }
+        return forward(
+          env.CHAT_ROOMS,
+          room,
+          request,
+          auth.userId,
+          "/ws",
+          `?chatId=${parts[1]}${deviceParam(url)}`
+        );
+      }
+      const routes: Record<string, string[]> = {
+        checkpoint: ["GET", "POST"],
+        tail: ["GET", "PUT"],
+        diff: ["GET", "PUT"],
+        stats: ["GET"],
+        reset: ["POST"]
+      };
+      if (parts.length === 3 && routes[parts[2]]?.includes(request.method)) {
+        // Query carries through (`seqCovered` on POST /checkpoint), as do
+        // headers (`x-chat2-frontier`, `range`).
+        return forward(env.CHAT_ROOMS, room, request, auth.userId, `/${parts[2]}`, url.search);
+      }
+      return json({ error: "not found" }, 404);
     }
 
     // ── workspace rooms (ARCHITECTURE §2.2/§6.1): same SessionRoom DO class;

--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -30,6 +30,8 @@
  *   PUT  /attachments/:sha256         — content-addressed upload
  *   GET  /attachments/:sha256
  *   HEAD /attachments/:sha256
+ *   PUT  /blob/:chatId/:partId        — tool-output sidecar (chat2-sync A2)
+ *   GET  /blob/:chatId/:partId
  */
 import { authenticate } from "./auth";
 import { handleAuthRoute } from "./auth-routes";
@@ -43,7 +45,11 @@ export { SessionRoom, DeviceRoom, RegistryRoom };
 
 const ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
 const SHA256_RE = /^[a-f0-9]{64}$/;
+/** Tool part ids are harness-minted (`tool-1`, `call_x`, `m1#c1`-style) —
+ * wider than ID_RE but still no slashes, so a part id can't traverse keys. */
+const PART_RE = /^[A-Za-z0-9._:#~-]{1,200}$/;
 const MAX_ATTACHMENT_BYTES = 32 * 1024 * 1024; // mirrors today's upload cap
+const MAX_TOOL_BLOB_BYTES = 1024 * 1024;
 
 const json = (value: unknown, status = 200): Response =>
   new Response(JSON.stringify(value), {
@@ -299,6 +305,40 @@ export default {
       // and replayed on the host's next join.
       if (parts[2] === "nudge" && request.method === "POST") {
         return forward(env.DEVICE_ROOMS, `d2/${deviceId}`, request, auth.userId, "/nudge", "");
+      }
+    }
+
+    // ── R2 tool-output sidecar (docs/chat2-sync.md A2): full tool outputs
+    //    and diffs live here, keyed `{chatId}/{partId}[.diff]`; the doc keeps
+    //    only a one-line summary + this key. Straight R2, no DO involvement —
+    //    the doc stays thin whether or not these uploads land. Per-user
+    //    prefix = owner auth (same trust shape as /attachments). ────────────
+    if (parts[0] === "blob" && parts.length === 3 && ID_RE.test(parts[1]) && PART_RE.test(parts[2])) {
+      const key = `blob/${auth.userId}/${parts[1]}/${parts[2]}`;
+      if (request.method === "PUT") {
+        const body = await request.arrayBuffer();
+        // Outputs are 4KiB-capped at the harness boundary; diffs can run
+        // larger but a sidecar entry is one tool result, never a dump.
+        if (body.byteLength > MAX_TOOL_BLOB_BYTES) return json({ error: "too_large" }, 413);
+        await env.BLOBS.put(key, body, {
+          httpMetadata: {
+            contentType: request.headers.get("content-type") ?? "text/plain; charset=utf-8"
+          }
+        });
+        return json({ ok: true, bytes: body.byteLength });
+      }
+      if (request.method === "GET" || request.method === "HEAD") {
+        const object =
+          request.method === "GET" ? await env.BLOBS.get(key) : await env.BLOBS.head(key);
+        if (!object) return json({ error: "not_found" }, 404);
+        const headers = new Headers();
+        object.writeHttpMetadata(headers);
+        headers.set("etag", object.httpEtag);
+        // Re-resolved tool parts overwrite their key, so short-lived caching only.
+        headers.set("cache-control", "private, max-age=300");
+        const body =
+          request.method === "GET" && "body" in object ? (object as R2ObjectBody).body : null;
+        return new Response(body, { headers });
       }
     }
 

--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -51,6 +51,15 @@ import installSh from "./install.sh";
 export { SessionRoom, DeviceRoom, RegistryRoom, ChatRoom };
 
 const ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+/** `decodeURIComponent` that answers `undefined` for malformed %-escapes. */
+const safeDecode = (segment: string): string | undefined => {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return undefined;
+  }
+};
 const SHA256_RE = /^[a-f0-9]{64}$/;
 /** Tool part ids are harness-minted (`tool-1`, `call_x`, `m1#c1`-style) —
  * wider than ID_RE but still no slashes, so a part id can't traverse keys. */
@@ -355,8 +364,16 @@ export default {
     //    only a one-line summary + this key. Straight R2, no DO involvement —
     //    the doc stays thin whether or not these uploads land. Per-user
     //    prefix = owner auth (same trust shape as /attachments). ────────────
-    if (parts[0] === "blob" && parts.length === 3 && ID_RE.test(parts[1]) && PART_RE.test(parts[2])) {
-      const key = `blob/${auth.userId}/${parts[1]}/${parts[2]}`;
+    if (parts[0] === "blob" && parts.length === 3 && ID_RE.test(parts[1])) {
+      // Percent-decode the part segment before validating: PART_RE allows
+      // `#` (`m1#c1`-style harness ids), which HTTP clients cannot send raw
+      // (fragment delimiter) — the host percent-encodes it. Decode-then-
+      // validate keeps traversal shut: `%2F` decodes to `/`, fails PART_RE.
+      const partId = safeDecode(parts[2]);
+      if (partId === undefined || !PART_RE.test(partId)) {
+        return json({ error: "bad part id" }, 400);
+      }
+      const key = `blob/${auth.userId}/${parts[1]}/${partId}`;
       if (request.method === "PUT") {
         const body = await request.arrayBuffer();
         // Outputs are 4KiB-capped at the harness boundary; diffs can run

--- a/edge/src/update-log.test.ts
+++ b/edge/src/update-log.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { LoroDoc } from "loro-crdt";
 import { CHUNK_BYTES } from "./blobs";
 import { appendUpdateRow, ensureUpdateLog, readUpdateRows } from "./update-log";
 
@@ -39,6 +40,10 @@ class FakeSql {
     if (query.startsWith("SELECT bytes, cont FROM updates")) {
       return this.rows.map((r) => ({ bytes: r.bytes, cont: r.cont }));
     }
+    if (query.startsWith("DELETE FROM updates")) {
+      this.rows = [];
+      return [];
+    }
     throw new Error(`FakeSql: unhandled query: ${query}`);
   }
 }
@@ -54,9 +59,13 @@ const bytesOf = (len: number, seed: number): Uint8Array => {
 const readAll = (fake: FakeSql): Uint8Array[] => [...readUpdateRows(asSql(fake))];
 
 /** Byte-identical check that stays fast on multi-MB arrays (vitest's deep
- * equality walks element-by-element and times out). */
-const sameBytes = (a: Uint8Array | undefined, b: Uint8Array): boolean =>
-  a !== undefined && Buffer.from(a.buffer, a.byteOffset, a.byteLength).equals(Buffer.from(b.buffer, b.byteOffset, b.byteLength));
+ * equality diffing times out; a plain loop doesn't). No Node Buffer — the
+ * tsconfig has workers types only. */
+const sameBytes = (a: Uint8Array | undefined, b: Uint8Array): boolean => {
+  if (a === undefined || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+};
 
 describe("update log chunking", () => {
   it("stores a small update as a single non-continuation row", () => {
@@ -124,5 +133,48 @@ describe("update log chunking", () => {
     ensureUpdateLog(asSql(sql));
     appendUpdateRow(asSql(sql), bytesOf(10, 1), 1);
     expect(readAll(sql).length).toBe(1);
+  });
+});
+
+describe("fold path over chunked rows", () => {
+  // The session-room fold rides two seams of this module: a cold `ensureDoc`
+  // replay imports each reassembled logical update (a chunked whale row group
+  // must come back as ONE importable update — Loro rejects a partial blob),
+  // and `foldLog` collapses the log into a snapshot with `DELETE FROM
+  // updates` before appends resume. Exercise that full cycle with a real
+  // LoroDoc, not just byte equality.
+  it("replays a chunked whale update, folds it into a snapshot, and keeps appending", () => {
+    const sql = new FakeSql();
+    ensureUpdateLog(asSql(sql));
+
+    // One commit big enough that its single update spans multiple rows.
+    const writer = new LoroDoc();
+    writer.getText("t").insert(0, "whale ".repeat(Math.ceil((2 * CHUNK_BYTES) / 6)));
+    writer.commit();
+    const whale = writer.export({ mode: "update" });
+    expect(whale.byteLength).toBeGreaterThan(CHUNK_BYTES);
+    appendUpdateRow(asSql(sql), whale, 1);
+    expect(sql.rows.length).toBeGreaterThan(1);
+
+    // Cold replay (ensureDoc): every reassembled update must import cleanly.
+    const replayed = new LoroDoc();
+    for (const update of readUpdateRows(asSql(sql))) replayed.import(update);
+    expect(replayed.getText("t").toString() === writer.getText("t").toString()).toBe(true);
+
+    // Fold (foldLog): snapshot the replayed doc, clear the log.
+    const snapshot = replayed.export({ mode: "snapshot" });
+    sql.exec("DELETE FROM updates");
+    expect(readAll(sql).length).toBe(0);
+
+    // Post-fold: new (chunked) appends land against the folded snapshot, and
+    // the next cold replay converges to the full doc.
+    const before = writer.version();
+    writer.getText("t").insert(0, "post-fold ".repeat(Math.ceil(CHUNK_BYTES / 10)));
+    writer.commit();
+    appendUpdateRow(asSql(sql), writer.export({ mode: "update", from: before }), 2);
+    const cold = new LoroDoc();
+    cold.import(snapshot);
+    for (const update of readUpdateRows(asSql(sql))) cold.import(update);
+    expect(cold.getText("t").toString() === writer.getText("t").toString()).toBe(true);
   });
 });

--- a/edge/test/workerd/chat-log.workerd.test.ts
+++ b/edge/test/workerd/chat-log.workerd.test.ts
@@ -1,0 +1,159 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { createBlobStore } from "../../src/blobs";
+import {
+  appendRow,
+  CHECKPOINT_BLOB,
+  commitCheckpoint,
+  ensureChatLog,
+  FRONTIER_BLOB,
+  headSeq,
+  logStats,
+  MAX_ROW_BYTES,
+  rowsAfter,
+  seqFloor
+} from "../../src/chat-log";
+
+/** chat2 log model (docs/chat2-sync.md B) against real DO SQLite — the same
+ * runtime whose ~2MB value cap sank s2's unchunked whale rows. chat2 rows are
+ * capped at 1MB by design, so the platform cap must never be reachable. */
+
+const inRoom = <T>(name: string, fn: (sql: SqlStorage) => T): Promise<T> => {
+  const stub = env.TEST_LOG.get(env.TEST_LOG.idFromName(`chat-${name}`));
+  return runInDurableObject(stub, (_instance, state) => {
+    ensureChatLog(state.storage.sql);
+    return fn(state.storage.sql);
+  });
+};
+
+const bytesOf = (len: number, seed: number): Uint8Array => {
+  const out = new Uint8Array(len);
+  for (let i = 0; i < len; i++) out[i] = (seed + i * 31) & 0xff;
+  return out;
+};
+
+const sameBytes = (a: Uint8Array | undefined, b: Uint8Array): boolean => {
+  if (a === undefined || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+};
+
+describe("chat2 log on real DO SQLite", () => {
+  it("appends assign dense seqs and read back byte-identical", async () => {
+    await inRoom("append", (sql) => {
+      const a = appendRow(sql, "dev-a", "b1", bytesOf(1000, 1), 10);
+      const b = appendRow(sql, "dev-b", "b2", bytesOf(100_000, 2), 11);
+      expect(a).toEqual({ ok: true, seq: 1, dup: false });
+      expect(b).toEqual({ ok: true, seq: 2, dup: false });
+      const rows = [...rowsAfter(sql, 0)];
+      expect(rows.map((r) => [r.seq, r.device, r.batchId])).toEqual([
+        [1, "dev-a", "b1"],
+        [2, "dev-b", "b2"]
+      ]);
+      expect(sameBytes(rows[1]!.bytes, bytesOf(100_000, 2))).toBe(true);
+      expect(headSeq(sql)).toBe(2);
+    });
+  });
+
+  it("batchId replay dedupes to the original seq without appending", async () => {
+    await inRoom("dedupe", (sql) => {
+      appendRow(sql, "dev-a", "b1", bytesOf(10, 1), 10);
+      // The reconnect re-push path: same batch, same bytes, later clock.
+      const replay = appendRow(sql, "dev-a", "b1", bytesOf(10, 1), 99);
+      expect(replay).toEqual({ ok: true, seq: 1, dup: true });
+      expect(headSeq(sql)).toBe(1);
+      expect([...rowsAfter(sql, 0)].length).toBe(1);
+    });
+  });
+
+  it("caps rows at 1MB — comfortably under the platform's ~2MB value cap", async () => {
+    await inRoom("cap", (sql) => {
+      expect(appendRow(sql, "d", "big", bytesOf(MAX_ROW_BYTES + 1, 3), 10)).toEqual({
+        ok: false,
+        error: "too_large"
+      });
+      expect(appendRow(sql, "d", "empty", new Uint8Array(0), 10)).toEqual({
+        ok: false,
+        error: "empty"
+      });
+      // A max-size row must actually fit in real SQLite (the cap's headroom
+      // claim, proven on the platform rather than assumed).
+      expect(appendRow(sql, "d", "max", bytesOf(MAX_ROW_BYTES, 4), 10).ok).toBe(true);
+      expect(sameBytes([...rowsAfter(sql, 0)][0]!.bytes, bytesOf(MAX_ROW_BYTES, 4))).toBe(true);
+    });
+  });
+
+  it("rowsAfter honors the cursor and the exclude-own-device reconnect path", async () => {
+    await inRoom("cursor", (sql) => {
+      appendRow(sql, "dev-a", "b1", bytesOf(8, 1), 10);
+      appendRow(sql, "dev-b", "b2", bytesOf(8, 2), 11);
+      appendRow(sql, "dev-a", "b3", bytesOf(8, 3), 12);
+      expect([...rowsAfter(sql, 1)].map((r) => r.seq)).toEqual([2, 3]);
+      // A reconnecting dev-a never re-downloads its own offline writes.
+      expect([...rowsAfter(sql, 0, "dev-a")].map((r) => r.batchId)).toEqual(["b2"]);
+    });
+  });
+
+  it("checkpoint commit prunes covered rows and stores blob + frontier", async () => {
+    await inRoom("checkpoint", (sql) => {
+      const blobs = createBlobStore(sql);
+      for (let i = 1; i <= 5; i++) appendRow(sql, "dev-a", `b${i}`, bytesOf(50, i), i);
+      const checkpoint = bytesOf(200_000, 9);
+      const frontier = bytesOf(40, 8);
+      const outcome = commitCheckpoint(sql, blobs, 3, frontier, checkpoint, 1000);
+      expect(outcome).toEqual({ ok: true, seqFloor: 3, pruned: 3 });
+      expect([...rowsAfter(sql, 0)].map((r) => r.seq)).toEqual([4, 5]);
+      expect(seqFloor(sql)).toBe(3);
+      expect(sameBytes(blobs.get(CHECKPOINT_BLOB), checkpoint)).toBe(true);
+      expect(sameBytes(blobs.get(FRONTIER_BLOB), frontier)).toBe(true);
+      const stats = logStats(sql);
+      expect(stats.checkpointSeq).toBe(3);
+      expect(stats.checkpointSize).toBe(200_000);
+      expect(stats.rowCount).toBe(2);
+    });
+  });
+
+  it("checkpoint guard is floor-monotonic and head-bounded", async () => {
+    await inRoom("guard", (sql) => {
+      const blobs = createBlobStore(sql);
+      for (let i = 1; i <= 4; i++) appendRow(sql, "dev-a", `b${i}`, bytesOf(50, i), i);
+      expect(commitCheckpoint(sql, blobs, 3, bytesOf(4, 1), bytesOf(100, 1), 1000).ok).toBe(true);
+      // Regressing the floor (a stale device posting an old rebuild) is
+      // rejected — the dumb replacement for s2's VV-monotonic R2 guard.
+      expect(commitCheckpoint(sql, blobs, 2, bytesOf(4, 2), bytesOf(100, 2), 2000)).toEqual({
+        ok: false,
+        error: "floor_regression"
+      });
+      // Claiming rows that don't exist yet is rejected.
+      expect(commitCheckpoint(sql, blobs, 99, bytesOf(4, 3), bytesOf(100, 3), 3000)).toEqual({
+        ok: false,
+        error: "ahead_of_head"
+      });
+      // A rejected commit must not clobber the stored blob (the guard runs
+      // BEFORE the write).
+      expect(sameBytes(blobs.get(CHECKPOINT_BLOB), bytesOf(100, 1))).toBe(true);
+      // Same-floor re-post (the benign two-identical-rebuilds race in M5) wins.
+      expect(commitCheckpoint(sql, blobs, 3, bytesOf(4, 4), bytesOf(100, 4), 4000).ok).toBe(true);
+      expect(sameBytes(blobs.get(CHECKPOINT_BLOB), bytesOf(100, 4))).toBe(true);
+    });
+  });
+
+  it("a churn cycle stays bounded: push → checkpoint → push never accumulates", async () => {
+    // The exit criterion shape from the plan (churn_stays_bounded): N rounds
+    // of streaming with periodic checkpoints leave rows ≤ one round's worth.
+    await inRoom("churn", (sql) => {
+      const blobs = createBlobStore(sql);
+      let pushed = 0;
+      for (let round = 0; round < 10; round++) {
+        for (let i = 0; i < 20; i++) {
+          pushed += 1;
+          appendRow(sql, "dev-a", `r${round}-${i}`, bytesOf(2000, pushed), pushed);
+        }
+        commitCheckpoint(sql, blobs, headSeq(sql), bytesOf(8, round), bytesOf(50_000, round), round);
+        expect(logStats(sql).rowCount).toBe(0);
+      }
+      expect(headSeq(sql)).toBe(200);
+      expect(seqFloor(sql)).toBe(200);
+    });
+  });
+});

--- a/edge/test/workerd/env.d.ts
+++ b/edge/test/workerd/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="@cloudflare/vitest-pool-workers" />
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv {
+    TEST_LOG: DurableObjectNamespace;
+  }
+}

--- a/edge/test/workerd/fixture.ts
+++ b/edge/test/workerd/fixture.ts
@@ -1,0 +1,11 @@
+import { DurableObject } from "cloudflare:workers";
+
+/** Bare SQLite-backed DO; tests reach its real `ctx.storage.sql` via
+ * `runInDurableObject` (the cloudflare-os TEST_OVERSEER pattern). */
+export class TestLogRoom extends DurableObject {}
+
+export default {
+  fetch(): Response {
+    return new Response("test fixture", { status: 404 });
+  }
+};

--- a/edge/test/workerd/update-log.workerd.test.ts
+++ b/edge/test/workerd/update-log.workerd.test.ts
@@ -1,0 +1,84 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { CHUNK_BYTES } from "../../src/blobs";
+import { appendUpdateRow, ensureUpdateLog, readUpdateRows } from "../../src/update-log";
+
+/** Real-runtime twin of src/update-log.test.ts: same seams, but against an
+ * actual SQLite-backed DO so the ~2MB value cap is the platform's, not a
+ * FakeSql constant. A cap change or a chunking regression fails here first. */
+
+// Each test gets its own DO (fresh storage) keyed by test name.
+const inRoom = <T>(name: string, fn: (sql: SqlStorage) => T): Promise<T> => {
+  const stub = env.TEST_LOG.get(env.TEST_LOG.idFromName(name));
+  return runInDurableObject(stub, (_instance, state) => fn(state.storage.sql));
+};
+
+const bytesOf = (len: number, seed: number): Uint8Array => {
+  const out = new Uint8Array(len);
+  for (let i = 0; i < len; i++) out[i] = (seed + i * 31) & 0xff;
+  return out;
+};
+
+// No Buffer in workerd; plain loop stays fast enough for a few MB.
+const sameBytes = (a: Uint8Array | undefined, b: Uint8Array): boolean => {
+  if (a === undefined || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+};
+
+describe("update log on real DO SQLite", () => {
+  it("the platform still caps SQL values around 2MB (the assumption FakeSql hardcodes)", async () => {
+    await inRoom("cap-probe", (sql) => {
+      sql.exec("CREATE TABLE probe (bytes BLOB)");
+      // A chunk-sized value must fit — CHUNK_BYTES exists to stay under the cap.
+      sql.exec("INSERT INTO probe (bytes) VALUES (?)", bytesOf(CHUNK_BYTES, 1).buffer);
+      // An unchunked whale-sized value must still be rejected; if this ever
+      // passes, the cap moved and CHUNK_BYTES/this tier need revisiting.
+      expect(() =>
+        sql.exec("INSERT INTO probe (bytes) VALUES (?)", bytesOf(3 * CHUNK_BYTES, 2).buffer)
+      ).toThrowError(/too big|toobig/i);
+    });
+  });
+
+  it("a whale update above the row cap round-trips byte-identically", async () => {
+    await inRoom("whale-roundtrip", (sql) => {
+      ensureUpdateLog(sql);
+      const whale = bytesOf(3 * CHUNK_BYTES + 123, 7);
+      appendUpdateRow(sql, whale, 42);
+      const back = [...readUpdateRows(sql)];
+      expect(back.length).toBe(1);
+      expect(sameBytes(back[0], whale)).toBe(true);
+    });
+  });
+
+  it("keeps interleaved small and chunked updates in seq order", async () => {
+    await inRoom("interleaved", (sql) => {
+      ensureUpdateLog(sql);
+      const updates = [bytesOf(10, 1), bytesOf(CHUNK_BYTES + 5, 2), bytesOf(20, 3)];
+      for (const u of updates) appendUpdateRow(sql, u, 42);
+      const back = [...readUpdateRows(sql)];
+      expect(back.length).toBe(3);
+      for (let i = 0; i < updates.length; i++) expect(sameBytes(back[i], updates[i]!)).toBe(true);
+    });
+  });
+
+  it("migrates a legacy pre-cont table via real ALTER TABLE", async () => {
+    await inRoom("legacy-migration", (sql) => {
+      // The table exactly as created before the cont column existed.
+      sql.exec(
+        "CREATE TABLE updates (seq INTEGER PRIMARY KEY AUTOINCREMENT, bytes BLOB NOT NULL, received_at INTEGER NOT NULL)"
+      );
+      sql.exec("INSERT INTO updates (bytes, received_at) VALUES (?, ?)", bytesOf(10, 1).buffer, 1);
+      sql.exec("INSERT INTO updates (bytes, received_at) VALUES (?, ?)", bytesOf(11, 2).buffer, 2);
+      ensureUpdateLog(sql);
+      // Legacy rows read back as one update each (ALTER's DEFAULT 0)…
+      expect([...readUpdateRows(sql)].length).toBe(2);
+      // …and post-migration chunked appends land on the migrated table.
+      appendUpdateRow(sql, bytesOf(CHUNK_BYTES + 1, 3), 3);
+      expect([...readUpdateRows(sql)].length).toBe(3);
+      // Idempotence on the (now migrated) real table.
+      ensureUpdateLog(sql);
+      expect([...readUpdateRows(sql)].length).toBe(3);
+    });
+  });
+});

--- a/edge/vitest.config.ts
+++ b/edge/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+// Pure-logic unit tests (Node, FakeSql). The workerd tier lives in
+// vitest.workerd.config.ts and must not be picked up here: its tests import
+// `cloudflare:test`, which only resolves inside the workers pool.
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"]
+  }
+});

--- a/edge/vitest.workerd.config.ts
+++ b/edge/vitest.workerd.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from "vitest/config";
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+
+// Runtime-real test tier: runs inside actual workerd via
+// @cloudflare/vitest-pool-workers, against a real SQLite-backed Durable
+// Object, so platform limits like the ~2MB SQLITE_TOOBIG row cap (the
+// 2026-08-05 whale sync freeze) are the runtime's own, not FakeSql constants.
+// `npm run test:workerd`.
+//
+// loro-wasm does NOT work in this tier: the pool's test runner evaluates
+// modules where wasm codegen is disallowed, while a real worker compiles the
+// base64-inlined module at startup (deployed edge and `wrangler dev` are
+// fine). loro-on-workerd coverage lives in the wrangler-dev scripts
+// (scripts/whale-check.mjs, scripts/fold-check.mjs).
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      main: "./test/workerd/fixture.ts",
+      miniflare: {
+        compatibilityDate: "2026-07-01",
+        durableObjects: {
+          TEST_LOG: { className: "TestLogRoom", useSQLite: true }
+        }
+      }
+    })
+  ],
+  resolve: {
+    // Mirror wrangler.jsonc: workerd cannot fetch loro's WASM by URL; the
+    // base64 entry inlines it.
+    alias: { "loro-crdt": "loro-crdt/base64" }
+  },
+  test: {
+    include: ["test/workerd/**/*.test.ts"]
+  }
+});

--- a/edge/wrangler.chat2test.jsonc
+++ b/edge/wrangler.chat2test.jsonc
@@ -1,0 +1,39 @@
+{
+  // TEMPORARY test deployment of the chat2-sync branch worker — dev auth,
+  // isolated R2 bucket, workers.dev only. Delete the worker + bucket after
+  // testing (scripts/chat2-e2e teardown). NOT the production config.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "comet-native-edge-chat2test2",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-01",
+  "account_id": "b57dde68ee5964dccc025437b5478a5b",
+  "workers_dev": true,
+  "rules": [{ "type": "Text", "globs": ["**/*.sh"], "fallthrough": true }],
+  "alias": {
+    "loro-crdt": "loro-crdt/base64"
+  },
+  "durable_objects": {
+    "bindings": [
+      { "name": "SESSION_ROOMS", "class_name": "SessionRoom" },
+      { "name": "DEVICE_ROOMS", "class_name": "DeviceRoom" },
+      { "name": "REGISTRY_ROOMS", "class_name": "RegistryRoom" },
+      { "name": "CHAT_ROOMS", "class_name": "ChatRoom" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["SessionRoom", "DeviceRoom"] },
+    { "tag": "v2", "new_sqlite_classes": ["RegistryRoom"] },
+    { "tag": "v3", "new_sqlite_classes": ["ChatRoom"] }
+  ],
+  "r2_buckets": [
+    { "binding": "BLOBS", "bucket_name": "comet-native-blobs-chat2test" },
+    { "binding": "RELEASES", "bucket_name": "comet-native-blobs-chat2test" }
+  ],
+  "vars": {
+    "WORKOS_CLIENT_ID": "client_01KWD0EAKZKD50YCQJNYSRE4BY",
+    "AUTH_MODE": "dev"
+  },
+  "observability": {
+    "enabled": true
+  }
+}

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -32,7 +32,8 @@
     "bindings": [
       { "name": "SESSION_ROOMS", "class_name": "SessionRoom" },
       { "name": "DEVICE_ROOMS", "class_name": "DeviceRoom" },
-      { "name": "REGISTRY_ROOMS", "class_name": "RegistryRoom" }
+      { "name": "REGISTRY_ROOMS", "class_name": "RegistryRoom" },
+      { "name": "CHAT_ROOMS", "class_name": "ChatRoom" }
     ]
   },
   "migrations": [
@@ -45,6 +46,12 @@
       // sync that replaces the Loro workspace doc rooms.
       "tag": "v2",
       "new_sqlite_classes": ["RegistryRoom"]
+    },
+    {
+      // chat2 session rooms (docs/chat2-sync.md) — dumb log relays that
+      // replace SessionRoom's loro-aware s2 rooms.
+      "tag": "v3",
+      "new_sqlite_classes": ["ChatRoom"]
     }
   ],
   "r2_buckets": [


### PR DESCRIPTION
Implements workstreams A, B, C1/C2, and M1 of the chat2 dumb-relay sync plan (docs/chat2-sync.md). Motivation: whale chats (1MB+ docs with capped tool outputs) wedge the current loro session rooms server-side; chat2 replaces the wasm-bearing room with a dumb authenticated log relay, and heals existing whales by thin rebuild instead of in-place repair.

- **A — thin docs** (9dff5d1): fold strips tool output to a 160-char summary + byte count and diffs to stats; full payloads go to an R2 sidecar (`PUT/GET /blob/:chatId/:partId`, 1MB cap) with render-time upgrade in the UI ("Show full output (N KB)").
- **B — ChatRoom DO** (3bc63f7): `edge/src/chat-room.ts` — zero-wasm append log modeled on RegistryRoom, with pure `chat-log.ts` (dedupe by batchId, checkpoint floor-guard) and a binary frame codec. Routes under `/chat2/:chatId/*`, new `CHAT_ROOMS` binding.
- **C1/C2 — Rust client** (d9c78a3): `crates/sync/src/chat_client.rs` with precise catch-up planning, reconnect-surviving pending queue (batchId replay), and a cursor+epoch-bearing snapshot store (migration v2, same-tx save rule).
- **M1 — thin rebuild** (df57aae): `rebuild_thin_doc` produces an epoch-2 thin doc + sidecar entries; idempotent, only Pending commands cross the rebuild.
- Test infra prep (ca8a6ba): edge tests split into unit/workerd tiers via vitest-pool-workers.

All suites green: Rust workspace 384+ UI / 68 doc / 31 sync tests; edge 36 unit + 11 workerd. (`cargo test -p comet-sync` needs `--features mock-server`.)

Not in this PR (next up): C3 host wiring (checkpoint policy, tail/diff publish over chat2, engine sink/fetcher impls), roomGen registry cutover, epoch<2 discard-and-adopt on readers. Nothing here changes live sync paths yet — new code is not wired into the host.

Fittingly, the session that built this had its own chat wedge mid-run via the exact bug class this replaces (room stopped acking at 02:01Z while "connected"; clientDisconnected churn 853/hr, zero exceptions) — with the whale chunking fix (6cee4af) already deployed, confirming a second silent failure mode remains in the s2 rooms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788922098&installation_model_id=425430&pr_number=34&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F34&signature=dfc4487b39b74ec5093f522285b31083e662d4ce8c9447dbfd434e4342c10fb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->