### PR TITLE
Changes header: searchable refs, menu gaps, version-skew copy, collapsed-sidebar takeover fix

### DIFF
--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -24,13 +24,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use gpui::{
-    AnyElement, App, Context, Entity, ListAlignment, ListState, SharedString, Subscription, Task,
-    Window, div, font, list, prelude::*, px,
+    AnyElement, App, Context, Entity, FocusHandle, Focusable as _, ListAlignment, ListState,
+    SharedString, Subscription, Task, Window, div, font, list, prelude::*, px,
 };
 
 use comet_proto::{Chat, CheckoutDiff};
 use comet_rpc::methods;
 
+use crate::composer::{ComposerInput, ComposerInputEvent};
 use crate::markdown::highlight::{Lang, LineCarry, Token, lang_for_tag, tokenize_line};
 use crate::markdown::render;
 use crate::motion::{self, AnimationExt as _, CHEVRON, COLLAPSE};
@@ -544,6 +545,21 @@ struct HighlightSlot {
     _task: Option<Task<()>>,
 }
 
+/// The open base-ref dropdown — the same searchable-menu recipe as the
+/// composer's ref picker and the spaces filter: a filter input on top
+/// (`PaletteSearch` context so ↑↓/⏎ bubble to the card's key handler),
+/// ranked substring rows below.
+struct RefMenu {
+    search: Entity<ComposerInput>,
+    /// Keyboard highlight within the filtered rows.
+    active: usize,
+    /// Tracked on the card — puts it on the keyboard dispatch path while the
+    /// search input holds focus (the structure every working picker uses).
+    focus: FocusHandle,
+    list_scroll: gpui::ScrollHandle,
+    _search_events: Subscription,
+}
+
 async fn yield_now() {
     let mut yielded = false;
     futures::future::poll_fn(move |cx| {
@@ -592,7 +608,7 @@ pub struct Changes {
     scoped_inflight: Option<String>,
     scoped_task: Option<Task<()>>,
     scope_menu: Popup<()>,
-    ref_menu: Popup<()>,
+    ref_menu: Popup<RefMenu>,
     _observe: Subscription,
 }
 
@@ -1066,6 +1082,88 @@ impl Changes {
         }
     }
 
+    fn open_ref_menu(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // "PaletteSearch" context: ↑↓/⏎ stay unbound in the input and bubble
+        // to the card's key handler.
+        let search =
+            cx.new(|cx| ComposerInput::with_context("Search branches…", "PaletteSearch", cx));
+        let search_events = cx.subscribe(&search, |this: &mut Self, _, event, cx| {
+            if matches!(event, ComposerInputEvent::Edited) {
+                if let Some(menu) = this.ref_menu.open_mut() {
+                    menu.active = 0;
+                }
+                cx.notify();
+            }
+        });
+        let handle = search.read(cx).focus_handle(cx);
+        // The highlight starts ON the current base (query is empty, so the
+        // filtered rows are just the branch list).
+        let active = self
+            .base_ref
+            .as_ref()
+            .and_then(|base| self.branches.iter().position(|b| b == base))
+            .unwrap_or(0);
+        self.ref_menu.open(RefMenu {
+            search,
+            active,
+            focus: cx.focus_handle(),
+            list_scroll: gpui::ScrollHandle::new(),
+            _search_events: search_events,
+        });
+        // Focusable before first paint (the add-space palette's proven order).
+        window.focus(&handle, cx);
+        cx.notify();
+    }
+
+    /// Filtered branch indices for the open ref menu (ranked substring match).
+    fn ref_menu_rows(&self, cx: &App) -> Vec<usize> {
+        let query = self
+            .ref_menu
+            .get()
+            .map(|menu| menu.search.read(cx).text().to_string())
+            .unwrap_or_default();
+        popover::filter_indices(&query, &self.branches)
+    }
+
+    /// Dropdown keys (bubbling from the focused search input): ↑↓ navigate,
+    /// ⏎ picks the highlighted branch, Esc closes.
+    fn ref_menu_key(&mut self, event: &gpui::KeyDownEvent, cx: &mut Context<Self>) {
+        // The card stays mounted (and focused) through the exit animation —
+        // keys must not drive a dying menu.
+        if !self.ref_menu.is_open() {
+            return;
+        }
+        let key = popover::classify_key(
+            event.keystroke.key.as_str(),
+            event.keystroke.modifiers.platform,
+            event.keystroke.modifiers.control,
+        );
+        match key {
+            popover::MenuKey::Escape => self.close_ref_menu(cx),
+            popover::MenuKey::Up | popover::MenuKey::Down => {
+                let count = self.ref_menu_rows(cx).len();
+                let delta = if key == popover::MenuKey::Up { -1 } else { 1 };
+                if let Some(menu) = self.ref_menu.open_mut() {
+                    menu.active = popover::menu_step(Some(menu.active), count, delta).unwrap_or(0);
+                    menu.list_scroll.scroll_to_item(menu.active);
+                    cx.notify();
+                }
+            }
+            popover::MenuKey::Enter | popover::MenuKey::ModEnter => {
+                let active = self.ref_menu.get().map(|m| m.active).unwrap_or(0);
+                let pick = self
+                    .ref_menu_rows(cx)
+                    .get(active)
+                    .and_then(|ix| self.branches.get(*ix).cloned());
+                if let Some(branch) = pick {
+                    self.set_base_ref(branch, cx);
+                    self.close_ref_menu(cx);
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Tokens for a file's diff lines (paint-only). Kicks a time-sliced
     /// background tokenize when missing; returns the current best.
     fn request_highlight(
@@ -1373,10 +1471,11 @@ impl Changes {
         let trigger = if self.scope_menu.get().is_some() {
             let closing = self.scope_menu.closing_since();
             let menu = self.render_scope_menu(&theme, cx);
-            trigger.relative().child(popover::anchored_menu_below(
+            trigger.relative().child(popover::anchored_menu_below_gap(
                 "changes-scope-menu",
                 menu,
                 closing,
+                10.0,
             ))
         } else {
             trigger
@@ -1463,14 +1562,14 @@ impl Changes {
             .on_mouse_down(gpui::MouseButton::Left, |_, window, _| {
                 window.prevent_default()
             })
-            .on_click(cx.listener(|this, _, _, cx| {
+            .on_click(cx.listener(|this, _, window, cx| {
                 cx.stop_propagation();
                 if this.ref_menu.is_open() {
                     this.close_ref_menu(cx);
+                    cx.notify();
                 } else {
-                    this.ref_menu.open(());
+                    this.open_ref_menu(window, cx);
                 }
-                cx.notify();
             }))
             .child(
                 div()
@@ -1487,10 +1586,11 @@ impl Changes {
         let trigger = if self.ref_menu.get().is_some() {
             let closing = self.ref_menu.closing_since();
             let menu = self.render_ref_menu(theme, cx);
-            trigger.relative().child(popover::anchored_menu_below(
+            trigger.relative().child(popover::anchored_menu_below_gap(
                 "changes-ref-menu",
                 menu,
                 closing,
+                10.0,
             ))
         } else {
             trigger
@@ -1502,6 +1602,9 @@ impl Changes {
                 .flex_row()
                 .items_center()
                 .gap(px(6.0))
+                // Extra room off the scope dropdown (row gap alone read
+                // cramped — user report).
+                .ml(px(6.0))
                 .child(
                     div()
                         .min_w_0()
@@ -1523,24 +1626,34 @@ impl Changes {
     }
 
     fn render_ref_menu(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
-        let branches = self.branches.clone();
+        let (search, active, focus, list_scroll) = {
+            let Some(menu) = self.ref_menu.get() else {
+                return div().into_any_element();
+            };
+            (
+                menu.search.clone(),
+                menu.active,
+                menu.focus.clone(),
+                menu.list_scroll.clone(),
+            )
+        };
+        let rows = self.ref_menu_rows(cx);
         let current = self.base_ref.clone();
-        let card = popover::popover_card(theme)
-            .w(px(220.0))
-            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.close_ref_menu(cx)));
-        if branches.is_empty() {
-            return card
-                .child(
-                    div()
-                        .px(px(8.0))
-                        .py(px(6.0))
-                        .text_size(px(12.0))
-                        .text_color(theme.text_faint)
-                        .child(SharedString::from("No branches")),
-                )
-                .into_any_element();
-        }
-        card.child(
+        let branches = self.branches.clone();
+
+        let list: AnyElement = if rows.is_empty() {
+            div()
+                .px(px(8.0))
+                .py(px(6.0))
+                .text_size(px(12.0))
+                .text_color(theme.text_faint)
+                .child(SharedString::from(if branches.is_empty() {
+                    "No branches"
+                } else {
+                    "No matching branches"
+                }))
+                .into_any_element()
+        } else {
             div()
                 .id("changes-ref-list")
                 .flex()
@@ -1548,27 +1661,50 @@ impl Changes {
                 .gap(px(2.0))
                 .max_h(px(240.0))
                 .overflow_y_scroll()
-                .children(branches.into_iter().enumerate().map(|(ix, name)| {
+                .track_scroll(&list_scroll)
+                .children(rows.into_iter().enumerate().map(|(row_ix, branch_ix)| {
+                    let name = branches[branch_ix].clone();
                     let selected = current.as_deref() == Some(name.as_str());
                     let label = name.clone();
-                    popover::menu_row(theme, selected, format!("changes-ref-row-{ix}"))
-                        .id(("changes-ref-row", ix))
-                        .on_click(cx.listener(move |this, _, _, cx| {
-                            this.set_base_ref(name.clone(), cx);
-                            this.close_ref_menu(cx);
-                        }))
-                        .child(
-                            div()
-                                .flex_1()
-                                .min_w_0()
-                                .truncate()
-                                .font_family(theme.font_mono.clone())
-                                .text_size(px(12.0))
-                                .child(SharedString::from(label)),
-                        )
-                })),
-        )
-        .into_any_element()
+                    popover::menu_row_nav(
+                        theme,
+                        selected,
+                        row_ix == active,
+                        format!("changes-ref-row-{row_ix}"),
+                    )
+                    .id(("changes-ref-row", row_ix))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.set_base_ref(name.clone(), cx);
+                        this.close_ref_menu(cx);
+                    }))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .truncate()
+                            .font_family(theme.font_mono.clone())
+                            .text_size(px(12.0))
+                            .child(SharedString::from(label)),
+                    )
+                }))
+                .into_any_element()
+        };
+
+        popover::popover_card(theme)
+            .w(px(240.0))
+            .track_focus(&focus)
+            .on_key_down(cx.listener(|this, event: &gpui::KeyDownEvent, _, cx| {
+                this.ref_menu_key(event, cx)
+            }))
+            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.close_ref_menu(cx)))
+            .flex()
+            .flex_col()
+            .child(popover::search_input_frame(
+                theme,
+                search.into_any_element(),
+            ))
+            .child(list)
+            .into_any_element()
     }
 
     fn render_header_strip(&self, theme: &Theme) -> Option<AnyElement> {
@@ -1851,7 +1987,11 @@ impl Render for Changes {
         };
         let error = self.error.clone();
         // Scoped fetch failures replace the content area. "no turn recorded"
-        // is the expected pre-first-turn state, not an error.
+        // is the expected pre-first-turn state, not an error; "unknown
+        // method" is version skew — the chat's host engine predates
+        // GetCheckoutDiff (a still-running daemon after an app update, or a
+        // remote device behind on releases) — say that instead of leaking
+        // the raw RPC error (user report).
         let scoped_notice: Option<(SharedString, bool)> = (!no_chat
             && scope != DiffScope::WorkingTree)
             .then(|| self.scoped_error.clone())
@@ -1860,6 +2000,13 @@ impl Render for Changes {
                 if message.contains("no turn recorded") {
                     (
                         SharedString::from("No turn recorded yet — send a message first"),
+                        false,
+                    )
+                } else if message.contains("unknown method") {
+                    (
+                        SharedString::from(
+                            "This chat's device is running an older Comet — update it to view branch and turn diffs",
+                        ),
                         false,
                     )
                 } else {

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -383,6 +383,18 @@ pub fn anchored_menu_below(
     content: AnyElement,
     closing: Option<std::time::Instant>,
 ) -> AnyElement {
+    anchored_menu_below_gap(id, content, closing, 6.0)
+}
+
+/// [`anchored_menu_below`] with a caller-chosen trigger→card gap — the
+/// changes-header dropdowns hang off a tight titlebar band and need more
+/// breathing room than the default 6px (user report; t3code sits near 10).
+pub fn anchored_menu_below_gap(
+    id: impl Into<SharedString>,
+    content: AnyElement,
+    closing: Option<std::time::Instant>,
+    gap: f32,
+) -> AnyElement {
     let exit = closing.map(exit_progress);
     let content = frosted_menu(exit, content);
     div()
@@ -398,7 +410,7 @@ pub fn anchored_menu_below(
                     .child(menu_motion(
                         id.into(),
                         exit,
-                        div().occlude().pt(px(6.0)).child(content),
+                        div().occlude().pt(px(gap)).child(content),
                     )),
             )
             .priority(1)

--- a/crates/ui/src/shell/tabs.rs
+++ b/crates/ui/src/shell/tabs.rs
@@ -127,8 +127,15 @@ impl Shell {
         // In takeover the title hides and the strip owns the whole band, so
         // the row's left inset pulls back to the sidebar seam — the title
         // inset would push the scope dropdown off the pane's own left gutter
-        // (user report: misaligned dead space).
-        let row_left = if takeover { sidebar_now } else { content_left };
+        // (user report: misaligned dead space). With the sidebar COLLAPSED
+        // the seam is the window edge, where the traffic lights + nav
+        // cluster overlay lives — the strip must still clear it or the scope
+        // dropdown renders underneath (user report).
+        let row_left = if takeover {
+            sidebar_now.max(self.title_bar_content_start() + plus_inset)
+        } else {
+            content_left
+        };
         let trailing: Option<gpui::AnyElement> = if !git || on_canvas {
             None
         } else if self.right_pane_open(cx) {


### PR DESCRIPTION
Follow-ups on the v0.1.43 changes panel (wing reports):

- **Searchable base-ref dropdown** — same recipe as the composer's ref picker / spaces filter: `PaletteSearch` input on top, ranked substring rows, ↑↓ navigate, ⏎ picks, Esc closes. Highlight starts on the current base.
- **Menu gaps** — the header dropdowns (scope + ref) open with a 10px gap via a new `anchored_menu_below_gap`; the default 6px read flush against the tight titlebar band. The ref selector also sits 12px off the scope dropdown (6px read cramped).
- **Version-skew copy** — a `GetCheckoutDiff` "unknown method" failure now reads *"This chat's device is running an older Comet — update it to view branch and turn diffs"* instead of leaking the raw RPC error. The skew is expected: the engine daemon keeps running across app updates, and remote hosts lag releases.
- **Collapsed-sidebar takeover fix** — with the sidebar collapsed, the takeover header strip started at the window edge and painted the scope dropdown under the traffic lights / nav cluster. Its left edge now clears the window-control cluster.

| | |
|---|---|
| Searchable ref menu (gap visible) | Filtered |
| ![ref menu](https://github.com/user-attachments/assets/652aaeaf-2570-49bc-b291-5594d97e26b9) | ![filtered](https://github.com/user-attachments/assets/23b0e1eb-e455-46b7-aafa-19980ab63323) |
| Scope menu gap | Takeover with collapsed sidebar — strip clears the nav cluster |
| ![scope gap](https://github.com/user-attachments/assets/b67bb9ff-b0d1-4752-9183-d8dc35acb3e8) | ![collapsed takeover](https://github.com/user-attachments/assets/a7cf0e57-3f6c-4f87-91b8-34f9905fcec1) |

All states driven live in the headless rig (filter typed, filtered row picked and applied — the header re-captured vs `nebula/pulsar-metrics`). Tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789078308&installation_model_id=425430&pr_number=43&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F43&signature=c30653832ac0811cccf65eeac1fde279416ef182e6b72753c086408eddd0497c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->