### PR TITLE
Collapsed-takeover header: scope dropdown on the cluster's 2px rhythm

### DIFF
--- a/crates/ui/src/shell/tabs.rs
+++ b/crates/ui/src/shell/tabs.rs
@@ -134,7 +134,13 @@ impl Shell {
         // strip doesn't want (it brings its own 8px pad), and doubling up
         // read as a hole after the `+` (user report).
         let row_left = if takeover {
-            let cluster_end = self.title_bar_content_start() - 10.0 + plus_inset;
+            // The scope dropdown should sit at the cluster's own 2px button
+            // rhythm off the `+` — anything more read as a hole in the button
+            // row (user report). Between `row_left` and the trigger box sit
+            // 16px of chrome (the row's 8px child gap + the strip's 8px pad),
+            // and `title_bar_content_start` adds a 10px text margin: land the
+            // box at cluster end + 2 ⇒ −(10 + 16 − 2).
+            let cluster_end = self.title_bar_content_start() - 10.0 + plus_inset - 14.0;
             sidebar_now.max(cluster_end)
         } else {
             content_left


### PR DESCRIPTION
The collapsed-sidebar takeover still left an 8px+ hole between the nav cluster's `+` and the scope dropdown — between `row_left` and the trigger box sit 16px of chrome (the titlebar row's 8px child gap plus the strip's 8px pad) the previous offset didn't account for. The box now lands at the cluster's own 2px button rhythm, so the dropdown reads as the next control in the row (measured off live pixels this time, not just eyeballed).

![takeover rhythm](https://github.com/user-attachments/assets/4e78f5f8-e921-4970-8d4b-73b6a73b837b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789082596&installation_model_id=425430&pr_number=46&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F46&signature=41fe84d8426cab4a7f8263f2e5dd09f399774a734743befe36b2180547a0594d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->