### PR TITLE
Add Cursor ACP harness (`cursor-agent acp`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Comet
 
-Control your coding agents (Claude Code, Codex, Grok, Hermes, Pi) from any of
-your devices.
+Control your coding agents (Claude Code, Codex, Cursor, Grok, Hermes, Pi) from
+any of your devices.
 
 ![Comet running a Claude Code session](docs/screenshot.png)
 

--- a/crates/engine/src/registry.rs
+++ b/crates/engine/src/registry.rs
@@ -199,9 +199,7 @@ impl HarnessRegistry {
             }
         };
         let tmp = path.with_extension("json.tmp");
-        if let Err(err) =
-            std::fs::write(&tmp, json).and_then(|()| std::fs::rename(&tmp, &path))
-        {
+        if let Err(err) = std::fs::write(&tmp, json).and_then(|()| std::fs::rename(&tmp, &path)) {
             tracing::warn!(error = %err, "harness-prefs save failed");
         }
     }
@@ -378,6 +376,23 @@ pub fn default_registry() -> HarnessRegistry {
         Box::new(|| comet_harness::AcpHarness::codex().installed()),
         Box::new(|| Ok(Arc::new(comet_harness::AcpHarness::codex()) as Arc<dyn Harness>)),
     );
+    // Cursor Agent over ACP (`cursor-agent acp`), same lazy pattern: the
+    // static descriptor mirrors AcpHarness::cursor() exactly. No steering
+    // extension (turn boundaries) and no effort ladder — Cursor bakes effort
+    // into the model id's bracket suffix instead of a `thought_level` option.
+    registry.register_lazy(
+        HarnessDescriptor {
+            id: HarnessId::Cursor,
+            name: "Cursor".into(),
+            supports_steering: true,
+            steering_mode: SteeringMode::TurnBoundary,
+            reasoning_levels: Vec::new(),
+            installed: true,
+            enabled: None,
+        },
+        Box::new(|| comet_harness::AcpHarness::cursor().installed()),
+        Box::new(|| Ok(Arc::new(comet_harness::AcpHarness::cursor()) as Arc<dyn Harness>)),
+    );
     // Grok Build over ACP, same lazy pattern: the static descriptor mirrors
     // AcpHarness::grok() exactly. No `_session/steering` extension yet, so
     // steers deliver at turn boundaries; the effort ladder applies per
@@ -492,6 +507,7 @@ mod tests {
                 HarnessId::Mock,
                 HarnessId::ClaudeCode,
                 HarnessId::Codex,
+                HarnessId::Cursor,
                 HarnessId::Grok,
                 HarnessId::Hermes,
                 HarnessId::Pi
@@ -517,7 +533,12 @@ mod tests {
                 ReasoningLevel::High
             ]
         );
-        // Hermes and Pi mirror their specs the same way.
+        // Cursor, Hermes and Pi mirror their specs the same way.
+        let cursor = registry.resolve(HarnessId::Cursor).unwrap();
+        assert_eq!(cursor.id(), HarnessId::Cursor);
+        assert_eq!(cursor.display_name(), "Cursor");
+        assert_eq!(cursor.steering_mode(), SteeringMode::TurnBoundary);
+        assert!(cursor.reasoning_levels().is_empty());
         let hermes = registry.resolve(HarnessId::Hermes).unwrap();
         assert_eq!(hermes.id(), HarnessId::Hermes);
         assert_eq!(hermes.display_name(), "Hermes");

--- a/crates/harness/src/acp/cursor.rs
+++ b/crates/harness/src/acp/cursor.rs
@@ -1,0 +1,751 @@
+//! Cursor ACP model enrichment.
+//!
+//! Cursor's ACP server has two picker shapes on the wire:
+//! - **variants** (default): exploded ids like `auto-smart[optimize_for=balanced]`.
+//! - **parameterized** (`clientCapabilities._meta.parameterizedModelPicker`):
+//!   base ids (`auto-smart`) plus real config options (`optimize_for`,
+//!   `effort`, `fast`, `thinking`, `context`).
+//!
+//! Comet opts into parameterized mode. Auto's Intelligence / Balance / Cost
+//! tiers are the `optimize_for` select advertised on the session. HTML effort
+//! badges still appear on some display names and are stripped.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use comet_proto::{Model, ModelOption, ModelOptionChoice, ReasoningLevel};
+use serde_json::Value;
+
+/// Strip Cursor's effort-badge HTML from a model name and return the plain
+/// label plus the badge text when present.
+///
+/// The badge is a muted High/Medium/Low chip in Cursor's own UI — not markup
+/// Comet can render — so callers put it on the description subline (or fold
+/// it into a Reasoning ladder when the family has multiple variants).
+pub(crate) fn clean_label(name: &str) -> (String, Option<String>) {
+    let mut badges = Vec::new();
+    let mut out = String::with_capacity(name.len());
+    let bytes = name.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            if let Some(end) = name[i..].find('>') {
+                let tag = &name[i..i + end + 1];
+                let lower = tag.to_ascii_lowercase();
+                if lower.starts_with("<span") {
+                    let content_start = i + end + 1;
+                    if let Some(close) = name[content_start..].to_ascii_lowercase().find("</span>")
+                    {
+                        let badge = name[content_start..content_start + close].trim();
+                        if !badge.is_empty() {
+                            badges.push(badge.to_owned());
+                        }
+                        i = content_start + close + "</span>".len();
+                        continue;
+                    }
+                }
+                // Drop any other tag wholesale.
+                i += end + 1;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    let mut label = out.split_whitespace().collect::<Vec<_>>().join(" ");
+    let badge = badges.into_iter().next();
+    // Display names sometimes duplicate the badge in plain text
+    // ("Example (Low)" + span Low). Trim a trailing copy so the subline is
+    // the only place it appears.
+    if let Some(badge) = badge.as_deref() {
+        for suffix in [
+            format!(" ({badge})"),
+            format!(" {badge}"),
+            format!("({badge})"),
+        ] {
+            if let Some(stripped) = label
+                .strip_suffix(&suffix)
+                .or_else(|| label.strip_suffix(&suffix.to_ascii_lowercase()))
+            {
+                label = stripped.trim_end().to_owned();
+                break;
+            }
+        }
+    }
+    (label, badge)
+}
+
+/// Bracket params on a Cursor model id (`key=value` pairs inside `[…]`).
+pub(crate) fn parse_params(model_id: &str) -> BTreeMap<String, String> {
+    let Some(start) = model_id.find('[') else {
+        return BTreeMap::new();
+    };
+    let Some(end) = model_id.rfind(']') else {
+        return BTreeMap::new();
+    };
+    if end <= start + 1 {
+        return BTreeMap::new();
+    }
+    let mut params = BTreeMap::new();
+    for part in model_id[start + 1..end].split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (k, v) = match part.split_once('=') {
+            Some((k, v)) => (k.trim(), v.trim()),
+            None => continue,
+        };
+        if !k.is_empty() {
+            params.insert(k.to_owned(), v.to_owned());
+        }
+    }
+    params
+}
+
+fn base_id(model_id: &str) -> &str {
+    model_id.split_once('[').map(|(b, _)| b).unwrap_or(model_id)
+}
+
+/// Family key used to collapse effort variants (`example-low` → `example`).
+pub(crate) fn family_key(model_id: &str) -> String {
+    let base = base_id(model_id);
+    for suffix in ["-low", "-medium", "-high", "-xhigh", "-max"] {
+        if let Some(stem) = base.strip_suffix(suffix) {
+            return stem.to_owned();
+        }
+    }
+    base.to_owned()
+}
+
+/// Effort / reasoning value declared on a Cursor model row, from brackets,
+/// id suffix, or the HTML badge.
+pub(crate) fn effort_of(model_id: &str, badge: Option<&str>) -> Option<String> {
+    let params = parse_params(model_id);
+    for key in ["effort", "reasoning", "reasoning_effort"] {
+        if let Some(v) = params.get(key) {
+            return Some(v.to_ascii_lowercase());
+        }
+    }
+    let base = base_id(model_id);
+    for (suffix, value) in [
+        ("-low", "low"),
+        ("-medium", "medium"),
+        ("-high", "high"),
+        ("-xhigh", "xhigh"),
+        ("-max", "max"),
+    ] {
+        if base.ends_with(suffix) {
+            return Some(value.into());
+        }
+    }
+    badge.map(|b| b.trim().to_ascii_lowercase())
+}
+
+pub(crate) fn reasoning_from_effort(value: &str) -> Option<ReasoningLevel> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "minimal" => Some(ReasoningLevel::Minimal),
+        "low" => Some(ReasoningLevel::Low),
+        "medium" => Some(ReasoningLevel::Medium),
+        "high" => Some(ReasoningLevel::High),
+        "xhigh" | "x-high" => Some(ReasoningLevel::XHigh),
+        "max" => Some(ReasoningLevel::Max),
+        _ => None,
+    }
+}
+
+fn effort_for_level(level: ReasoningLevel) -> &'static str {
+    match level {
+        ReasoningLevel::Minimal => "minimal",
+        ReasoningLevel::Low => "low",
+        ReasoningLevel::Medium => "medium",
+        ReasoningLevel::High => "high",
+        ReasoningLevel::XHigh => "xhigh",
+        ReasoningLevel::Max => "max",
+        // Cursor never advertises these; map to the top of its ladder.
+        ReasoningLevel::Ultra | ReasoningLevel::Ultracode | ReasoningLevel::Ultrathink => "xhigh",
+    }
+}
+
+/// Strip a Cursor exploded-variant suffix (`auto-smart[optimize_for=cost]` →
+/// `auto-smart`) so a saved id from the old picker still matches parameterized
+/// `session/set_config_option`.
+pub(crate) fn strip_variant_suffix(id: &str) -> &str {
+    id.split_once('[').map(|(b, _)| b).unwrap_or(id)
+}
+
+/// Auto's Optimize For trait (Intelligence / Balance / Cost). Injected on
+/// `auto-smart` even when the current wire model isn't Auto — Cursor's ACP
+/// session only lists parameters for the selected model.
+pub(crate) fn optimize_for_option(current: Option<&str>) -> ModelOption {
+    ModelOption {
+        id: "optimize_for".into(),
+        label: "Optimize For".into(),
+        choices: vec![
+            ModelOptionChoice {
+                id: "intelligence".into(),
+                label: "Intelligence".into(),
+            },
+            ModelOptionChoice {
+                id: "balanced".into(),
+                label: "Balance".into(),
+            },
+            ModelOptionChoice {
+                id: "cost".into(),
+                label: "Cost".into(),
+            },
+        ],
+        default_choice: match current {
+            Some(v @ ("intelligence" | "cost")) => v.to_owned(),
+            _ => "balanced".into(),
+        },
+    }
+}
+
+fn mode_option(current: Option<&str>) -> ModelOption {
+    let default = match current {
+        Some("plan") => "plan",
+        Some("ask") => "ask",
+        _ => "agent",
+    };
+    ModelOption {
+        id: "mode".into(),
+        label: "Mode".into(),
+        choices: vec![
+            ModelOptionChoice {
+                id: "agent".into(),
+                label: "Agent".into(),
+            },
+            ModelOptionChoice {
+                id: "plan".into(),
+                label: "Plan".into(),
+            },
+            ModelOptionChoice {
+                id: "ask".into(),
+                label: "Ask".into(),
+            },
+        ],
+        default_choice: default.into(),
+    }
+}
+
+fn param_description(params: &BTreeMap<String, String>, badge: Option<&str>) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(ctx) = params.get("context") {
+        parts.push(ctx.clone());
+    }
+    let effort = params
+        .get("effort")
+        .or_else(|| params.get("reasoning"))
+        .or_else(|| params.get("reasoning_effort"))
+        .cloned()
+        .or_else(|| badge.map(str::to_owned));
+    if let Some(effort) = effort {
+        // Title-case the badge-style label Cursor uses in HTML.
+        let pretty = match effort.to_ascii_lowercase().as_str() {
+            "xhigh" | "x-high" => "XHigh".into(),
+            other => {
+                let mut c = other.chars();
+                match c.next() {
+                    Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+                    None => other.to_owned(),
+                }
+            }
+        };
+        parts.push(pretty);
+    }
+    if params.get("fast").is_some_and(|v| v == "true")
+        || params.get("speed").is_some_and(|v| v == "true")
+    {
+        parts.push("Fast".into());
+    }
+    if params.get("thinking").is_some_and(|v| v == "true") {
+        parts.push("Thinking".into());
+    }
+    if params.get("optimize_for").is_some_and(|v| v == "balanced") {
+        parts.push("Balanced".into());
+    }
+    (!parts.is_empty()).then(|| parts.join(" · "))
+}
+
+fn config_options(session: &Value) -> &[Value] {
+    session
+        .get("configOptions")
+        .and_then(Value::as_array)
+        .map(|a| a.as_slice())
+        .unwrap_or_default()
+}
+
+fn option_current<'a>(options: &'a [Value], id: &str) -> Option<&'a str> {
+    options
+        .iter()
+        .find(|o| o.get("id").and_then(Value::as_str) == Some(id))
+        .and_then(|o| o.get("currentValue").and_then(Value::as_str))
+}
+
+fn model_option_from_config(option: &Value) -> Option<ModelOption> {
+    let id = option.get("id").and_then(Value::as_str)?;
+    let label = option.get("name").and_then(Value::as_str).unwrap_or(id);
+    let choices: Vec<ModelOptionChoice> = option
+        .get("options")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(|c| {
+            let cid = c.get("value").and_then(Value::as_str)?;
+            Some(ModelOptionChoice {
+                id: cid.to_owned(),
+                label: c
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or(cid)
+                    .to_owned(),
+            })
+        })
+        .collect();
+    if choices.len() < 2 {
+        return None;
+    }
+    let default_choice = option
+        .get("currentValue")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| choices.first().map(|c| c.id.clone()))?;
+    Some(ModelOption {
+        id: id.to_owned(),
+        label: label.to_owned(),
+        choices,
+        default_choice,
+    })
+}
+
+fn thought_ladder(option: &Value) -> Option<Vec<ReasoningLevel>> {
+    let mut ladder: Vec<ReasoningLevel> = option
+        .get("options")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(|c| c.get("value").and_then(Value::as_str))
+        .filter_map(reasoning_from_effort)
+        .collect();
+    ladder.sort();
+    ladder.dedup();
+    (ladder.len() >= 2).then_some(ladder)
+}
+
+fn is_auto_smart(id: &str) -> bool {
+    strip_variant_suffix(id) == "auto-smart"
+}
+
+/// Majority base ids (no `[key=value]` suffix) → parameterized picker.
+fn looks_parameterized(models: &[Model]) -> bool {
+    if models.is_empty() {
+        return true;
+    }
+    let exploded = models
+        .iter()
+        .filter(|m| parse_params(&m.id).len() > 0)
+        .count();
+    exploded * 2 < models.len()
+}
+
+/// Rewrite the wire model list into Comet's picker shape.
+pub(crate) fn enrich_models(models: Vec<Model>, session: &Value) -> Vec<Model> {
+    let options = config_options(session);
+    let mode_current = option_current(options, "mode");
+    if looks_parameterized(&models) {
+        enrich_parameterized(models, options, mode_current)
+    } else {
+        enrich_exploded(models, mode_current)
+    }
+}
+
+/// Parameterized catalog: base ids + real config options. Cursor's ACP
+/// session only lists parameters for the *currently selected* model, so we
+/// never copy those onto every row — Auto always gets Optimize For (from
+/// the wire, or the public Intelligence/Balance/Cost defaults), and the
+/// current model's extra options/ladder stay on that row alone.
+fn enrich_parameterized(
+    models: Vec<Model>,
+    options: &[Value],
+    mode_current: Option<&str>,
+) -> Vec<Model> {
+    let mode = mode_option(mode_current);
+    let optimize = options
+        .iter()
+        .find(|o| o.get("id").and_then(Value::as_str) == Some("optimize_for"))
+        .and_then(model_option_from_config)
+        .unwrap_or_else(|| optimize_for_option(option_current(options, "optimize_for")));
+    let current_id = option_current(options, "model").map(strip_variant_suffix);
+    let current_extras: Vec<ModelOption> = options
+        .iter()
+        .filter(|o| {
+            matches!(
+                o.get("category").and_then(Value::as_str),
+                Some("model_config")
+            ) && o.get("id").and_then(Value::as_str) != Some("optimize_for")
+        })
+        .filter_map(model_option_from_config)
+        .collect();
+    let mut current_ladder = Vec::new();
+    let mut current_thought_toggles = Vec::new();
+    for option in options
+        .iter()
+        .filter(|o| o.get("category").and_then(Value::as_str) == Some("thought_level"))
+    {
+        if let Some(ladder) = thought_ladder(option) {
+            current_ladder = ladder;
+        } else if let Some(toggle) = model_option_from_config(option) {
+            current_thought_toggles.push(toggle);
+        }
+    }
+
+    models
+        .into_iter()
+        .map(|mut model| {
+            let (label, _) = clean_label(&model.label);
+            model.label = label;
+            model.id = strip_variant_suffix(&model.id).to_owned();
+            // Discovery clones the current model's wire traits onto every
+            // row; those are wrong under parameterized mode.
+            model.options.clear();
+            model.reasoning_levels.clear();
+            model.options.push(mode.clone());
+            if is_auto_smart(&model.id) {
+                model.options.push(optimize.clone());
+            }
+            if current_id == Some(model.id.as_str()) {
+                model.options.extend(current_extras.iter().cloned());
+                model
+                    .options
+                    .extend(current_thought_toggles.iter().cloned());
+                model.reasoning_levels = current_ladder.clone();
+            }
+            model
+        })
+        .collect()
+}
+
+/// Legacy exploded-variant catalog (no parameterizedModelPicker): cleaned
+/// labels, Mode, and collapsed effort families whose Reasoning ladder
+/// switches the model id.
+fn enrich_exploded(models: Vec<Model>, mode_current: Option<&str>) -> Vec<Model> {
+    // Preserve wire order while grouping by family.
+    let mut family_order: Vec<String> = Vec::new();
+    let mut families: BTreeMap<String, Vec<Model>> = BTreeMap::new();
+    for model in models {
+        let key = family_key(&model.id);
+        if !families.contains_key(&key) {
+            family_order.push(key.clone());
+        }
+        families.entry(key).or_default().push(model);
+    }
+
+    let mode = mode_option(mode_current);
+    let mut out = Vec::with_capacity(family_order.len());
+    for key in family_order {
+        let members = families.remove(&key).unwrap_or_default();
+        if members.is_empty() {
+            continue;
+        }
+        // Map each member → (effort token, cleaned model).
+        let annotated: Vec<(Option<String>, Model)> = members
+            .into_iter()
+            .map(|mut model| {
+                let (label, badge) = clean_label(&model.label);
+                let params = parse_params(&model.id);
+                let effort = effort_of(&model.id, badge.as_deref());
+                model.label = label;
+                if model.description.as_ref().is_none_or(|d| d.is_empty()) {
+                    model.description = param_description(&params, badge.as_deref());
+                }
+                (effort, model)
+            })
+            .collect();
+
+        let distinct_efforts: BTreeSet<String> =
+            annotated.iter().filter_map(|(e, _)| e.clone()).collect();
+        if annotated.len() > 1 && distinct_efforts.len() > 1 {
+            // Collapse: keep the highest-effort row's id as the default pick,
+            // expose every effort as a Reasoning choice.
+            let mut ladder: Vec<ReasoningLevel> = distinct_efforts
+                .iter()
+                .filter_map(|e| reasoning_from_effort(e))
+                .collect();
+            ladder.sort();
+            ladder.dedup();
+            let default = annotated
+                .iter()
+                .rev()
+                .find(|(e, _)| {
+                    e.as_deref()
+                        .is_some_and(|v| matches!(v, "high" | "xhigh" | "max"))
+                })
+                .or_else(|| annotated.last())
+                .map(|(_, m)| m.clone())
+                .unwrap_or_else(|| annotated[0].1.clone());
+            let (label, _) = clean_label(&default.label);
+            // Prefer the family stem name without "(Low)" / effort noise.
+            let label = annotated
+                .iter()
+                .map(|(_, m)| m.label.clone())
+                .min_by_key(|l| l.len())
+                .unwrap_or(label);
+            out.push(Model {
+                id: default.id,
+                label,
+                description: Some("Effort variants".into()),
+                reasoning_levels: ladder,
+                options: vec![mode.clone()],
+            });
+            continue;
+        }
+
+        for (_, mut model) in annotated {
+            // Locked single-variant params stay on the description; Mode is
+            // the one trait every Cursor row can actually change.
+            model.options.insert(0, mode.clone());
+            // A lone effort value is not a ladder — don't pretend it is.
+            model.reasoning_levels.clear();
+            out.push(model);
+        }
+    }
+    out
+}
+
+/// Pick the advertised Cursor model id for a requested id + preferred efforts.
+///
+/// Returns `None` when the family has no effort variants to choose among, so
+/// the generic ACP model picker (1M compose, exact match) stays in charge.
+/// When siblings differ by effort, the first preferred effort that matches
+/// an advertised row wins.
+pub(crate) fn pick_model_id(
+    requested: &str,
+    efforts: &[&str],
+    available: &[&str],
+) -> Option<String> {
+    let family = family_key(requested);
+    let siblings: Vec<&str> = available
+        .iter()
+        .copied()
+        .filter(|id| family_key(id) == family)
+        .collect();
+    if siblings.is_empty() {
+        return None;
+    }
+    let distinct: BTreeSet<String> = siblings
+        .iter()
+        .filter_map(|id| effort_of(id, None))
+        .collect();
+    if distinct.len() <= 1 {
+        return None;
+    }
+    for effort in efforts {
+        let want = effort.to_ascii_lowercase();
+        if let Some(id) = siblings
+            .iter()
+            .find(|id| effort_of(id, None).as_deref() == Some(want.as_str()))
+        {
+            return Some((*id).to_owned());
+        }
+    }
+    if available.contains(&requested) {
+        return Some(requested.to_owned());
+    }
+    siblings
+        .iter()
+        .find(|id| {
+            effort_of(id, None)
+                .as_deref()
+                .is_some_and(|v| matches!(v, "high" | "xhigh" | "max"))
+        })
+        .or_else(|| siblings.first())
+        .map(|id| (*id).to_owned())
+}
+
+/// Preference-ordered effort tokens for a Comet reasoning pick, used when
+/// resolving a Cursor family variant.
+pub(crate) fn effort_tokens(level: ReasoningLevel) -> Vec<&'static str> {
+    let primary = effort_for_level(level);
+    match level {
+        ReasoningLevel::XHigh => vec![primary, "max", "high"],
+        ReasoningLevel::Max => vec![primary, "xhigh", "high"],
+        ReasoningLevel::High => vec![primary, "xhigh", "medium"],
+        _ => vec![primary],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use comet_proto::Model;
+    use serde_json::json;
+
+    #[test]
+    fn clean_label_strips_span_badges_without_duplicating() {
+        let (label, badge) = clean_label("Example <span>High</span>");
+        assert_eq!(label, "Example");
+        assert_eq!(badge.as_deref(), Some("High"));
+
+        let (label, badge) = clean_label("Example (Low) <span>Low</span>");
+        assert_eq!(label, "Example");
+        assert_eq!(badge.as_deref(), Some("Low"));
+
+        let (label, badge) = clean_label("Opus 5");
+        assert_eq!(label, "Opus 5");
+        assert!(badge.is_none());
+    }
+
+    #[test]
+    fn parse_params_reads_bracket_suffix() {
+        let p = parse_params("claude-opus-5[thinking=true,context=1m,effort=high,fast=false]");
+        assert_eq!(p.get("effort").map(String::as_str), Some("high"));
+        assert_eq!(p.get("context").map(String::as_str), Some("1m"));
+        assert_eq!(p.get("fast").map(String::as_str), Some("false"));
+        assert!(parse_params("gemini-3.1-pro[]").is_empty());
+        assert!(parse_params("gemini-3.1-pro").is_empty());
+    }
+
+    #[test]
+    fn enrich_collapses_effort_family_and_injects_mode() {
+        let models = enrich_models(
+            vec![
+                Model {
+                    id: "example[reasoning_effort=high]".into(),
+                    label: "Example <span>High</span>".into(),
+                    description: None,
+                    reasoning_levels: vec![],
+                    options: vec![],
+                },
+                Model {
+                    id: "example-low[]".into(),
+                    label: "Example (Low) <span>Low</span>".into(),
+                    description: None,
+                    reasoning_levels: vec![],
+                    options: vec![],
+                },
+                Model {
+                    id: "example-medium[]".into(),
+                    label: "Example (Medium) <span>Medium</span>".into(),
+                    description: None,
+                    reasoning_levels: vec![],
+                    options: vec![],
+                },
+                Model {
+                    id: "composer-2.5[fast=true]".into(),
+                    label: "Composer 2.5".into(),
+                    description: None,
+                    reasoning_levels: vec![],
+                    options: vec![],
+                },
+            ],
+            &json!({ "configOptions": [{ "id": "mode", "currentValue": "agent" }] }),
+        );
+        assert_eq!(models.len(), 2);
+        let example = models.iter().find(|m| m.label == "Example").unwrap();
+        assert_eq!(
+            example.reasoning_levels,
+            vec![
+                ReasoningLevel::Low,
+                ReasoningLevel::Medium,
+                ReasoningLevel::High
+            ]
+        );
+        assert!(example.options.iter().any(|o| o.id == "mode"));
+        let composer = models.iter().find(|m| m.label == "Composer 2.5").unwrap();
+        assert!(composer.reasoning_levels.is_empty());
+        assert_eq!(composer.description.as_deref(), Some("Fast"));
+        assert_eq!(composer.options[0].id, "mode");
+    }
+
+    #[test]
+    fn parameterized_catalog_injects_optimize_for_on_auto_only() {
+        let models = enrich_models(
+            vec![
+                Model {
+                    id: "auto-smart".into(),
+                    label: "Auto".into(),
+                    description: None,
+                    reasoning_levels: vec![ReasoningLevel::High],
+                    options: vec![],
+                },
+                Model {
+                    id: "composer-2.5".into(),
+                    label: "Composer 2.5".into(),
+                    description: None,
+                    reasoning_levels: vec![ReasoningLevel::High],
+                    options: vec![],
+                },
+                Model {
+                    id: "claude-opus-5".into(),
+                    label: "Opus 5".into(),
+                    description: None,
+                    reasoning_levels: vec![],
+                    options: vec![],
+                },
+            ],
+            &json!({
+                "configOptions": [
+                    { "id": "mode", "category": "mode", "currentValue": "agent" },
+                    {
+                        "id": "model",
+                        "category": "model",
+                        "currentValue": "composer-2.5",
+                    },
+                    {
+                        "id": "fast",
+                        "category": "model_config",
+                        "name": "Fast",
+                        "type": "select",
+                        "currentValue": "true",
+                        "options": [
+                            { "value": "false", "name": "Off" },
+                            { "value": "true", "name": "Fast" },
+                        ],
+                    },
+                ]
+            }),
+        );
+        let auto = models.iter().find(|m| m.id == "auto-smart").unwrap();
+        let optimize = auto
+            .options
+            .iter()
+            .find(|o| o.id == "optimize_for")
+            .expect("Auto must expose Optimize For");
+        assert_eq!(
+            optimize
+                .choices
+                .iter()
+                .map(|c| c.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["intelligence", "balanced", "cost"]
+        );
+        assert!(auto.reasoning_levels.is_empty());
+        let composer = models.iter().find(|m| m.id == "composer-2.5").unwrap();
+        assert!(composer.options.iter().any(|o| o.id == "fast"));
+        assert!(composer.options.iter().all(|o| o.id != "optimize_for"));
+        let opus = models.iter().find(|m| m.id == "claude-opus-5").unwrap();
+        assert!(opus.options.iter().all(|o| o.id == "mode"));
+        assert!(opus.reasoning_levels.is_empty());
+    }
+
+    #[test]
+    fn pick_model_id_switches_family_by_effort() {
+        let available = [
+            "example[reasoning_effort=high]",
+            "example-low[]",
+            "example-medium[]",
+            "composer-2.5[fast=true]",
+        ];
+        assert_eq!(
+            pick_model_id("example[reasoning_effort=high]", &["low"], &available).as_deref(),
+            Some("example-low[]")
+        );
+        assert_eq!(
+            pick_model_id("example-low[]", &["high"], &available).as_deref(),
+            Some("example[reasoning_effort=high]")
+        );
+        assert_eq!(
+            pick_model_id("composer-2.5[fast=true]", &["high"], &available).as_deref(),
+            None,
+            "single-variant families defer to the generic picker"
+        );
+    }
+}

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -2,8 +2,9 @@
 //! stdio, protocol v1) and maps its session updates onto [`AgentEvent`]s. One
 //! implementation covers every ACP agent; [`AcpHarness::grok`] configures it
 //! for xAI's Grok Build (`grok agent stdio`), the first registered agent —
-//! [`AcpHarness::hermes`] (Nous Research, `hermes acp`) and [`AcpHarness::pi`]
-//! (pi.dev via `pi-acp`) followed.
+//! [`AcpHarness::hermes`] (Nous Research, `hermes acp`), [`AcpHarness::pi`]
+//! (pi.dev via `pi-acp`) and [`AcpHarness::cursor`] (`cursor-agent acp`)
+//! followed.
 //!
 //! - `initialize` (protocolVersion 1, fs/terminal capabilities declined) →
 //!   `session/new`, or `session/load` with a fresh-session fallback when
@@ -16,6 +17,10 @@
 //!   plans → Todo, `available_commands_update` → [`AgentEvent::AvailableCommands`].
 //! - Permission requests are auto-accepted with the agent's preferred allow
 //!   option — parity with the claude/codex harnesses' unattended yolo mode.
+//! - Cursor's `cursor/*` extension methods get answered rather than refused:
+//!   `ask_question` and `create_plan` BLOCK the turn until the client replies,
+//!   so an unanswered one wedges the run. `ask_question` routes to the input
+//!   bridge, `create_plan` auto-accepts, and todos render as a chip.
 //! - Steering: agents advertising the `_session/steering` extension
 //!   (`initialize._meta.steering.supported`) get mid-turn injection; others
 //!   (Grok today) queue steers and deliver them as the next `session/prompt`
@@ -24,6 +29,7 @@
 //! - Interrupt: `session/cancel`, escalating SIGTERM → SIGKILL; the stream
 //!   always ends with `Done { status: Interrupted }`.
 
+mod cursor;
 mod normalize;
 
 use std::collections::VecDeque;
@@ -47,7 +53,7 @@ use comet_proto::{
 
 use crate::jsonrpc::{Incoming, RpcClient};
 use crate::{Harness, HarnessError, RunControls, Signal, send_signal, shutdown_child};
-use normalize::{map_update, parse_commands, preferred_allow_option};
+use normalize::{cursor_todo_events, map_update, parse_commands, preferred_allow_option};
 
 /// Per-agent configuration: which binary to spawn and what to tell the picker.
 struct AcpAgentSpec {
@@ -297,6 +303,67 @@ fn grok_spec() -> AcpAgentSpec {
     }
 }
 
+fn cursor_install_paths() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        dirs.push(home.join(".local").join("bin").join("cursor-agent"));
+        dirs.push(home.join(".cursor").join("bin").join("cursor-agent"));
+    }
+    dirs.push(PathBuf::from("/opt/homebrew/bin/cursor-agent"));
+    dirs.push(PathBuf::from("/usr/local/bin/cursor-agent"));
+    dirs
+}
+
+fn cursor_spec() -> AcpAgentSpec {
+    AcpAgentSpec {
+        id: HarnessId::Cursor,
+        display_name: "Cursor",
+        executable: "cursor-agent",
+        env_override: "CURSOR_EXECUTABLE",
+        // Native ACP server — no adapter package in between.
+        args: &["acp"],
+        npx_package: None,
+        extra_paths: cursor_install_paths,
+        cli_executable: "cursor-agent",
+        cli_extra_paths: cursor_install_paths,
+        install_hint: "cursor-agent (searched PATH, the login shell's PATH, ~/.local/bin, \
+             ~/.cursor/bin, /opt/homebrew/bin, and /usr/local/bin; install with \
+             `curl https://cursor.com/install -fsS | bash`, then `cursor-agent login`; \
+             set CURSOR_EXECUTABLE to override)",
+        // Fallback only: `session/new` advertises the account's models and
+        // the wire always wins. Keep this list to well-known public ids.
+        models: || {
+            vec![
+                Model {
+                    id: "auto-smart".into(),
+                    label: "Auto".into(),
+                    description: Some("Cursor picks the model per request".into()),
+                    reasoning_levels: Vec::new(),
+                    options: vec![cursor::optimize_for_option(Some("balanced"))],
+                },
+                Model {
+                    id: "composer-2.5".into(),
+                    label: "Composer 2.5".into(),
+                    description: Some("Cursor's own fast coding model".into()),
+                    reasoning_levels: Vec::new(),
+                    options: Vec::new(),
+                },
+            ]
+        },
+        // No `_session/steering` extension: steers deliver at turn boundaries.
+        steering_mode: SteeringMode::TurnBoundary,
+        // Descriptor ladder stays empty; live discovery fills it for families
+        // that actually advertise effort variants (see `cursor::enrich_models`).
+        reasoning_levels: &[],
+        prompt_transform: identity_transform,
+        // Cursor has no thought_level config option — effort rides the model
+        // id. When a collapsed family exposes a Reasoning ladder, these
+        // tokens pick the matching sibling via `cursor::pick_model_id`.
+        effort_values: |reasoning, _| reasoning.map(cursor::effort_tokens).unwrap_or_default(),
+        ladder_extras: &[],
+    }
+}
+
 fn hermes_install_paths() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
@@ -452,6 +519,11 @@ impl AcpHarness {
         Self::with_spec(codex_spec())
     }
 
+    /// Cursor Agent (`cursor-agent acp`) — Cursor's native ACP server.
+    pub fn cursor() -> Self {
+        Self::with_spec(cursor_spec())
+    }
+
     /// Grok Build (`grok agent stdio`) — xAI's native ACP agent.
     pub fn grok() -> Self {
         Self::with_spec(grok_spec())
@@ -562,7 +634,9 @@ impl AcpHarness {
             }
         };
         let discovery = async {
-            let init = client.request("initialize", initialize_params()).await?;
+            let init = client
+                .request("initialize", initialize_params(self.spec.id))
+                .await?;
             let mut commands = scan_available_commands(&init);
             if commands.is_empty() {
                 let cwd = std::env::var("HOME").unwrap_or_else(|_| "/".into());
@@ -624,12 +698,19 @@ impl AcpHarness {
             }
         };
         let discovery = async {
-            client.request("initialize", initialize_params()).await?;
+            client
+                .request("initialize", initialize_params(self.spec.id))
+                .await?;
             let cwd = std::env::var("HOME").unwrap_or_else(|_| "/".into());
             let session = client
                 .request("session/new", json!({ "cwd": cwd, "mcpServers": [] }))
                 .await?;
             let mut models = models_from_session(&session, &(self.spec.models)());
+            // Cursor: parameterized picker (base ids + optimize_for / effort /
+            // fast) when the client opts in; exploded-variant fallback otherwise.
+            if self.spec.id == HarnessId::Cursor {
+                models = cursor::enrich_models(models, &session);
+            }
             // Prompt-convention modes (Claude Ultrathink) extend any real
             // ladder — never an effort-less model's empty one.
             for model in &mut models {
@@ -974,7 +1055,17 @@ struct Session {
     stderr_tail: crate::StderrTail,
 }
 
-fn initialize_params() -> Value {
+fn initialize_params(harness: HarnessId) -> Value {
+    let mut capabilities = json!({
+        "fs": { "readTextFile": false, "writeTextFile": false },
+        "terminal": false,
+    });
+    // Cursor's ACP server exposes Auto's Optimize For (and other model
+    // parameters) when the client opts into parameterizedModelPicker;
+    // without it the catalog uses exploded variant ids.
+    if harness == HarnessId::Cursor {
+        capabilities["_meta"] = json!({ "parameterizedModelPicker": true });
+    }
     json!({
         "protocolVersion": 1,
         "clientInfo": {
@@ -985,10 +1076,7 @@ fn initialize_params() -> Value {
         // Declined: agents fall back to their own fs/terminal access, which
         // is what comet wants — the working tree is the source of truth for
         // the diff pane, and commands belong to the agent's own sandbox.
-        "clientCapabilities": {
-            "fs": { "readTextFile": false, "writeTextFile": false },
-            "terminal": false,
-        },
+        "clientCapabilities": capabilities,
     })
 }
 
@@ -1132,25 +1220,43 @@ fn config_option_sets(
             .collect();
 
         let wanted: Option<Value> = match (kind, category) {
-            ("select", Some("model")) => model
-                .and_then(|m| pick_model_value(m, &available, context_1m))
-                .map(Value::String),
+            ("select", Some("model")) => {
+                // Parameterized Cursor uses base ids; a saved exploded id
+                // (`auto-smart[optimize_for=cost]`) still has to match. When
+                // the catalog is still exploded, effort siblings switch via
+                // `pick_model_id`.
+                let requested = model.map(cursor::strip_variant_suffix);
+                requested
+                    .and_then(|m| cursor::pick_model_id(m, efforts, &available))
+                    .or_else(|| requested.and_then(|m| pick_model_value(m, &available, context_1m)))
+                    .or_else(|| model.and_then(|m| pick_model_value(m, &available, context_1m)))
+                    .map(Value::String)
+            }
             // Unattended parity with the retired custom adapters (claude
             // bypassPermissions / codex approvalPolicy never): pick the
             // no-prompts mode when the agent offers one. claude-agent-acp
             // calls it `bypassPermissions`, codex-acp `agent-full-access`
             // (approvalPolicy "never" + danger-full-access sandbox).
-            ("select", Some("mode")) => [
-                "bypassPermissions",
-                "bypass_permissions",
-                "yolo",
-                "agent-full-access",
-                "danger-full-access",
-                "full-access",
-            ]
-            .into_iter()
-            .find(|v| available.contains(v))
-            .map(|v| Value::String(v.to_owned())),
+            // Cursor instead exposes agent/plan/ask — those arrive as a
+            // Traits "Mode" option and win when the run selected one.
+            ("select", Some("mode")) => model_options
+                .get("mode")
+                .and_then(Value::as_str)
+                .filter(|c| available.contains(c))
+                .map(|c| Value::String(c.to_owned()))
+                .or_else(|| {
+                    [
+                        "bypassPermissions",
+                        "bypass_permissions",
+                        "yolo",
+                        "agent-full-access",
+                        "danger-full-access",
+                        "full-access",
+                    ]
+                    .into_iter()
+                    .find(|v| available.contains(v))
+                    .map(|v| Value::String(v.to_owned()))
+                }),
             ("select", Some("thought_level")) => efforts
                 .iter()
                 .find(|c| available.contains(*c))
@@ -1263,23 +1369,63 @@ fn prompt_turn(
 /// sessions run unattended). Everything else (fs, terminal, elicitation) was
 /// declined at initialize, so a stray request gets method-not-found rather
 /// than wedging the agent.
-fn handle_server_request(client: &RpcClient, id: Value, method: &str, params: &Value) {
-    if method != "session/request_permission" {
-        tracing::debug!(target: "comet_harness::acp", "unhandled server request: {method}");
-        client.respond_error(&id, -32601, &format!("unsupported method: {method}"));
-        return;
-    }
-    let options: Vec<Value> = params
-        .get("options")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    match preferred_allow_option(&options) {
-        Some(option_id) => client.respond(
-            &id,
-            json!({ "outcome": { "outcome": "selected", "optionId": option_id } }),
-        ),
-        None => client.respond(&id, json!({ "outcome": { "outcome": "cancelled" } })),
+fn handle_server_request(
+    client: &RpcClient,
+    id: Value,
+    method: &str,
+    params: &Value,
+) -> Vec<AgentEvent> {
+    match method {
+        "session/request_permission" => {
+            let options: Vec<Value> = params
+                .get("options")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            match preferred_allow_option(&options) {
+                Some(option_id) => client.respond(
+                    &id,
+                    json!({ "outcome": { "outcome": "selected", "optionId": option_id } }),
+                ),
+                None => client.respond(&id, json!({ "outcome": { "outcome": "cancelled" } })),
+            }
+            Vec::new()
+        }
+        // Cursor blocks the turn on plan approval; unattended parity means
+        // accepting it and rendering the phases as a todo chip.
+        CURSOR_CREATE_PLAN => {
+            client.respond(&id, json!({ "outcome": { "outcome": "accepted" } }));
+            cursor_todo_events(params, CURSOR_PLAN_CHIP)
+        }
+        CURSOR_UPDATE_TODOS => {
+            let todos = params
+                .get("todos")
+                .cloned()
+                .unwrap_or(Value::Array(Vec::new()));
+            client.respond(
+                &id,
+                json!({ "outcome": { "outcome": "accepted", "todos": todos } }),
+            );
+            cursor_todo_events(params, CURSOR_TODOS_CHIP)
+        }
+        // Subagent tasks run inside cursor-agent; this only reports one
+        // finished. Image generation has nowhere to land in a comet session.
+        CURSOR_TASK => {
+            client.respond(&id, json!({ "outcome": { "outcome": "completed" } }));
+            Vec::new()
+        }
+        CURSOR_GENERATE_IMAGE => {
+            client.respond(
+                &id,
+                json!({ "outcome": { "outcome": "rejected", "reason": "comet cannot render generated images" } }),
+            );
+            Vec::new()
+        }
+        _ => {
+            tracing::debug!(target: "comet_harness::acp", "unhandled server request: {method}");
+            client.respond_error(&id, -32601, &format!("unsupported method: {method}"));
+            Vec::new()
+        }
     }
 }
 
@@ -1316,10 +1462,13 @@ fn handle_server_request_live(
     method: &str,
     params: &Value,
     request_input: &std::sync::Arc<RequestInputFn>,
-) {
+) -> Vec<AgentEvent> {
+    if method == CURSOR_ASK_QUESTION {
+        ask_cursor_questions(client, id, params, request_input);
+        return Vec::new();
+    }
     if method != "session/request_permission" {
-        handle_server_request(client, id, method, params);
-        return;
+        return handle_server_request(client, id, method, params);
     }
     let options: Vec<Value> = params
         .get("options")
@@ -1327,8 +1476,7 @@ fn handle_server_request_live(
         .cloned()
         .unwrap_or_default();
     if !is_user_question(&options) {
-        handle_server_request(client, id, method, params);
-        return;
+        return handle_server_request(client, id, method, params);
     }
     let names: Vec<String> = options
         .iter()
@@ -1375,6 +1523,155 @@ fn handle_server_request_live(
             None => client.respond(&id, json!({ "outcome": { "outcome": "cancelled" } })),
         }
     });
+    Vec::new()
+}
+
+/// Cursor's ACP extension methods (`https://cursor.com/docs/cli/acp`).
+/// `ask_question` and `create_plan` BLOCK the agent until answered, so every
+/// one of these gets a response even when comet has nothing to do with it.
+const CURSOR_ASK_QUESTION: &str = "cursor/ask_question";
+const CURSOR_CREATE_PLAN: &str = "cursor/create_plan";
+const CURSOR_UPDATE_TODOS: &str = "cursor/update_todos";
+const CURSOR_TASK: &str = "cursor/task";
+const CURSOR_GENERATE_IMAGE: &str = "cursor/generate_image";
+
+/// Stable chip ids so repeated todo/plan updates refresh in place, matching
+/// the `acp-plan` convention in the normalizer.
+const CURSOR_PLAN_CHIP: &str = "cursor-plan";
+const CURSOR_TODOS_CHIP: &str = "cursor-todos";
+
+/// The same extension methods arriving without an id: nothing to answer, and
+/// only the todo-carrying ones have anything to render. The docs describe
+/// todos/task/image as fire-and-forget while also giving them response
+/// shapes, so both arrival styles are handled.
+fn cursor_notification_events(method: &str, params: &Value) -> Vec<AgentEvent> {
+    match method {
+        CURSOR_UPDATE_TODOS => cursor_todo_events(params, CURSOR_TODOS_CHIP),
+        CURSOR_CREATE_PLAN => cursor_todo_events(params, CURSOR_PLAN_CHIP),
+        _ => Vec::new(),
+    }
+}
+
+/// `cursor/ask_question` → the engine's input bridge. Unlike a permission
+/// question this carries a LIST of questions, each with its own labelled
+/// options and multi-select flag, and answers go back as option ids. Handled
+/// in a subtask so the message loop keeps draining while the user decides;
+/// a dropped resolver degrades to `cancelled`, never a silent pick.
+fn ask_cursor_questions(
+    client: &RpcClient,
+    id: Value,
+    params: &Value,
+    request_input: &std::sync::Arc<RequestInputFn>,
+) {
+    let asked = cursor_questions(params);
+    if asked.is_empty() {
+        client.respond(
+            &id,
+            json!({ "outcome": { "outcome": "skipped", "reason": "no answerable questions" } }),
+        );
+        return;
+    }
+    let client = client.clone();
+    let request_input = std::sync::Arc::clone(request_input);
+    tokio::spawn(async move {
+        let answers = (request_input)(asked.iter().map(|q| q.question.clone()).collect())
+            .await
+            .unwrap_or_default();
+        client.respond(&id, cursor_answer_outcome(&asked, &answers));
+    });
+}
+
+/// One `cursor/ask_question` entry: the comet-side question plus what is
+/// needed to answer it — the wire id, and the label→optionId table (comet's
+/// input bridge speaks labels, cursor expects option ids).
+struct CursorQuestion {
+    wire_id: String,
+    question: UserInputQuestion,
+    choices: Vec<(String, String)>,
+}
+
+fn cursor_questions(params: &Value) -> Vec<CursorQuestion> {
+    let header = params
+        .get("title")
+        .and_then(Value::as_str)
+        .unwrap_or("Agent question");
+    params
+        .get("questions")
+        .and_then(Value::as_array)
+        .map(|a| a.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|q| {
+            let wire_id = q.get("id").and_then(Value::as_str)?.to_owned();
+            let choices: Vec<(String, String)> = q
+                .get("options")
+                .and_then(Value::as_array)
+                .map(|a| a.as_slice())
+                .unwrap_or_default()
+                .iter()
+                .filter_map(|o| {
+                    let oid = o.get("id").and_then(Value::as_str)?;
+                    let label = o.get("label").and_then(Value::as_str).unwrap_or(oid);
+                    Some((label.to_owned(), oid.to_owned()))
+                })
+                .collect();
+            // An option-less question has no answer comet could send back.
+            if choices.is_empty() {
+                return None;
+            }
+            Some(CursorQuestion {
+                wire_id,
+                question: UserInputQuestion {
+                    // Comet-minted: cursor's ids ("q1") repeat across turns.
+                    id: new_message_id(),
+                    header: header.to_owned(),
+                    question: q
+                        .get("prompt")
+                        .and_then(Value::as_str)
+                        .unwrap_or("The agent needs your input.")
+                        .to_owned(),
+                    options: choices.iter().map(|(label, _)| label.clone()).collect(),
+                    multi_select: q
+                        .get("allowMultiple")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                },
+                choices,
+            })
+        })
+        .collect()
+}
+
+/// Chosen labels → the `answered` outcome. Nothing recognisable coming back
+/// (dropped resolver, unknown labels) degrades to `cancelled` so the agent
+/// unblocks without comet inventing a pick.
+fn cursor_answer_outcome(asked: &[CursorQuestion], answers: &[UserInputAnswer]) -> Value {
+    let picked: Vec<Value> = asked
+        .iter()
+        .filter_map(|asked| {
+            let labels = &answers
+                .iter()
+                .find(|a| a.question_id == asked.question.id)?
+                .labels;
+            let ids: Vec<&str> = labels
+                .iter()
+                .filter_map(|label| {
+                    asked
+                        .choices
+                        .iter()
+                        .find(|(l, _)| l == label)
+                        .map(|(_, oid)| oid.as_str())
+                })
+                .collect();
+            (!ids.is_empty())
+                .then(|| json!({ "questionId": asked.wire_id, "selectedOptionIds": ids }))
+        })
+        .collect();
+    if picked.is_empty() {
+        json!({ "outcome": { "outcome": "cancelled" } })
+    } else {
+        json!({ "outcome": { "outcome": "answered", "answers": picked } })
+    }
 }
 
 /// Await a setup request while draining incoming messages, so a `session/load`
@@ -1466,7 +1763,9 @@ async fn run_session(session: Session) {
 
     // ---- handshake + session (interruptible) ------------------------------
     let setup = async {
-        let init = client.request("initialize", initialize_params()).await?;
+        let init = client
+            .request("initialize", initialize_params(harness))
+            .await?;
         let steer_ext = steering_supported(&init);
         let init_commands = scan_available_commands(&init);
 
@@ -1518,13 +1817,59 @@ async fn run_session(session: Session) {
         // session's advertised config options (ACP has no per-prompt model
         // field). Best-effort: a rejected set is logged, never fatal — the
         // agent's default runs.
+        //
+        // Cursor parameterized mode only lists parameters for the *current*
+        // model. Set the model first, then apply optimize_for / effort / fast
+        // against the refreshed configOptions in the response.
         let efforts = effort_values(request.reasoning, request.model.as_deref());
+        let requested_model = request.model.as_deref().map(cursor::strip_variant_suffix);
+        let mut options_snapshot = session_response;
+        if harness == HarnessId::Cursor {
+            let model_sets = config_option_sets(
+                &options_snapshot,
+                requested_model,
+                &[],
+                &serde_json::Map::new(),
+            );
+            if let Some((_, payload)) = model_sets.iter().find(|(id, _)| id == "model") {
+                let mut params = serde_json::Map::new();
+                params.insert("sessionId".into(), session_id.clone().into());
+                params.insert("configId".into(), "model".into());
+                if let Some(payload) = payload.as_object() {
+                    for (k, v) in payload {
+                        params.insert(k.clone(), v.clone());
+                    }
+                }
+                match request_draining(
+                    &client,
+                    &mut incoming,
+                    "session/set_config_option",
+                    Value::Object(params),
+                )
+                .await
+                {
+                    Ok(resp) if resp.get("configOptions").is_some() => {
+                        options_snapshot = resp;
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            target: "comet_harness::acp",
+                            "session/set_config_option model rejected (agent default runs): {e}"
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
         for (config_id, payload) in config_option_sets(
-            &session_response,
-            request.model.as_deref(),
+            &options_snapshot,
+            requested_model,
             &efforts,
             &request.model_options,
         ) {
+            if harness == HarnessId::Cursor && config_id == "model" {
+                continue;
+            }
             let mut params = serde_json::Map::new();
             params.insert("sessionId".into(), session_id.clone().into());
             params.insert("configId".into(), config_id.clone().into());
@@ -1628,8 +1973,7 @@ async fn run_session(session: Session) {
     // deadlocks against a full incoming channel when the agent floods
     // updates (the reader blocks on the channel and never parses the
     // steering response).
-    let mut steering_call: Option<(String, BoxFuture<'static, Result<Value, HarnessError>>)> =
-        None;
+    let mut steering_call: Option<(String, BoxFuture<'static, Result<Value, HarnessError>>)> = None;
     let mut steer_backlog: VecDeque<String> = VecDeque::new();
     let mut steering_open = true;
     let mut interrupted = false;
@@ -1698,10 +2042,13 @@ async fn run_session(session: Session) {
                 let mut consumer_gone = false;
                 while let Ok(inc) = incoming.try_recv() {
                     match inc {
-                        Incoming::Notification { method, params }
-                            if method == "session/update" =>
-                        {
-                            for ev in session_update_events(&params, &session_id) {
+                        Incoming::Notification { method, params } => {
+                            let events = if method == "session/update" {
+                                session_update_events(&params, &session_id)
+                            } else {
+                                cursor_notification_events(&method, &params)
+                            };
+                            for ev in events {
                                 if !send(&event_tx, ev).await {
                                     consumer_gone = true;
                                     break;
@@ -1709,13 +2056,18 @@ async fn run_session(session: Session) {
                             }
                         }
                         Incoming::Request { id, method, params } => {
-                            handle_server_request_live(
+                            for ev in handle_server_request_live(
                                 &client,
                                 id,
                                 &method,
                                 &params,
                                 &request_input,
-                            );
+                            ) {
+                                if !send(&event_tx, ev).await {
+                                    consumer_gone = true;
+                                    break;
+                                }
+                            }
                         }
                         _ => {}
                     }
@@ -1788,18 +2140,27 @@ async fn run_session(session: Session) {
 
             inc = incoming.recv() => match inc {
                 Some(Incoming::Notification { method, params }) => {
-                    if method == "session/update" {
-                        for ev in session_update_events(&params, &session_id) {
-                            if !send(&event_tx, ev).await {
-                                break 'main;
-                            }
-                        }
-                    }
                     // Other notifications (other sessions, agent noise) are
                     // tolerated by design.
+                    let events = if method == "session/update" {
+                        session_update_events(&params, &session_id)
+                    } else {
+                        cursor_notification_events(&method, &params)
+                    };
+                    for ev in events {
+                        if !send(&event_tx, ev).await {
+                            break 'main;
+                        }
+                    }
                 }
                 Some(Incoming::Request { id, method, params }) => {
-                    handle_server_request_live(&client, id, &method, &params, &request_input);
+                    for ev in
+                        handle_server_request_live(&client, id, &method, &params, &request_input)
+                    {
+                        if !send(&event_tx, ev).await {
+                            break 'main;
+                        }
+                    }
                 }
                 Some(Incoming::Eof) | None => {
                     // The turn ends via a request RESPONSE, which races EOF
@@ -1883,10 +2244,13 @@ async fn run_session(session: Session) {
                         let mut consumer_gone = false;
                         while let Ok(inc) = incoming.try_recv() {
                             match inc {
-                                Incoming::Notification { method, params }
-                                    if method == "session/update" =>
-                                {
-                                    for ev in session_update_events(&params, &session_id) {
+                                Incoming::Notification { method, params } => {
+                                    let events = if method == "session/update" {
+                                        session_update_events(&params, &session_id)
+                                    } else {
+                                        cursor_notification_events(&method, &params)
+                                    };
+                                    for ev in events {
                                         if !send(&event_tx, ev).await {
                                             consumer_gone = true;
                                             break;
@@ -1894,13 +2258,18 @@ async fn run_session(session: Session) {
                                     }
                                 }
                                 Incoming::Request { id, method, params } => {
-                                    handle_server_request_live(
+                                    for ev in handle_server_request_live(
                                         &client,
                                         id,
                                         &method,
                                         &params,
                                         &request_input,
-                                    );
+                                    ) {
+                                        if !send(&event_tx, ev).await {
+                                            consumer_gone = true;
+                                            break;
+                                        }
+                                    }
                                 }
                                 _ => {}
                             }
@@ -2067,6 +2436,7 @@ async fn run_session(session: Session) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use comet_proto::{TodoItem, ToolCall};
 
     #[test]
     fn steering_capability_reads_initialize_meta() {
@@ -2306,7 +2676,13 @@ mod tests {
         let models = models_from_session(&response, &[]);
         assert_eq!(
             models.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
-            vec!["default", "opus[1m]", "claude-fable-5[1m]", "sonnet", "haiku"]
+            vec![
+                "default",
+                "opus[1m]",
+                "claude-fable-5[1m]",
+                "sonnet",
+                "haiku"
+            ]
         );
         assert!(models.iter().all(|m| m.options.is_empty()));
     }
@@ -2328,6 +2704,270 @@ mod tests {
         assert!(models[0].options.iter().any(|o| o.id == "serviceTier"));
         // …unknown ids get none.
         assert!(models[1].options.is_empty());
+    }
+
+    /// `cursor/ask_question` carries several questions at once, each with its
+    /// own labelled options — the round trip must answer with OPTION IDS,
+    /// keyed by cursor's wire ids, not the labels comet showed the user.
+    #[test]
+    fn cursor_questions_round_trip_labels_back_to_option_ids() {
+        let asked = cursor_questions(&json!({
+            "toolCallId": "call_123",
+            "title": "Need input",
+            "questions": [
+                {
+                    "id": "q1",
+                    "prompt": "Which mode?",
+                    "options": [
+                        { "id": "agent", "label": "Agent" },
+                        { "id": "plan", "label": "Plan" },
+                    ],
+                },
+                {
+                    "id": "q2",
+                    "prompt": "Which targets?",
+                    "options": [
+                        { "id": "ios", "label": "iOS" },
+                        { "id": "mac", "label": "macOS" },
+                    ],
+                    "allowMultiple": true,
+                },
+                // No options: unanswerable, so it never reaches the user.
+                { "id": "q3", "prompt": "Anything else?" },
+            ],
+        }));
+        assert_eq!(asked.len(), 2);
+        assert_eq!(asked[0].question.header, "Need input");
+        assert_eq!(asked[0].question.question, "Which mode?");
+        assert_eq!(asked[0].question.options, vec!["Agent", "Plan"]);
+        assert!(!asked[0].question.multi_select);
+        assert!(asked[1].question.multi_select);
+        // Cursor's repeatable ids never leak into comet's question ids.
+        assert_ne!(asked[0].question.id, "q1");
+
+        let answers = vec![
+            UserInputAnswer {
+                question_id: asked[0].question.id.clone(),
+                labels: vec!["Plan".into()],
+            },
+            UserInputAnswer {
+                question_id: asked[1].question.id.clone(),
+                labels: vec!["iOS".into(), "macOS".into()],
+            },
+        ];
+        assert_eq!(
+            cursor_answer_outcome(&asked, &answers),
+            json!({
+                "outcome": {
+                    "outcome": "answered",
+                    "answers": [
+                        { "questionId": "q1", "selectedOptionIds": ["plan"] },
+                        { "questionId": "q2", "selectedOptionIds": ["ios", "mac"] },
+                    ],
+                }
+            })
+        );
+    }
+
+    /// A dropped resolver (or labels from a stale panel) must unblock the
+    /// agent as `cancelled` — never a silent pick of some default option.
+    #[test]
+    fn cursor_answers_degrade_to_cancelled_not_a_silent_pick() {
+        let asked = cursor_questions(&json!({
+            "questions": [{
+                "id": "q1",
+                "prompt": "Ship it?",
+                "options": [{ "id": "yes", "label": "Yes" }],
+            }],
+        }));
+        let cancelled = json!({ "outcome": { "outcome": "cancelled" } });
+        assert_eq!(cursor_answer_outcome(&asked, &[]), cancelled);
+        let stale = vec![UserInputAnswer {
+            question_id: asked[0].question.id.clone(),
+            labels: vec!["Maybe".into()],
+        }];
+        assert_eq!(cursor_answer_outcome(&asked, &stale), cancelled);
+    }
+
+    /// Cursor's todo-bearing extension methods render as chips with stable
+    /// ids, so a stream of updates refreshes one chip instead of stacking.
+    #[test]
+    fn cursor_todo_notifications_map_to_stable_chips() {
+        let todos = json!({
+            "toolCallId": "call_125",
+            "merge": true,
+            "todos": [
+                { "id": "1", "content": "Set up project", "status": "completed" },
+                { "id": "2", "content": "Add auth", "status": "in_progress" },
+            ],
+        });
+        let chip_id = |events: &[AgentEvent]| match &events[0] {
+            AgentEvent::ToolCall { id, .. } => id.clone(),
+            other => panic!("expected a tool call, got {other:?}"),
+        };
+        let updated = cursor_notification_events(CURSOR_UPDATE_TODOS, &todos);
+        assert_eq!(chip_id(&updated), CURSOR_TODOS_CHIP);
+        assert_eq!(
+            updated[0],
+            AgentEvent::ToolCall {
+                id: CURSOR_TODOS_CHIP.into(),
+                call: ToolCall::Todo {
+                    items: vec![
+                        TodoItem {
+                            text: "Set up project".into(),
+                            done: true
+                        },
+                        TodoItem {
+                            text: "Add auth".into(),
+                            done: false
+                        },
+                    ]
+                },
+            }
+        );
+        // A plan lands on its own chip, so the two never overwrite each other.
+        let planned = cursor_notification_events(CURSOR_CREATE_PLAN, &todos);
+        assert_eq!(chip_id(&planned), CURSOR_PLAN_CHIP);
+        // Everything else is noise comet has nothing to render for.
+        assert!(cursor_notification_events(CURSOR_TASK, &todos).is_empty());
+        assert!(cursor_notification_events(CURSOR_GENERATE_IMAGE, &todos).is_empty());
+        assert!(cursor_notification_events("cursor/unknown", &todos).is_empty());
+    }
+
+    /// The Cursor slot drives `cursor-agent acp` directly — no adapter
+    /// package — and opts into the parameterized model picker.
+    #[test]
+    fn cursor_spec_targets_the_native_acp_server() {
+        let spec = cursor_spec();
+        assert_eq!(spec.id, HarnessId::Cursor);
+        assert_eq!(spec.display_name, "Cursor");
+        assert_eq!(spec.executable, "cursor-agent");
+        assert_eq!(spec.args, &["acp"]);
+        assert!(spec.npx_package.is_none());
+        assert_eq!(spec.steering_mode, SteeringMode::TurnBoundary);
+        assert!(spec.reasoning_levels.is_empty());
+        assert!(
+            (spec.models)()
+                .iter()
+                .all(|m| m.reasoning_levels.is_empty())
+        );
+        let auto = (spec.models)()
+            .into_iter()
+            .find(|m| m.id == "auto-smart")
+            .expect("static Auto");
+        assert!(auto.options.iter().any(|o| o.id == "optimize_for"));
+        assert_eq!(
+            (spec.effort_values)(Some(ReasoningLevel::Low), None),
+            vec!["low"]
+        );
+        assert_eq!(
+            initialize_params(HarnessId::Cursor)["clientCapabilities"]["_meta"]["parameterizedModelPicker"],
+            json!(true)
+        );
+        assert!(
+            initialize_params(HarnessId::Grok)["clientCapabilities"]
+                .get("_meta")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn cursor_mode_trait_wins_over_no_prompt_fallback() {
+        let cursor = json!({
+            "sessionId": "s-1",
+            "configOptions": [{
+                "id": "mode",
+                "category": "mode",
+                "type": "select",
+                "currentValue": "agent",
+                "options": [
+                    { "value": "agent" },
+                    { "value": "plan" },
+                    { "value": "ask" },
+                ],
+            }, {
+                "id": "model",
+                "category": "model",
+                "type": "select",
+                "currentValue": "example[reasoning_effort=high]",
+                "options": [
+                    { "value": "example[reasoning_effort=high]" },
+                    { "value": "example-low[]" },
+                    { "value": "example-medium[]" },
+                ],
+            }],
+        });
+        let mut opts = serde_json::Map::new();
+        opts.insert("mode".into(), json!("plan"));
+        assert_eq!(
+            config_option_sets(&cursor, None, &[], &opts),
+            vec![("mode".to_owned(), json!({ "value": "plan" }))]
+        );
+        // Reasoning Low switches the effort family to the -low sibling.
+        assert_eq!(
+            config_option_sets(
+                &cursor,
+                Some("example[reasoning_effort=high]"),
+                &["low"],
+                &serde_json::Map::new()
+            ),
+            vec![("model".to_owned(), json!({ "value": "example-low[]" }))]
+        );
+    }
+
+    #[test]
+    fn cursor_optimize_for_sets_on_parameterized_auto() {
+        let cursor = json!({
+            "sessionId": "s-1",
+            "configOptions": [{
+                "id": "mode",
+                "category": "mode",
+                "type": "select",
+                "currentValue": "agent",
+                "options": [
+                    { "value": "agent" },
+                    { "value": "plan" },
+                    { "value": "ask" },
+                ],
+            }, {
+                "id": "model",
+                "category": "model",
+                "type": "select",
+                "currentValue": "composer-2.5",
+                "options": [
+                    { "value": "auto-smart" },
+                    { "value": "composer-2.5" },
+                ],
+            }, {
+                "id": "optimize_for",
+                "category": "model_config",
+                "type": "select",
+                "currentValue": "balanced",
+                "options": [
+                    { "value": "intelligence" },
+                    { "value": "balanced" },
+                    { "value": "cost" },
+                ],
+            }],
+        });
+        let mut opts = serde_json::Map::new();
+        opts.insert("optimize_for".into(), json!("cost"));
+        let sets = config_option_sets(
+            &cursor,
+            Some("auto-smart[optimize_for=balanced]"),
+            &[],
+            &opts,
+        );
+        assert!(
+            sets.iter()
+                .any(|(id, v)| id == "model" && v == &json!({ "value": "auto-smart" })),
+            "{sets:?}"
+        );
+        assert!(
+            sets.iter()
+                .any(|(id, v)| id == "optimize_for" && v == &json!({ "value": "cost" })),
+            "{sets:?}"
+        );
     }
 
     #[test]

--- a/crates/harness/src/acp/normalize.rs
+++ b/crates/harness/src/acp/normalize.rs
@@ -97,9 +97,68 @@ fn first_location(update: &Value) -> Option<String> {
     path.as_str().filter(|p| !p.is_empty()).map(str::to_owned)
 }
 
+/// Cursor (and similar ACP agents) put a human summary in `title` — generic
+/// labels ("Read File", "grep") before args arrive, or a markdown-wrapped
+/// command (`` `ls -la` `` with inner backticks escaped as `\``). Those are
+/// display strings, not typed arguments; using them as path/pattern/command
+/// dumps the label (and its escapes) into the transcript chip.
+fn is_placeholder_title(title: &str) -> bool {
+    matches!(
+        title.trim(),
+        "grep"
+            | "Find"
+            | "Terminal"
+            | "Read File"
+            | "Edit File"
+            | "Delete File"
+            | "Web Search"
+            | "Web Fetch"
+            | "Codebase Search"
+            | "Read TODOs"
+            | "Update TODOs"
+            | "Read Lints"
+            | "Task: Subagent task"
+            | "Subagent task"
+            | "List MCP Resources"
+            | "Fetch MCP Resource"
+    )
+}
+
+/// Unwrap a single markdown code span used as an ACP exec title.
+fn unwrap_command_title(title: &str) -> Option<String> {
+    let inner = title.trim().strip_prefix('`')?.strip_suffix('`')?;
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' && chars.peek() == Some(&'`') {
+            chars.next();
+            out.push('`');
+        } else {
+            out.push(c);
+        }
+    }
+    let out = out.trim();
+    if out.is_empty() || is_placeholder_title(out) {
+        None
+    } else {
+        Some(out.to_owned())
+    }
+}
+
+fn arg_from_title(title: &str) -> Option<String> {
+    let t = title.trim();
+    if t.is_empty() || is_placeholder_title(t) {
+        None
+    } else {
+        Some(t.to_owned())
+    }
+}
+
 /// Reduce an ACP tool call (kind + title + rawInput + locations + diff
 /// content) to the typed [`ToolCall`] comet renders. Best-effort: agents vary
 /// in how much structure they put in `rawInput`, so every arm has a fallback.
+/// Title is only used when it looks like a real arg — never a placeholder
+/// label or markdown-escaped summary.
 fn typed_call(update: &Value) -> ToolCall {
     let kind = update
         .get("kind")
@@ -115,12 +174,18 @@ fn typed_call(update: &Value) -> ToolCall {
     };
     match kind {
         "execute" => ToolCall::Exec {
-            command: raw_str("command").unwrap_or(title),
+            command: raw_str("command")
+                .or_else(|| unwrap_command_title(&title))
+                .or_else(|| arg_from_title(&title))
+                .unwrap_or_default(),
         },
         "read" => ToolCall::ReadFile {
             path: raw_str("path")
+                .or_else(|| raw_str("file_path"))
+                .or_else(|| raw_str("filePath"))
                 .or_else(|| first_location(update))
-                .unwrap_or(title),
+                .or_else(|| arg_from_title(&title))
+                .unwrap_or_default(),
         },
         "edit" | "delete" | "move" => {
             // A diff pins down the file and shape; otherwise fall back to the
@@ -139,7 +204,11 @@ fn typed_call(update: &Value) -> ToolCall {
                     }
                 }
             } else {
-                match raw_str("path").or_else(|| first_location(update)) {
+                match raw_str("path")
+                    .or_else(|| raw_str("file_path"))
+                    .or_else(|| raw_str("filePath"))
+                    .or_else(|| first_location(update))
+                {
                     Some(path) if kind == "edit" => ToolCall::EditFile {
                         path,
                         old_string: None,
@@ -149,16 +218,29 @@ fn typed_call(update: &Value) -> ToolCall {
                 }
             }
         }
-        "search" => ToolCall::Search {
-            pattern: raw_str("pattern")
-                .or_else(|| raw_str("query"))
-                .unwrap_or(title),
-            path: raw_str("path"),
-        },
+        "search" => {
+            // Cursor web search is kind "search" + rawInput.searchTerm; grep
+            // / glob / codebase search use pattern or query.
+            if let Some(query) = raw_str("searchTerm") {
+                ToolCall::WebSearch { query }
+            } else {
+                ToolCall::Search {
+                    pattern: raw_str("pattern")
+                        .or_else(|| raw_str("globPattern"))
+                        .or_else(|| raw_str("query"))
+                        .or_else(|| arg_from_title(&title))
+                        .unwrap_or_default(),
+                    path: raw_str("path"),
+                }
+            }
+        }
         "fetch" => match raw_str("url") {
             Some(url) => ToolCall::WebFetch { url, prompt: None },
             None => ToolCall::WebSearch {
-                query: raw_str("query").unwrap_or(title),
+                query: raw_str("searchTerm")
+                    .or_else(|| raw_str("query"))
+                    .or_else(|| arg_from_title(&title))
+                    .unwrap_or_default(),
             },
         },
         // Kindless (or unknown-kind) update carrying a diff: an edit in all
@@ -179,6 +261,20 @@ fn typed_call(update: &Value) -> ToolCall {
                 }
             }
         }
+        _ if raw_str("_toolName").as_deref() == Some("task") => ToolCall::Unknown {
+            name: raw_str("description")
+                .filter(|d| d != "Subagent task")
+                .map(|d| format!("Task: {d}"))
+                .or_else(|| arg_from_title(&title))
+                .unwrap_or_else(|| {
+                    if title.is_empty() {
+                        "Task".into()
+                    } else {
+                        title
+                    }
+                }),
+            input: raw.cloned(),
+        },
         _ => ToolCall::Unknown {
             name: if title.is_empty() { kind.into() } else { title },
             input: raw.cloned(),
@@ -317,6 +413,35 @@ pub(crate) fn parse_commands(value: Option<&Value>) -> Vec<SlashCommand> {
             })
         })
         .collect()
+}
+
+/// Cursor's `cursor/update_todos` and `cursor/create_plan` carry a `todos`
+/// array (`{id, content, status}`) instead of ACP's `plan`/`entries`. Both
+/// render as the same kind of chip; the caller picks a stable id so repeated
+/// updates refresh in place rather than stacking.
+pub(crate) fn cursor_todo_events(params: &Value, chip_id: &str) -> Vec<AgentEvent> {
+    let Some(todos) = params.get("todos").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let items = todos
+        .iter()
+        .map(|t| TodoItem {
+            text: str_field(t, "content"),
+            done: t.get("status").and_then(Value::as_str) == Some("completed"),
+        })
+        .collect();
+    vec![
+        AgentEvent::ToolCall {
+            id: chip_id.to_owned(),
+            call: ToolCall::Todo { items },
+        },
+        AgentEvent::ToolResult {
+            id: chip_id.to_owned(),
+            is_error: false,
+            output: None,
+            diff: None,
+        },
+    ]
 }
 
 /// `session/request_permission` options (`{optionId, name, kind}`) → the
@@ -573,5 +698,150 @@ mod tests {
         let only_reject = vec![json!({ "optionId": "no", "kind": "reject_once" })];
         assert_eq!(preferred_allow_option(&only_reject), Some("no".into()));
         assert_eq!(preferred_allow_option(&[]), None);
+    }
+
+    /// Cursor ACP opens tool cards with a display `title` before `rawInput`
+    /// is filled (Search "grep", Read "Read File", Web "Web Fetch"). Those
+    /// labels must not become typed args.
+    #[test]
+    fn cursor_placeholder_titles_are_not_typed_args() {
+        let grep = json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t1",
+            "title": "grep",
+            "kind": "search",
+            "rawInput": {},
+        });
+        assert_eq!(
+            map_update(&grep),
+            vec![AgentEvent::ToolCall {
+                id: "t1".into(),
+                call: ToolCall::Search {
+                    pattern: String::new(),
+                    path: None,
+                },
+            }]
+        );
+
+        let read = json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t2",
+            "title": "Read File",
+            "kind": "read",
+            "rawInput": {},
+        });
+        assert_eq!(
+            map_update(&read),
+            vec![AgentEvent::ToolCall {
+                id: "t2".into(),
+                call: ToolCall::ReadFile {
+                    path: String::new(),
+                },
+            }]
+        );
+
+        let fetch = json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t3",
+            "title": "Web Fetch",
+            "kind": "fetch",
+            "rawInput": {},
+        });
+        assert_eq!(
+            map_update(&fetch),
+            vec![AgentEvent::ToolCall {
+                id: "t3".into(),
+                call: ToolCall::WebSearch {
+                    query: String::new(),
+                },
+            }]
+        );
+
+        let web = json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t4",
+            "title": "Web Search",
+            "kind": "search",
+            "rawInput": {},
+        });
+        assert_eq!(
+            map_update(&web),
+            vec![AgentEvent::ToolCall {
+                id: "t4".into(),
+                call: ToolCall::Search {
+                    pattern: String::new(),
+                    path: None,
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn cursor_search_term_maps_to_web_search() {
+        let update = json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t1",
+            "title": "Web Search: \"multitask cli\"",
+            "kind": "search",
+            "rawInput": { "searchTerm": "multitask cli" },
+        });
+        assert_eq!(
+            map_update(&update),
+            vec![AgentEvent::ToolCall {
+                id: "t1".into(),
+                call: ToolCall::WebSearch {
+                    query: "multitask cli".into(),
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn cursor_exec_title_unwraps_markdown_backtick_escapes() {
+        let update = json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t1",
+            "title": "`echo \\`hi\\``",
+            "kind": "execute",
+            "rawInput": {},
+        });
+        assert_eq!(
+            map_update(&update),
+            vec![AgentEvent::ToolCall {
+                id: "t1".into(),
+                call: ToolCall::Exec {
+                    command: "echo `hi`".into(),
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn cursor_task_uses_description_not_placeholder_title() {
+        let update = json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t1",
+            "title": "Task: Subagent task",
+            "kind": "other",
+            "rawInput": {
+                "_toolName": "task",
+                "description": "Look up multitask docs",
+                "prompt": "find the reminder",
+            },
+        });
+        assert_eq!(
+            map_update(&update),
+            vec![AgentEvent::ToolCall {
+                id: "t1".into(),
+                call: ToolCall::Unknown {
+                    name: "Task: Look up multitask docs".into(),
+                    input: Some(json!({
+                        "_toolName": "task",
+                        "description": "Look up multitask docs",
+                        "prompt": "find the reminder",
+                    })),
+                },
+            }]
+        );
     }
 }

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -3,8 +3,8 @@
 //!
 //! Every production harness is the shared [`AcpHarness`] with a per-agent
 //! spec: Claude Code via the org-maintained `claude-agent-acp` adapter, Codex
-//! via `codex-acp`, Grok Build and Hermes natively, pi via the community
-//! `pi-acp` adapter. Decision record:
+//! via `codex-acp`, Cursor, Grok Build and Hermes natively, pi via the
+//! community `pi-acp` adapter. Decision record:
 //! docs/research/acp.md (the bespoke stream-json/app-server adapters this
 //! crate used to hold are documented historically in
 //! docs/research/harness.md).

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -279,6 +279,10 @@ async fn claude_and_codex_specs_drive_the_same_wire() {
             AcpHarness::hermes().with_executable(fixture_path()),
         ),
         ("pi", AcpHarness::pi().with_executable(fixture_path())),
+        (
+            "cursor",
+            AcpHarness::cursor().with_executable(fixture_path()),
+        ),
     ] {
         let (controls, _steer, _token) = controls();
         let events = run_to_end(&h, request("scenario:happy"), controls).await;
@@ -400,7 +404,11 @@ async fn steer_racing_the_turn_end_never_emits_steered_after_done() {
     .await
     .expect("run finished in time");
 
-    assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)], "{events:?}");
+    assert_eq!(
+        dones(&events),
+        vec![(DoneStatus::Completed, None)],
+        "{events:?}"
+    );
     let steered = events
         .iter()
         .position(|e| matches!(e, AgentEvent::Steered { .. }))
@@ -409,7 +417,10 @@ async fn steer_racing_the_turn_end_never_emits_steered_after_done() {
         .iter()
         .position(|e| matches!(e, AgentEvent::Done { .. }))
         .expect("checked above");
-    assert!(steered < done, "Steered after Done strands the session: {events:?}");
+    assert!(
+        steered < done,
+        "Steered after Done strands the session: {events:?}"
+    );
 }
 
 #[tokio::test]
@@ -685,6 +696,158 @@ async fn real_claude_adapter_end_to_end() {
     assert_eq!(dones(&events)[0].0, DoneStatus::Completed, "{events:?}");
 }
 
+/// The Cursor slot against the real `cursor-agent acp` server: discovery
+/// (free) plus one tiny prompt. Run explicitly:
+/// `cargo test -p comet-harness --test acp -- --ignored real_cursor`
+#[tokio::test]
+#[ignore = "needs the cursor-agent CLI authenticated + network; costs one tiny prompt"]
+async fn real_cursor_adapter_end_to_end() {
+    // `session/new` is the source of truth for models — the static catalog is
+    // a fallback, so a live account must produce more than it.
+    let models = AcpHarness::cursor().models().await.expect("discovery");
+    assert!(models.len() > 5, "{models:?}");
+    assert!(
+        models
+            .iter()
+            .any(|m| m.id == "composer-2.5" || m.id.starts_with("composer-2.5")),
+        "{models:?}"
+    );
+    // Parameterized picker: base ids, no raw HTML, Mode on every row, Auto
+    // exposes Intelligence / Balance / Cost.
+    assert!(
+        models.iter().all(|m| !m.label.contains('<')),
+        "html leaked into labels: {:?}",
+        models
+            .iter()
+            .filter(|m| m.label.contains('<'))
+            .map(|m| &m.label)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        models
+            .iter()
+            .all(|m| m.options.iter().any(|o| o.id == "mode")),
+        "Mode trait missing"
+    );
+    let auto = models
+        .iter()
+        .find(|m| m.id == "auto-smart")
+        .expect("parameterized Auto id");
+    let optimize = auto
+        .options
+        .iter()
+        .find(|o| o.id == "optimize_for")
+        .expect("Optimize For");
+    let tiers: Vec<&str> = optimize.choices.iter().map(|c| c.id.as_str()).collect();
+    assert!(tiers.contains(&"intelligence"), "{tiers:?}");
+    assert!(tiers.contains(&"balanced"), "{tiers:?}");
+    assert!(tiers.contains(&"cost"), "{tiers:?}");
+
+    let (controls, steer_tx, _token) = controls();
+    let harness = AcpHarness::cursor();
+    let mut req = request("Reply with exactly the word ACP-OK and nothing else.");
+    req.model = models
+        .iter()
+        .find(|m| m.id == "composer-2.5" || m.id.starts_with("composer-2.5"))
+        .map(|m| m.id.clone());
+    req.reasoning = None;
+    req.cwd = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let stream = harness.run(req, controls).await.expect("run starts");
+    let events = tokio::time::timeout(Duration::from_secs(180), async move {
+        let mut stream = stream;
+        let mut steer = Some(steer_tx);
+        let mut events = Vec::new();
+        while let Some(ev) = stream.next().await {
+            let ev = ev.expect("stream event");
+            if matches!(ev, AgentEvent::Done { .. }) {
+                steer = None;
+            }
+            events.push(ev);
+        }
+        drop(steer);
+        events
+    })
+    .await
+    .expect("real run finished in time");
+    let text: String = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::TextDelta { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(text.contains("ACP-OK"), "unexpected reply: {text:?}");
+    assert_eq!(dones(&events).len(), 1, "{events:?}");
+    assert_eq!(dones(&events)[0].0, DoneStatus::Completed, "{events:?}");
+}
+
+/// Cursor's todo extension reaches the stream as a chip, and its tools land
+/// through the standard `session/update` path. Worth pinning live: the docs
+/// call `cursor/update_todos` a fire-and-forget notification, but the CLI
+/// sends it as a REQUEST — an unanswered one would stall the turn. Run:
+/// `cargo test -p comet-harness --test acp -- --ignored real_cursor_todos`
+#[tokio::test]
+#[ignore = "needs the cursor-agent CLI authenticated + network; costs one small prompt"]
+async fn real_cursor_todos_and_tools_reach_the_stream() {
+    let (controls, steer_tx, _token) = controls();
+    let harness = AcpHarness::cursor();
+    let mut req = request(
+        "Use your todo tool to record 3 steps, then run `echo hi` in the shell. \
+         Keep it brief.",
+    );
+    req.reasoning = None;
+    req.cwd = std::env::temp_dir().to_string_lossy().into_owned();
+    let stream = harness.run(req, controls).await.expect("run starts");
+    let events = tokio::time::timeout(Duration::from_secs(240), async move {
+        let mut stream = stream;
+        let mut steer = Some(steer_tx);
+        let mut events = Vec::new();
+        while let Some(ev) = stream.next().await {
+            let ev = ev.expect("stream event");
+            if matches!(ev, AgentEvent::Done { .. }) {
+                steer = None;
+            }
+            events.push(ev);
+        }
+        drop(steer);
+        events
+    })
+    .await
+    .expect("real run finished in time");
+    let todos: Vec<&AgentEvent> = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                AgentEvent::ToolCall {
+                    call: comet_proto::ToolCall::Todo { .. },
+                    ..
+                }
+            )
+        })
+        .collect();
+    assert!(!todos.is_empty(), "no todo chip: {events:?}");
+    // Repeated updates refresh one chip rather than stacking new ones.
+    assert!(
+        todos.iter().all(|e| matches!(
+            e,
+            AgentEvent::ToolCall { id, .. } if id == "cursor-todos"
+        )),
+        "todo chips must share the stable id: {todos:?}"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCall {
+                call: comet_proto::ToolCall::Exec { .. },
+                ..
+            }
+        )),
+        "no exec tool call: {events:?}"
+    );
+    assert_eq!(dones(&events)[0].0, DoneStatus::Completed, "{events:?}");
+}
+
 #[test]
 fn descriptor_surface_matches_registry_expectations() {
     let harness = AcpHarness::grok();
@@ -749,6 +912,18 @@ async fn models_fall_back_to_the_static_catalog_when_the_probe_fails() {
     let models = harness.models().await.expect("static fallback");
     let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
     assert_eq!(ids, vec!["default"], "{models:?}");
+}
+
+#[test]
+fn cursor_descriptor_surface_matches_registry_expectations() {
+    let cursor = AcpHarness::cursor();
+    assert_eq!(cursor.id(), HarnessId::Cursor);
+    assert_eq!(cursor.display_name(), "Cursor");
+    assert!(cursor.supports_steering());
+    assert_eq!(cursor.steering_mode(), SteeringMode::TurnBoundary);
+    // Cursor carries effort in the model id's bracket suffix, so there is no
+    // separate ladder for the Reasoning dropdown to drive.
+    assert!(cursor.reasoning_levels().is_empty());
 }
 
 #[test]

--- a/crates/ui/src/settings/harnesses.rs
+++ b/crates/ui/src/settings/harnesses.rs
@@ -37,7 +37,7 @@ pub fn blurb(harness: HarnessId) -> &'static str {
     match harness {
         HarnessId::ClaudeCode => "Anthropic's coding agent, driven through the Claude Code CLI.",
         HarnessId::Codex => "OpenAI's coding agent, driven through the Codex CLI.",
-        HarnessId::Cursor => "Cursor's CLI agent.",
+        HarnessId::Cursor => "Cursor's coding agent, driven through the cursor-agent CLI.",
         HarnessId::Grok => "xAI's Grok Build agent (grok CLI).",
         HarnessId::Hermes => "Nous Research's Hermes Agent (hermes CLI).",
         HarnessId::Pi => "The pi coding agent (pi CLI).",
@@ -50,7 +50,7 @@ pub fn cli_name(harness: HarnessId) -> &'static str {
     match harness {
         HarnessId::ClaudeCode => "claude",
         HarnessId::Codex => "codex",
-        HarnessId::Cursor => "cursor",
+        HarnessId::Cursor => "cursor-agent",
         HarnessId::Grok => "grok",
         HarnessId::Hermes => "hermes",
         HarnessId::Pi => "pi",

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -56,7 +56,7 @@ not built yet).
 | --- | --- | --- |
 | Claude Code adapter | done | stream-json, model discovery/effort ladders, AskUserQuestion → requestInput, steering via persistent input, init dedup, subagent filtering. **Live-verified against the real `claude` CLI 2.1.215**: doc-queued run → host executor → subprocess → streamed reply landed complete in the doc. |
 | Codex adapter | done | `codex app-server` JSON-RPC (thread/start/resume, sandbox policy). |
-| Cursor adapter | deferred | Parity item scheduled after Codex; no CLI surface settled. |
+| Cursor (ACP) | done | Shared `AcpHarness` spec; `cursor-agent acp` (Cursor's native ACP server), turn-boundary steering, no effort ladder (effort rides the model id's bracket suffix). Cursor's blocking extension methods are answered: `cursor/ask_question` → requestInput, `cursor/create_plan` auto-accepts, `cursor/update_todos` → todo chip. **Live-verified against the real `cursor-agent` CLI**: model discovery, streamed reply, todo chip and exec tool calls. |
 | Grok (ACP) | done | Shared `AcpHarness` spec; `grok agent stdio`, turn-boundary steering. |
 | Hermes (ACP) | done | Shared `AcpHarness` spec; `hermes acp` (Nous Research's native ACP server), turn-boundary steering, no effort ladder yet. |
 | Pi (ACP) | done | Shared `AcpHarness` spec; community `pi-acp` adapter (pinned 0.0.33, npx fallback), turn-boundary steering, minimal→max thinking ladder. |
@@ -99,13 +99,12 @@ not built yet).
 - **Mobile app** — out of scope for the native rewrite so far.
 - **E2EE** — transport is TLS + WorkOS bearers; end-to-end encryption of doc
   contents not designed.
-- **Cursor harness** (§4).
 - **macOS packaging execution** — config + steps in `dist/` only (needs a Mac).
 - **Engine hardening**: single-instance lock, parent-PID watchdog, crash
   shield, idle reaper / stall watchdog, boot warm-open of recent chats.
 
 ## Summary
 
-Table rows above: **39 done · 6 partial · 1 deferred** (Cursor harness), plus
-the cross-cutting deferrals (mobile, E2EE, macOS packaging execution,
-engine hardening) — the last overlaps the named gaps in the partial rows.
+Table rows above: **40 done · 6 partial**, plus the cross-cutting deferrals
+(mobile, E2EE, macOS packaging execution, engine hardening) — the last
+overlaps the named gaps in the partial rows.


### PR DESCRIPTION
## Summary
- Add Cursor as a Comet harness/plugin driven by `cursor-agent acp` (native ACP server, turn-boundary steering).
- Answer Cursor's blocking extension methods so a turn cannot wedge: `cursor/ask_question` → input bridge, `cursor/create_plan` auto-accepts, `cursor/update_todos` → todo chip.
- Opt into Cursor's parameterized model picker (`clientCapabilities._meta.parameterizedModelPicker`): base ids, Auto's Optimize For (Intelligence / Balance / Cost), Mode trait, and effort variants on the model id.