### PR TITLE
Traits chip: show the selected options instead of a bare "Traits" label

### DIFF
--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -188,9 +188,12 @@ pub fn reasoning_label(level: ReasoningLevel) -> &'static str {
     }
 }
 
-/// The TraitsPicker trigger summary: non-default reasoning + non-default model
-/// option choices, joined with " · " (comet: "High · 1M · Fast"). `None` when
-/// everything is at its default.
+/// The TraitsPicker trigger summary: the effective reasoning level plus every
+/// model option's effective choice — the explicit pick when one is saved and
+/// still offered, else the option's default — joined with " · " ("High · 1M ·
+/// Fast", Cursor's "Agent · Balance"). Defaults are spelled out rather than
+/// hidden so the run's configuration reads without opening the popover; `None`
+/// only when the model has nothing to describe (no ladder, no options).
 pub fn traits_summary(
     model: Option<&Model>,
     reasoning: Option<ReasoningLevel>,
@@ -202,12 +205,11 @@ pub fn traits_summary(
     }
     if let Some(model) = model {
         for option in &model.options {
-            let Some(choice_id) = selections.get(&option.id).and_then(|v| v.as_str()) else {
-                continue;
-            };
-            if choice_id == option.default_choice {
-                continue;
-            }
+            let choice_id = selections
+                .get(&option.id)
+                .and_then(|v| v.as_str())
+                .filter(|id| option.choices.iter().any(|c| c.id == *id))
+                .unwrap_or(&option.default_choice);
             if let Some(choice) = option.choices.iter().find(|c| c.id == choice_id) {
                 parts.push(choice.label.clone());
             }
@@ -218,6 +220,30 @@ pub fn traits_summary(
     } else {
         Some(parts.join(" · "))
     }
+}
+
+/// Whether any trait departs from its default — the trigger brightens only
+/// then, so a customized run still stands out now that the summary always
+/// names the effective choices.
+pub fn traits_customized(
+    model: Option<&Model>,
+    reasoning: Option<ReasoningLevel>,
+    ladder: &[ReasoningLevel],
+    selections: &serde_json::Map<String, serde_json::Value>,
+) -> bool {
+    if reasoning != default_reasoning(ladder) {
+        return true;
+    }
+    model.is_some_and(|model| {
+        model.options.iter().any(|option| {
+            selections
+                .get(&option.id)
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| {
+                    id != option.default_choice && option.choices.iter().any(|c| c.id == id)
+                })
+        })
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -3014,6 +3040,12 @@ impl Render for Pickers {
             self.effective_reasoning(cx),
             &explicit_options,
         );
+        let traits_active = traits_customized(
+            self.selected_model(cx),
+            self.effective_reasoning(cx),
+            &self.trait_ladder(cx),
+            &explicit_options,
+        );
         let traits_label: SharedString = traits_set
             .clone()
             .map(SharedString::from)
@@ -3062,9 +3094,11 @@ impl Render for Pickers {
             .gap(px(4.0));
         // Model chip (brand icon + model name) beside a separate Traits chip
         // (t3code TraitsPicker arrangement): the trigger label is the joined
-        // non-default summary ("High · 1M · Fast"), falling back to "Traits".
-        // No chip at all when the model has neither a ladder nor options
-        // (e.g. Hermes today) — a dead trigger reads as broken.
+        // effective summary ("High · 1M · Fast", "Agent · Balance") so the
+        // run's traits read without opening; it brightens only when something
+        // departs from its default. No chip at all when the model has neither
+        // a ladder nor options (e.g. Hermes today) — a dead trigger reads as
+        // broken.
         let model_chip = self.trigger_chip(
             PickerKind::HarnessModel,
             model_label,
@@ -3082,7 +3116,7 @@ impl Render for Pickers {
             self.trigger_chip(
                 PickerKind::Traits,
                 traits_label,
-                traits_set.is_some(),
+                traits_active,
                 None,
                 None,
                 &theme,
@@ -3178,15 +3212,19 @@ mod tests {
             traits_summary(Some(&model), Some(ReasoningLevel::High), &selections),
             Some("High · 1M · Fast".to_string())
         );
-        // All defaults → no summary.
+        // All defaults: the effective choices still read on the trigger.
         assert_eq!(
             traits_summary(Some(&model), None, &serde_json::Map::new()),
-            None
+            Some("Standard · Normal".to_string())
         );
-        // Default-choice selections don't count as non-default.
-        let mut defaults = serde_json::Map::new();
-        defaults.insert("speed".into(), serde_json::Value::String("normal".into()));
-        assert_eq!(traits_summary(Some(&model), None, &defaults), None);
+        // A saved choice the option no longer offers falls back to the default
+        // label rather than vanishing or echoing a stale id.
+        let mut stale = serde_json::Map::new();
+        stale.insert("speed".into(), serde_json::Value::String("ludicrous".into()));
+        assert_eq!(
+            traits_summary(Some(&model), None, &stale),
+            Some("Standard · Normal".to_string())
+        );
         // Reasoning shows without a model too.
         assert_eq!(
             traits_summary(
@@ -3196,6 +3234,45 @@ mod tests {
             ),
             Some("Ultrathink".to_string())
         );
+        // Nothing to describe → "Traits" fallback upstream.
+        assert_eq!(traits_summary(None, None, &serde_json::Map::new()), None);
+
+        // Customized (bright trigger) only when something departs from its
+        // default: default-choice selections and the default reasoning level
+        // don't count; stale ids don't either.
+        let ladder = model.reasoning_levels.clone();
+        assert!(traits_customized(
+            Some(&model),
+            Some(ReasoningLevel::High),
+            &ladder,
+            &selections
+        ));
+        assert!(!traits_customized(
+            Some(&model),
+            default_reasoning(&ladder),
+            &ladder,
+            &serde_json::Map::new()
+        ));
+        let mut defaults = serde_json::Map::new();
+        defaults.insert("speed".into(), serde_json::Value::String("normal".into()));
+        assert!(!traits_customized(
+            Some(&model),
+            default_reasoning(&ladder),
+            &ladder,
+            &defaults
+        ));
+        assert!(!traits_customized(
+            Some(&model),
+            default_reasoning(&ladder),
+            &ladder,
+            &stale
+        ));
+        assert!(traits_customized(
+            Some(&model),
+            Some(ReasoningLevel::Medium),
+            &ladder,
+            &serde_json::Map::new()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The composer's Traits chip used to read a bare **"Traits"** whenever every pick was at its default, so you couldn't tell a session's Mode / Optimize For / effort without opening the popover. The trigger now always names each trait's **effective** choice — reasoning plus every model option, defaults included — joined the same way as the old non-default summary ("Agent · Balance", "High · 1M · Fast").

- Default state stays visually quiet: the chip only **brightens** when a pick departs from its default, so a customized run still stands out at a glance.
- A saved choice the option no longer offers falls back to the default's label instead of echoing a stale id or vanishing.
- `traits_customized()` carries the brightness decision; unit tests cover effective summaries, stale-id fallback, and the customized/default boundary (including reasoning vs. the ladder default).

## Verification (headless rig, real agents)
Cursor screenshots below were taken on this branch merged with #39 locally, since Cursor's Mode/Optimize For options are the motivating case; the Claude ladder shots are this branch on main.

Cursor Auto at defaults — chip reads `Agent · Balance`, muted:

<img src="https://github.com/user-attachments/assets/c9cac8a5-c353-4a8e-bddd-3c783650e990" width="720" />

Picking Plan + Cost — chip flips to `Plan · Cost` and brightens:

<img src="https://github.com/user-attachments/assets/87c8e0f1-ccba-4032-83f7-39ee50d4f7d1" width="720" />

Claude ladder: default shows `High` (muted); an explicit Ultrathink pick shows bright:

<img src="https://github.com/user-attachments/assets/6eae7e89-8fdc-4634-963a-be8732ee5aa6" width="720" />

Closed-popover resting state:

<img src="https://github.com/user-attachments/assets/104803a4-c4a4-4a86-87b2-393cc219193e" width="720" />

`comet-ui` suite green (390 tests); no new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789122913&installation_model_id=425430&pr_number=53&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F53&signature=2a5a8b40c8fbb90dabdf8a7ae07a166f62ff49b47ea866a1573820d072b9769a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->