### PR TITLE
Changes header: truncate long refs, tighten collapsed-takeover inset

### DIFF
--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -1505,19 +1505,32 @@ impl Changes {
         popover::popover_card(theme)
             .w(px(180.0))
             .on_mouse_down_out(cx.listener(|this, _, _, cx| this.close_scope_menu(cx)))
-            .children(DiffScope::ALL.into_iter().enumerate().map(|(ix, scope)| {
-                popover::menu_row(theme, scope == current, format!("changes-scope-row-{ix}"))
-                    .id(("changes-scope-row", ix))
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.set_scope(scope, cx);
-                        this.close_scope_menu(cx);
-                    }))
-                    .child(
-                        div()
-                            .flex_1()
-                            .child(SharedString::from(scope.label())),
-                    )
-            }))
+            .child(
+                // The 2px row gap every other menu carries — rows straight on
+                // the card abutted, adjacent washes read as one slab (user
+                // report).
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(2.0))
+                    .children(DiffScope::ALL.into_iter().enumerate().map(|(ix, scope)| {
+                        popover::menu_row(
+                            theme,
+                            scope == current,
+                            format!("changes-scope-row-{ix}"),
+                        )
+                        .id(("changes-scope-row", ix))
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.set_scope(scope, cx);
+                            this.close_scope_menu(cx);
+                        }))
+                        .child(
+                            div()
+                                .flex_1()
+                                .child(SharedString::from(scope.label())),
+                        )
+                    })),
+            )
             .into_any_element()
     }
 

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -1545,7 +1545,10 @@ impl Changes {
             .id("changes-ref-trigger")
             .h(px(22.0))
             .px(px(6.0))
-            .flex_none()
+            // Shrinkable, like the branch label beside it — a flex_none
+            // trigger with a long base name plowed over the header buttons
+            // (user report); both sides truncate instead.
+            .min_w_0()
             .flex()
             .flex_row()
             .items_center()
@@ -1573,6 +1576,8 @@ impl Changes {
             }))
             .child(
                 div()
+                    .min_w_0()
+                    .truncate()
                     .font_family(theme.font_mono.clone())
                     .text_size(px(11.5))
                     .text_color(theme.text)
@@ -1581,6 +1586,7 @@ impl Changes {
             .child(
                 crate::icons::icon(crate::icons::ALT_ARROW_DOWN)
                     .size(px(11.0))
+                    .flex_none()
                     .text_color(theme.text_muted.opacity(0.7)),
             );
         let trigger = if self.ref_menu.get().is_some() {
@@ -1722,6 +1728,8 @@ impl Changes {
                 .border_color(crate::theme::hairline(0.06))
                 .child(
                     div()
+                        .min_w_0()
+                        .truncate()
                         .text_size(px(12.0))
                         .text_color(theme.text_muted)
                         .child(SharedString::from(scope_label(

--- a/crates/ui/src/shell/tabs.rs
+++ b/crates/ui/src/shell/tabs.rs
@@ -129,10 +129,13 @@ impl Shell {
         // inset would push the scope dropdown off the pane's own left gutter
         // (user report: misaligned dead space). With the sidebar COLLAPSED
         // the seam is the window edge, where the traffic lights + nav
-        // cluster overlay lives — the strip must still clear it or the scope
-        // dropdown renders underneath (user report).
+        // cluster overlay lives — the strip must still clear it, but only
+        // just: `title_bar_content_start` carries a 10px TEXT margin the
+        // strip doesn't want (it brings its own 8px pad), and doubling up
+        // read as a hole after the `+` (user report).
         let row_left = if takeover {
-            sidebar_now.max(self.title_bar_content_start() + plus_inset)
+            let cluster_end = self.title_bar_content_start() - 10.0 + plus_inset;
+            sidebar_now.max(cluster_end)
         } else {
             content_left
         };
@@ -165,7 +168,16 @@ impl Shell {
                     // gutter, so the scope label sits flush over the stats
                     // strip below.
                     .pl(px(8.0))
-                    .child(div().flex_1().min_w_0().h_full().child(controls))
+                    // Clipped: a long base-ref name must truncate inside the
+                    // controls, never paint under the buttons to the right.
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .h_full()
+                            .overflow_hidden()
+                            .child(controls),
+                    )
                     .child(header_icon_button(
                         "expand-changes",
                         icons::EXPAND_ARROWS,


### PR DESCRIPTION
Two takeover-header reports on v0.1.45:

- **Long ref overflow** — a long base-ref name plowed over the fold/expand/close buttons: the base trigger was `flex_none`, so it couldn't shrink and the row overflowed (paint order stacked the text under the buttons). Both sides of the ref selector now truncate (`min_w_0` + truncating labels on the trigger and the branch label), the controls wrapper clips as a backstop, and the stats-strip label truncates too.
- **Collapsed-sidebar takeover hole** — the strip's left inset double-counted `title_bar_content_start`'s 10px text margin on top of its own 8px pad, leaving a gap after the nav cluster's `+`. The text margin is dropped; the scope dropdown now sits 8px off the `+`.

| | |
|---|---|
| Long base ref — both sides ellipsize, buttons clear | Collapsed-sidebar takeover — tight after the `+` |
| ![truncated](https://github.com/user-attachments/assets/98b05a2e-d050-4db7-89f6-76deee9f952d) | ![collapsed](https://github.com/user-attachments/assets/1a9c8799-d848-40b4-b504-dc075b5d2e70) |

Driven live in the rig (long branch picked through the search menu). Tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)