### PR TITLE
User bubble text: selectable like rendered markdown

### DIFF
--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -733,6 +733,40 @@ fn selection_wash(theme: &Theme) -> Hsla {
     theme.accent.opacity(0.35) // indigo-400
 }
 
+/// Selection support for a plain (non-markdown) text element — the user
+/// bubble. Paints the selection wash under the glyphs, registers the element
+/// into the frame's document-ordered registry (so drags span into adjacent
+/// markdown rows and Cmd+C joins in order), and re-registers the mouse
+/// listeners. Call from a paint-phase canvas that sits UNDER the text.
+pub(crate) fn paint_text_selection(
+    window: &mut Window,
+    key: &std::sync::Arc<str>,
+    text: &SharedString,
+    layout: &gpui::TextLayout,
+    theme: &Theme,
+) {
+    if let Some(range) = super::selection::wash_range(key) {
+        for rect in range_rects(layout, &range, 0.0, 0.0) {
+            window.paint_quad(quad(
+                rect,
+                px(0.0),
+                selection_wash(theme),
+                px(0.0),
+                gpui::transparent_black(),
+                BorderStyle::default(),
+            ));
+        }
+    }
+    REGISTRY.with(|r| {
+        r.borrow_mut().push(RegEntry {
+            key: key.clone(),
+            text: text.clone(),
+            layout: layout.clone(),
+        })
+    });
+    register_selection_listeners(window, key, text, layout);
+}
+
 /// One painted text element, registered per frame in document order — the
 /// continuity model that lets a drag span paragraphs/list items (Zed gets
 /// this for free from its single-element markdown; our tree rebuilds it).

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2078,11 +2078,7 @@ impl Transcript {
                                 .line_height(px(22.0))
                                 .text_color(theme.text)
                                 .when(pending, |el| el.opacity(0.65))
-                                .child(if mentions.is_empty() {
-                                    text.into_any_element()
-                                } else {
-                                    user_mention_text(text, mentions, &theme)
-                                }),
+                                .child(user_bubble_text(&row.id, text, mentions, &theme)),
                         ),
                     );
                 }
@@ -2679,7 +2675,12 @@ impl Transcript {
 /// gpui's line-layout cache (identical text + runs ⇒ reuse) and the underlay
 /// repaints O(chips) quads — no layout work, no re-projection (spans were
 /// computed once in [`rows_for_entry`]).
-fn user_mention_text(
+/// The user bubble's text: runs split at mention-chip boundaries (one plain
+/// run when there are none), with the same selection machinery as rendered
+/// markdown — the element registers into the frame's document-ordered
+/// registry, so drags select, span into adjacent rows, and Cmd+C copies.
+fn user_bubble_text(
+    row_id: &SharedString,
     text: SharedString,
     mentions: Arc<Vec<crate::composer::SentMentionSpan>>,
     theme: &Theme,
@@ -2718,6 +2719,8 @@ fn user_mention_text(
     let styled = StyledText::new(text.clone()).with_runs(runs);
     let layout = styled.layout().clone();
     let wash = theme.code_wash;
+    let sel_key: std::sync::Arc<str> = format!("{row_id}:u").into();
+    let sel_theme = theme.clone();
     let underlay = canvas(
         |_, _, _| (),
         move |_, _, window, _| {
@@ -2733,6 +2736,7 @@ fn user_mention_text(
                     ));
                 }
             }
+            render::paint_text_selection(window, &sel_key, &text, &layout, &sel_theme);
         },
     )
     .absolute()


### PR DESCRIPTION
## Summary
- Text in sent (user) message bubbles is now selectable, reusing the transcript's existing selection machinery instead of rendering as inert plain text.
- `render.rs`: new `paint_text_selection()` helper exposing the registry/wash/mouse-listener wiring for plain (non-markdown) text elements.
- `transcript.rs`: the user bubble's two text paths (plain, and with mention chips) merge into one `user_bubble_text()` builder that paints through a canvas underlay calling that helper.

Because bubbles register into the same per-frame document-ordered registry as markdown rows, you get drag selection, double-click word / triple-click message, Cmd+C copy, and drags that span from a user bubble into the assistant reply below it.

## Testing
- `cargo check -p comet-ui` — no new warnings
- `cargo test -p comet-ui` selection + transcript suites: 33 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789083904&installation_model_id=425430&pr_number=48&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F48&signature=7297e60fb360499ee5cd7d49bf5ff9c49367dffd8b872b0df657a637074f422e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->