### PR TITLE
Folder picker: slash-to-descend, tab completion, ctrl-n/p

### DIFF
--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -1267,6 +1267,11 @@ pub struct ComposerInput {
     last_width: f32,
     /// Raw Markdown → chip display projection from the last layout pass.
     projection: TextProjection,
+    /// Inline completion preview: painted in faint ink after the text while
+    /// the caret sits at the end (palette tab-completion). Owned by the
+    /// wrapper — it recomputes and re-sets this on every render pass, so the
+    /// input never has to know what the completion means.
+    ghost: Option<SharedString>,
     /// File mentions are a composer feature, not a behavior of generic inputs
     /// (picker searches and rename fields also use this type).
     mentions_enabled: bool,
@@ -1337,6 +1342,7 @@ impl ComposerInput {
             max_line_width: 0.0,
             last_width: 0.0,
             projection: TextProjection::default(),
+            ghost: None,
             mentions_enabled: false,
             layout_epoch: 0,
             display_is_placeholder: true,
@@ -1483,6 +1489,16 @@ impl ComposerInput {
 
     pub fn is_empty(&self) -> bool {
         self.content.is_empty()
+    }
+
+    /// Set (or clear) the inline completion preview. Only paints while the
+    /// caret sits at the end of a non-empty draft — see the prepaint gate.
+    pub fn set_ghost(&mut self, ghost: Option<SharedString>, cx: &mut Context<Self>) {
+        if self.ghost == ghost {
+            return;
+        }
+        self.ghost = ghost;
+        cx.notify();
     }
 
     pub fn has_newline(&self) -> bool {
@@ -2741,6 +2757,10 @@ struct ComposerTextPrepaint {
     mention_quads: Vec<PaintQuad>,
     mention_hits: Vec<MentionHit>,
     selection_quads: Vec<PaintQuad>,
+    /// Completion preview: window-space origin of the end-of-text caret plus
+    /// the suffix to paint there (shaped at paint time — it never joins the
+    /// content's own layout, so hit-testing and the caret ignore it).
+    ghost: Option<(Point<Pixels>, SharedString)>,
 }
 
 impl IntoElement for ComposerTextElement {
@@ -2932,11 +2952,29 @@ impl gpui::Element for ComposerTextElement {
                 }),
             });
         }
+        // The ghost only shows where accepting it would insert: a collapsed
+        // caret at the end of real (non-placeholder, non-IME) text.
+        let ghost = input
+            .ghost
+            .clone()
+            .filter(|g| {
+                !g.is_empty()
+                    && !input.display_is_placeholder
+                    && input.marked_range.is_none()
+                    && input.selected_range.is_empty()
+                    && input.cursor_offset() == input.content.len()
+            })
+            .and_then(|g| {
+                input
+                    .point_for_index(input.content.len())
+                    .map(|p| (point(origin.x + p.x, origin.y + p.y), g))
+            });
         ComposerTextPrepaint {
             cursor,
             mention_quads,
             mention_hits,
             selection_quads,
+            ghost,
         }
     }
 
@@ -2995,6 +3033,30 @@ impl gpui::Element for ComposerTextElement {
                     cx,
                 );
                 y += height;
+            }
+            if let Some((ghost_origin, ghost)) = prepaint.ghost.take() {
+                let style = window.text_style();
+                let font_size = style.font_size.to_pixels(window.rem_size());
+                let run = TextRun {
+                    len: ghost.len(),
+                    font: style.font(),
+                    color: Theme::of(cx).text_faint,
+                    background_color: None,
+                    underline: None,
+                    strikethrough: None,
+                };
+                let line = window
+                    .text_system()
+                    .shape_line(ghost, font_size, &[run], None);
+                // (Clipping comes from the surrounding content mask.)
+                let _ = line.paint(
+                    ghost_origin,
+                    line_height,
+                    gpui::TextAlign::Left,
+                    None,
+                    window,
+                    cx,
+                );
             }
             // Caret only when this input is actually focused in an active
             // window (Electron hides it on window deactivation too), and only

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -263,6 +263,28 @@ pub fn completion_prefix_len(name: &str, query: &str) -> Option<usize> {
     Some(len)
 }
 
+/// Resolve a typed path segment against folder `names` (slash-descend):
+/// exact match first — case-SENSITIVE before case-insensitive, so `GitHub/`
+/// picks a `GitHub` sibling over `github` — then a unique case-insensitive
+/// prefix. Ambiguity resolves to `None`: the slash stays in the query.
+pub fn segment_target(names: &[&str], query: &str) -> Option<usize> {
+    if let Some(ix) = names.iter().position(|n| *n == query) {
+        return Some(ix);
+    }
+    if let Some(ix) = names
+        .iter()
+        .position(|n| completion_prefix_len(n, query) == Some(n.len()))
+    {
+        return Some(ix);
+    }
+    let mut hits = names
+        .iter()
+        .enumerate()
+        .filter(|(_, n)| completion_prefix_len(n, query).is_some());
+    let (ix, _) = hits.next()?;
+    hits.next().is_none().then_some(ix)
+}
+
 /// Breadcrumb segments for a path: `(label, full path)`, root first.
 pub fn breadcrumbs(path: &str) -> Vec<(String, String)> {
     let mut out: Vec<(String, String)> = vec![("/".to_string(), "/".to_string())];
@@ -3205,6 +3227,20 @@ mod tests {
         // Multibyte names slice on a char boundary.
         assert_eq!(completion_prefix_len("héllo", "hé"), Some(3));
         assert_eq!(&"héllo"[3..], "llo");
+    }
+
+    #[test]
+    fn segment_target_resolution() {
+        let names = ["github", "GitHub", "worktree"];
+        // Exact casing beats the earlier case-insensitive sibling…
+        assert_eq!(segment_target(&names, "GitHub"), Some(1));
+        assert_eq!(segment_target(&names, "github"), Some(0));
+        // …but with no exact-cased hit, case-insensitive exact still lands.
+        assert_eq!(segment_target(&names, "WORKTREE"), Some(2));
+        // Unique prefix descends; an ambiguous one keeps the slash honest.
+        assert_eq!(segment_target(&names, "work"), Some(2));
+        assert_eq!(segment_target(&names, "g"), None);
+        assert_eq!(segment_target(&names, "x"), None);
     }
 
     #[test]

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -246,6 +246,23 @@ pub fn child_path(base: &str, name: &str) -> String {
     }
 }
 
+/// Byte length of `name`'s prefix matching `query`, compared char-for-char
+/// case-insensitively; `None` when `query` isn't a prefix of `name`. The
+/// length indexes into `name` (not `query`) so the completion suffix keeps
+/// the folder's real casing: `("Documents", "doc") → Some(3)` → `"uments"`.
+pub fn completion_prefix_len(name: &str, query: &str) -> Option<usize> {
+    let mut len = 0;
+    let mut name_chars = name.chars();
+    for qc in query.chars() {
+        let nc = name_chars.next()?;
+        if !nc.to_lowercase().eq(qc.to_lowercase()) {
+            return None;
+        }
+        len += nc.len_utf8();
+    }
+    Some(len)
+}
+
 /// Breadcrumb segments for a path: `(label, full path)`, root first.
 pub fn breadcrumbs(path: &str) -> Vec<(String, String)> {
     let mut out: Vec<(String, String)> = vec![("/".to_string(), "/".to_string())];
@@ -3173,6 +3190,21 @@ mod tests {
         assert_eq!(labels, ["/", "home", "w", "dev"]);
         assert_eq!(crumbs[2].1, "/home/w");
         assert_eq!(breadcrumbs("/").len(), 1);
+    }
+
+    #[test]
+    fn completion_prefix_lengths() {
+        // Case-insensitive; the length indexes into the NAME's bytes.
+        assert_eq!(completion_prefix_len("Documents", "doc"), Some(3));
+        assert_eq!(&"Documents"[3..], "uments");
+        assert_eq!(completion_prefix_len("comet", "comet"), Some(5));
+        assert_eq!(completion_prefix_len("comet", ""), Some(0));
+        assert_eq!(completion_prefix_len("comet", "dev"), None);
+        // Longer than the name → not a prefix.
+        assert_eq!(completion_prefix_len("dev", "devel"), None);
+        // Multibyte names slice on a char boundary.
+        assert_eq!(completion_prefix_len("héllo", "hé"), Some(3));
+        assert_eq!(&"héllo"[3..], "llo");
     }
 
     #[test]

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -243,6 +243,11 @@ pub fn classify_key(key: &str, cmd: bool, ctrl: bool) -> MenuKey {
     match key {
         "up" => MenuKey::Up,
         "down" => MenuKey::Down,
+        // Readline/emacs motion: ctrl-n/ctrl-p mirror ↓/↑ in every picker.
+        // Safe to claim frame-wide — neither chord is a text-editing binding
+        // in the palette keymaps, so they always bubble here unconsumed.
+        "n" if ctrl => MenuKey::Down,
+        "p" if ctrl => MenuKey::Up,
         "enter" if cmd || ctrl => MenuKey::ModEnter,
         "enter" => MenuKey::Enter,
         "escape" => MenuKey::Escape,
@@ -712,6 +717,24 @@ pub fn key_hint(theme: &Theme, icon_path: &'static str, label: &'static str) -> 
         .child(key_hint_label(theme, label))
 }
 
+/// A footer legend whose cap holds a WORD ("tab", "esc") instead of a glyph
+/// — for keys with no icon in the set.
+pub fn key_hint_text(theme: &Theme, cap: &'static str, label: &'static str) -> gpui::Div {
+    div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap(px(5.0))
+        .child(
+            key_cap(theme)
+                .text_size(px(11.0))
+                .font_family(theme.font_mono.clone())
+                .text_color(theme.text_muted.opacity(0.7))
+                .child(SharedString::from(cap)),
+        )
+        .child(key_hint_label(theme, label))
+}
+
 /// A footer legend whose cap holds TWO glyphs split by a hairline
 /// ("[ ↑ | ↓ ] Navigate") sharing one verb.
 pub fn key_hint_pair(
@@ -982,6 +1005,11 @@ mod tests {
         assert_eq!(classify_key("escape", false, false), MenuKey::Escape);
         assert_eq!(classify_key("backspace", false, false), MenuKey::Backspace);
         assert_eq!(classify_key("a", false, false), MenuKey::Other);
+        // Readline motion — only with ctrl held.
+        assert_eq!(classify_key("n", false, true), MenuKey::Down);
+        assert_eq!(classify_key("p", false, true), MenuKey::Up);
+        assert_eq!(classify_key("n", false, false), MenuKey::Other);
+        assert_eq!(classify_key("p", true, false), MenuKey::Other);
     }
 
     #[test]

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -9,7 +9,7 @@
 //! Child module of `shell` so it renders straight off `Shell`'s private state.
 
 use super::*;
-use crate::pickers::{breadcrumbs, browser_rows, parent_path};
+use crate::pickers::{breadcrumbs, browser_rows, completion_prefix_len, parent_path};
 use comet_proto::{ChatIndicator, Device, FolderListing, Space};
 use gpui::FocusHandle;
 
@@ -43,7 +43,9 @@ pub(super) enum SpacesMenuRow {
 pub(super) struct AddSpaceFlow {
     /// The device currently browsed (the highlighted rail row).
     device: Option<Device>,
-    /// Filter input; Enter descends into the highlighted folder.
+    /// Filter input; Enter descends into the highlighted folder. Carries the
+    /// tab-completion ghost (the faint suffix ⇥ accepts), and a trailing `/`
+    /// on a folder-naming query descends immediately.
     search: Entity<ComposerInput>,
     browser: Loadable<FolderListing>,
     /// Requested browser path (`None` = the device's default, i.e. home).
@@ -909,6 +911,13 @@ impl Shell {
             cx.new(|cx| ComposerInput::with_context("Search folders…", "PaletteSearch", cx));
         let search_events = cx.subscribe(&search, |this: &mut Shell, _, event, cx| {
             if matches!(event, ComposerInputEvent::Edited) {
+                // Typing `/` after a query that names a folder descends into
+                // it — the query reads as a path segment, so the slash IS the
+                // pick (shell-style). Otherwise the slash stays in the query
+                // (it matches nothing, which is honest feedback).
+                if this.add_space_slash_descend(cx) {
+                    return;
+                }
                 if let Some(flow) = this.add_space.as_mut() {
                     flow.active = 0;
                 }
@@ -998,6 +1007,88 @@ impl Shell {
         }
         search.update(cx, |input, cx| input.set_text("", cx));
         self.load_space_folders(Some(full), cx);
+    }
+
+    /// Slash-descend: when the query ends in `/` and the part before it names
+    /// a folder of the current listing (exact name, else a unique prefix),
+    /// descend into it as though it were picked. Returns whether it fired —
+    /// descending clears the query, so the caller must not keep acting on the
+    /// old text.
+    fn add_space_slash_descend(&mut self, cx: &mut Context<Self>) -> bool {
+        let target = {
+            let Some(flow) = self.add_space.as_ref() else {
+                return false;
+            };
+            let text = flow.search.read(cx).text().to_string();
+            let Some(query) = text.strip_suffix('/') else {
+                return false;
+            };
+            if query.is_empty() || query.contains('/') {
+                return false;
+            }
+            let Some(listing) = flow.browser.ready() else {
+                return false;
+            };
+            let dirs = browser_rows(listing);
+            dirs.iter()
+                .find(|e| completion_prefix_len(&e.name, query) == Some(e.name.len()))
+                .copied()
+                .or_else(|| {
+                    let mut hits = dirs
+                        .iter()
+                        .filter(|e| completion_prefix_len(&e.name, query).is_some());
+                    let first = hits.next()?;
+                    hits.next().is_none().then_some(*first)
+                })
+                .map(|entry| {
+                    (
+                        crate::pickers::child_path(&listing.path, &entry.name),
+                        entry.is_repo,
+                    )
+                })
+        };
+        let Some((full, is_repo)) = target else {
+            return false;
+        };
+        self.add_space_descend(full, is_repo, cx);
+        true
+    }
+
+    /// The tab-completion target: the highlighted row when the query prefixes
+    /// its name, else the first prefix match (filtering ranks those first).
+    /// `(full name, remaining suffix)`; `None` on an empty query or when the
+    /// match is already complete.
+    fn add_space_completion(&self, cx: &App) -> Option<(String, String)> {
+        let flow = self.add_space.as_ref()?;
+        let query = flow.search.read(cx).text().to_string();
+        if query.is_empty() {
+            return None;
+        }
+        let rows = self.add_space_filtered(cx);
+        let entry = rows
+            .get(flow.active)
+            .filter(|e| completion_prefix_len(&e.name, &query).is_some())
+            .or_else(|| {
+                rows.iter()
+                    .find(|e| completion_prefix_len(&e.name, &query).is_some())
+            })?;
+        let len = completion_prefix_len(&entry.name, &query)?;
+        if len >= entry.name.len() {
+            return None;
+        }
+        Some((entry.name.clone(), entry.name[len..].to_string()))
+    }
+
+    /// ⇥: accept the completion — the query becomes the full folder name
+    /// (the ghost the input was previewing). Descending stays on `/`/⏎.
+    fn add_space_accept_completion(&mut self, cx: &mut Context<Self>) {
+        let Some((name, _)) = self.add_space_completion(cx) else {
+            return;
+        };
+        if let Some(flow) = self.add_space.as_ref() {
+            let search = flow.search.clone();
+            search.update(cx, |input, cx| input.set_text(name, cx));
+        }
     }
 
     /// Descend into a specific folder row (mouse path); clears the query.
@@ -1180,9 +1271,11 @@ impl Shell {
     }
 
     /// Palette keys (bubbling from the focused search input) — every legend
-    /// maps to a REAL key: ↑↓ navigate, →/⏎ open the highlighted folder,
-    /// ← up a level, ⌘⏎ add the OPEN folder, ⌫ (empty query) also goes up,
-    /// esc closes.
+    /// maps to a REAL key: ↑↓ (or ctrl-n/p) navigate, →/⏎ open the
+    /// highlighted folder, ← up a level, ⇥ completes the query to the
+    /// previewed folder name, ⌘⏎ add the OPEN folder, ⌫ (empty query) also
+    /// goes up, esc closes. (Typing `/` also descends — see the Edited
+    /// subscription.)
     fn add_space_key(&mut self, event: &gpui::KeyDownEvent, cx: &mut Context<Self>) {
         // ←/→ act on the FOLDERS, not the text cursor — the palette is a
         // navigator first; queries are short and edited with ⌫.
@@ -1193,6 +1286,12 @@ impl Shell {
             }
             "left" => {
                 self.add_space_go_up(cx);
+                return;
+            }
+            // Unbound in "PaletteSearch" (like enter), so it bubbles here
+            // instead of editing text or moving focus.
+            "tab" => {
+                self.add_space_accept_completion(cx);
                 return;
             }
             _ => {}
@@ -1286,6 +1385,13 @@ impl Shell {
         };
         let devices = self.state.read(cx).devices.clone();
         let rows = self.add_space_filtered(cx);
+        // Push the completion preview into the input — the faint suffix ahead
+        // of the caret that ⇥ accepts. Recomputed every render (query, active
+        // row, and listing all move it); `set_ghost` no-ops when unchanged.
+        let ghost = self
+            .add_space_completion(cx)
+            .map(|(_, suffix)| SharedString::from(suffix));
+        search.update(cx, |input, cx| input.set_ghost(ghost, cx));
         let query_empty = search.read(cx).is_empty();
         let hairline = crate::theme::hairline(0.06);
         let now = Utc::now();
@@ -1754,6 +1860,7 @@ impl Shell {
             ))
             .child(popover::key_hint(&theme, icons::ARROW_LEFT, "Up"))
             .child(popover::key_hint(&theme, icons::ARROW_RIGHT, "Open"))
+            .child(popover::key_hint_text(&theme, "tab", "Complete"))
             .when_some(error, |el, message| {
                 el.child(
                     div()

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -1010,8 +1010,9 @@ impl Shell {
     }
 
     /// Slash-descend: when the query ends in `/` and the part before it names
-    /// a folder of the current listing (exact name, else a unique prefix),
-    /// descend into it as though it were picked. Returns whether it fired —
+    /// a folder of the current listing (exact name — matching casing wins
+    /// over a case-colliding sibling — else a unique prefix), descend into it
+    /// as though it were picked. Returns whether it fired —
     /// descending clears the query, so the caller must not keep acting on the
     /// old text.
     fn add_space_slash_descend(&mut self, cx: &mut Context<Self>) -> bool {
@@ -1030,22 +1031,13 @@ impl Shell {
                 return false;
             };
             let dirs = browser_rows(listing);
-            dirs.iter()
-                .find(|e| completion_prefix_len(&e.name, query) == Some(e.name.len()))
-                .copied()
-                .or_else(|| {
-                    let mut hits = dirs
-                        .iter()
-                        .filter(|e| completion_prefix_len(&e.name, query).is_some());
-                    let first = hits.next()?;
-                    hits.next().is_none().then_some(*first)
-                })
-                .map(|entry| {
-                    (
-                        crate::pickers::child_path(&listing.path, &entry.name),
-                        entry.is_repo,
-                    )
-                })
+            let names: Vec<&str> = dirs.iter().map(|e| e.name.as_str()).collect();
+            crate::pickers::segment_target(&names, query).map(|ix| {
+                (
+                    crate::pickers::child_path(&listing.path, &dirs[ix].name),
+                    dirs[ix].is_repo,
+                )
+            })
         };
         let Some((full, is_repo)) = target else {
             return false;


### PR DESCRIPTION
The add-space palette (⌘K → New project…) browsed folders with arrows only. Three additions make it read like a shell prompt.

## Slash descends

Typing `/` after a query that names a folder in the current listing — exact name, or a unique prefix — enters that folder exactly as if you'd picked it, and clears the query. A slash that matches nothing just stays in the query, and the list shows "No folders match".

Scoped to single path segments, since the palette browses one level at a time. Chaining works naturally: `fun/` descends, then `comet/` descends again.

## Tab completion with a ghost preview

`ComposerInput` gained first-class ghost-text support: a `set_ghost` API plus prepaint/paint logic drawing the completion suffix in faint ink at the end-of-text caret. It only paints for a collapsed caret at the end of non-empty, non-IME text, and never joins the real text layout — hit-testing, selection, and the caret are unaffected.

The palette recomputes the completion each render: the highlighted row if the query prefixes its name, else the first prefix match. Matching is case-insensitive but the ghost keeps the folder's real casing, so typing `doc` previews `uments` for `Documents`. That's `completion_prefix_len` in `pickers.rs` — a pure helper returning a byte length into the *name*, unit-tested including multibyte input.

**Tab** accepts the ghost, filling in the full folder name; `/` or Enter then descends. New `tab · Complete` chip in the footer legend.

## ctrl-n / ctrl-p

`classify_key` now maps ctrl-n → Down and ctrl-p → Up. Every picker routes keys through it (folder browser, spaces filter, branch picker, harness/model, traits), so they all get readline motion, not just this palette. Neither chord is bound in the composer or palette keymaps, so both bubble to the frame unconsumed.

## Testing

`cargo test -p comet-ui` — 386 passed. New unit tests cover `completion_prefix_len` (casing, multibyte, non-prefix) and the ctrl-n/p classification including the negative cases (bare `n`, cmd-`p`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789101724&installation_model_id=425430&pr_number=50&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F50&signature=2062dc071f939ed31afa4c5a450ac32ebe883c0d4e8a2182f8dc284609316526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->