### PR TITLE
Popovers: clicking an open menu's trigger closes it (no close-and-reopen)

### DIFF
--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -1784,12 +1784,16 @@ impl Changes {
             ))
             .on_hover(motion::hover_listener("changes-scope-trigger"))
             .occlude()
-            .on_mouse_down(gpui::MouseButton::Left, |_, window, _| {
-                window.prevent_default()
-            })
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(|this, _, window, _| {
+                    window.prevent_default();
+                    this.scope_menu.note_trigger_press();
+                }),
+            )
             .on_click(cx.listener(|this, _, _, cx| {
                 cx.stop_propagation();
-                if this.scope_menu.is_open() {
+                if this.scope_menu.take_press_was_open() {
                     this.close_scope_menu(cx);
                 } else {
                     this.scope_menu.open(());
@@ -1914,12 +1918,16 @@ impl Changes {
             ))
             .on_hover(motion::hover_listener("changes-ref-trigger"))
             .occlude()
-            .on_mouse_down(gpui::MouseButton::Left, |_, window, _| {
-                window.prevent_default()
-            })
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(|this, _, window, _| {
+                    window.prevent_default();
+                    this.ref_menu.note_trigger_press();
+                }),
+            )
             .on_click(cx.listener(|this, _, window, cx| {
                 cx.stop_propagation();
-                if this.ref_menu.is_open() {
+                if this.ref_menu.take_press_was_open() {
                     this.close_ref_menu(cx);
                     cx.notify();
                 } else {

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -13,7 +13,6 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
 
 use gpui::{
     AnyElement, App, Context, Entity, FocusHandle, Focusable as _, KeyDownEvent, SharedString,
@@ -383,9 +382,6 @@ pub struct Pickers {
     /// Shared search / URL / name input, reused across popovers.
     search: Entity<ComposerInput>,
     focus: FocusHandle,
-    /// Re-open suppression after outside-click dismissal (the dismiss and the
-    /// trigger click would otherwise toggle twice).
-    suppressed: Option<(PickerKind, Instant)>,
     /// `COMET_OPEN_PICKER` boot: keep claiming focus until it sticks, so
     /// keyboard nav drives the data-side-opened popover (headless rigs have
     /// no synthetic pointer, but synthetic keys do arrive).
@@ -526,7 +522,6 @@ impl Pickers {
             model_scroll: gpui::ScrollHandle::new(),
             search,
             focus: cx.focus_handle(),
-            suppressed: None,
             boot_focus_pending: boot_open.is_some(),
             load_task: None,
             refs_task: None,
@@ -707,8 +702,7 @@ impl Pickers {
         self.open.get().copied()
     }
 
-    /// Begin the exit animation without arming re-open suppression (the
-    /// toggle-close path — the next trigger click should reopen normally).
+    /// Begin the exit animation (shared by every close path).
     fn animate_close(&mut self, cx: &mut Context<Self>) {
         if self.open.begin_close() {
             popover::reap_popup(cx, |pickers: &mut Self| &mut pickers.open);
@@ -716,9 +710,6 @@ impl Pickers {
     }
 
     fn close(&mut self, cx: &mut Context<Self>) {
-        if let Some(kind) = self.open_kind() {
-            self.suppressed = Some((kind, Instant::now()));
-        }
         self.animate_close(cx);
         cx.notify();
     }
@@ -732,16 +723,14 @@ impl Pickers {
     }
 
     fn toggle(&mut self, kind: PickerKind, window: &mut Window, cx: &mut Context<Self>) {
-        if self.open_kind() == Some(kind) {
+        // A press that found this picker open closes it — the card's
+        // `on_mouse_down_out` already began the close on that same press,
+        // so by click time the popup reads as closed and a plain toggle
+        // would reopen it. A press while a DIFFERENT picker is open doesn't
+        // count (see note_trigger_press_matching): that click switches.
+        let pressed_open = self.open.take_press_was_open();
+        if self.open_kind() == Some(kind) || pressed_open {
             self.animate_close(cx);
-            cx.notify();
-            return;
-        }
-        // A just-dismissed popover's trigger click must not instantly reopen.
-        if let Some((suppressed, at)) = self.suppressed.take()
-            && suppressed == kind
-            && at.elapsed() < Duration::from_millis(400)
-        {
             cx.notify();
             return;
         }
@@ -1849,6 +1838,12 @@ impl Pickers {
             })
             .on_hover(motion::hover_listener(id))
             .cursor_pointer()
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(move |this, _, _, _| {
+                    this.open.note_trigger_press_matching(|open| *open == kind)
+                }),
+            )
             .on_click(cx.listener(move |this, _, window, cx| this.toggle(kind, window, cx)))
             .when_some(chip_icon, |el, (path, tint)| {
                 el.child(
@@ -1908,6 +1903,12 @@ impl Pickers {
             })
             .on_hover(motion::hover_listener(id))
             .cursor_pointer()
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(move |this, _, _, _| {
+                    this.open.note_trigger_press_matching(|open| *open == kind)
+                }),
+            )
             .on_click(cx.listener(move |this, _, window, cx| this.toggle(kind, window, cx)))
             .child(
                 crate::icons::icon(icon_path)

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -68,11 +68,17 @@ pub struct Popup<T> {
     /// `Some((state, closing_since))` while mounted; `closing_since` is the
     /// exit-phase start.
     inner: Option<(T, Option<std::time::Instant>)>,
+    /// Whether the popup was still mounted when the current trigger press
+    /// began — see [`Self::note_trigger_press`].
+    pressed_while_open: bool,
 }
 
 impl<T> Default for Popup<T> {
     fn default() -> Self {
-        Self { inner: None }
+        Self {
+            inner: None,
+            pressed_while_open: false,
+        }
     }
 }
 
@@ -132,6 +138,33 @@ impl<T> Popup<T> {
             }
             _ => false,
         }
+    }
+
+    /// Record, from the trigger's `on_mouse_down`, whether this popup is
+    /// still mounted. The anchored card's `on_mouse_down_out` fires on that
+    /// same press and begins the close, so by click (mouse-up) time the
+    /// popup already reads as closed — the click handler alone cannot tell
+    /// "this press dismissed it; stay closed" from "open fresh", and a
+    /// plain toggle closes-and-reopens (user report). Both handler orders
+    /// work: open and mid-exit each count as mounted. Every trigger click
+    /// is preceded by a trigger mouse-down, so the note is never stale.
+    pub fn note_trigger_press(&mut self) {
+        self.note_trigger_press_matching(|_| true);
+    }
+
+    /// [`Self::note_trigger_press`] for popups whose state distinguishes
+    /// which trigger owns them (e.g. one `Popup<PickerKind>` shared by
+    /// several triggers): only a press on the OWNING trigger counts, so
+    /// clicking a different trigger switches menus instead of swallowing.
+    pub fn note_trigger_press_matching(&mut self, owns: impl FnOnce(&T) -> bool) {
+        self.pressed_while_open = self.inner.as_ref().is_some_and(|(value, _)| owns(value));
+    }
+
+    /// Consume the press note: `true` when the press that produced the
+    /// current click found the popup mounted — the click should leave it
+    /// closed rather than reopen it.
+    pub fn take_press_was_open(&mut self) -> bool {
+        std::mem::take(&mut self.pressed_while_open)
     }
 
     /// Drop the state if the exit phase has run its course. A popup reopened
@@ -958,6 +991,40 @@ pub fn error_row(theme: &Theme, message: &str) -> gpui::Div {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn trigger_press_note_distinguishes_dismiss_from_open() {
+        let mut popup: Popup<u8> = Popup::default();
+
+        // Fresh open: press finds nothing mounted → click opens.
+        popup.note_trigger_press();
+        assert!(!popup.take_press_was_open());
+        popup.open(1);
+
+        // Trigger click while open: the card's mouse-down-out begins the
+        // close on the press (either handler order) — the note still reads
+        // mounted, so the click must NOT reopen.
+        popup.note_trigger_press();
+        popup.begin_close();
+        assert!(popup.take_press_was_open());
+        // Out-handler first, trigger note second: mid-exit still counts.
+        popup.open(1);
+        popup.begin_close();
+        popup.note_trigger_press();
+        assert!(popup.take_press_was_open());
+
+        // The note is consumed — a later click starts clean.
+        assert!(!popup.take_press_was_open());
+
+        // Kind-keyed popups: a press on a DIFFERENT trigger doesn't count,
+        // so that click switches menus instead of swallowing.
+        let mut popup: Popup<u8> = Popup::default();
+        popup.open(1);
+        popup.note_trigger_press_matching(|kind| *kind == 2);
+        assert!(!popup.take_press_was_open());
+        popup.note_trigger_press_matching(|kind| *kind == 1);
+        assert!(popup.take_press_was_open());
+    }
 
     #[test]
     fn menu_step_wraps_and_enters() {

--- a/crates/ui/src/settings/accounts.rs
+++ b/crates/ui/src/settings/accounts.rs
@@ -176,9 +176,6 @@ pub struct AccountsPage {
     /// accounts RPCs are relay-forwardable, CLI logins are per-device).
     target_device: Option<String>,
     device_menu: popover::Popup<()>,
-    /// Outside-click dismissal instant — suppresses the trigger click that
-    /// follows the same mouse-down from instantly reopening the menu.
-    device_menu_dismissed_at: Option<std::time::Instant>,
     snapshot: Loadable<AgentAccountsSnapshot>,
     /// Account id with an in-flight Switch/Forget.
     busy_account: Option<String>,
@@ -205,7 +202,6 @@ impl AccountsPage {
             state,
             target_device: None,
             device_menu: popover::Popup::default(),
-            device_menu_dismissed_at: None,
             snapshot: Loadable::Idle,
             busy_account: None,
             login: None,
@@ -318,14 +314,16 @@ impl AccountsPage {
                     gpui::transparent_black()
                 })
                 .when(!open, |el| el.hover(|s| s.bg(crate::theme::ink(0.04))))
+                .on_mouse_down(
+                    gpui::MouseButton::Left,
+                    cx.listener(|this, _, _, _| this.device_menu.note_trigger_press()),
+                )
                 .on_click(cx.listener(|this, _, _, cx| {
-                    let just_dismissed = this
-                        .device_menu_dismissed_at
-                        .is_some_and(|at| at.elapsed() < Duration::from_millis(400));
-                    this.device_menu_dismissed_at = None;
-                    if this.device_menu.is_open() {
+                    // A press that found the menu open closes it (the card's
+                    // mouse-down-out already began the close) — never reopen.
+                    if this.device_menu.take_press_was_open() {
                         this.close_device_menu(cx);
-                    } else if !just_dismissed {
+                    } else {
                         this.device_menu.open(());
                     }
                     cx.notify();
@@ -364,7 +362,6 @@ impl AccountsPage {
             let menu = popover::popover_card(theme)
                 .w(px(220.0))
                 .on_mouse_down_out(cx.listener(|this, _, _, cx| {
-                    this.device_menu_dismissed_at = Some(std::time::Instant::now());
                     this.close_device_menu(cx);
                 }))
                 .flex()

--- a/crates/ui/src/settings/harnesses.rs
+++ b/crates/ui/src/settings/harnesses.rs
@@ -14,7 +14,6 @@
 //! gate (plus "can't disable the last enabled harness") where the state
 //! lives, so a raced or stale toggle self-corrects from the RPC reply.
 
-use std::time::Duration;
 
 use gpui::{
     AnyElement, Context, Entity, IntoElement, Render, SharedString, Task, Window, div, prelude::*,
@@ -65,8 +64,11 @@ pub struct HarnessesPage {
     /// passthrough). Retargeted by the page-header device switcher.
     target_device: Option<String>,
     device_menu_open: bool,
-    /// Outside-click dismissal vs trigger-click race (the Accounts pattern).
-    device_menu_dismissed_at: Option<std::time::Instant>,
+    /// Whether the menu was open when the trigger press began — the menu's
+    /// `on_mouse_down_out` closes it on that same press, so by click time a
+    /// plain toggle would reopen (the [`popover::Popup`] press note, for
+    /// this page's bool-state menu).
+    device_menu_pressed_open: bool,
     /// Last refused/failed toggle (engine guards), shown in the error strip.
     error: Option<String>,
     load_task: Option<Task<()>>,
@@ -80,7 +82,7 @@ impl HarnessesPage {
             harnesses: Loadable::Idle,
             target_device: None,
             device_menu_open: false,
-            device_menu_dismissed_at: None,
+            device_menu_pressed_open: false,
             error: None,
             load_task: None,
             toggle_task: None,
@@ -227,12 +229,17 @@ impl HarnessesPage {
                     gpui::transparent_black()
                 })
                 .when(!open, |el| el.hover(|s| s.bg(crate::theme::ink(0.04))))
+                .on_mouse_down(
+                    gpui::MouseButton::Left,
+                    cx.listener(|this, _, _, _| {
+                        this.device_menu_pressed_open = this.device_menu_open;
+                    }),
+                )
                 .on_click(cx.listener(|this, _, _, cx| {
-                    let just_dismissed = this
-                        .device_menu_dismissed_at
-                        .is_some_and(|at| at.elapsed() < Duration::from_millis(400));
-                    this.device_menu_open = !this.device_menu_open && !just_dismissed;
-                    this.device_menu_dismissed_at = None;
+                    // A press that found the menu open closes it — never
+                    // reopen on the same gesture.
+                    let pressed_open = std::mem::take(&mut this.device_menu_pressed_open);
+                    this.device_menu_open = !pressed_open && !this.device_menu_open;
                     cx.notify();
                 }))
                 .child(
@@ -269,7 +276,6 @@ impl HarnessesPage {
                 .w(px(220.0))
                 .on_mouse_down_out(cx.listener(|this, _, _, cx| {
                     this.device_menu_open = false;
-                    this.device_menu_dismissed_at = Some(std::time::Instant::now());
                     cx.notify();
                 }))
                 .flex()

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -480,10 +480,6 @@ pub struct Shell {
     add_space: Option<AddSpaceFlow>,
     /// The sidebar's space-filter dropdown.
     spaces_menu: popover::Popup<spaces::SpacesMenu>,
-    /// When the dropdown was closed by an outside mouse-down; lets the
-    /// trigger's click tell "toggle closed" apart from "just dismissed by
-    /// this same click" (same guard as `user_menu_dismissed_at`).
-    spaces_menu_dismissed_at: Option<std::time::Instant>,
     /// Chat id whose STATUS CORNER is under the pointer — just that corner
     /// swaps to the archive button (t3code's settle-on-hover); hovering the
     /// row body leaves the status readable.
@@ -496,9 +492,6 @@ pub struct Shell {
     /// it (a row's FIRST appearance never chimes, so boot stays silent).
     sound_prev: std::collections::HashMap<String, comet_proto::SessionStatus>,
     user_menu: popover::Popup<()>,
-    /// Outside-click dismissal instant — suppresses the trigger click that
-    /// follows the same mouse-down from instantly reopening the menu.
-    user_menu_dismissed_at: Option<std::time::Instant>,
     /// Inline sidebar error strip (mutation failures); click dismisses.
     sidebar_notice: Option<SharedString>,
     /// Local lifecycle of an in-app update (macOS bundle swap) — the engine's
@@ -707,13 +700,11 @@ impl Shell {
             delete_space_confirm: None,
             add_space: None,
             spaces_menu: popover::Popup::default(),
-            spaces_menu_dismissed_at: None,
             chat_status_hover: None,
             sidebar_scroll: gpui::ScrollHandle::new(),
             space_boot_applied: false,
             sound_prev: std::collections::HashMap::new(),
             user_menu: popover::Popup::default(),
-            user_menu_dismissed_at: None,
             sidebar_notice: None,
             update_flow: UpdateFlow::Idle,
             update_task: None,
@@ -2667,16 +2658,16 @@ impl Shell {
                 )
             })
             .on_hover(motion::hover_listener("user-menu-trigger"))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, _| this.user_menu.note_trigger_press()),
+            )
             .on_click(cx.listener(|this, _, _, cx| {
-                // A click that just dismissed the menu (outside-click on the
-                // trigger) must not instantly reopen it.
-                let just_dismissed = this
-                    .user_menu_dismissed_at
-                    .is_some_and(|at| at.elapsed() < Duration::from_millis(400));
-                this.user_menu_dismissed_at = None;
-                if this.user_menu.is_open() {
+                // A press that found the menu open closes it (the card's
+                // mouse-down-out already began the close) — never reopen.
+                if this.user_menu.take_press_was_open() {
                     this.close_user_menu(cx);
-                } else if !just_dismissed {
+                } else {
                     this.user_menu.open(());
                 }
                 cx.notify();
@@ -2732,7 +2723,6 @@ impl Shell {
             let menu = popover::popover_card(theme)
                 .w(px(self.settings.sidebar_width - 2.0 * Theme::SPACE_SM))
                 .on_mouse_down_out(cx.listener(|this, _, _, cx| {
-                    this.user_menu_dismissed_at = Some(std::time::Instant::now());
                     this.close_user_menu(cx);
                 }))
                 .flex()

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -321,18 +321,16 @@ impl Shell {
             })
             .on_hover(motion::hover_listener("spaces-filter"))
             .cursor_pointer()
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(|this, _, _, _| this.spaces_menu.note_trigger_press()),
+            )
             .on_click(cx.listener(|this, _, window, cx| {
-                // The menu's `on_mouse_down_out` already closed it on this
-                // click's mouse-down (the trigger is outside the card), so by
-                // the time the click lands the menu reads as closed — without
-                // the guard, clicking the open trigger would close-and-reopen.
-                let just_dismissed = this
-                    .spaces_menu_dismissed_at
-                    .is_some_and(|at| at.elapsed() < Duration::from_millis(400));
-                this.spaces_menu_dismissed_at = None;
-                if this.spaces_menu.is_open() {
+                // A press that found the menu open closes it (the card's
+                // mouse-down-out already began the close) — never reopen.
+                if this.spaces_menu.take_press_was_open() {
                     this.close_spaces_menu(cx);
-                } else if !just_dismissed {
+                } else {
                     this.open_spaces_menu(window, cx);
                 }
             }))
@@ -561,7 +559,6 @@ impl Shell {
                 this.spaces_menu_key(event, cx)
             }))
             .on_mouse_down_out(cx.listener(|this, _, _, cx| {
-                this.spaces_menu_dismissed_at = Some(std::time::Instant::now());
                 this.close_spaces_menu(cx);
             }))
             .flex()


### PR DESCRIPTION
Clicking the ref dropdown (or any popover trigger) while open visibly closed and reopened it. The anchored card's `on_mouse_down_out` fires on the trigger *press* — the trigger sits outside the card — and begins the close, so by click time (mouse-up) the popup reads as closed and a plain toggle reopens it.

`Popup` now owns the guard: `note_trigger_press()` records at the trigger's mouse-down whether the popup is still mounted (open **or** mid-exit, so either handler order works), and the click consumes it via `take_press_was_open()` — press-was-open means close and stay closed. `note_trigger_press_matching()` covers kind-keyed popups (the composer pickers share one `Popup<PickerKind>`): only a press on the owning trigger counts, so clicking a different picker's trigger still switches menus.

Converted every toggle trigger:
- **changes pane scope + ref dropdowns** — previously unguarded (the reported bug)
- shell user menu, sidebar spaces filter, settings accounts/harnesses device switchers, all composer pickers — replacing their bespoke 400ms `*_dismissed_at` / `suppressed` timestamps, which also swallowed a legitimate trigger click landing within 400ms of dismissing the menu by clicking elsewhere

Right-click context menus (chat/space rows) are untouched — they're not toggles.

## Testing
- `cargo test -p comet-ui` — 394 pass; new unit test walks the press-note lifecycle in both handler orders and the kind-keyed switching case.
- `cargo clippy -p comet-ui` — clean.
- The mouse-down-out-fires-on-trigger-press ordering this relies on is the same fact the replaced 400ms guards were built around (shell user menu et al.), so the mechanism is already proven in this codebase; a live click-through pass is queued for when the machine's screen unlocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789147676&installation_model_id=425430&pr_number=56&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F56&signature=595708106bea6a65f83d41d583a8e12c0e4fa803088e6859f7747ad7f2193363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->