### PR TITLE
Changes panel: flush glass pane, diff scopes, ref selector

### DIFF
--- a/crates/engine/src/diff_sync.rs
+++ b/crates/engine/src/diff_sync.rs
@@ -18,6 +18,12 @@
 //! Fast recursive `notify` watchers (debounced [`WATCH_DEBOUNCE`]) are backed by a
 //! slow 2-minute repair tick because native watchers may coalesce or drop events.
 //! Snapshots carry a sha256 checksum; an unchanged checksum publishes nothing.
+//!
+//! Beyond the working-tree watch, the service also answers one-shot
+//! `GetCheckoutDiff` captures for the Changes pane's scopes: *branch changes*
+//! (vs `merge-base(baseRef, HEAD)`, same capture path with the base overridden)
+//! and *latest turn* (vs a temp-index `write-tree` snapshot taken when a turn
+//! dispatches — see [`CheckoutDiffSync::note_turn_start`]).
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -96,6 +102,18 @@ struct CheckoutEntry {
     _watchers: Vec<notify::RecommendedWatcher>,
 }
 
+/// Working-tree snapshot recorded when a chat's turn dispatches — the diff
+/// base for the Changes pane's "Latest turn" scope. In-memory only: after an
+/// engine restart the scope is unavailable until the next turn.
+#[derive(Debug, Clone)]
+pub struct TurnSnapshot {
+    /// Canonical checkout root the tree was captured in.
+    pub root: PathBuf,
+    /// `git write-tree` sha of the tracked + untracked (unignored) tree.
+    pub tree: String,
+    pub at: chrono::DateTime<chrono::Utc>,
+}
+
 struct DiffSyncInner {
     repos: Repos,
     workspace: WorkspaceHost,
@@ -104,6 +122,8 @@ struct DiffSyncInner {
     http: reqwest::Client,
     entries: Mutex<HashMap<String, Arc<CheckoutEntry>>>,
     diffs_tx: watch::Sender<Vec<CheckoutDiff>>,
+    /// chat_id → turn-start tree (see [`TurnSnapshot`]).
+    turn_trees: Mutex<HashMap<String, TurnSnapshot>>,
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
@@ -134,6 +154,7 @@ impl CheckoutDiffSync {
                 http: reqwest::Client::new(),
                 entries: Mutex::new(HashMap::new()),
                 diffs_tx,
+                turn_trees: Mutex::new(HashMap::new()),
             }),
         };
         tokio::spawn(diff_sync_task(
@@ -160,6 +181,44 @@ impl CheckoutDiffSync {
         for entry in lock(&self.inner.entries).values() {
             let _ = entry.kick_tx.send(());
         }
+    }
+
+    /// A turn is starting for `chat_id` in `cwd`: snapshot the checkout's tree
+    /// in the background so "Latest turn" has a base. Best-effort — failures
+    /// only log; a chat outside a checkout simply records nothing.
+    pub fn note_turn_start(&self, chat_id: &str, cwd: &str) {
+        let inner = Arc::downgrade(&self.inner);
+        let chat_id = chat_id.to_string();
+        let cwd = PathBuf::from(cwd);
+        tokio::spawn(async move {
+            let Some(inner) = inner.upgrade() else { return };
+            let identity = match inner.repos.checkout_identity(&cwd).await {
+                Ok(identity) => identity,
+                Err(_) => return, // not a checkout
+            };
+            match snapshot_tree(&identity.root).await {
+                Ok(tree) => {
+                    lock(&inner.turn_trees).insert(
+                        chat_id,
+                        TurnSnapshot {
+                            root: identity.root,
+                            tree,
+                            at: chrono::Utc::now(),
+                        },
+                    );
+                }
+                Err(err) => {
+                    tracing::debug!(chat = %chat_id, error = %err,
+                        "diff-sync: turn snapshot failed");
+                }
+            }
+        });
+    }
+
+    /// The recorded turn-start snapshot for a chat, if any turn dispatched
+    /// since boot.
+    pub fn turn_snapshot(&self, chat_id: &str) -> Option<TurnSnapshot> {
+        lock(&self.inner.turn_trees).get(chat_id).cloned()
     }
 }
 
@@ -675,14 +734,27 @@ fn untracked_patch(path: &str, content: &str) -> String {
 /// as synthesized new-file hunks. 3MiB patch cap with a `truncated` flag; sha256
 /// checksum over branch ‖ head ‖ patch ‖ files ‖ truncated.
 pub async fn capture_diff(repos: &Repos, root: &Path) -> Result<DiffSnapshot, EngineError> {
+    capture_diff_against(repos, root, None).await
+}
+
+/// [`capture_diff`] with the diff base overridable: `None` keeps the
+/// working-tree behavior (vs HEAD / the empty tree); `Some(committish)` diffs
+/// the working tree against that base instead ("Branch changes" passes the
+/// merge-base with the comparison ref). Untracked files synthesize as new
+/// either way — they are new relative to any committed base.
+pub async fn capture_diff_against(
+    repos: &Repos,
+    root: &Path,
+    base_override: Option<&str>,
+) -> Result<DiffSnapshot, EngineError> {
     let head = capture_git(root, &["rev-parse", "--verify", "HEAD"], 256)
         .await
         .map(|c| String::from_utf8_lossy(&c.stdout).trim().to_string())
         .unwrap_or_default();
-    let base: &str = if head.is_empty() {
-        EMPTY_TREE_SHA
-    } else {
-        &head
+    let base: &str = match base_override {
+        Some(base) => base,
+        None if head.is_empty() => EMPTY_TREE_SHA,
+        None => &head,
     };
     let branch = repos
         .current_branch(root)
@@ -799,6 +871,163 @@ pub async fn capture_diff(repos: &Repos, root: &Path) -> Result<DiffSnapshot, En
             deletions: 0,
             binary,
         });
+    }
+
+    let additions: u32 = files.iter().map(|f| f.additions).sum();
+    let deletions: u32 = files.iter().map(|f| f.deletions).sum();
+    let files_json = serde_json::to_string(&files)
+        .map_err(|e| EngineError::Other(format!("diff files serialize: {e}")))?;
+    let mut hasher = Sha256::new();
+    hasher.update(branch.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(head.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(patch.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(files_json.as_bytes());
+    hasher.update(if truncated { b"1" } else { b"0" });
+    let checksum = crate::repos::hex(&hasher.finalize());
+
+    Ok(DiffSnapshot {
+        branch,
+        head_sha: (!head.is_empty()).then_some(head),
+        patch,
+        files,
+        additions,
+        deletions,
+        truncated,
+        checksum,
+    })
+}
+
+/// `git merge-base <base_ref> HEAD` — the diff base for "Branch changes".
+/// Errors when the ref is unknown or the histories are unrelated.
+pub async fn merge_base(root: &Path, base_ref: &str) -> Result<String, EngineError> {
+    let capture = capture_git(root, &["merge-base", base_ref, "HEAD"], 256).await?;
+    let sha = String::from_utf8_lossy(&capture.stdout).trim().to_string();
+    if sha.is_empty() {
+        return Err(EngineError::Other(format!(
+            "no merge base with {base_ref}"
+        )));
+    }
+    Ok(sha)
+}
+
+/// Write the checkout's current tracked + untracked (unignored) tree into the
+/// object db via a throwaway index: `git add -A` under `GIT_INDEX_FILE`, then
+/// `git write-tree`. The real index is never touched. Costs one full hash pass
+/// over the working tree (no stat cache in a fresh index) — run once per turn
+/// dispatch, that is the same cost class as the untracked-file reads the watch
+/// capture already does.
+pub async fn snapshot_tree(root: &Path) -> Result<String, EngineError> {
+    let index = std::env::temp_dir().join(format!(
+        "comet-turn-index-{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_micros()
+    ));
+    let run = |args: &[&str]| {
+        let mut cmd = tokio::process::Command::new("git");
+        cmd.arg("-C").arg(root).args(args);
+        cmd.env("GIT_INDEX_FILE", &index);
+        cmd.stdin(std::process::Stdio::null());
+        cmd.output()
+    };
+    let added = run(&["add", "-A", "--ignore-errors", "."])
+        .await
+        .map_err(|e| EngineError::Other(format!("git add failed: {e}")))?;
+    if !added.status.success() {
+        let _ = tokio::fs::remove_file(&index).await;
+        return Err(EngineError::Other(format!(
+            "git add: {}",
+            String::from_utf8_lossy(&added.stderr).trim()
+        )));
+    }
+    let written = run(&["write-tree"])
+        .await
+        .map_err(|e| EngineError::Other(format!("git write-tree failed: {e}")));
+    let _ = tokio::fs::remove_file(&index).await;
+    let written = written?;
+    if !written.status.success() {
+        return Err(EngineError::Other(format!(
+            "git write-tree: {}",
+            String::from_utf8_lossy(&written.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&written.stdout).trim().to_string())
+}
+
+/// "Latest turn" capture: tree-to-tree diff from the turn-start snapshot to a
+/// fresh [`snapshot_tree`] of the current state. Both trees carry untracked
+/// (unignored) files, so no synthesis is needed and a file that was already
+/// untracked at turn start diffs correctly (the watch capture's synthesis
+/// would misreport it as entirely new).
+pub async fn capture_turn_diff(
+    repos: &Repos,
+    root: &Path,
+    turn_tree: &str,
+) -> Result<DiffSnapshot, EngineError> {
+    let current = snapshot_tree(root).await?;
+    let head = capture_git(root, &["rev-parse", "--verify", "HEAD"], 256)
+        .await
+        .map(|c| String::from_utf8_lossy(&c.stdout).trim().to_string())
+        .unwrap_or_default();
+    let branch = repos
+        .current_branch(root)
+        .await
+        .unwrap_or_else(|_| "HEAD".into());
+
+    let names = capture_git(
+        root,
+        &[
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            turn_tree,
+            &current,
+            "--",
+        ],
+        2 * 1024 * 1024,
+    )
+    .await?;
+    let nums = capture_git(
+        root,
+        &[
+            "diff",
+            "--numstat",
+            "-z",
+            "--find-renames",
+            turn_tree,
+            &current,
+            "--",
+        ],
+        2 * 1024 * 1024,
+    )
+    .await?;
+    let tracked = capture_git(
+        root,
+        &[
+            "diff",
+            "--no-ext-diff",
+            "--no-color",
+            "--find-renames",
+            "--unified=3",
+            turn_tree,
+            &current,
+            "--",
+        ],
+        MAX_PATCH_BYTES,
+    )
+    .await?;
+
+    let mut files = parse_name_status(&names.stdout);
+    apply_numstat(&mut files, &nums.stdout);
+    let mut patch = String::from_utf8_lossy(&tracked.stdout).to_string();
+    let truncated = tracked.truncated || names.truncated || nums.truncated;
+    if tracked.truncated {
+        let boundary = patch.rfind('\n').unwrap_or(0);
+        patch.truncate(boundary);
+        patch.push_str("\n# Comet diff truncated\n");
     }
 
     let additions: u32 = files.iter().map(|f| f.additions).sum();

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -31,7 +31,10 @@ pub mod workspace_host;
 
 pub use agent_accounts::{AgentAccounts, AgentAccountsConfig};
 pub use auth::{Auth, AuthConfig, AuthState, AuthUser, OrgMembership};
-pub use diff_sync::{CheckoutDiffSync, DiffSidecar, DiffSnapshot, capture_diff};
+pub use diff_sync::{
+    CheckoutDiffSync, DiffSidecar, DiffSnapshot, TurnSnapshot, capture_diff, capture_diff_against,
+    capture_turn_diff, merge_base, snapshot_tree,
+};
 pub use doc_host::{ChatDocHandle, DocHost, DocHostConfig, EdgeConfig};
 pub use instance_lock::InstanceLock;
 pub use registry::{HarnessDescriptor, HarnessRegistry, default_registry};
@@ -197,6 +200,11 @@ impl EngineCore {
             repos.clone(),
         ));
         let diff_sync = CheckoutDiffSync::start(repos.clone(), workspace.clone(), &device_id, edge);
+        // Turn starts snapshot the checkout tree — the "Latest turn" diff base.
+        let turn_diff = diff_sync.clone();
+        sessions.set_turn_listener(Arc::new(move |chat_id, cwd| {
+            turn_diff.note_turn_start(chat_id, cwd);
+        }));
         let spaces_sync = SpacesSync::start(repos.clone(), workspace.clone(), &device_id);
         Ok(Self {
             sessions,

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -757,6 +757,7 @@ fn forwardable(method: &str) -> bool {
             | methods::DELETE_WORKTREE
             // Checkout diffs are produced on the device holding the checkout.
             | methods::WATCH_CHECKOUT_DIFFS
+            | methods::GET_CHECKOUT_DIFF
             // Terminals live on the chat's host device.
             | methods::OPEN_TERMINAL
             | methods::SUBSCRIBE_TERMINAL
@@ -1090,6 +1091,68 @@ impl RpcService for EngineRpc {
             }
             methods::WATCH_CHECKOUT_DIFFS => {
                 Ok(RpcReply::Stream(watch_stream(self.diff_sync.watch_diffs())))
+            }
+            // One-shot scoped capture for the Changes pane: `branch` diffs the
+            // working tree against merge-base(baseRef, HEAD); `turn` diffs the
+            // turn-start tree snapshot against the current tree; anything else
+            // is the plain working-tree capture.
+            methods::GET_CHECKOUT_DIFF => {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct P {
+                    cwd: String,
+                    #[serde(default)]
+                    mode: String,
+                    base_ref: Option<String>,
+                    chat_id: Option<String>,
+                }
+                let p: P = parse_params(params)?;
+                let identity = self
+                    .repos
+                    .checkout_identity(std::path::Path::new(&p.cwd))
+                    .await
+                    .map_err(|e| RpcError::Failed(e.to_string()))?;
+                let root = identity.root.as_path();
+                let snapshot = match p.mode.as_str() {
+                    "branch" => {
+                        let base_ref = p
+                            .base_ref
+                            .as_deref()
+                            .ok_or_else(|| RpcError::Failed("baseRef required".into()))?;
+                        let base = crate::diff_sync::merge_base(root, base_ref)
+                            .await
+                            .map_err(|e| RpcError::Failed(e.to_string()))?;
+                        crate::diff_sync::capture_diff_against(&self.repos, root, Some(&base))
+                            .await
+                    }
+                    "turn" => {
+                        let chat_id = p
+                            .chat_id
+                            .as_deref()
+                            .ok_or_else(|| RpcError::Failed("chatId required".into()))?;
+                        let snapshot = self
+                            .diff_sync
+                            .turn_snapshot(chat_id)
+                            .filter(|s| s.root == identity.root)
+                            .ok_or_else(|| RpcError::Failed("no turn recorded".into()))?;
+                        crate::diff_sync::capture_turn_diff(&self.repos, root, &snapshot.tree)
+                            .await
+                    }
+                    _ => crate::diff_sync::capture_diff(&self.repos, root).await,
+                }
+                .map_err(|e| RpcError::Failed(e.to_string()))?;
+                RpcReply::value(&comet_proto::CheckoutDiff {
+                    checkout_id: identity.id,
+                    device_id: self.doc_host.device_id().to_string(),
+                    cwd: identity.root.to_string_lossy().to_string(),
+                    patch: snapshot.patch,
+                    files: snapshot.files,
+                    additions: snapshot.additions,
+                    deletions: snapshot.deletions,
+                    truncated: snapshot.truncated,
+                    checksum: snapshot.checksum,
+                    updated_at: chrono::Utc::now(),
+                })
             }
             methods::LIST_REPOS => RpcReply::value(&self.repos.list().await),
             methods::ADD_REPO => {

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -115,7 +115,14 @@ struct Inner {
     harness_sessions: Mutex<HashMap<String, HarnessSessionRef>>,
     /// Auto-titler for untitled chats (wired at engine assembly; absent in bare tests).
     titles: OnceLock<crate::titles::TitleGenerator>,
+    /// Fired with `(chat_id, cwd)` when a user prompt starts a turn (fresh
+    /// dispatch or accepted steer) — the diff sync snapshots the checkout tree
+    /// for the Changes pane's "Latest turn" scope. Absent in bare tests.
+    turn_listener: OnceLock<TurnListener>,
 }
+
+/// Turn-start hook: called with `(chat_id, cwd)`.
+pub type TurnListener = Arc<dyn Fn(&str, &str) + Send + Sync>;
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(PoisonError::into_inner)
@@ -146,6 +153,7 @@ impl SessionsEngine {
                 last_requests: Mutex::new(HashMap::new()),
                 harness_sessions: Mutex::new(HashMap::new()),
                 titles: OnceLock::new(),
+                turn_listener: OnceLock::new(),
             }),
         }
     }
@@ -160,6 +168,17 @@ impl SessionsEngine {
     /// completed exchange the run task fires it for still-untitled chats.
     pub fn set_titles(&self, titles: crate::titles::TitleGenerator) {
         let _ = self.inner.titles.set(titles);
+    }
+
+    /// Wire the turn-start listener (called once at engine assembly).
+    pub fn set_turn_listener(&self, listener: TurnListener) {
+        let _ = self.inner.turn_listener.set(listener);
+    }
+
+    fn note_turn_start(&self, chat_id: &str, cwd: &str) {
+        if let Some(listener) = self.inner.turn_listener.get() {
+            listener(chat_id, cwd);
+        }
     }
 
     fn doc_handle(&self, chat_id: &str) -> Result<Arc<ChatDocHandle>, EngineError> {
@@ -263,6 +282,8 @@ impl SessionsEngine {
         // Project-less chats store cwd `~` (the creating device can't know the
         // host's home); expand it here, on the host, where the run spawns.
         request.cwd = expand_home(&request.cwd);
+        // Every dispatched prompt is a turn — routed steer or fresh run alike.
+        self.note_turn_start(chat_id, &request.cwd);
         let routed = lock(&self.inner.runs).get(chat_id).map(|h| {
             (
                 h.run_id.clone(),
@@ -444,6 +465,11 @@ impl SessionsEngine {
         });
         let handle = self.doc_handle(chat_id)?;
         handle.write_user_message(&user_id, prompt, now_ms())?;
+        // A routed steer is a turn too. Fired here (not only on the confirmed
+        // path) — a reclaim falls back to dispatch, which just re-snapshots.
+        if let Some(request) = self.last_request(chat_id) {
+            self.note_turn_start(chat_id, &request.cwd);
+        }
         if self.is_live(chat_id, &run_id) {
             self.set_status(chat_id, SessionStatus::Working, false);
             self.inner.note_message(chat_id, prompt);

--- a/crates/engine/tests/m5_repos_diffs_terminals.rs
+++ b/crates/engine/tests/m5_repos_diffs_terminals.rs
@@ -8,7 +8,10 @@ use std::time::Duration;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 
-use comet_engine::{EngineCore, HarnessRegistry, Repos, Terminals, capture_diff};
+use comet_engine::{
+    EngineCore, HarnessRegistry, Repos, Terminals, capture_diff, capture_diff_against,
+    capture_turn_diff, merge_base, snapshot_tree,
+};
 use comet_proto::TerminalEvent;
 use comet_rpc::methods;
 
@@ -344,6 +347,81 @@ async fn diff_capture_tracked_untracked_and_checksum() {
         .await
         .expect("changed capture");
     assert_ne!(snapshot.checksum, changed.checksum);
+}
+
+#[tokio::test]
+async fn diff_capture_against_merge_base_shows_branch_changes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo_dir = tmp.path().join("repo");
+    init_repo(&repo_dir).await;
+    let repos = test_repos(&tmp.path().join("data"));
+
+    // Branch off, commit a change, then edit the working tree on top.
+    git(&repo_dir, &["checkout", "-b", "feature"]).await;
+    std::fs::write(repo_dir.join("c.txt"), "committed on feature\n").expect("write c.txt");
+    git(&repo_dir, &["add", "."]).await;
+    git(&repo_dir, &["commit", "-m", "feature work"]).await;
+    std::fs::write(repo_dir.join("a.txt"), "one\ntwo\nuncommitted\n").expect("edit a.txt");
+
+    // Working-tree capture sees only the uncommitted edit.
+    let working = capture_diff(&repos, &repo_dir).await.expect("working");
+    assert!(working.patch.contains("+uncommitted"));
+    assert!(!working.patch.contains("committed on feature"));
+
+    // Branch capture (vs merge-base with main) sees the commit AND the edit.
+    let base = merge_base(&repo_dir, "main").await.expect("merge base");
+    let branch = capture_diff_against(&repos, &repo_dir, Some(&base))
+        .await
+        .expect("branch capture");
+    assert!(branch.patch.contains("+committed on feature"));
+    assert!(branch.patch.contains("+uncommitted"));
+    assert!(branch.files.iter().any(|f| f.path == "c.txt"));
+
+    // Unknown ref errors instead of silently falling back.
+    assert!(merge_base(&repo_dir, "no-such-ref").await.is_err());
+}
+
+#[tokio::test]
+async fn turn_diff_captures_only_changes_since_snapshot() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo_dir = tmp.path().join("repo");
+    init_repo(&repo_dir).await;
+    let repos = test_repos(&tmp.path().join("data"));
+
+    // Pre-turn state: a tracked edit and an untracked file already exist.
+    std::fs::write(repo_dir.join("a.txt"), "one\ntwo\npre-turn\n").expect("edit a.txt");
+    std::fs::write(repo_dir.join("pre.txt"), "before the turn\n").expect("pre.txt");
+    let turn_tree = snapshot_tree(&repo_dir).await.expect("snapshot");
+
+    // Nothing changed yet: the turn diff is empty (pre-existing untracked
+    // files must NOT reappear as new).
+    let clean = capture_turn_diff(&repos, &repo_dir, &turn_tree)
+        .await
+        .expect("clean turn diff");
+    assert!(clean.patch.is_empty(), "unexpected: {}", clean.patch);
+    assert!(clean.files.is_empty());
+
+    // The "turn" edits one file and adds another.
+    std::fs::write(repo_dir.join("pre.txt"), "before the turn\nedited in turn\n")
+        .expect("edit pre.txt");
+    std::fs::write(repo_dir.join("turn.txt"), "made this turn\n").expect("turn.txt");
+    let turn = capture_turn_diff(&repos, &repo_dir, &turn_tree)
+        .await
+        .expect("turn diff");
+    assert!(turn.patch.contains("+edited in turn"));
+    assert!(turn.patch.contains("+made this turn"));
+    assert!(
+        !turn.patch.contains("pre-turn"),
+        "pre-turn tracked edit leaked into the turn diff"
+    );
+    assert!(turn.files.iter().any(|f| f.path == "turn.txt"));
+    let pre = turn
+        .files
+        .iter()
+        .find(|f| f.path == "pre.txt")
+        .expect("pre.txt summary");
+    assert_eq!(pre.status, "modified");
+    assert_eq!(pre.additions, 1);
 }
 
 #[tokio::test]

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -93,6 +93,7 @@ pub mod methods {
     /// Checkout-diff stream for the target device's chats (DataRpc,
     /// relay-forwardable — diffs are produced where the checkout lives).
     pub const WATCH_CHECKOUT_DIFFS: &str = "WatchCheckoutDiffs";
+    pub const GET_CHECKOUT_DIFF: &str = "GetCheckoutDiff";
     // Agent accounts (ControlRpc, relay-forwardable — CLI logins are per-device).
     pub const LIST_AGENT_ACCOUNTS: &str = "ListAgentAccounts";
     pub const ACTIVATE_AGENT_ACCOUNT: &str = "ActivateAgentAccount";

--- a/crates/ui/assets/icons/expand-arrows.svg
+++ b/crates/ui/assets/icons/expand-arrows.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 4h6v6m-.5-5.5L13 11M10 20H4v-6m.5 5.5L11 13"/></svg>

--- a/crates/ui/assets/icons/fold-vertical.svg
+++ b/crates/ui/assets/icons/fold-vertical.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 3.5l5 4.5 5-4.5M7 20.5l5-4.5 5 4.5M5 12h14"/></svg>

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -12,7 +12,11 @@
 //!   and a 200 ms chevron transition;
 //! - syntax highlight reuses the markdown tokenizer per diff line, computed
 //!   time-sliced on the background executor and applied as paint-only run
-//!   colors (layout never changes).
+//!   colors (layout never changes);
+//! - scopes (t3code parity): *Working tree* rides the watch stream; *Branch
+//!   changes* (vs a selectable base ref, default branch preselected) and
+//!   *Latest turn* fetch one-shot `GetCheckoutDiff` captures, refreshed when
+//!   the watch checksum says the tree moved.
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -30,6 +34,7 @@ use comet_rpc::methods;
 use crate::markdown::highlight::{Lang, LineCarry, Token, lang_for_tag, tokenize_line};
 use crate::markdown::render;
 use crate::motion::{self, AnimationExt as _, CHEVRON, COLLAPSE};
+use crate::popover::{self, Popup};
 use crate::state::{AppState, EngineHandle};
 use crate::theme::Theme;
 
@@ -368,6 +373,86 @@ pub fn uncommitted_label(count: usize) -> String {
     }
 }
 
+/// What the pane diffs against (t3code's scope dropdown).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DiffScope {
+    /// Uncommitted changes vs HEAD — the live watch stream.
+    #[default]
+    WorkingTree,
+    /// Everything this branch adds over `merge-base(base_ref, HEAD)`,
+    /// working tree included.
+    Branch,
+    /// Changes since the current chat's last turn started.
+    LatestTurn,
+}
+
+impl DiffScope {
+    pub const ALL: [DiffScope; 3] = [Self::WorkingTree, Self::Branch, Self::LatestTurn];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::WorkingTree => "Working tree",
+            Self::Branch => "Branch changes",
+            Self::LatestTurn => "Latest turn",
+        }
+    }
+
+    /// Wire value for `GetCheckoutDiff` `mode` (and parse-key discriminant).
+    pub fn mode(self) -> &'static str {
+        match self {
+            Self::WorkingTree => "workingTree",
+            Self::Branch => "branch",
+            Self::LatestTurn => "turn",
+        }
+    }
+}
+
+/// Header-strip label per scope.
+pub fn scope_label(scope: DiffScope, count: usize, base: Option<&str>) -> String {
+    let files = if count == 1 { "file" } else { "files" };
+    match scope {
+        DiffScope::WorkingTree => uncommitted_label(count),
+        DiffScope::Branch => match base {
+            Some(base) => format!("{count} Changed {files} vs {base}"),
+            None => format!("{count} Changed {files}"),
+        },
+        DiffScope::LatestTurn => format!("{count} Changed {files} this turn"),
+    }
+}
+
+/// The comparison ref the branch scope preselects. `branches` comes from
+/// `ListBranches` with the repo's default branch first — but a repo with no
+/// `origin/HEAD` falls back to the *checked-out* branch there, and comparing a
+/// branch with itself is useless; prefer `main`/`master` in that case.
+pub fn default_base_ref(branches: &[String], current: Option<&str>) -> Option<String> {
+    let first = branches.first()?;
+    if current != Some(first.as_str()) {
+        return Some(first.clone());
+    }
+    for candidate in ["main", "master"] {
+        if branches.iter().any(|b| b == candidate) {
+            return Some(candidate.to_string());
+        }
+    }
+    branches
+        .iter()
+        .find(|b| current != Some(b.as_str()))
+        .or(Some(first))
+        .cloned()
+}
+
+/// Empty-state copy per scope.
+pub fn clean_message(scope: DiffScope, base: Option<&str>) -> String {
+    match scope {
+        DiffScope::WorkingTree => "No uncommitted changes".to_string(),
+        DiffScope::Branch => match base {
+            Some(base) => format!("No changes vs {base}"),
+            None => "No branch changes".to_string(),
+        },
+        DiffScope::LatestTurn => "No changes this turn".to_string(),
+    }
+}
+
 /// Fold a `WatchCheckoutDiffs` frame into the diff set. Accepts either a full
 /// list (replace) or a single `CheckoutDiff` (upsert by checkout id) — the
 /// contract streams `CheckoutDiff` items, but list frames cost nothing to
@@ -473,6 +558,12 @@ async fn yield_now() {
     .await
 }
 
+/// Shell-facing events from the pane's toolbar.
+pub enum PaneEvent {
+    /// The expand button: widen/restore the panel (shell owns the width).
+    ToggleExpand,
+}
+
 /// The Changes pane entity. Lazy: no RPC until [`Changes::ensure_watch`] runs
 /// (the shell calls it when the pane first opens).
 pub struct Changes {
@@ -491,8 +582,27 @@ pub struct Changes {
     folds: HashMap<String, FileFold>,
     highlights: HashMap<String, HighlightSlot>,
     list: ListState,
+    /// What the pane diffs against (toolbar dropdown).
+    scope: DiffScope,
+    /// Comparison ref for [`DiffScope::Branch`] — preset to the repo's
+    /// default branch once the branch list lands.
+    base_ref: Option<String>,
+    branches: Vec<String>,
+    /// `device:cwd` the branch list was fetched for.
+    branches_for: Option<String>,
+    branches_task: Option<Task<()>>,
+    /// One-shot scoped capture (Branch / Latest turn) + its fetch key.
+    scoped: Option<CheckoutDiff>,
+    scoped_for: Option<String>,
+    scoped_error: Option<SharedString>,
+    scoped_inflight: Option<String>,
+    scoped_task: Option<Task<()>>,
+    scope_menu: Popup<()>,
+    ref_menu: Popup<()>,
     _observe: Subscription,
 }
+
+impl gpui::EventEmitter<PaneEvent> for Changes {}
 
 impl Changes {
     pub fn new(state: Entity<AppState>, cx: &mut Context<Self>) -> Self {
@@ -509,6 +619,18 @@ impl Changes {
             folds: HashMap::new(),
             highlights: HashMap::new(),
             list: ListState::new(0, ListAlignment::Top, px(320.0)),
+            scope: DiffScope::default(),
+            base_ref: None,
+            branches: Vec::new(),
+            branches_for: None,
+            branches_task: None,
+            scoped: None,
+            scoped_for: None,
+            scoped_error: None,
+            scoped_inflight: None,
+            scoped_task: None,
+            scope_menu: Popup::default(),
+            ref_menu: Popup::default(),
             _observe: observe,
         }
     }
@@ -617,12 +739,228 @@ impl Changes {
         resolve_diff(&self.diffs, chat).cloned()
     }
 
-    /// Reconcile parsed content with the currently-resolved diff.
+    /// The checkout root the scoped RPCs address: the watch-resolved diff's
+    /// canonical cwd when available, else the chat row's own.
+    fn scoped_cwd(&self, cx: &App) -> Option<String> {
+        if let Some(diff) = self.resolved(cx) {
+            return Some(diff.cwd);
+        }
+        self.state.read(cx).selected_chat_row()?.cwd.clone()
+    }
+
+    /// The diff the pane currently displays: the watch stream for the working
+    /// tree, the one-shot scoped capture otherwise.
+    fn active_diff(&self, cx: &App) -> Option<CheckoutDiff> {
+        match self.scope {
+            DiffScope::WorkingTree => self.resolved(cx),
+            _ => self.scoped.clone(),
+        }
+    }
+
+    /// Scope discriminant folded into the parse key, so a scope or base
+    /// switch re-parses even when checksums collide.
+    fn scope_key(&self) -> String {
+        match self.scope {
+            DiffScope::WorkingTree => "wt".to_string(),
+            DiffScope::Branch => format!("br:{}", self.base_ref.as_deref().unwrap_or("")),
+            DiffScope::LatestTurn => "turn".to_string(),
+        }
+    }
+
+    fn parse_key(&self, diff: &CheckoutDiff) -> String {
+        format!(
+            "{}:{}:{}",
+            diff.checkout_id,
+            diff.checksum,
+            self.scope_key()
+        )
+    }
+
+    /// Fetch the branch list for the selected chat's checkout (idempotent per
+    /// device+cwd); the repo's default branch (first entry) becomes the
+    /// comparison base unless the user already picked one that still exists.
+    fn ensure_branches(&mut self, cx: &mut Context<Self>) {
+        let Some(cwd) = self.scoped_cwd(cx) else {
+            return;
+        };
+        let target = self.desired_target(cx);
+        let key = format!("{}:{}", target.as_deref().unwrap_or("local"), cwd);
+        if self.branches_for.as_deref() == Some(key.as_str()) {
+            return;
+        }
+        let Some(engine) = self.state.read(cx).engine().cloned() else {
+            return;
+        };
+        self.branches_for = Some(key.clone());
+        self.branches_task = Some(cx.spawn(async move |this, cx| {
+            let mut params = serde_json::Map::new();
+            params.insert("repoPath".into(), serde_json::Value::String(cwd));
+            if let Some(target) = target {
+                params.insert("targetDeviceId".into(), serde_json::Value::String(target));
+            }
+            let result = engine
+                .client()
+                .call(methods::LIST_BRANCHES, serde_json::Value::Object(params))
+                .await;
+            this.update(cx, |changes, cx| {
+                if changes.branches_for.as_deref() != Some(key.as_str()) {
+                    return; // superseded by a chat/device switch
+                }
+                match result {
+                    Ok(value) => {
+                        changes.branches =
+                            serde_json::from_value::<Vec<String>>(value).unwrap_or_default();
+                        let keep = changes
+                            .base_ref
+                            .as_ref()
+                            .is_some_and(|base| changes.branches.contains(base));
+                        if !keep {
+                            let current = changes
+                                .state
+                                .read(cx)
+                                .selected_chat_row()
+                                .and_then(|chat| chat.branch.clone());
+                            changes.base_ref =
+                                default_base_ref(&changes.branches, current.as_deref());
+                        }
+                        changes.sync(cx);
+                    }
+                    Err(err) => {
+                        tracing::debug!(error = %err, "changes: branch list failed");
+                        // Allow a retry on the next state change.
+                        changes.branches_for = None;
+                    }
+                }
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    /// Keep the one-shot scoped capture fresh. The fetch key folds in the
+    /// watch checksum, so any working-tree change (or commit — HEAD rides the
+    /// checksum) re-captures; a context change (chat/scope/base) clears the
+    /// stale content first so the pane shows the spinner, while a
+    /// checksum-only refresh keeps the old diff visible until the new one
+    /// lands.
+    fn ensure_scoped(&mut self, cx: &mut Context<Self>) {
+        if self.scope == DiffScope::WorkingTree {
+            self.scoped_inflight = None;
+            self.scoped_task = None;
+            return;
+        }
+        let Some(chat_id) = self
+            .state
+            .read(cx)
+            .selected_chat_row()
+            .map(|chat| chat.id.clone())
+        else {
+            return;
+        };
+        let Some(cwd) = self.scoped_cwd(cx) else {
+            return;
+        };
+        let base = match self.scope {
+            DiffScope::Branch => match &self.base_ref {
+                Some(base) => Some(base.clone()),
+                None => return, // branch list still loading
+            },
+            _ => None,
+        };
+        let target = self.desired_target(cx);
+        let context = format!(
+            "{}|{}|{}|{}|{}",
+            target.as_deref().unwrap_or("local"),
+            chat_id,
+            cwd,
+            self.scope.mode(),
+            base.as_deref().unwrap_or("")
+        );
+        let watch_sum = self.resolved(cx).map(|d| d.checksum).unwrap_or_default();
+        let key = format!("{context}|{watch_sum}");
+        if self.scoped_for.as_deref() == Some(key.as_str())
+            || self.scoped_inflight.as_deref() == Some(key.as_str())
+        {
+            return;
+        }
+        if self
+            .scoped_for
+            .as_deref()
+            .is_none_or(|prev| !prev.starts_with(&format!("{context}|")))
+        {
+            self.scoped = None;
+            self.scoped_error = None;
+        }
+        let Some(engine) = self.state.read(cx).engine().cloned() else {
+            return;
+        };
+        let mode = self.scope.mode();
+        self.scoped_inflight = Some(key.clone());
+        self.scoped_task = Some(cx.spawn(async move |this, cx| {
+            let mut params = serde_json::Map::new();
+            params.insert("cwd".into(), serde_json::Value::String(cwd));
+            params.insert("mode".into(), serde_json::Value::String(mode.to_string()));
+            params.insert("chatId".into(), serde_json::Value::String(chat_id));
+            if let Some(base) = base {
+                params.insert("baseRef".into(), serde_json::Value::String(base));
+            }
+            if let Some(target) = target {
+                params.insert("targetDeviceId".into(), serde_json::Value::String(target));
+            }
+            let result = engine
+                .client()
+                .call(methods::GET_CHECKOUT_DIFF, serde_json::Value::Object(params))
+                .await;
+            this.update(cx, |changes, cx| {
+                if changes.scoped_inflight.as_deref() != Some(key.as_str()) {
+                    return; // superseded
+                }
+                changes.scoped_inflight = None;
+                match result.and_then(|value| {
+                    serde_json::from_value::<CheckoutDiff>(value)
+                        .map_err(|e| comet_rpc::RpcError::Failed(e.to_string()))
+                }) {
+                    Ok(diff) => {
+                        changes.scoped = Some(diff);
+                        changes.scoped_error = None;
+                    }
+                    Err(err) => {
+                        changes.scoped = None;
+                        changes.scoped_error = Some(err.to_string().into());
+                    }
+                }
+                changes.scoped_for = Some(key);
+                changes.sync(cx);
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    fn set_scope(&mut self, scope: DiffScope, cx: &mut Context<Self>) {
+        if self.scope != scope {
+            self.scope = scope;
+            self.sync(cx);
+        }
+        cx.notify();
+    }
+
+    fn set_base_ref(&mut self, base: String, cx: &mut Context<Self>) {
+        if self.base_ref.as_deref() != Some(base.as_str()) {
+            self.base_ref = Some(base);
+            self.sync(cx);
+        }
+        cx.notify();
+    }
+
+    /// Reconcile parsed content with the currently-active diff.
     fn sync(&mut self, cx: &mut Context<Self>) {
         // The watch follows the selected chat's host device (idempotent when
         // the target is unchanged); a boot-deferred attempt retries here too.
         self.ensure_watch(cx);
-        let Some(diff) = self.resolved(cx) else {
+        self.ensure_branches(cx);
+        self.ensure_scoped(cx);
+        let Some(diff) = self.active_diff(cx) else {
             if self.parsed.take().is_some() {
                 self.list.reset(0);
                 self.folds.clear();
@@ -631,7 +969,7 @@ impl Changes {
             }
             return;
         };
-        let key = format!("{}:{}", diff.checkout_id, diff.checksum);
+        let key = self.parse_key(&diff);
         if self.parsed.as_ref().is_some_and(|p| p.key == key) {
             return;
         }
@@ -649,8 +987,8 @@ impl Changes {
             this.update(cx, |changes, cx| {
                 // Late results for a superseded diff are re-checked by key.
                 let current = changes
-                    .resolved(cx)
-                    .map(|d| format!("{}:{}", d.checkout_id, d.checksum));
+                    .active_diff(cx)
+                    .map(|d| changes.parse_key(&d));
                 if current.as_deref() != Some(key.as_str()) {
                     return;
                 }
@@ -692,6 +1030,48 @@ impl Changes {
         fold.collapsed = !currently_collapsed;
         fold.epoch += 1;
         fold.toggled_at = Some(std::time::Instant::now());
+    }
+
+    /// Every parsed file currently folded shut?
+    fn all_collapsed(&self) -> bool {
+        let Some(parsed) = &self.parsed else {
+            return false;
+        };
+        !parsed.files.is_empty()
+            && parsed.files.iter().all(|file| {
+                self.folds
+                    .get(&file.path)
+                    .is_some_and(|fold| fold.collapsed)
+            })
+    }
+
+    /// Collapse every file section, or expand them all when everything is
+    /// already shut (the toolbar's fold button, t3code parity). Steady-state
+    /// writes — no per-row tween arming, the whole list just snaps.
+    fn toggle_collapse_all(&mut self, cx: &mut Context<Self>) {
+        let Some(parsed) = &self.parsed else {
+            return;
+        };
+        let collapse = !self.all_collapsed();
+        let paths: Vec<String> = parsed.files.iter().map(|f| f.path.clone()).collect();
+        for path in paths {
+            let fold = self.folds.entry(path).or_default();
+            fold.collapsed = collapse;
+            fold.toggled_at = None;
+        }
+        cx.notify();
+    }
+
+    fn close_scope_menu(&mut self, cx: &mut Context<Self>) {
+        if self.scope_menu.begin_close() {
+            popover::reap_popup(cx, |changes: &mut Self| &mut changes.scope_menu);
+        }
+    }
+
+    fn close_ref_menu(&mut self, cx: &mut Context<Self>) {
+        if self.ref_menu.begin_close() {
+            popover::reap_popup(cx, |changes: &mut Self| &mut changes.ref_menu);
+        }
     }
 
     /// Tokens for a file's diff lines (paint-only). Kicks a time-sliced
@@ -914,6 +1294,275 @@ impl Changes {
             .into_any_element()
     }
 
+    /// A small hover-washed icon button for the toolbar.
+    fn toolbar_button(
+        id: &'static str,
+        icon_path: &'static str,
+        theme: &Theme,
+    ) -> gpui::Stateful<gpui::Div> {
+        div()
+            .id(id)
+            .size(px(24.0))
+            .flex_none()
+            .flex()
+            .items_center()
+            .justify_center()
+            .rounded(px(6.0))
+            .cursor_pointer()
+            .bg(motion::hover_blend(
+                id,
+                crate::theme::wash(0.0),
+                crate::theme::wash(0.14),
+            ))
+            .on_hover(motion::hover_listener(id))
+            .child(
+                crate::icons::icon(icon_path)
+                    .size(px(14.0))
+                    .text_color(theme.text_muted.opacity(0.7)),
+            )
+    }
+
+    /// Toolbar: the scope dropdown on the left, fold-all + expand on the
+    /// right (t3code parity).
+    fn render_toolbar(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+        let scope = self.scope;
+        let trigger = div()
+            .id("changes-scope-trigger")
+            .h(px(24.0))
+            .px(px(8.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(6.0))
+            .rounded(px(6.0))
+            .cursor_pointer()
+            .bg(motion::hover_blend(
+                "changes-scope-trigger",
+                crate::theme::wash(0.05),
+                crate::theme::wash(0.14),
+            ))
+            .on_hover(motion::hover_listener("changes-scope-trigger"))
+            .on_click(cx.listener(|this, _, _, cx| {
+                if this.scope_menu.is_open() {
+                    this.close_scope_menu(cx);
+                } else {
+                    this.scope_menu.open(());
+                }
+                cx.notify();
+            }))
+            .child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(theme.text)
+                    .child(SharedString::from(scope.label())),
+            )
+            .child(
+                crate::icons::icon(crate::icons::ALT_ARROW_DOWN)
+                    .size(px(12.0))
+                    .text_color(theme.text_muted.opacity(0.7)),
+            );
+        let trigger = if self.scope_menu.get().is_some() {
+            let closing = self.scope_menu.closing_since();
+            let menu = self.render_scope_menu(theme, cx);
+            trigger.relative().child(popover::anchored_menu_below(
+                "changes-scope-menu",
+                menu,
+                closing,
+            ))
+        } else {
+            trigger
+        };
+
+        let fold = Self::toolbar_button("changes-fold-all", crate::icons::SORT_VERTICAL, theme)
+            .on_click(cx.listener(|this, _, _, cx| this.toggle_collapse_all(cx)));
+        let expand = Self::toolbar_button(
+            "changes-expand-pane",
+            crate::icons::SIDEBAR_MINIMALISTIC,
+            theme,
+        )
+        .on_click(cx.listener(|_, _, _, cx| cx.emit(PaneEvent::ToggleExpand)));
+
+        div()
+            .flex_none()
+            .h(px(40.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(6.0))
+            .px(px(Theme::SPACE_MD))
+            .border_b_1()
+            .border_color(crate::theme::hairline(0.06))
+            .child(trigger)
+            .child(div().flex_1())
+            .child(fold)
+            .child(expand)
+            .into_any_element()
+    }
+
+    fn render_scope_menu(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+        let current = self.scope;
+        popover::popover_card(theme)
+            .w(px(180.0))
+            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.close_scope_menu(cx)))
+            .children(DiffScope::ALL.into_iter().enumerate().map(|(ix, scope)| {
+                popover::menu_row(theme, scope == current, format!("changes-scope-row-{ix}"))
+                    .id(("changes-scope-row", ix))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.set_scope(scope, cx);
+                        this.close_scope_menu(cx);
+                    }))
+                    .child(
+                        div()
+                            .flex_1()
+                            .child(SharedString::from(scope.label())),
+                    )
+            }))
+            .into_any_element()
+    }
+
+    /// `{branch} → {base ⌄}` — which ref the branch scope compares against
+    /// (t3code's ref strip). Branch scope only.
+    fn render_ref_strip(&mut self, theme: &Theme, cx: &mut Context<Self>) -> Option<AnyElement> {
+        if self.scope != DiffScope::Branch {
+            return None;
+        }
+        let branch = self
+            .state
+            .read(cx)
+            .selected_chat_row()
+            .and_then(|chat| chat.branch.clone())
+            .unwrap_or_else(|| "HEAD".to_string());
+        let base = self
+            .base_ref
+            .clone()
+            .unwrap_or_else(|| "…".to_string());
+        let trigger = div()
+            .id("changes-ref-trigger")
+            .h(px(22.0))
+            .px(px(6.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(4.0))
+            .rounded(px(6.0))
+            .cursor_pointer()
+            .bg(motion::hover_blend(
+                "changes-ref-trigger",
+                crate::theme::wash(0.0),
+                crate::theme::wash(0.12),
+            ))
+            .on_hover(motion::hover_listener("changes-ref-trigger"))
+            .on_click(cx.listener(|this, _, _, cx| {
+                if this.ref_menu.is_open() {
+                    this.close_ref_menu(cx);
+                } else {
+                    this.ref_menu.open(());
+                }
+                cx.notify();
+            }))
+            .child(
+                div()
+                    .font_family(theme.font_mono.clone())
+                    .text_size(px(11.5))
+                    .text_color(theme.text)
+                    .child(SharedString::from(base)),
+            )
+            .child(
+                crate::icons::icon(crate::icons::ALT_ARROW_DOWN)
+                    .size(px(11.0))
+                    .text_color(theme.text_muted.opacity(0.7)),
+            );
+        let trigger = if self.ref_menu.get().is_some() {
+            let closing = self.ref_menu.closing_since();
+            let menu = self.render_ref_menu(theme, cx);
+            trigger.relative().child(popover::anchored_menu_below(
+                "changes-ref-menu",
+                menu,
+                closing,
+            ))
+        } else {
+            trigger
+        };
+        Some(
+            div()
+                .flex_none()
+                .h(px(32.0))
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(8.0))
+                .px(px(Theme::SPACE_MD))
+                .border_b_1()
+                .border_color(crate::theme::hairline(0.06))
+                .child(
+                    div()
+                        .min_w_0()
+                        .truncate()
+                        .font_family(theme.font_mono.clone())
+                        .text_size(px(11.5))
+                        .text_color(theme.text_dim)
+                        .child(SharedString::from(branch)),
+                )
+                .child(
+                    crate::icons::icon(crate::icons::ARROW_RIGHT)
+                        .size(px(12.0))
+                        .flex_none()
+                        .text_color(theme.text_faint),
+                )
+                .child(trigger)
+                .into_any_element(),
+        )
+    }
+
+    fn render_ref_menu(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+        let branches = self.branches.clone();
+        let current = self.base_ref.clone();
+        let card = popover::popover_card(theme)
+            .w(px(220.0))
+            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.close_ref_menu(cx)));
+        if branches.is_empty() {
+            return card
+                .child(
+                    div()
+                        .px(px(8.0))
+                        .py(px(6.0))
+                        .text_size(px(12.0))
+                        .text_color(theme.text_faint)
+                        .child(SharedString::from("No branches")),
+                )
+                .into_any_element();
+        }
+        card.child(
+            div()
+                .id("changes-ref-list")
+                .flex()
+                .flex_col()
+                .gap(px(2.0))
+                .max_h(px(240.0))
+                .overflow_y_scroll()
+                .children(branches.into_iter().enumerate().map(|(ix, name)| {
+                    let selected = current.as_deref() == Some(name.as_str());
+                    let label = name.clone();
+                    popover::menu_row(theme, selected, format!("changes-ref-row-{ix}"))
+                        .id(("changes-ref-row", ix))
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.set_base_ref(name.clone(), cx);
+                            this.close_ref_menu(cx);
+                        }))
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .truncate()
+                                .font_family(theme.font_mono.clone())
+                                .text_size(px(12.0))
+                                .child(SharedString::from(label)),
+                        )
+                })),
+        )
+        .into_any_element()
+    }
+
     fn render_header_strip(&self, theme: &Theme) -> Option<AnyElement> {
         let parsed = self.parsed.as_ref()?;
         Some(
@@ -931,7 +1580,11 @@ impl Changes {
                     div()
                         .text_size(px(12.0))
                         .text_color(theme.text_muted)
-                        .child(SharedString::from(uncommitted_label(parsed.file_count))),
+                        .child(SharedString::from(scope_label(
+                            self.scope,
+                            parsed.file_count,
+                            self.base_ref.as_deref(),
+                        ))),
                 )
                 .child(
                     div()
@@ -1177,84 +1830,124 @@ pub(crate) fn render_file_body(
 impl Render for Changes {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = Theme::of(cx).clone();
-        let resolved = self.resolved(cx);
+        let active = self.active_diff(cx);
+        let scope = self.scope;
+        let base = self.base_ref.clone();
         // With no session selected (new-chat canvas) there is nothing to
         // prepare — show the quiet empty state, not an endless spinner.
-        let phase = if self.state.read(cx).selected_chat_row().is_none() {
+        let no_chat = self.state.read(cx).selected_chat_row().is_none();
+        let phase = if no_chat {
             DiffPhase::Clean
         } else {
-            diff_phase(resolved.as_ref())
+            diff_phase(active.as_ref())
         };
         let error = self.error.clone();
-
-        let content: AnyElement = match phase {
-            DiffPhase::Preparing => div()
-                .flex_1()
-                .flex()
-                .flex_col()
-                .items_center()
-                .justify_center()
-                .gap(px(Theme::SPACE_SM))
-                .child(crate::loaders::gradient_spinner(
-                    "changes-preparing",
-                    &theme,
-                    3.0,
-                    cx.entity_id(),
-                    cx,
-                ))
-                .child(
-                    div()
-                        .text_size(px(12.0))
-                        .text_color(theme.text_faint)
-                        .child(SharedString::from("Preparing diff…")),
-                )
-                .into_any_element(),
-            DiffPhase::Clean => div()
-                .flex_1()
-                .flex()
-                .items_center()
-                .justify_center()
-                .text_size(px(12.0))
-                .text_color(theme.text_faint)
-                .child(SharedString::from("No uncommitted changes"))
-                .into_any_element(),
-            DiffPhase::List => {
-                if self.parsed.is_some() {
-                    div()
-                        .flex_1()
-                        .min_h_0()
-                        .flex()
-                        .flex_col()
-                        .children(self.render_header_strip(&theme))
-                        .child(
-                            list(self.list.clone(), cx.processor(Self::render_row))
-                                .flex_1()
-                                .with_sizing_behavior(gpui::ListSizingBehavior::Auto),
-                        )
-                        .into_any_element()
+        // Scoped fetch failures replace the content area. "no turn recorded"
+        // is the expected pre-first-turn state, not an error.
+        let scoped_notice: Option<(SharedString, bool)> = (!no_chat
+            && scope != DiffScope::WorkingTree)
+            .then(|| self.scoped_error.clone())
+            .flatten()
+            .map(|message| {
+                if message.contains("no turn recorded") {
+                    (
+                        SharedString::from("No turn recorded yet — send a message first"),
+                        false,
+                    )
                 } else {
-                    // Diff known, parse still running.
-                    div()
-                        .flex_1()
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .child(crate::loaders::gradient_spinner(
-                            "changes-parsing",
-                            &theme,
-                            3.0,
-                            cx.entity_id(),
-                            cx,
-                        ))
-                        .into_any_element()
+                    (message, true)
+                }
+            });
+
+        let content: AnyElement = if let Some((message, warn)) = scoped_notice {
+            div()
+                .flex_1()
+                .flex()
+                .items_center()
+                .justify_center()
+                .px(px(Theme::SPACE_LG))
+                .text_size(px(12.0))
+                .text_color(if warn {
+                    theme.warning.opacity(0.85)
+                } else {
+                    theme.text_faint
+                })
+                .child(message)
+                .into_any_element()
+        } else {
+            match phase {
+                DiffPhase::Preparing => div()
+                    .flex_1()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .justify_center()
+                    .gap(px(Theme::SPACE_SM))
+                    .child(crate::loaders::gradient_spinner(
+                        "changes-preparing",
+                        &theme,
+                        3.0,
+                        cx.entity_id(),
+                        cx,
+                    ))
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .text_color(theme.text_faint)
+                            .child(SharedString::from("Preparing diff…")),
+                    )
+                    .into_any_element(),
+                DiffPhase::Clean => div()
+                    .flex_1()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .text_size(px(12.0))
+                    .text_color(theme.text_faint)
+                    .child(SharedString::from(clean_message(scope, base.as_deref())))
+                    .into_any_element(),
+                    DiffPhase::List => {
+                    if self.parsed.is_some() {
+                        div()
+                            .flex_1()
+                            .min_h_0()
+                            .flex()
+                            .flex_col()
+                            .children(self.render_header_strip(&theme))
+                            .child(
+                                list(self.list.clone(), cx.processor(Self::render_row))
+                                    .flex_1()
+                                    .with_sizing_behavior(gpui::ListSizingBehavior::Auto),
+                            )
+                            .into_any_element()
+                    } else {
+                        // Diff known, parse still running.
+                        div()
+                            .flex_1()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .child(crate::loaders::gradient_spinner(
+                                "changes-parsing",
+                                &theme,
+                                3.0,
+                                cx.entity_id(),
+                                cx,
+                            ))
+                            .into_any_element()
+                    }
                 }
             }
         };
 
+        let toolbar = self.render_toolbar(&theme, cx);
+        let ref_strip = self.render_ref_strip(&theme, cx);
         div()
             .size_full()
             .flex()
             .flex_col()
+            .child(toolbar)
+            .children(ref_strip)
             .when_some(error, |el, message| {
                 el.child(
                     div()
@@ -1508,6 +2201,84 @@ rename to new_name.rs
         assert_eq!(uncommitted_label(0), "0 Uncommitted changes");
         assert_eq!(uncommitted_label(1), "1 Uncommitted change");
         assert_eq!(uncommitted_label(4), "4 Uncommitted changes");
+    }
+
+    #[test]
+    fn scope_labels_and_clean_messages() {
+        assert_eq!(
+            scope_label(DiffScope::WorkingTree, 2, None),
+            "2 Uncommitted changes"
+        );
+        assert_eq!(
+            scope_label(DiffScope::Branch, 1, Some("main")),
+            "1 Changed file vs main"
+        );
+        assert_eq!(scope_label(DiffScope::Branch, 3, None), "3 Changed files");
+        assert_eq!(
+            scope_label(DiffScope::LatestTurn, 2, None),
+            "2 Changed files this turn"
+        );
+        assert_eq!(
+            clean_message(DiffScope::WorkingTree, None),
+            "No uncommitted changes"
+        );
+        assert_eq!(
+            clean_message(DiffScope::Branch, Some("develop")),
+            "No changes vs develop"
+        );
+        assert_eq!(
+            clean_message(DiffScope::LatestTurn, None),
+            "No changes this turn"
+        );
+    }
+
+    #[test]
+    fn base_ref_defaults_to_repo_default_then_main() {
+        let branches = |names: &[&str]| -> Vec<String> {
+            names.iter().map(|n| n.to_string()).collect()
+        };
+        // Engine order puts the repo default first — take it when it isn't
+        // the checked-out branch itself.
+        let b = branches(&["main", "feature"]);
+        assert_eq!(
+            default_base_ref(&b, Some("feature")).as_deref(),
+            Some("main")
+        );
+        // No origin/HEAD: engine "default" is the current branch — fall
+        // through to main/master.
+        let b = branches(&["feature", "main"]);
+        assert_eq!(
+            default_base_ref(&b, Some("feature")).as_deref(),
+            Some("main")
+        );
+        let b = branches(&["feature", "master"]);
+        assert_eq!(
+            default_base_ref(&b, Some("feature")).as_deref(),
+            Some("master")
+        );
+        // No main/master: any branch that isn't the current one.
+        let b = branches(&["feature", "develop"]);
+        assert_eq!(
+            default_base_ref(&b, Some("feature")).as_deref(),
+            Some("develop")
+        );
+        // Checked out ON main: comparing main with itself is the honest
+        // default (empty branch diff).
+        let b = branches(&["main", "feature"]);
+        assert_eq!(default_base_ref(&b, Some("main")).as_deref(), Some("main"));
+        // Single-branch repo, and empty list.
+        let b = branches(&["main"]);
+        assert_eq!(default_base_ref(&b, Some("main")).as_deref(), Some("main"));
+        assert_eq!(default_base_ref(&[], Some("main")), None);
+    }
+
+    #[test]
+    fn scope_modes_are_wire_stable() {
+        // `mode` is the GetCheckoutDiff wire contract — engine matches on it.
+        assert_eq!(DiffScope::WorkingTree.mode(), "workingTree");
+        assert_eq!(DiffScope::Branch.mode(), "branch");
+        assert_eq!(DiffScope::LatestTurn.mode(), "turn");
+        assert_eq!(DiffScope::default(), DiffScope::WorkingTree);
     }
 
     #[test]

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -1382,7 +1382,7 @@ impl Changes {
             trigger
         };
 
-        let fold = Self::header_button("changes-fold-all", crate::icons::SORT_VERTICAL, &theme)
+        let fold = Self::header_button("changes-fold-all", crate::icons::FOLD_VERTICAL, &theme)
             .on_click(cx.listener(|this, _, _, cx| {
                 cx.stop_propagation();
                 this.toggle_collapse_all(cx);

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -558,12 +558,6 @@ async fn yield_now() {
     .await
 }
 
-/// Shell-facing events from the pane's toolbar.
-pub enum PaneEvent {
-    /// The expand button: widen/restore the panel (shell owns the width).
-    ToggleExpand,
-}
-
 /// The Changes pane entity. Lazy: no RPC until [`Changes::ensure_watch`] runs
 /// (the shell calls it when the pane first opens).
 pub struct Changes {
@@ -601,8 +595,6 @@ pub struct Changes {
     ref_menu: Popup<()>,
     _observe: Subscription,
 }
-
-impl gpui::EventEmitter<PaneEvent> for Changes {}
 
 impl Changes {
     pub fn new(state: Entity<AppState>, cx: &mut Context<Self>) -> Self {
@@ -1294,8 +1286,10 @@ impl Changes {
             .into_any_element()
     }
 
-    /// A small hover-washed icon button for the toolbar.
-    fn toolbar_button(
+    /// A small hover-washed icon button for the pane header. The header lives
+    /// inside the titlebar drag strip, so the button occludes and swallows the
+    /// mouse-down (same discipline as the shell's `header_icon_button`).
+    fn header_button(
         id: &'static str,
         icon_path: &'static str,
         theme: &Theme,
@@ -1315,6 +1309,10 @@ impl Changes {
                 crate::theme::wash(0.14),
             ))
             .on_hover(motion::hover_listener(id))
+            .occlude()
+            .on_mouse_down(gpui::MouseButton::Left, |_, window, _| {
+                window.prevent_default()
+            })
             .child(
                 crate::icons::icon(icon_path)
                     .size(px(14.0))
@@ -1322,14 +1320,20 @@ impl Changes {
             )
     }
 
-    /// Toolbar: the scope dropdown on the left, fold-all + expand on the
-    /// right (t3code parity).
-    fn render_toolbar(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+    /// The pane-header controls: scope dropdown, `{branch} → {base ⌄}` ref
+    /// selector (branch scope), fold-all. Rendered BY THE SHELL inside the
+    /// session titlebar's trailing section (the band above the pane) — the
+    /// titlebar overlay owns that strip's hit-testing, so controls mounted
+    /// under it would never see a click. The expand and close buttons ride
+    /// alongside, shell-owned (they mutate shell state).
+    pub fn render_header_controls(&mut self, cx: &mut Context<Self>) -> AnyElement {
+        let theme = Theme::of(cx).clone();
         let scope = self.scope;
         let trigger = div()
             .id("changes-scope-trigger")
             .h(px(24.0))
             .px(px(8.0))
+            .flex_none()
             .flex()
             .flex_row()
             .items_center()
@@ -1342,7 +1346,12 @@ impl Changes {
                 crate::theme::wash(0.14),
             ))
             .on_hover(motion::hover_listener("changes-scope-trigger"))
+            .occlude()
+            .on_mouse_down(gpui::MouseButton::Left, |_, window, _| {
+                window.prevent_default()
+            })
             .on_click(cx.listener(|this, _, _, cx| {
+                cx.stop_propagation();
                 if this.scope_menu.is_open() {
                     this.close_scope_menu(cx);
                 } else {
@@ -1363,7 +1372,7 @@ impl Changes {
             );
         let trigger = if self.scope_menu.get().is_some() {
             let closing = self.scope_menu.closing_since();
-            let menu = self.render_scope_menu(theme, cx);
+            let menu = self.render_scope_menu(&theme, cx);
             trigger.relative().child(popover::anchored_menu_below(
                 "changes-scope-menu",
                 menu,
@@ -1373,29 +1382,22 @@ impl Changes {
             trigger
         };
 
-        let fold = Self::toolbar_button("changes-fold-all", crate::icons::SORT_VERTICAL, theme)
-            .on_click(cx.listener(|this, _, _, cx| this.toggle_collapse_all(cx)));
-        let expand = Self::toolbar_button(
-            "changes-expand-pane",
-            crate::icons::SIDEBAR_MINIMALISTIC,
-            theme,
-        )
-        .on_click(cx.listener(|_, _, _, cx| cx.emit(PaneEvent::ToggleExpand)));
+        let fold = Self::header_button("changes-fold-all", crate::icons::SORT_VERTICAL, &theme)
+            .on_click(cx.listener(|this, _, _, cx| {
+                cx.stop_propagation();
+                this.toggle_collapse_all(cx);
+            }));
 
         div()
-            .flex_none()
-            .h(px(40.0))
+            .size_full()
             .flex()
             .flex_row()
             .items_center()
             .gap(px(6.0))
-            .px(px(Theme::SPACE_MD))
-            .border_b_1()
-            .border_color(crate::theme::hairline(0.06))
             .child(trigger)
+            .children(self.render_ref_selector(&theme, cx))
             .child(div().flex_1())
             .child(fold)
-            .child(expand)
             .into_any_element()
     }
 
@@ -1421,8 +1423,12 @@ impl Changes {
     }
 
     /// `{branch} → {base ⌄}` — which ref the branch scope compares against
-    /// (t3code's ref strip). Branch scope only.
-    fn render_ref_strip(&mut self, theme: &Theme, cx: &mut Context<Self>) -> Option<AnyElement> {
+    /// (t3code's ref strip), inlined into the pane header. Branch scope only.
+    fn render_ref_selector(
+        &mut self,
+        theme: &Theme,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
         if self.scope != DiffScope::Branch {
             return None;
         }
@@ -1440,6 +1446,7 @@ impl Changes {
             .id("changes-ref-trigger")
             .h(px(22.0))
             .px(px(6.0))
+            .flex_none()
             .flex()
             .flex_row()
             .items_center()
@@ -1452,7 +1459,12 @@ impl Changes {
                 crate::theme::wash(0.12),
             ))
             .on_hover(motion::hover_listener("changes-ref-trigger"))
+            .occlude()
+            .on_mouse_down(gpui::MouseButton::Left, |_, window, _| {
+                window.prevent_default()
+            })
             .on_click(cx.listener(|this, _, _, cx| {
+                cx.stop_propagation();
                 if this.ref_menu.is_open() {
                     this.close_ref_menu(cx);
                 } else {
@@ -1485,15 +1497,11 @@ impl Changes {
         };
         Some(
             div()
-                .flex_none()
-                .h(px(32.0))
+                .min_w_0()
                 .flex()
                 .flex_row()
                 .items_center()
-                .gap(px(8.0))
-                .px(px(Theme::SPACE_MD))
-                .border_b_1()
-                .border_color(crate::theme::hairline(0.06))
+                .gap(px(6.0))
                 .child(
                     div()
                         .min_w_0()
@@ -1940,14 +1948,10 @@ impl Render for Changes {
             }
         };
 
-        let toolbar = self.render_toolbar(&theme, cx);
-        let ref_strip = self.render_ref_strip(&theme, cx);
         div()
             .size_full()
             .flex()
             .flex_col()
-            .child(toolbar)
-            .children(ref_strip)
             .when_some(error, |el, message| {
                 el.child(
                     div()

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -79,6 +79,9 @@ icon_assets![
     // Hand-drawn expand/maximize arrows in the Solar Linear style (like the
     // terminal/plus/return ports) — the set has no expand glyph.
     (EXPAND_ARROWS, "expand-arrows"),
+    // Hand-drawn fold-all chevrons, drawn as a family with EXPAND_ARROWS
+    // (same stroke, caps, 90° joints) — Solar has no unfold-less either.
+    (FOLD_VERTICAL, "fold-vertical"),
     (ALT_ARROW_LEFT, "alt-arrow-left"),
     (ALT_ARROW_RIGHT, "alt-arrow-right"),
     (SMARTPHONE, "smartphone"),

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -76,6 +76,9 @@ icon_assets![
     // terminal/plus/close ports) — the set has no return glyph.
     (RETURN, "return"),
     (ALT_ARROW_DOWN, "alt-arrow-down"),
+    // Hand-drawn expand/maximize arrows in the Solar Linear style (like the
+    // terminal/plus/return ports) — the set has no expand glyph.
+    (EXPAND_ARROWS, "expand-arrows"),
     (ALT_ARROW_LEFT, "alt-arrow-left"),
     (ALT_ARROW_RIGHT, "alt-arrow-right"),
     (SMARTPHONE, "smartphone"),

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -981,6 +981,11 @@ impl Shell {
             return changes.clone();
         }
         let changes = cx.new(|cx| Changes::new(self.state.clone(), cx));
+        // The pane's expand button changes shell-owned width settings.
+        cx.subscribe(&changes, |this, _, event, cx| match event {
+            crate::changes::PaneEvent::ToggleExpand => this.toggle_right_pane_expand(cx),
+        })
+        .detach();
         self.changes = Some(changes.clone());
         changes
     }
@@ -3377,9 +3382,10 @@ impl Shell {
         } else {
             gpui::Empty.into_any_element()
         };
-        // Its OWN inset card (user request): the conversation card's right
-        // gutter is the gap; padding (not margins) keeps the tweened width
-        // container clean, and the resize grabber floats over the gap.
+        // Flush panel (user request — the inset card is gone): full window
+        // height with a left hairline, glass-friendly like the terminal dock
+        // (translucent over the frost; solid otherwise). The resize grabber
+        // floats over the border seam.
         let handle = self
             .resize_handle(
                 "right-pane-resize",
@@ -3392,33 +3398,48 @@ impl Shell {
             .bottom_0()
             // INSIDE the width-clipped container (a negative inset was
             // clipped into unreachability — user-reported dead resize),
-            // overlapping the card's left border.
+            // overlapping the panel's left border.
             .left(px(0.0));
-        let card = div()
+        let panel_bg = if theme.is_glass() { bg.opacity(0.4) } else { bg };
+        let panel = div()
             .size_full()
-            .rounded(px(12.0))
-            .border_1()
+            .flex()
+            .flex_col()
+            .border_l_1()
             .border_color(theme.border)
-            .bg(bg)
+            .bg(panel_bg)
             .overflow_hidden()
+            // The titlebar is a glass overlay over the full-height content
+            // row; the panel's own chrome starts below it.
+            .pt(px(Theme::TITLEBAR_HEIGHT))
             .child(content);
         let target = self.right_target(cx);
         self.pane_container(
             self.right_tween,
             target,
-            // Flush under the titlebar (the full-height content row puts the
-            // chrome overlay above us, so the pad IS the titlebar height),
-            // 8px bottom/right gutters.
             div()
                 .h_full()
                 .relative()
-                .pt(px(Theme::TITLEBAR_HEIGHT))
-                .pb(px(8.0))
-                .pr(px(8.0))
-                .child(card)
+                .child(panel)
                 .child(handle)
                 .into_any_element(),
         )
+    }
+
+    /// Toggle the changes panel between its saved width and the expanded
+    /// maximum (the Changes toolbar's expand button, t3code parity). Rides the
+    /// same width tween as open/close so the jump glides.
+    fn toggle_right_pane_expand(&mut self, cx: &mut Context<Self>) {
+        let from = self.right_target(cx);
+        let expanded = self.settings.right_pane_width >= RIGHT_PANE_MAX - 1.0;
+        self.settings.right_pane_width = if expanded {
+            RIGHT_PANE_DEFAULT
+        } else {
+            RIGHT_PANE_MAX
+        };
+        self.right_tween = Some(WidthTween::new(from, self.right_target(cx)));
+        self.schedule_save(cx);
+        cx.notify();
     }
 
     fn render_gate_card(&mut self, phase: &GatePhase, cx: &mut Context<Self>) -> AnyElement {
@@ -4178,15 +4199,11 @@ impl Render for Shell {
                     Empty.into_any_element()
                 };
                 let overlays = self.render_overlays(window.viewport_size(), window, cx);
-                // The signature frame: the conversation card and — when the
-                // changes pane is open — a SECOND inset card beside it, both
-                // rounded hairline-bordered floats on the frost shell (the
-                // changes card is built inside `render_right_pane`).
                 // Copied out (not held) — `render_title_bar` needs `cx` mutable.
                 let border_color = Theme::of(cx).border;
-                // No inset card (user request): the conversation column sits
+                // No inset cards (user request): the conversation column sits
                 // flush and unbordered, the transcript directly on the frost
-                // glass — only the changes pane keeps its floating card
+                // glass; the changes pane is a flush left-bordered glass panel
                 // (built inside `render_right_pane`).
                 let card: AnyElement = div()
                     .flex_1()
@@ -4231,7 +4248,7 @@ impl Render for Shell {
                 // The content row spans the FULL window height — the titlebar
                 // overlays it (glass, no fill), so the transcript can scroll
                 // under the header and fade out at its edge. Columns that
-                // must NOT underlap (sidebar content, the changes card,
+                // must NOT underlap (sidebar content, the changes panel,
                 // settings) pad themselves down by the titlebar height.
                 let page = div()
                     .size_full()

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -536,6 +536,13 @@ pub struct Shell {
     debug_gate: Option<GatePhase>,
     sidebar_tween: Option<WidthTween>,
     right_tween: Option<WidthTween>,
+    /// Changes-panel takeover (the header's expand button): the panel fills
+    /// everything right of the sidebar and the conversation column collapses
+    /// to zero. Session-local view state — never persisted, reset on close.
+    right_pane_expanded: bool,
+    /// Viewport width stamped each frame at render — the expanded panel's
+    /// width target ([`Self::right_target`] has no `Window`).
+    viewport_width: f32,
     terminal_tween: Option<WidthTween>,
     /// Last observed `window.is_fullscreen()` (`None` before first paint) —
     /// flips key the traffic-light inset tween.
@@ -708,6 +715,8 @@ impl Shell {
             debug_gate,
             sidebar_tween: None,
             right_tween: None,
+            right_pane_expanded: false,
+            viewport_width: 1280.0,
             terminal_tween: None,
             fullscreen: None,
             titlebar_tween: None,
@@ -943,10 +952,16 @@ impl Shell {
     }
 
     fn right_target(&self, cx: &App) -> f32 {
-        if self.right_pane_open(cx) {
-            self.settings.right_pane_width
-        } else {
+        if !self.right_pane_open(cx) {
             0.0
+        } else if self.right_pane_expanded {
+            // Takeover: everything right of the sidebar; the conversation
+            // column (flex_1) collapses to zero behind it. Rides the sidebar's
+            // width tween so a sidebar toggle mid-takeover stays seamless.
+            let sidebar_now = self.eval_tween(self.sidebar_tween, self.sidebar_target());
+            (self.viewport_width - sidebar_now).max(RIGHT_PANE_MIN)
+        } else {
+            self.settings.right_pane_width
         }
     }
 
@@ -966,6 +981,11 @@ impl Shell {
         let from = self.right_target(cx);
         let key = self.panel_key(cx);
         let open = self.panels.toggle_changes(&key);
+        if !open {
+            // Closing always leaves takeover mode — reopening at full bleed
+            // with the conversation gone read as a broken chat.
+            self.right_pane_expanded = false;
+        }
         self.right_tween = Some(WidthTween::new(from, self.right_target(cx)));
         if open {
             // Lazy: the Changes entity (and its WatchCheckoutDiffs) exists only
@@ -981,11 +1001,6 @@ impl Shell {
             return changes.clone();
         }
         let changes = cx.new(|cx| Changes::new(self.state.clone(), cx));
-        // The pane's expand button changes shell-owned width settings.
-        cx.subscribe(&changes, |this, _, event, cx| match event {
-            crate::changes::PaneEvent::ToggleExpand => this.toggle_right_pane_expand(cx),
-        })
-        .detach();
         self.changes = Some(changes.clone());
         changes
     }
@@ -3414,6 +3429,9 @@ impl Shell {
             .pt(px(Theme::TITLEBAR_HEIGHT))
             .child(content);
         let target = self.right_target(cx);
+        // Takeover mode has no drag width — the handle would fight the
+        // viewport-derived target.
+        let handle = (!self.right_pane_expanded).then_some(handle);
         self.pane_container(
             self.right_tween,
             target,
@@ -3421,24 +3439,19 @@ impl Shell {
                 .h_full()
                 .relative()
                 .child(panel)
-                .child(handle)
+                .children(handle)
                 .into_any_element(),
         )
     }
 
-    /// Toggle the changes panel between its saved width and the expanded
-    /// maximum (the Changes toolbar's expand button, t3code parity). Rides the
-    /// same width tween as open/close so the jump glides.
+    /// Toggle the changes-panel takeover (the header's expand button, t3code
+    /// parity): the panel grows to fill everything right of the sidebar,
+    /// hiding the conversation column; toggling back restores the saved
+    /// width. Rides the same width tween as open/close so the jump glides.
     fn toggle_right_pane_expand(&mut self, cx: &mut Context<Self>) {
         let from = self.right_target(cx);
-        let expanded = self.settings.right_pane_width >= RIGHT_PANE_MAX - 1.0;
-        self.settings.right_pane_width = if expanded {
-            RIGHT_PANE_DEFAULT
-        } else {
-            RIGHT_PANE_MAX
-        };
+        self.right_pane_expanded = !self.right_pane_expanded;
         self.right_tween = Some(WidthTween::new(from, self.right_target(cx)));
-        self.schedule_save(cx);
         cx.notify();
     }
 
@@ -4169,7 +4182,11 @@ impl Render for Shell {
                 }
                 // MessageRail width gate: hide below 48rem of main-panel width.
                 let viewport = f32::from(window.viewport_size().width);
-                let main_width = viewport - self.sidebar_target() - self.right_target(cx) - 10.0;
+                // Stamped for `right_target` — the expanded changes panel
+                // sizes itself to the viewport.
+                self.viewport_width = viewport;
+                let main_width =
+                    (viewport - self.sidebar_target() - self.right_target(cx) - 10.0).max(0.0);
                 // Clearance excludes the terminal dock: the transcript
                 // viewport ends at the dock's top (see the underlay in
                 // `render_main`), so only the chrome above it overlaps.

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3420,8 +3420,12 @@ impl Shell {
             .size_full()
             .flex()
             .flex_col()
-            .border_l_1()
-            .border_color(theme.border)
+            // In takeover the panel's left edge IS the sidebar seam, which
+            // already carries the sidebar tone's right hairline — a second
+            // border there doubled up (user report).
+            .when(!self.right_pane_expanded, |el| {
+                el.border_l_1().border_color(theme.border)
+            })
             .bg(panel_bg)
             .overflow_hidden()
             // The titlebar is a glass overlay over the full-height content

--- a/crates/ui/src/shell/tabs.rs
+++ b/crates/ui/src/shell/tabs.rs
@@ -124,6 +124,11 @@ impl Shell {
         // the new-session canvas (user request) — nothing to diff yet.
         let takeover =
             git && !on_canvas && self.right_pane_open(cx) && self.right_pane_expanded;
+        // In takeover the title hides and the strip owns the whole band, so
+        // the row's left inset pulls back to the sidebar seam — the title
+        // inset would push the scope dropdown off the pane's own left gutter
+        // (user report: misaligned dead space).
+        let row_left = if takeover { sidebar_now } else { content_left };
         let trailing: Option<gpui::AnyElement> = if !git || on_canvas {
             None
         } else if self.right_pane_open(cx) {
@@ -132,7 +137,7 @@ impl Shell {
             // The row's own left padding is part of its content box: a strip
             // wider than what's left after it overflows and clips at the right
             // edge (flex_none never shrinks) — cap to the available width.
-            let avail = self.viewport_width - content_left - pr;
+            let avail = self.viewport_width - row_left - pr;
             let controls = self
                 .changes_pane(cx)
                 .update(cx, |changes, cx| changes.render_header_controls(cx));
@@ -149,7 +154,10 @@ impl Shell {
                     // padding), so this width starts the strip exactly at the
                     // pane's left border — and rides the open/close tween.
                     .w(px((right_now - pr).min(avail).max(0.0)))
-                    .pl(px(Theme::SPACE_MD))
+                    // 8 + the trigger's own 8px pad = the pane's 16px text
+                    // gutter, so the scope label sits flush over the stats
+                    // strip below.
+                    .pl(px(8.0))
                     .child(div().flex_1().min_w_0().h_full().child(controls))
                     .child(header_icon_button(
                         "expand-changes",
@@ -183,7 +191,7 @@ impl Shell {
             .items_center()
             .pt(px(Theme::TITLEBAR_TOP_PAD))
             .gap(px(8.0))
-            .pl(px(content_left))
+            .pl(px(row_left))
             .pr(px(titlebar_right_padding(
                 cfg!(target_os = "windows"),
                 Theme::SPACE_LG,

--- a/crates/ui/src/shell/tabs.rs
+++ b/crates/ui/src/shell/tabs.rs
@@ -113,6 +113,70 @@ impl Shell {
         // cluster as it collapses.
         let content_left =
             (sidebar_now + Theme::SPACE_LG).max(self.title_bar_content_start() + plus_inset);
+
+        // Trailing titlebar section. With the changes pane open this is the
+        // PANE'S HEADER — a strip exactly as wide as the pane carrying its
+        // controls (scope dropdown, ref selector, fold-all from the Changes
+        // entity; expand + close shell-side). It lives up here because the
+        // titlebar overlay owns this band's hit-testing: controls mounted in
+        // the pane itself would sit under the drag region and never see a
+        // click. Closed, it is just the stable open/close toggle. Hidden on
+        // the new-session canvas (user request) — nothing to diff yet.
+        let takeover =
+            git && !on_canvas && self.right_pane_open(cx) && self.right_pane_expanded;
+        let trailing: Option<gpui::AnyElement> = if !git || on_canvas {
+            None
+        } else if self.right_pane_open(cx) {
+            let right_now = self.eval_tween(self.right_tween, self.right_target(cx));
+            let pr = titlebar_right_padding(cfg!(target_os = "windows"), Theme::SPACE_LG);
+            // The row's own left padding is part of its content box: a strip
+            // wider than what's left after it overflows and clips at the right
+            // edge (flex_none never shrinks) — cap to the available width.
+            let avail = self.viewport_width - content_left - pr;
+            let controls = self
+                .changes_pane(cx)
+                .update(cx, |changes, cx| changes.render_header_controls(cx));
+            Some(
+                div()
+                    .flex_none()
+                    .h_full()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap(px(4.0))
+                    .overflow_hidden()
+                    // Right edge already sits at viewport − pr (the row's own
+                    // padding), so this width starts the strip exactly at the
+                    // pane's left border — and rides the open/close tween.
+                    .w(px((right_now - pr).min(avail).max(0.0)))
+                    .pl(px(Theme::SPACE_MD))
+                    .child(div().flex_1().min_w_0().h_full().child(controls))
+                    .child(header_icon_button(
+                        "expand-changes",
+                        icons::EXPAND_ARROWS,
+                        &theme,
+                        cx.listener(|this, _, _, cx| this.toggle_right_pane_expand(cx)),
+                    ))
+                    .child(header_icon_button(
+                        "toggle-changes",
+                        icons::SIDEBAR_MINIMALISTIC,
+                        &theme,
+                        cx.listener(|this, _, _, cx| this.toggle_right_pane(cx)),
+                    ))
+                    .into_any_element(),
+            )
+        } else {
+            Some(
+                header_icon_button(
+                    "toggle-changes",
+                    icons::SIDEBAR_MINIMALISTIC,
+                    &theme,
+                    cx.listener(|this, _, _, cx| this.toggle_right_pane(cx)),
+                )
+                .into_any_element(),
+            )
+        };
+
         let inner = div()
             .size_full()
             .flex()
@@ -124,7 +188,10 @@ impl Shell {
                 cfg!(target_os = "windows"),
                 Theme::SPACE_LG,
             )))
-            .child(
+            // In panel takeover the header strip spans the whole band — the
+            // title would sit UNDER it (both flex_none, the row overflows and
+            // paint order stacks them), so it hides for the duration.
+            .when(!takeover, |el| el.child(
                 div()
                     .min_w_0()
                     .flex()
@@ -164,19 +231,9 @@ impl Shell {
                                 .child(target),
                         )
                     }),
-            )
+            ))
             .child(div().flex_1())
-            // Stable location: the toggle shows whether the pane is open or
-            // not (the pane's own header is gone). Hidden on the new-session
-            // canvas (user request) — there's no session to diff yet.
-            .when(git && !on_canvas, |el| {
-                el.child(header_icon_button(
-                    "toggle-changes",
-                    icons::SIDEBAR_MINIMALISTIC,
-                    &theme,
-                    cx.listener(|this, _, _, cx| this.toggle_right_pane(cx)),
-                ))
-            });
+            .children(trailing);
 
         // The unified window titlebar: full-width on the glass shell, ABOVE
         // the inset card. No bottom border — the card's own hairline is the


### PR DESCRIPTION
The right Changes pane drops its inset card for a flush, full-height panel — left hairline border, glass-friendly translucent fill like the terminal dock. Its controls live in the **pane header** (the titlebar band above it): a diff-scope dropdown (**Working tree / Branch changes / Latest turn**), a `{branch} → {base ⌄}` ref selector defaulting to the main branch, **fold-all** (a hand-drawn fold glyph in the same family as the expand arrows), an **expand-arrows takeover** button, and the close toggle.

## UI

- `shell.rs`: `render_right_pane` builds a flush panel (`border_l`, `theme.bg` at 0.4 opacity under glass, full window height) instead of the rounded inset card.
- Header controls render inside the session titlebar's trailing section, sized exactly to the pane width (riding the open/close tween) — the titlebar overlay owns that band's hit-testing, so controls mounted in the pane itself would never see a click. Scope/ref/fold come from the `Changes` entity; expand + close are shell-side.
- **Expand = takeover**: the panel fills everything right of the sidebar and the conversation column collapses to zero (t3code behavior). The session title hides for the duration, the header strip starts flush at the sidebar seam (scope dropdown aligned on the pane's text gutter), the panel's left border drops (the sidebar's right hairline already draws that seam — no double border), the resize handle is disabled, and closing the pane always drops takeover. New hand-drawn `expand-arrows` glyph in the Solar Linear style.
- Base-ref default: the repo default branch from `ListBranches`; when that falls back to the checked-out branch itself (no `origin/HEAD`), prefer `main`/`master`.

## Engine

- New relay-forwardable `GetCheckoutDiff {cwd, mode, baseRef?, chatId?}` RPC. `branch` reuses the working-tree capture with the base overridden to `merge-base(baseRef, HEAD)` (untracked synthesis still applies); `turn` diffs tree-to-tree so files already untracked at turn start diff correctly instead of reappearing as new.
- Turn snapshots: `SessionsEngine` fires a turn listener on every dispatched prompt (fresh run *and* routed steer); `CheckoutDiffSync` answers with a throwaway-index `git add -A` + `write-tree` snapshot (real index untouched). In-memory only — after an engine restart the scope reads "No turn recorded yet" until the next message.
- Working tree keeps riding the `WatchCheckoutDiffs` stream untouched; scoped captures re-fetch whenever the watch checksum says the tree moved (commits included — HEAD rides the checksum).

## Screenshots

| | |
|---|---|
| Working tree — flush panel, header controls in the titlebar band | Scope dropdown |
| ![working tree](https://github.com/user-attachments/assets/3e4ccdf0-e4ae-421c-8652-a47b160b0507) | ![scope dropdown](https://github.com/user-attachments/assets/d5e1f752-401c-4323-a795-c96a6cf048a6) |
| Branch changes — `branch → main` ref selector in the header | Expanded takeover — conversation hidden, full-bleed diff |
| ![branch changes](https://github.com/user-attachments/assets/df8e9337-ad7c-4e5c-8f52-5b23b510c57d) | ![takeover](https://github.com/user-attachments/assets/0a032846-2335-42c1-8f19-cf6aee1e44c1) |
| Latest turn — only the post-dispatch edits | Fold-all |
| ![latest turn](https://github.com/user-attachments/assets/9624e40a-6b78-4ba2-b1ae-114536c9c245) | ![fold all](https://github.com/user-attachments/assets/f11cc5be-d6e2-4729-986e-5f7a7fc17c15) |
| Light mode (glass) | |
| ![light glass](https://github.com/user-attachments/assets/b22831fe-208e-4399-b7eb-0d0c6001e269) | |

## Tests

- Engine: `diff_capture_against_merge_base_shows_branch_changes` (branch capture sees committed + uncommitted work, unknown ref errors), `turn_diff_captures_only_changes_since_snapshot` (pre-existing untracked files don't reappear; only turn edits diff).
- UI: scope labels/empty states, wire-stable `mode` values, `default_base_ref` fallback ladder.
- Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
