### PR TITLE
Bootstrap checkpoint heals dep-hole chat2 rooms

### DIFF
--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -915,6 +915,37 @@ impl DocHost {
                             *client_slot = Some(client);
                         }
                         tracing::info!(chat = %chat, "chat2 room joined (converged)");
+                        // Bootstrap heal: a room with NO checkpoint can't
+                        // cover its rows' causal deps for cold readers — a
+                        // pre-0.1.34 first contact whose init batch never
+                        // went up (every reader parks every row on missing
+                        // deps, transcript invisible forever), or a host
+                        // whose WS pushes strand. The checkpoint is the
+                        // universal patch: full doc over plain HTTP. Checked
+                        // once, shortly after join (an idle chat never hits
+                        // the quiesce tick, so the tick can't be the only
+                        // trigger).
+                        if host.is_host(&chat) {
+                            let host = host.clone();
+                            let weak = weak.clone();
+                            tokio::spawn(async move {
+                                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                                let Some(handle) = weak.upgrade() else { return };
+                                let no_checkpoint = lock(&handle.chat2)
+                                    .as_ref()
+                                    .is_some_and(|c| c.stats().checkpoint_size == 0);
+                                let has_content = handle
+                                    .doc
+                                    .read_entries()
+                                    .map(|e| !e.is_empty())
+                                    .unwrap_or(false);
+                                if no_checkpoint && has_content {
+                                    tracing::info!(chat = %handle.chat_id,
+                                        "chat2 room has rows but no checkpoint; posting bootstrap checkpoint");
+                                    host.spawn_chat2_checkpoint(&handle, "bootstrap");
+                                }
+                            });
+                        }
                         // Host recovery duties (C3): a wiped room needs a
                         // seed checkpoint or fresh readers see only
                         // post-reset rows; rejected pushes reach peers only

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -278,6 +278,10 @@ pub struct ChatStatsSnapshot {
     pub head_seq: u64,
     pub seq_floor: u64,
     pub checkpoint_seq: u64,
+    /// Byte size of the room's stored checkpoint (0 = none). The host's
+    /// bootstrap heal keys off this: a room with rows but NO checkpoint
+    /// cannot cover its rows' causal deps for cold readers.
+    pub checkpoint_size: u64,
     pub row_count: u64,
     pub row_bytes: u64,
     pub pending_pushes: u64,
@@ -505,6 +509,7 @@ impl ChatClient {
             head_seq: server.head_seq,
             seq_floor: server.seq_floor,
             checkpoint_seq: server.checkpoint_seq,
+            checkpoint_size: server.checkpoint_size,
             row_count: server.row_count,
             row_bytes: server.row_bytes,
             pending_pushes: shared.pending.len() as u64,


### PR DESCRIPTION
A chat2 room seeded by a pre-first-contact-push host (0.1.33-era) strands every reader on missing loro deps — hit live by home-laptop's new session created minutes before 0.1.34 landed. Hosts now post a full checkpoint whenever their room has rows but no checkpoint; readers converge via CheckpointThenRows. Smoke green (8/8), suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788975670&installation_model_id=425430&pr_number=38&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F38&signature=a3a962c91db0b9402f461ad52ccc9d84406896e5c19cd0570b9d93f543a6affc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->