### PR TITLE
Sessions: quiesce watchdog + fold self-continued output (stuck-Working fix)

### DIFF
--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -1119,6 +1119,28 @@ async fn drive_run(
     const SESSION_IDLE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
     let mut idle_since: Option<tokio::time::Instant> = None;
     let steerable = harness.supports_steering();
+    // TURN-QUIESCE WATCHDOG (2026-08-12 stuck-Working incident): a harness
+    // that loses a turn's Done — the adapter never settles `session/prompt`
+    // even though the agent finished — strands Working forever: the live
+    // heartbeat above keeps the row fresh, and there is no per-turn timeout
+    // by design. This is NOT that stall timeout: it never ends the run or
+    // errors anything. When the stream has been silent past the window AND
+    // the fold shows completed output with nothing in flight (no unresolved
+    // tool, no open question), the turn parks exactly like a Done would —
+    // segment finalized Complete, status Idle, child and mailbox warm. A
+    // false trip (the agent was quietly waiting on something invisible)
+    // costs a status dip: the parked-resume path below re-arms Working the
+    // moment output flows again, and nothing is lost. `COMET_TURN_QUIESCE_MS`
+    // overrides the window; 0 disables.
+    let quiesce_after: Option<std::time::Duration> = match std::env::var("COMET_TURN_QUIESCE_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        Some(0) => None,
+        Some(ms) => Some(std::time::Duration::from_millis(ms)),
+        None => Some(std::time::Duration::from_secs(120)),
+    };
+    let mut last_stream_activity = tokio::time::Instant::now();
 
     let final_status = loop {
         let event: AgentEvent = tokio::select! {
@@ -1203,11 +1225,64 @@ async fn drive_run(
                 dirty = false;
                 continue;
             }
+            // Turn-quiesce watchdog (see the knob above). Armed only when the
+            // fold says nothing is in flight: an unresolved tool part is a
+            // command still running (legitimately silent for minutes — the
+            // rejected stall-timeout case), an unresolved input part is a
+            // question awaiting the user. The live-plan chip is exempt from
+            // the tool check: it is a singleton that never resolves. An EMPTY
+            // fold still arms — a Steered boundary that no output ever
+            // follows is one of the wedge shapes — it just parks without
+            // writing a segment (an empty finalize would leave a stub entry).
+            _ = tokio::time::sleep_until(
+                last_stream_activity + quiesce_after.unwrap_or_default()
+            ), if quiesce_after.is_some()
+                && idle_since.is_none()
+                && !interrupted
+                && steerable
+                && !folded.iter().any(|p| match p {
+                    MessagePart::Tool { id, resolved: false, .. } => {
+                        id != comet_proto::LIVE_PLAN_TOOL_ID
+                    }
+                    MessagePart::Input { resolved: false, .. } => true,
+                    _ => false,
+                }) =>
+            {
+                tracing::warn!(
+                    chat = %chat_id,
+                    quiet_ms = quiesce_after.unwrap_or_default().as_millis() as u64,
+                    "turn quiesced: stream silent after completed output with no \
+                     turn-end; parking (suspected missing harness Done)"
+                );
+                if !folded.is_empty() || writer.is_some() {
+                    if let Err(err) = finish_segment(
+                        doc_ref,
+                        writer.take(),
+                        &entry_id,
+                        &device_id,
+                        segment_started,
+                        &folded,
+                        MessageStatus::Complete,
+                    ) {
+                        tracing::warn!(chat = %chat_id, error = %err, "quiesce segment finish failed");
+                    }
+                    inner.note_message(&chat_id, &folded_text(&folded));
+                }
+                folded.clear();
+                dirty = false;
+                entry_id = new_id();
+                segment_started = now_ms();
+                idle_since = Some(tokio::time::Instant::now());
+                inner.set_status(&chat_id, SessionStatus::Idle, false);
+                continue;
+            }
         };
 
         // Any stream activity proves the run is alive — keep the session's
-        // freshness inside the UI's 45s staleness window (throttled).
+        // freshness inside the UI's 45s staleness window (throttled), and
+        // push the quiesce watchdog's window out.
         inner.touch_session(&chat_id);
+        last_stream_activity = tokio::time::Instant::now();
         // The engine's input bridge is the sole authority on input requests:
         // it mints the id and parks the resolver BEFORE emitting the event,
         // so a legitimate id is always pending here. A harness emitting its
@@ -1231,40 +1306,81 @@ async fn drive_run(
                 continue;
             }
         }
-        // PARKED: only a steer boundary (or an input round-trip / terminal
-        // Done) re-opens the session. The ACP child keeps forwarding
-        // `session/update` frames after a turn completes — late
-        // tool_call_updates for long-running commands, command refreshes,
-        // reasoning heartbeats. Treating those as "the next turn" re-armed
-        // Working with no Done ever coming (the eternally-running session
-        // bug) and folded orphan parts into a phantom segment.
+        // PARKED: a steer boundary, a terminal Done, or SELF-CONTINUED OUTPUT
+        // re-opens the session; everything else stays gated. The ACP child
+        // keeps forwarding `session/update` frames after a turn completes,
+        // and they split two ways:
+        //
+        // - Post-turn NOISE — late tool_call_updates for commands folded in a
+        //   prior segment, command refreshes, reasoning heartbeats. Treating
+        //   those as "the next turn" re-armed Working with no Done ever
+        //   coming (the eternally-running session bug) and folded orphan
+        //   parts into a phantom segment. Still dropped.
+        // - SELF-CONTINUED WORK — Claude Code re-invokes itself when a
+        //   background task finishes (turns no prompt started) and streams
+        //   real output for them. Dropping those LOST transcript content
+        //   (2026-08-12: "Build finished successfully…" streamed by the
+        //   agent, absent from the doc). Fresh text or a genuinely new tool
+        //   call resumes the session: new segment, Working, and the turn
+        //   settles again via Done — or via the quiesce watchdog, which is
+        //   what makes this resume safe where the naive version was not.
+        //
+        // The RESUME_GATE separates the two by arrival time: a finished
+        // turn's tail flush lands within milliseconds of its Done, while a
+        // self-continued turn starts a whole new agent round trip (seconds
+        // at minimum, minutes in the incident). Inside the gate everything
+        // non-boundary stays inert, exactly as before.
+        const RESUME_GATE: std::time::Duration = std::time::Duration::from_secs(1);
         if idle_since.is_some() {
-            match &event {
-                AgentEvent::Steered { .. } => {
-                    idle_since = None;
-                    inner.set_status(&chat_id, SessionStatus::Working, true);
-                }
-                AgentEvent::Done { .. } => {
-                    idle_since = None;
-                }
-                // A question with NO turn behind it (post-turn permission
-                // noise): answer it empty right here. Un-parking into
-                // AwaitingInput would disarm the idle reaper with no Done
-                // ever coming — stranded status, leaked warm child.
-                AgentEvent::InputRequested { request_id, .. } => {
-                    let resolver = lock(&inner.runs)
-                        .get(&chat_id)
-                        .and_then(|h| lock(&h.pending_inputs).remove(request_id));
-                    if let Some(tx) = resolver {
-                        let _ = tx.send(Vec::new());
+            let self_continued = idle_since
+                .is_some_and(|parked_at| parked_at.elapsed() >= RESUME_GATE)
+                && (matches!(
+                    &event,
+                    AgentEvent::TextDelta { text } if !text.is_empty()
+                ) || matches!(
+                    &event,
+                    AgentEvent::ToolCall { id, .. }
+                        if id == comet_proto::LIVE_PLAN_TOOL_ID || !seen_tools.contains(id)
+                ));
+            if self_continued {
+                tracing::info!(
+                    chat = %chat_id,
+                    "parked session resumed by self-continued agent output"
+                );
+                idle_since = None;
+                // The park cleared the fold; rotate to a fresh entry and
+                // fall through — this event is the new segment's first part.
+                entry_id = new_id();
+                segment_started = now_ms();
+                inner.set_status(&chat_id, SessionStatus::Working, true);
+            } else {
+                match &event {
+                    AgentEvent::Steered { .. } => {
+                        idle_since = None;
+                        inner.set_status(&chat_id, SessionStatus::Working, true);
                     }
-                    tracing::debug!(chat = %chat_id, "parked session: post-turn input request auto-declined");
-                    continue;
+                    AgentEvent::Done { .. } => {
+                        idle_since = None;
+                    }
+                    // A question with NO turn behind it (post-turn permission
+                    // noise): answer it empty right here. Un-parking into
+                    // AwaitingInput would disarm the idle reaper with no Done
+                    // ever coming — stranded status, leaked warm child.
+                    AgentEvent::InputRequested { request_id, .. } => {
+                        let resolver = lock(&inner.runs)
+                            .get(&chat_id)
+                            .and_then(|h| lock(&h.pending_inputs).remove(request_id));
+                        if let Some(tx) = resolver {
+                            let _ = tx.send(Vec::new());
+                        }
+                        tracing::debug!(chat = %chat_id, "parked session: post-turn input request auto-declined");
+                        continue;
+                    }
+                    // A stale answer settling after its turn already closed:
+                    // nothing is running — stay parked.
+                    AgentEvent::InputResolved { .. } => continue,
+                    _ => continue,
                 }
-                // A stale answer settling after its turn already closed:
-                // nothing is running — stay parked.
-                AgentEvent::InputResolved { .. } => continue,
-                _ => continue,
             }
         }
         // Empty reasoning deltas are PURE heartbeats: redacted thinking and

--- a/crates/engine/tests/turn_quiesce.rs
+++ b/crates/engine/tests/turn_quiesce.rs
@@ -1,0 +1,491 @@
+//! Turn-quiesce watchdog + parked self-continuation, mocked against the
+//! 2026-08-12 stuck-Working incident workflow (chat 15c8be78, Claude via
+//! claude-agent-acp — but the failure shape is harness-agnostic):
+//!
+//! 1. A turn completes (Done) → the session parks Idle.
+//! 2. The agent re-invokes ITSELF on a background-task notification and
+//!    streams real output with no prompt behind it. The old parked gate
+//!    dropped that output on the floor ("Build finished successfully…"
+//!    existed in the agent's session data, was absent from comet's doc).
+//! 3. A steer ("what about now") becomes the next turn — the agent answers,
+//!    and the turn-end reply is LOST upstream. No Done ever arrives; the
+//!    session read Working forever (the live heartbeat defeats the 45s
+//!    staleness gate by design, and there is no per-turn timeout).
+//!
+//! The fixes under test: parked sessions RESUME on self-continued output
+//! (fold it, show Working), and the quiesce watchdog settles any turn whose
+//! stream goes silent after completed output with nothing in flight —
+//! without ending the run, so a false trip costs a status dip, not content.
+
+use std::sync::{Arc, Once};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use tokio::sync::{Mutex, mpsc};
+
+use comet_doc::{MessagePart, MessageRole, MessageStatus, SessionMessageEntry};
+use comet_engine::{EngineCore, HarnessRegistry, SteerOutcome};
+use comet_harness::{Harness, HarnessError, RunControls};
+use comet_proto::{
+    AgentEvent, DoneStatus, HarnessId, Model, ReasoningLevel, RunRequest, SandboxLevel,
+    SessionStatus, SteeringMode, ToolCall,
+};
+
+const CHAT: &str = "chat-quiesce";
+/// Watchdog window for every test in this file (the process-global env knob
+/// is set once, before any engine assembles).
+const QUIESCE_MS: u64 = 300;
+
+fn init_quiesce_env() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: called before any engine (and thus any reader of the var)
+        // exists in this test process; all tests share the one value.
+        unsafe { std::env::set_var("COMET_TURN_QUIESCE_MS", QUIESCE_MS.to_string()) };
+    });
+}
+
+fn run_request(prompt: &str) -> RunRequest {
+    RunRequest {
+        prompt: prompt.into(),
+        harness: None,
+        model: None,
+        reasoning: None,
+        model_options: Default::default(),
+        cwd: "/tmp".into(),
+        sandbox: SandboxLevel::WorkspaceWrite,
+        auto_approve: true,
+        attachments: Vec::new(),
+        resume: None,
+    }
+}
+
+fn done(status: DoneStatus) -> AgentEvent {
+    AgentEvent::Done {
+        status,
+        result: None,
+        error: None,
+        session_id: Some("hs-q".into()),
+    }
+}
+
+fn session_started() -> AgentEvent {
+    AgentEvent::SessionStarted {
+        harness: HarnessId::Mock,
+        model: "mock-1".into(),
+        tools: vec![],
+        cwd: "/tmp".into(),
+        session_id: "hs-q".into(),
+        assistant_message_id: "a-q".into(),
+    }
+}
+
+fn text(t: &str) -> AgentEvent {
+    AgentEvent::TextDelta { text: t.into() }
+}
+
+/// Feed-by-hand harness: the test pushes events through a channel, so it can
+/// model turn boundaries, self-continuation, and a LOST turn-end exactly.
+/// Accepted steers are confirmed with a `Steered` boundary, like the ACP
+/// adapters do. The feed is served only to the test's own dispatch (matched
+/// by prompt) — the engine's auto-titler also runs this harness, and gets an
+/// immediately-completed empty stream instead.
+struct FeedHarness {
+    main_prompt: String,
+    feed: Mutex<Option<mpsc::UnboundedReceiver<AgentEvent>>>,
+}
+
+#[async_trait]
+impl Harness for FeedHarness {
+    fn id(&self) -> HarnessId {
+        HarnessId::Mock
+    }
+    fn display_name(&self) -> &str {
+        "Feed"
+    }
+    fn supports_steering(&self) -> bool {
+        true
+    }
+    fn steering_mode(&self) -> SteeringMode {
+        SteeringMode::StepBoundary
+    }
+    fn reasoning_levels(&self) -> &[ReasoningLevel] {
+        &[ReasoningLevel::Medium]
+    }
+    async fn models(&self) -> Result<Vec<Model>, HarnessError> {
+        Ok(vec![])
+    }
+    async fn run(
+        &self,
+        request: RunRequest,
+        mut controls: RunControls,
+    ) -> Result<BoxStream<'static, Result<AgentEvent, HarnessError>>, HarnessError> {
+        if request.prompt != self.main_prompt {
+            // The auto-titler's side run: complete instantly with nothing.
+            let events = vec![Ok(done(DoneStatus::Completed))];
+            return Ok(futures::stream::iter(events).boxed());
+        }
+        let mut feed = self
+            .feed
+            .lock()
+            .await
+            .take()
+            .expect("FeedHarness serves the main dispatch once per test");
+        let (tx, rx) = mpsc::channel::<Result<AgentEvent, HarnessError>>(64);
+        tokio::spawn(async move {
+            let mut steering_open = true;
+            loop {
+                tokio::select! {
+                    // Steers first: a Steered boundary always precedes feed
+                    // events the test sends after steering (determinism).
+                    biased;
+                    steer = controls.steering.recv(), if steering_open => match steer {
+                        Some(_) => {
+                            let boundary = AgentEvent::Steered {
+                                assistant_message_id: None,
+                                next_assistant_message_id: None,
+                            };
+                            if tx.send(Ok(boundary)).await.is_err() {
+                                return;
+                            }
+                        }
+                        None => steering_open = false,
+                    },
+                    event = feed.recv() => match event {
+                        Some(event) => {
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
+                            }
+                        }
+                        None => return,
+                    },
+                }
+            }
+        });
+        Ok(futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|event| (event, rx))
+        })
+        .boxed())
+    }
+}
+
+struct Rig {
+    core: EngineCore,
+    feed: mpsc::UnboundedSender<AgentEvent>,
+    _dir: tempfile::TempDir,
+}
+
+fn assemble(main_prompt: &str) -> Rig {
+    init_quiesce_env();
+    let (feed, rx) = mpsc::unbounded_channel();
+    let registry = HarnessRegistry::new();
+    registry.register(Arc::new(FeedHarness {
+        main_prompt: main_prompt.into(),
+        feed: Mutex::new(Some(rx)),
+    }));
+    let dir = tempfile::tempdir().unwrap();
+    let core = EngineCore::assemble(dir.path(), Arc::new(registry), HarnessId::Mock, None)
+        .expect("engine core assembles");
+    Rig {
+        core,
+        feed,
+        _dir: dir,
+    }
+}
+
+fn status(core: &EngineCore) -> Option<SessionStatus> {
+    core.sessions.session_status(CHAT).map(|s| s.status)
+}
+
+/// Tolerant read (see e2e.rs): a snapshot mid-segment-write deserializes with
+/// fields missing — treat that instant as "not yet".
+fn entries(core: &EngineCore) -> Vec<SessionMessageEntry> {
+    core.doc_host
+        .open(CHAT)
+        .ok()
+        .and_then(|h| h.doc().read_entries().ok())
+        .unwrap_or_default()
+}
+
+fn assistant_texts(core: &EngineCore) -> Vec<(String, Option<MessageStatus>)> {
+    entries(core)
+        .into_iter()
+        .filter(|e| e.role == MessageRole::Assistant)
+        .map(|e| {
+            let text = e
+                .parts
+                .iter()
+                .filter_map(|p| match p {
+                    MessagePart::Text { text, .. } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            (text, e.status)
+        })
+        .collect()
+}
+
+async fn wait_for<F>(mut predicate: F, what: &str)
+where
+    F: FnMut() -> bool,
+{
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while !predicate() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for {what}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Steps 1+2 of the incident: a completed turn parks the session; the agent
+/// then self-continues (background-task re-invocation) with no prompt. The
+/// output must land in the transcript (it used to be dropped), the session
+/// must read Working while it streams, and — with no Done ever coming for a
+/// self-started turn — the watchdog must settle it back to Idle.
+#[tokio::test]
+async fn parked_self_continuation_folds_and_requiesces() {
+    let rig = assemble("pull waku and benchmark it");
+    rig.core
+        .sessions
+        .dispatch(
+            CHAT,
+            HarnessId::Mock,
+            run_request("pull waku and benchmark it"),
+            None,
+        )
+        .await
+        .expect("dispatch");
+
+    // Turn 1 completes normally → parked Idle.
+    rig.feed.send(session_started()).unwrap();
+    rig.feed.send(text("Still going, and healthy.")).unwrap();
+    rig.feed.send(done(DoneStatus::Completed)).unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "park after Done",
+    )
+    .await;
+
+    // Self-continuation: streamed output with NO turn behind it, arriving
+    // well past the resume gate (a real one follows a whole agent round
+    // trip — the incident's came five minutes after the park).
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    rig.feed
+        .send(text("Build finished successfully. Launching Waku."))
+        .unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Working),
+        "parked session resumes Working on self-continued output",
+    )
+    .await;
+
+    // No Done will ever come for a self-started turn: the watchdog parks it.
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "watchdog re-parks the self-continued turn",
+    )
+    .await;
+
+    // The self-continued output is in the doc as its own COMPLETE entry —
+    // this exact text was lost in the incident.
+    let texts = assistant_texts(&rig.core);
+    assert!(
+        texts.iter().any(|(t, s)| {
+            t.contains("Build finished successfully") && *s == Some(MessageStatus::Complete)
+        }),
+        "self-continued output must fold into a complete transcript entry, got {texts:#?}"
+    );
+
+    rig.core.sessions.shutdown().await;
+}
+
+/// Step 3 of the incident: a steer becomes the next turn, the agent answers,
+/// and the turn-end reply is LOST. The session must not read Working forever
+/// — the watchdog settles it, and the answer text survives in the doc.
+#[tokio::test]
+async fn missing_turn_end_settles_instead_of_working_forever() {
+    let rig = assemble("pull waku and benchmark it");
+    rig.core
+        .sessions
+        .dispatch(
+            CHAT,
+            HarnessId::Mock,
+            run_request("pull waku and benchmark it"),
+            None,
+        )
+        .await
+        .expect("dispatch");
+
+    rig.feed.send(session_started()).unwrap();
+    rig.feed.send(text("Cloned and building.")).unwrap();
+    rig.feed.send(done(DoneStatus::Completed)).unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "park after Done",
+    )
+    .await;
+
+    // "what about now" — routed into the live run's mailbox; the harness
+    // confirms it with a Steered boundary, which re-arms Working.
+    let outcome = rig
+        .core
+        .sessions
+        .steer(CHAT, "what about now", None)
+        .await
+        .expect("steer");
+    assert!(matches!(outcome, SteerOutcome::Accepted));
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Working),
+        "steer boundary re-arms Working",
+    )
+    .await;
+
+    // The agent answers… and its Done is lost upstream. Nothing else comes.
+    rig.feed.send(text("Done — here are the results.")).unwrap();
+
+    // Old behavior: Working forever (heartbeat keeps the row fresh; no
+    // turn timeout). New behavior: the watchdog settles the turn.
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "watchdog settles the turn whose Done was lost",
+    )
+    .await;
+    let texts = assistant_texts(&rig.core);
+    assert!(
+        texts.iter().any(|(t, s)| {
+            t.contains("here are the results") && *s == Some(MessageStatus::Complete)
+        }),
+        "the lost-Done turn's answer must still finalize in the doc, got {texts:#?}"
+    );
+
+    rig.core.sessions.shutdown().await;
+}
+
+/// The guard the design comment insists on: a long-running tool call is
+/// legitimately silent for minutes — an unresolved tool part must hold the
+/// watchdog off no matter how long the stream is quiet.
+#[tokio::test]
+async fn open_tool_call_never_quiesces() {
+    let rig = assemble("run the slow build");
+    rig.core
+        .sessions
+        .dispatch(
+            CHAT,
+            HarnessId::Mock,
+            run_request("run the slow build"),
+            None,
+        )
+        .await
+        .expect("dispatch");
+
+    rig.feed.send(session_started()).unwrap();
+    rig.feed.send(text("Kicking off the build.")).unwrap();
+    rig.feed
+        .send(AgentEvent::ToolCall {
+            id: "tool-slow".into(),
+            call: ToolCall::Exec {
+                command: "cargo build --release".into(),
+            },
+        })
+        .unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Working),
+        "run starts Working",
+    )
+    .await;
+
+    // Several full watchdog windows of silence mid-tool-call.
+    tokio::time::sleep(Duration::from_millis(QUIESCE_MS * 4)).await;
+    assert_eq!(
+        status(&rig.core),
+        Some(SessionStatus::Working),
+        "an unresolved tool call must never quiesce"
+    );
+
+    // The tool resolves and the turn ends normally.
+    rig.feed
+        .send(AgentEvent::ToolResult {
+            id: "tool-slow".into(),
+            is_error: false,
+            output: None,
+            diff: None,
+        })
+        .unwrap();
+    rig.feed.send(text("Build done.")).unwrap();
+    rig.feed.send(done(DoneStatus::Completed)).unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "clean turn end",
+    )
+    .await;
+
+    rig.core.sessions.shutdown().await;
+}
+
+/// Post-turn noise (the original eternally-running-session bug) must STILL be
+/// gated: a stale tool echo for an id folded in a prior segment does not
+/// resume a parked session.
+#[tokio::test]
+async fn stale_tool_echo_stays_parked() {
+    let rig = assemble("do a thing");
+    rig.core
+        .sessions
+        .dispatch(CHAT, HarnessId::Mock, run_request("do a thing"), None)
+        .await
+        .expect("dispatch");
+
+    rig.feed.send(session_started()).unwrap();
+    rig.feed
+        .send(AgentEvent::ToolCall {
+            id: "tool-echoed".into(),
+            call: ToolCall::Exec {
+                command: "sleep 600".into(),
+            },
+        })
+        .unwrap();
+    rig.feed
+        .send(AgentEvent::ToolResult {
+            id: "tool-echoed".into(),
+            is_error: false,
+            output: None,
+            diff: None,
+        })
+        .unwrap();
+    rig.feed
+        .send(text("Started it in the background."))
+        .unwrap();
+    rig.feed.send(done(DoneStatus::Completed)).unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "park after Done",
+    )
+    .await;
+
+    // A late tool_call_update re-emitted as a full ToolCall for the OLD id —
+    // sent past the resume gate, so it is the seen-tools guard (not the
+    // gate) keeping the session parked.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    rig.feed
+        .send(AgentEvent::ToolCall {
+            id: "tool-echoed".into(),
+            call: ToolCall::Exec {
+                command: "sleep 600".into(),
+            },
+        })
+        .unwrap();
+
+    // Give the echo ample time to (wrongly) resume the session.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        status(&rig.core),
+        Some(SessionStatus::Idle),
+        "a stale tool echo must not resume a parked session"
+    );
+
+    rig.core.sessions.shutdown().await;
+}

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -2074,6 +2074,18 @@ async fn run_session(session: Session) {
     let mut turn_content_seen = false;
     let mut open_tools: std::collections::HashSet<String> = std::collections::HashSet::new();
     let open_questions = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // PREVENTION, ahead of all the recovery above: never send a
+    // `session/prompt` into a session that is visibly mid SELF-CONTINUED
+    // turn — that prompt's reply is what the adapter drops (the verified
+    // starve). Visibly busy = an open tool call, or stream traffic within
+    // BUSY_RECENT, with no prompt of ours outstanding. The discipline is
+    // Zed's, verified against the real adapter: `session/cancel` the
+    // unowned turn, give it CANCEL_FLUSH to die and drain, then prompt.
+    // This makes the interactive path starve-free; the settle layers below
+    // remain for the notification race a client cannot see coming.
+    const BUSY_RECENT: Duration = Duration::from_secs(3);
+    const CANCEL_FLUSH: Duration = Duration::from_secs(2);
+    let mut cancel_flush_deadline: Option<tokio::time::Instant> = None;
 
     'main: loop {
         tokio::select! {
@@ -2474,6 +2486,37 @@ async fn run_session(session: Session) {
                 }
             },
 
+            // Busy-session cancel flushed (see BUSY_RECENT/CANCEL_FLUSH
+            // above): the unowned self-continued turn had its cancel and a
+            // drain window; the queued steer becomes a fresh prompt on a
+            // now-idle agent.
+            _ = tokio::time::sleep_until(
+                cancel_flush_deadline.unwrap_or_else(tokio::time::Instant::now)
+            ), if cancel_flush_deadline.is_some() && !interrupted => {
+                cancel_flush_deadline = None;
+                if turn.is_none()
+                    && let Some(text) = queued_steers.pop_front()
+                {
+                    let (prev, next) = rotate(&mut assistant_message_id);
+                    if !send(
+                        &event_tx,
+                        AgentEvent::Steered {
+                            assistant_message_id: Some(prev),
+                            next_assistant_message_id: Some(next),
+                        },
+                    )
+                    .await
+                    {
+                        break 'main;
+                    }
+                    done_current = false;
+                    turn_content_seen = false;
+                    open_tools.clear();
+                    last_update_at = tokio::time::Instant::now();
+                    turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
+                }
+            },
+
             // BLANKET quiet settle (see `quiet_settle` above), adapter-
             // agnostic: content streamed, every tool resolved, no question
             // pending, stream quiet past the window with the prompt still
@@ -2569,7 +2612,29 @@ async fn run_session(session: Session) {
                     // Same transform as the initial prompt: Claude's
                     // Ultrathink prefix rides every steer too.
                     let text = prompt_transform(request.reasoning, &msg.prompt);
-                    if turn.is_none() {
+                    if turn.is_none() && cancel_flush_deadline.is_some() {
+                        // A busy-session cancel is already in flight: this
+                        // steer lines up behind it and dispatches at flush.
+                        queued_steers.push_back(text);
+                    } else if turn.is_none()
+                        && (!open_tools.is_empty()
+                            || last_update_at.elapsed() < BUSY_RECENT)
+                    {
+                        // Mid self-continued turn (see BUSY_RECENT above):
+                        // cancel it rather than prompt into the starve.
+                        tracing::info!(
+                            target: "comet_harness::acp",
+                            "steer into a self-continuing session; cancelling \
+                             the unowned turn before prompting"
+                        );
+                        client.notify(
+                            "session/cancel",
+                            Some(json!({ "sessionId": session_id })),
+                        );
+                        queued_steers.push_back(text);
+                        cancel_flush_deadline =
+                            Some(tokio::time::Instant::now() + CANCEL_FLUSH);
+                    } else if turn.is_none() {
                         // Idle between turns: a steer is simply the next turn.
                         let (prev, next) = rotate(&mut assistant_message_id);
                         if !send(

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -1720,6 +1720,18 @@ fn prompt_like_request(
     Box::pin(async move { client.request(method, params).await })
 }
 
+/// True for the session's terminal accounting frame: a `usage_update`
+/// carrying `cost`, which claude-agent-acp derives once per turn from the
+/// CLI's result message — the turn-is-over tell that survives even when the
+/// prompt response itself is dropped (the starved-turn bug).
+fn is_turn_end_cost_update(params: &Value, session_id: &str) -> bool {
+    params.get("sessionId").and_then(Value::as_str) == Some(session_id)
+        && params.get("update").is_some_and(|u| {
+            u.get("sessionUpdate").and_then(Value::as_str) == Some("usage_update")
+                && u.get("cost").is_some()
+        })
+}
+
 /// A mid-turn `_session/steering` call. `idleBehavior: promptRequired`
 /// covers the turn-ended race: the agent hands the text back instead of
 /// firing an untracked turn.
@@ -1995,6 +2007,19 @@ async fn run_session(session: Session) {
     // the queued steer is promoted to a fresh turn.
     const STARVE_GRACE: Duration = Duration::from_secs(2);
     let mut starve_deadline: Option<tokio::time::Instant> = None;
+    // Deterministic turn-end hint (claude-agent-acp, verified against
+    // 0.66.0): the adapter derives exactly one cost-bearing `usage_update`
+    // per turn from the CLI's terminal result — INCLUDING turns whose
+    // prompt response it then drops (the starve above; the cost frame and
+    // the response share a timestamp in every healthy trace). While our
+    // prompt is outstanding, that update means the turn is already over:
+    // give the real response a short head start (it lands within
+    // milliseconds when it lands at all), then settle via the recovery arm.
+    // This is what keeps a dropped reply's stuck-Working window near zero
+    // instead of watchdog-length. Gated to Claude — the one adapter whose
+    // cost semantics are verified end-of-turn-only.
+    const COST_HINT_GRACE: Duration = Duration::from_secs(1);
+    let cost_hint_enabled = harness == HarnessId::ClaudeCode;
 
     'main: loop {
         tokio::select! {
@@ -2155,6 +2180,24 @@ async fn run_session(session: Session) {
 
             inc = incoming.recv() => match inc {
                 Some(Incoming::Notification { method, params }) => {
+                    // Turn-end cost hint (see COST_HINT_GRACE above): arm the
+                    // fast settle when the turn's terminal accounting frame
+                    // arrives with our prompt still unsettled.
+                    if cost_hint_enabled
+                        && turn.is_some()
+                        && !interrupted
+                        && starve_deadline.is_none()
+                        && method == "session/update"
+                        && is_turn_end_cost_update(&params, &session_id)
+                    {
+                        tracing::debug!(
+                            target: "comet_harness::acp",
+                            "turn-end cost update observed with the prompt \
+                             unsettled; arming fast settle"
+                        );
+                        starve_deadline =
+                            Some(tokio::time::Instant::now() + COST_HINT_GRACE);
+                    }
                     // Other notifications (other sessions, agent noise) are
                     // tolerated by design.
                     let events = if method == "session/update" {
@@ -2362,21 +2405,23 @@ async fn run_session(session: Session) {
                 }
             },
 
-            // Starved-turn recovery (see STARVE_GRACE above): the grace
-            // elapsed with the prompt still unsettled after the adapter
-            // reported noRunningTurn. Close the dead turn out with a Done —
-            // its output already streamed as session/updates and its text
-            // was delivered via the CLI's own queue — then promote the
-            // queued steer to a fresh prompt, which settles normally on a
-            // now-idle agent (verified against the real adapter).
+            // Starved-turn recovery: the grace elapsed with the prompt still
+            // unsettled after turn-end evidence — either the turn's terminal
+            // cost frame (COST_HINT_GRACE, ~immediate) or a steering call
+            // answered noRunningTurn (STARVE_GRACE). Close the dead turn out
+            // with a Done — its output already streamed as session/updates
+            // and its text was delivered via the CLI's own queue — then
+            // promote any queued steer to a fresh prompt, which settles
+            // normally on a now-idle agent (verified against the real
+            // adapter).
             _ = tokio::time::sleep_until(
                 starve_deadline.unwrap_or_else(tokio::time::Instant::now)
             ), if starve_deadline.is_some() && turn.is_some() && !interrupted => {
                 starve_deadline = None;
                 tracing::warn!(
                     target: "comet_harness::acp",
-                    "prompt starved (noRunningTurn evidence outlived the grace); \
-                     settling the dead turn and promoting the queued steer"
+                    "prompt response missing past turn-end evidence; settling \
+                     the dead turn (and promoting any queued steer)"
                 );
                 // Drop the dead future: a response that somehow arrives later
                 // resolves a closed channel harmlessly.

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -1981,11 +1981,26 @@ async fn run_session(session: Session) {
     let mut done_current = false;
     let mut done_after_interrupt = false;
     let mut escalation: Option<tokio::task::JoinHandle<()>> = None;
+    // Starved-turn recovery (2026-08-12 stuck-Working incident): a
+    // `session/prompt` sent while the agent runs a SELF-CONTINUED turn (a
+    // background-task re-invocation no prompt started) starves —
+    // claude-agent-acp does not track turns it did not start, so the merged
+    // turn's result is never attributed to the pending prompt (reproduced
+    // against 0.66.0; the prompt's TEXT still reaches the model, queued by
+    // the CLI). The tell is protocol evidence, not timing: a steering call
+    // answered `promptRequired`/`noRunningTurn` while OUR prompt is
+    // outstanding means the adapter has no turn that could ever settle it.
+    // A short grace covers the true turn-end race (its response lands within
+    // milliseconds); past it, the dead prompt is closed out with a Done and
+    // the queued steer is promoted to a fresh turn.
+    const STARVE_GRACE: Duration = Duration::from_secs(2);
+    let mut starve_deadline: Option<tokio::time::Instant> = None;
 
     'main: loop {
         tokio::select! {
             res = async { turn.as_mut().expect("guarded by if").await }, if turn.is_some() => {
                 turn = None;
+                starve_deadline = None;
                 // Settle an in-flight `_session/steering` call BEFORE closing
                 // the turn: its response rides the same stdout as the prompt
                 // response, so by now it is (nearly always) already parsed —
@@ -2295,7 +2310,27 @@ async fn run_session(session: Session) {
                     }
                 } else if turn.is_some() {
                     // Raced the turn end: redeliver at the boundary the
-                    // loop is about to hit.
+                    // loop is about to hit. `noRunningTurn` is stronger —
+                    // the adapter says nothing is running while our prompt
+                    // is still outstanding: the starved-turn signature. Arm
+                    // the grace deadline; if the prompt's response does not
+                    // land first, the recovery arm below settles the dead
+                    // turn and promotes this steer.
+                    if res
+                        .as_ref()
+                        .ok()
+                        .and_then(|r| r.get("reason"))
+                        .and_then(Value::as_str)
+                        == Some("noRunningTurn")
+                    {
+                        tracing::warn!(
+                            target: "comet_harness::acp",
+                            "steering answered noRunningTurn with a prompt \
+                             outstanding; arming starved-turn recovery"
+                        );
+                        starve_deadline =
+                            Some(tokio::time::Instant::now() + STARVE_GRACE);
+                    }
                     queued_steers.push_back(text);
                 } else {
                     // The turn ended while the call was in flight and its
@@ -2324,6 +2359,66 @@ async fn run_session(session: Session) {
                     }
                     // No live turn to inject into: boundary delivery.
                     queued_steers.push_back(next_text);
+                }
+            },
+
+            // Starved-turn recovery (see STARVE_GRACE above): the grace
+            // elapsed with the prompt still unsettled after the adapter
+            // reported noRunningTurn. Close the dead turn out with a Done —
+            // its output already streamed as session/updates and its text
+            // was delivered via the CLI's own queue — then promote the
+            // queued steer to a fresh prompt, which settles normally on a
+            // now-idle agent (verified against the real adapter).
+            _ = tokio::time::sleep_until(
+                starve_deadline.unwrap_or_else(tokio::time::Instant::now)
+            ), if starve_deadline.is_some() && turn.is_some() && !interrupted => {
+                starve_deadline = None;
+                tracing::warn!(
+                    target: "comet_harness::acp",
+                    "prompt starved (noRunningTurn evidence outlived the grace); \
+                     settling the dead turn and promoting the queued steer"
+                );
+                // Drop the dead future: a response that somehow arrives later
+                // resolves a closed channel harmlessly.
+                turn = None;
+                let (prev, _next) = rotate(&mut assistant_message_id);
+                if !send(
+                    &event_tx,
+                    AgentEvent::AssistantMessageCompleted { assistant_message_id: prev },
+                )
+                .await
+                {
+                    break 'main;
+                }
+                done_current = true;
+                if !send(
+                    &event_tx,
+                    AgentEvent::Done {
+                        status: DoneStatus::Completed,
+                        result: None,
+                        error: None,
+                        session_id: Some(session_id.clone()),
+                    },
+                )
+                .await
+                {
+                    break 'main;
+                }
+                if let Some(text) = queued_steers.pop_front() {
+                    let (prev, next) = rotate(&mut assistant_message_id);
+                    if !send(
+                        &event_tx,
+                        AgentEvent::Steered {
+                            assistant_message_id: Some(prev),
+                            next_assistant_message_id: Some(next),
+                        },
+                    )
+                    .await
+                    {
+                        break 'main;
+                    }
+                    done_current = false;
+                    turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
                 }
             },
 

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -2617,11 +2617,21 @@ async fn run_session(session: Session) {
                         // steer lines up behind it and dispatches at flush.
                         queued_steers.push_back(text);
                     } else if turn.is_none()
+                        && !cost_hint_enabled
                         && (!open_tools.is_empty()
                             || last_update_at.elapsed() < BUSY_RECENT)
                     {
                         // Mid self-continued turn (see BUSY_RECENT above):
                         // cancel it rather than prompt into the starve.
+                        //
+                        // Claude skips this branch ON PURPOSE and prompts
+                        // straight in — its NATIVE semantics: the CLI queues
+                        // the message and folds it into the running turn (no
+                        // work lost, verified from live session data). The
+                        // adapter drops that prompt's reply, and the
+                        // cost-frame settle reconstructs it ~1s after the
+                        // merged turn really ends. Only adapters with no
+                        // verified turn-end frame pay the cancel.
                         tracing::info!(
                             target: "comet_harness::acp",
                             "steer into a self-continuing session; cancelling \

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -1462,9 +1462,10 @@ fn handle_server_request_live(
     method: &str,
     params: &Value,
     request_input: &std::sync::Arc<RequestInputFn>,
+    open_questions: &std::sync::Arc<std::sync::atomic::AtomicUsize>,
 ) -> Vec<AgentEvent> {
     if method == CURSOR_ASK_QUESTION {
-        ask_cursor_questions(client, id, params, request_input);
+        ask_cursor_questions(client, id, params, request_input, open_questions);
         return Vec::new();
     }
     if method != "session/request_permission" {
@@ -1501,6 +1502,10 @@ fn handle_server_request_live(
     };
     let client = client.clone();
     let request_input = std::sync::Arc::clone(request_input);
+    // Pending questions block the agent — the quiet-settle must not read
+    // that silence as a finished turn.
+    let open_questions = std::sync::Arc::clone(open_questions);
+    open_questions.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     tokio::spawn(async move {
         let answers = (request_input)(vec![question.clone()])
             .await
@@ -1522,6 +1527,7 @@ fn handle_server_request_live(
             ),
             None => client.respond(&id, json!({ "outcome": { "outcome": "cancelled" } })),
         }
+        open_questions.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
     });
     Vec::new()
 }
@@ -1562,6 +1568,7 @@ fn ask_cursor_questions(
     id: Value,
     params: &Value,
     request_input: &std::sync::Arc<RequestInputFn>,
+    open_questions: &std::sync::Arc<std::sync::atomic::AtomicUsize>,
 ) {
     let asked = cursor_questions(params);
     if asked.is_empty() {
@@ -1573,11 +1580,14 @@ fn ask_cursor_questions(
     }
     let client = client.clone();
     let request_input = std::sync::Arc::clone(request_input);
+    let open_questions = std::sync::Arc::clone(open_questions);
+    open_questions.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     tokio::spawn(async move {
         let answers = (request_input)(asked.iter().map(|q| q.question.clone()).collect())
             .await
             .unwrap_or_default();
         client.respond(&id, cursor_answer_outcome(&asked, &answers));
+        open_questions.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
     });
 }
 
@@ -1718,6 +1728,27 @@ fn prompt_like_request(
     params: Value,
 ) -> BoxFuture<'static, Result<Value, HarnessError>> {
     Box::pin(async move { client.request(method, params).await })
+}
+
+/// Track the liveness signals the blanket quiet-settle keys on: content
+/// proves the turn produced something; an open tool call or a pending
+/// question proves silence is legitimate.
+fn track_turn_signals(
+    ev: &AgentEvent,
+    content_seen: &mut bool,
+    open_tools: &mut std::collections::HashSet<String>,
+) {
+    match ev {
+        AgentEvent::TextDelta { text } if !text.is_empty() => *content_seen = true,
+        AgentEvent::ToolCall { id, .. } => {
+            *content_seen = true;
+            open_tools.insert(id.clone());
+        }
+        AgentEvent::ToolResult { id, .. } => {
+            open_tools.remove(id);
+        }
+        _ => {}
+    }
 }
 
 /// True for the session's terminal accounting frame: a `usage_update`
@@ -2020,6 +2051,29 @@ async fn run_session(session: Session) {
     // cost semantics are verified end-of-turn-only.
     const COST_HINT_GRACE: Duration = Duration::from_secs(1);
     let cost_hint_enabled = harness == HarnessId::ClaudeCode;
+    // BLANKET dropped-reply settle, adapter-agnostic: any ACP agent whose
+    // prompt response goes missing must not strand the turn. Signals that
+    // exist in core ACP stand in for the adapter-specific cost frame: once
+    // the turn has streamed content, every tool call it opened has resolved,
+    // no permission/question round-trip is pending, and the stream has been
+    // quiet past the window, the turn is settled through the same recovery
+    // arm. A false settle is recoverable by design (the engine folds any
+    // later output as a self-continued segment and re-arms Working; a late
+    // response resolves a dropped channel), which is what makes a tight
+    // window safe where a hard per-turn timeout was rejected.
+    // `COMET_ACP_QUIET_SETTLE_MS` overrides; 0 disables.
+    let quiet_settle: Option<Duration> = match std::env::var("COMET_ACP_QUIET_SETTLE_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        Some(0) => None,
+        Some(ms) => Some(Duration::from_millis(ms)),
+        None => Some(Duration::from_secs(30)),
+    };
+    let mut last_update_at = tokio::time::Instant::now();
+    let mut turn_content_seen = false;
+    let mut open_tools: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let open_questions = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
     'main: loop {
         tokio::select! {
@@ -2102,6 +2156,7 @@ async fn run_session(session: Session) {
                                 &method,
                                 &params,
                                 &request_input,
+                                &open_questions,
                             ) {
                                 if !send(&event_tx, ev).await {
                                     consumer_gone = true;
@@ -2172,6 +2227,9 @@ async fn run_session(session: Session) {
                         break 'main;
                     }
                     done_current = false;
+                    turn_content_seen = false;
+                    open_tools.clear();
+                    last_update_at = tokio::time::Instant::now();
                     turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
                 } else if !steering_open {
                     break 'main;
@@ -2180,6 +2238,7 @@ async fn run_session(session: Session) {
 
             inc = incoming.recv() => match inc {
                 Some(Incoming::Notification { method, params }) => {
+                    last_update_at = tokio::time::Instant::now();
                     // Turn-end cost hint (see COST_HINT_GRACE above): arm the
                     // fast settle when the turn's terminal accounting frame
                     // arrives with our prompt still unsettled.
@@ -2206,15 +2265,21 @@ async fn run_session(session: Session) {
                         cursor_notification_events(&method, &params)
                     };
                     for ev in events {
+                        track_turn_signals(&ev, &mut turn_content_seen, &mut open_tools);
                         if !send(&event_tx, ev).await {
                             break 'main;
                         }
                     }
                 }
                 Some(Incoming::Request { id, method, params }) => {
-                    for ev in
-                        handle_server_request_live(&client, id, &method, &params, &request_input)
-                    {
+                    for ev in handle_server_request_live(
+                        &client,
+                        id,
+                        &method,
+                        &params,
+                        &request_input,
+                        &open_questions,
+                    ) {
                         if !send(&event_tx, ev).await {
                             break 'main;
                         }
@@ -2322,6 +2387,7 @@ async fn run_session(session: Session) {
                                         &method,
                                         &params,
                                         &request_input,
+                                        &open_questions,
                                     ) {
                                         if !send(&event_tx, ev).await {
                                             consumer_gone = true;
@@ -2392,6 +2458,9 @@ async fn run_session(session: Session) {
                         break 'main;
                     }
                     done_current = false;
+                    turn_content_seen = false;
+                    open_tools.clear();
+                    last_update_at = tokio::time::Instant::now();
                     turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
                 }
                 while let Some(next_text) = steer_backlog.pop_front() {
@@ -2405,10 +2474,35 @@ async fn run_session(session: Session) {
                 }
             },
 
+            // BLANKET quiet settle (see `quiet_settle` above), adapter-
+            // agnostic: content streamed, every tool resolved, no question
+            // pending, stream quiet past the window with the prompt still
+            // unsettled. Feeds the recovery arm below by expiring its
+            // deadline — one settle path for all three evidence sources.
+            _ = tokio::time::sleep_until(
+                last_update_at + quiet_settle.unwrap_or_default()
+            ), if quiet_settle.is_some()
+                && starve_deadline.is_none()
+                && turn.is_some()
+                && !interrupted
+                && turn_content_seen
+                && open_tools.is_empty()
+                && open_questions.load(std::sync::atomic::Ordering::SeqCst) == 0 =>
+            {
+                tracing::warn!(
+                    target: "comet_harness::acp",
+                    quiet_ms = quiet_settle.unwrap_or_default().as_millis() as u64,
+                    "turn quiet past the settle window with completed output; \
+                     treating the prompt response as dropped"
+                );
+                starve_deadline = Some(tokio::time::Instant::now());
+            },
+
             // Starved-turn recovery: the grace elapsed with the prompt still
-            // unsettled after turn-end evidence — either the turn's terminal
-            // cost frame (COST_HINT_GRACE, ~immediate) or a steering call
-            // answered noRunningTurn (STARVE_GRACE). Close the dead turn out
+            // unsettled after turn-end evidence — the turn's terminal cost
+            // frame (COST_HINT_GRACE, ~immediate), a steering call answered
+            // noRunningTurn (STARVE_GRACE), or the blanket quiet settle
+            // above. Close the dead turn out
             // with a Done — its output already streamed as session/updates
             // and its text was delivered via the CLI's own queue — then
             // promote any queued steer to a fresh prompt, which settles
@@ -2463,6 +2557,9 @@ async fn run_session(session: Session) {
                         break 'main;
                     }
                     done_current = false;
+                    turn_content_seen = false;
+                    open_tools.clear();
+                    last_update_at = tokio::time::Instant::now();
                     turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
                 }
             },
@@ -2487,6 +2584,9 @@ async fn run_session(session: Session) {
                             break 'main;
                         }
                         done_current = false;
+                        turn_content_seen = false;
+                        open_tools.clear();
+                        last_update_at = tokio::time::Instant::now();
                         turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
                     } else if steer_ext {
                         // Mid-turn injection via the `_session/steering`

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -2072,6 +2072,13 @@ async fn run_session(session: Session) {
     };
     let mut last_update_at = tokio::time::Instant::now();
     let mut turn_content_seen = false;
+    // A steering injection makes the cost hint unsafe for the REST of the
+    // turn: the adapter emits a cost-bearing usage_update for the injected
+    // message itself, mid-turn, indistinguishable in shape from the
+    // terminal one (verified against 0.66.0 — premature Done exactly one
+    // grace after injection). Steered turns settle off their real response
+    // (healthy in every trace); the quiet settle stays as their backstop.
+    let mut steered_this_turn = false;
     let mut open_tools: std::collections::HashSet<String> = std::collections::HashSet::new();
     let open_questions = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     // PREVENTION, ahead of all the recovery above: never send a
@@ -2240,6 +2247,7 @@ async fn run_session(session: Session) {
                     }
                     done_current = false;
                     turn_content_seen = false;
+                    steered_this_turn = false;
                     open_tools.clear();
                     last_update_at = tokio::time::Instant::now();
                     turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
@@ -2257,6 +2265,11 @@ async fn run_session(session: Session) {
                     if cost_hint_enabled
                         && turn.is_some()
                         && !interrupted
+                        && !steered_this_turn
+                        // An in-flight steering call means an injection cost
+                        // frame may already be on the wire ahead of its
+                        // response (select order is not the pipe order).
+                        && steering_call.is_none()
                         && starve_deadline.is_none()
                         && method == "session/update"
                         && is_turn_end_cost_update(&params, &session_id)
@@ -2371,6 +2384,11 @@ async fn run_session(session: Session) {
                     // and no Done ever coming — the stranded-Working /
                     // eternal-timer bug. Post-turn: nothing left to do.
                     if turn.is_some() {
+                        steered_this_turn = true;
+                        // The injection proves the turn is LIVE: any settle
+                        // deadline armed off a cost frame that raced this
+                        // response is invalid evidence.
+                        starve_deadline = None;
                         // Pre-injection updates can still sit in `incoming`
                         // (responses bypass that queue): drain them into the
                         // CURRENT segment first, or text the agent streamed
@@ -2471,6 +2489,7 @@ async fn run_session(session: Session) {
                     }
                     done_current = false;
                     turn_content_seen = false;
+                    steered_this_turn = false;
                     open_tools.clear();
                     last_update_at = tokio::time::Instant::now();
                     turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
@@ -2511,9 +2530,13 @@ async fn run_session(session: Session) {
                     }
                     done_current = false;
                     turn_content_seen = false;
+                    steered_this_turn = false;
                     open_tools.clear();
                     last_update_at = tokio::time::Instant::now();
                     turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
+                } else if turn.is_none() && !steering_open {
+                    // Mailbox closed while the flush waited: nothing left.
+                    break 'main;
                 }
             },
 
@@ -2601,9 +2624,14 @@ async fn run_session(session: Session) {
                     }
                     done_current = false;
                     turn_content_seen = false;
+                    steered_this_turn = false;
                     open_tools.clear();
                     last_update_at = tokio::time::Instant::now();
                     turn = Some(prompt_turn(client.clone(), session_id.clone(), text));
+                } else if !steering_open {
+                    // Mirror the normal turn-settled exit: mailbox closed
+                    // and nothing left to run — the session is over.
+                    break 'main;
                 }
             },
 
@@ -2660,6 +2688,7 @@ async fn run_session(session: Session) {
                         }
                         done_current = false;
                         turn_content_seen = false;
+                        steered_this_turn = false;
                         open_tools.clear();
                         last_update_at = tokio::time::Instant::now();
                         turn = Some(prompt_turn(client.clone(), session_id.clone(), text));

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -1296,3 +1296,191 @@ async fn claude_busy_steer_rides_native_queueing_and_the_cost_frame() {
         "settle at {done2_at:?} — should ride the cost frame (~1s), not EOF"
     );
 }
+
+/// Every installed real agent, through the one shared loop all the
+/// starve/settle changes live in: a short live turn with a mid-turn steer —
+/// injection on StepBoundary agents, boundary delivery on TurnBoundary ones,
+/// busy-path handling where it applies. Contract per agent that starts:
+/// every Done is Completed and the stream ENDS (no stranding) inside the
+/// budget. Agents that fail auth/startup are reported and skipped. Run:
+/// `cargo test -p comet-harness --test acp -- --ignored --nocapture real_all_harnesses`
+#[tokio::test]
+#[ignore = "runs every installed+authenticated agent CLI; costs a few small prompts"]
+async fn real_all_harnesses_settle_with_a_mid_turn_steer() {
+    let agents: Vec<(&str, AcpHarness)> = vec![
+        ("claude", AcpHarness::claude()),
+        ("codex", AcpHarness::codex()),
+        ("cursor", AcpHarness::cursor()),
+        ("grok", AcpHarness::grok()),
+        ("pi", AcpHarness::pi()),
+    ];
+    let mut failures: Vec<String> = Vec::new();
+    for (name, h) in agents {
+        let (controls, steer_tx, _token) = controls();
+        let mut req = request(
+            "Write the numbers 1 2 3 4 5, one per line, then stop. \
+             If another instruction arrives, follow it too.",
+        );
+        req.model = None;
+        req.reasoning = None;
+        req.cwd = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+        let stream = match h.run(req, controls).await {
+            Ok(s) => s,
+            Err(e) => {
+                println!("[{name}] SKIP — did not start: {e}");
+                continue;
+            }
+        };
+        let outcome = tokio::time::timeout(Duration::from_secs(120), async move {
+            let mut stream = stream;
+            let mut events = Vec::new();
+            let mut steer = Some(steer_tx);
+            while let Some(ev) = stream.next().await {
+                let ev = ev.expect("stream event");
+                if matches!(ev, AgentEvent::TextDelta { .. })
+                    && let Some(tx) = steer.take()
+                {
+                    let _ = tx
+                        .send(SteerMessage {
+                            prompt: "Also write the word EXTRA on its own line.".into(),
+                            message_id: None,
+                        })
+                        .await;
+                    // Sender drops: the mailbox closes, so once every turn
+                    // settles the stream must end — stranding shows as the
+                    // 120s timeout.
+                }
+                events.push(ev);
+            }
+            events
+        })
+        .await;
+        match outcome {
+            Err(_) => failures.push(format!("[{name}] STRANDED: stream still open after 120s")),
+            Ok(events) => {
+                let ds = dones(&events);
+                let auth_failure = ds.iter().any(|(s, e)| {
+                    *s == DoneStatus::Errored
+                        && e.as_deref().is_some_and(|e| {
+                            let e = e.to_lowercase();
+                            e.contains("auth") || e.contains("login") || e.contains("not installed")
+                        })
+                });
+                if auth_failure {
+                    println!("[{name}] SKIP — needs auth: {ds:?}");
+                } else if ds.is_empty() || ds.iter().any(|(s, _)| *s != DoneStatus::Completed) {
+                    failures.push(format!("[{name}] BAD DONES: {ds:?}"));
+                } else {
+                    let texts = events
+                        .iter()
+                        .filter(|e| matches!(e, AgentEvent::TextDelta { .. }))
+                        .count();
+                    println!(
+                        "[{name}] OK — {} turn(s) settled, {texts} text deltas",
+                        ds.len()
+                    );
+                }
+            }
+        }
+    }
+    assert!(failures.is_empty(), "{failures:#?}");
+}
+
+/// Debug variant of the multi-harness sweep, claude only, printing every
+/// event with a timestamp — for diagnosing strands the sweep can only name.
+/// `cargo test -p comet-harness --test acp -- --ignored --nocapture real_claude_debug`
+#[tokio::test]
+#[ignore = "debug harness; needs the claude CLI; costs one small prompt"]
+async fn real_claude_debug_steer_trace() {
+    let (controls, steer_tx, _token) = controls();
+    let h = AcpHarness::claude();
+    let mut req = request(
+        "Write the numbers 1 2 3 4 5, one per line, then stop. \
+         If another instruction arrives, follow it too.",
+    );
+    req.model = None;
+    req.reasoning = None;
+    req.cwd = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let started = std::time::Instant::now();
+    let stream = h.run(req, controls).await.expect("run starts");
+    let _ = tokio::time::timeout(Duration::from_secs(60), async move {
+        let mut stream = stream;
+        let mut steer = Some(steer_tx);
+        while let Some(ev) = stream.next().await {
+            let ev = ev.expect("stream event");
+            let t = started.elapsed();
+            match &ev {
+                AgentEvent::TextDelta { text } => println!("{t:?} TEXT {:?}", &text[..text.len().min(40)]),
+                other => println!("{t:?} {other:?}"),
+            }
+            if matches!(ev, AgentEvent::TextDelta { .. })
+                && let Some(tx) = steer.take()
+            {
+                println!("{:?} >>> sending steer", started.elapsed());
+                let _ = tx
+                    .send(SteerMessage {
+                        prompt: "Also write the word EXTRA on its own line.".into(),
+                        message_id: None,
+                    })
+                    .await;
+            }
+        }
+        println!("{:?} <<< stream ended", started.elapsed());
+    })
+    .await;
+    println!("{:?} === test done (timeout means strand)", started.elapsed());
+}
+
+/// The injection cost frame must never settle a steered turn: the fixture
+/// stamps a mid-turn cost frame right after the injection (real adapter
+/// behavior, indistinguishable in shape from the terminal frame), holds the
+/// turn open past the 1s cost grace + 2s slack, then finishes normally.
+/// Exactly one Done; the post-injection text folds into the same turn.
+#[tokio::test]
+async fn injection_cost_frame_never_settles_a_steered_turn() {
+    let (controls, steer, _token) = controls();
+    let harness = AcpHarness::claude().with_executable(fixture_path());
+    let stream = harness
+        .run(request("scenario:steer-cost-noise"), controls)
+        .await
+        .expect("run starts");
+    let events = tokio::time::timeout(Duration::from_secs(15), async move {
+        let mut events = Vec::new();
+        let mut stream = stream;
+        let mut steer = Some(steer);
+        while let Some(ev) = stream.next().await {
+            let ev = ev.expect("stream event");
+            if matches!(ev, AgentEvent::TextDelta { ref text } if text == "first")
+                && let Some(tx) = steer.take()
+            {
+                tx.send(SteerMessage {
+                    prompt: "redirect please".into(),
+                    message_id: None,
+                })
+                .await
+                .expect("steer sent");
+            }
+            events.push(ev);
+        }
+        events
+    })
+    .await
+    .expect("run finished in time");
+
+    assert_eq!(
+        dones(&events),
+        vec![(DoneStatus::Completed, None)],
+        "a premature cost-frame settle would double-Done: {events:?}"
+    );
+    // The post-injection text arrives BEFORE the single Done — a false
+    // settle would flip that order.
+    let tail = events
+        .iter()
+        .position(|e| matches!(e, AgentEvent::TextDelta { text } if text == "steered tail"))
+        .expect("steered tail must fold into the live turn: {events:?}");
+    let done = events
+        .iter()
+        .position(|e| matches!(e, AgentEvent::Done { .. }))
+        .expect("done asserted above");
+    assert!(tail < done, "{events:?}");
+}

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -1057,3 +1057,110 @@ async fn dropped_reply_settles_fast_off_the_turn_end_cost_frame() {
          before the fixture's 6s exit"
     );
 }
+
+/// Full-stack verification of the 2026-08-12 starve fix against the REAL
+/// adapter + CLI: prompt#1 backgrounds a task and ends; the CLI
+/// self-continues on its notification and runs a 20s foreground command; a
+/// steer lands mid-way (becoming a session/prompt the adapter drops the
+/// reply for); the harness must settle off the turn-end cost frame within
+/// seconds of the agent finishing. Costs a few small prompts. Run explicitly:
+/// `cargo test -p comet-harness --test acp -- --ignored real_claude_starve`
+#[tokio::test]
+#[ignore = "needs the claude CLI authenticated + network; costs a few small prompts"]
+async fn real_claude_starve_settles_off_the_cost_frame() {
+    let (controls, steer_tx, _token) = controls();
+    let harness = AcpHarness::claude();
+    let mut req = request(
+        "Use the Bash tool exactly twice, then stop.\n\
+         First call: run the command `sleep 8; echo task-finished` with \
+         run_in_background set to true.\n\
+         Then reply with exactly the word: started\n\
+         IMPORTANT: later, when a task notification about that background \
+         task arrives, make one FOREGROUND Bash call: `sleep 20; echo waited` \
+         (no run_in_background), then reply with exactly: done waiting",
+    );
+    req.model = None;
+    req.reasoning = None;
+    req.cwd = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let stream = harness.run(req, controls).await.expect("run starts");
+
+    let collected = tokio::time::timeout(Duration::from_secs(240), async move {
+        let mut stream = stream;
+        let mut events: Vec<(std::time::Instant, AgentEvent)> = Vec::new();
+        let mut dones_seen = 0usize;
+        let mut steer = Some(steer_tx);
+        let mut steer_sent_at: Option<std::time::Instant> = None;
+        let mut steer_task: Option<tokio::task::JoinHandle<std::time::Instant>> = None;
+        while let Some(ev) = stream.next().await {
+            let ev = ev.expect("stream event");
+            let now = std::time::Instant::now();
+            if matches!(ev, AgentEvent::Done { .. }) {
+                dones_seen += 1;
+                if dones_seen == 1 {
+                    // Steer 16s after the first turn settles: the background
+                    // task (8s) has exited and the CLI is inside its
+                    // self-continued turn's 20s foreground command.
+                    let tx = steer.take().expect("one steer");
+                    steer_task = Some(tokio::spawn(async move {
+                        tokio::time::sleep(Duration::from_secs(16)).await;
+                        let at = std::time::Instant::now();
+                        let _ = tx
+                            .send(SteerMessage {
+                                prompt: "what about now".into(),
+                                message_id: None,
+                            })
+                            .await;
+                        at
+                    }));
+                }
+            }
+            events.push((now, ev));
+            if dones_seen == 2 {
+                if let Some(task) = steer_task.take() {
+                    steer_sent_at = task.await.ok();
+                }
+                break;
+            }
+        }
+        (events, steer_sent_at)
+    })
+    .await
+    .expect("run should settle without any watchdog — before the fix this timed out");
+
+    let (events, steer_sent_at) = collected;
+    let evs: Vec<&AgentEvent> = events.iter().map(|(_, e)| e).collect();
+    let done_times: Vec<std::time::Instant> = events
+        .iter()
+        .filter(|(_, e)| matches!(e, AgentEvent::Done { .. }))
+        .map(|(t, _)| *t)
+        .collect();
+    assert_eq!(done_times.len(), 2, "{evs:?}");
+    for (_, e) in events.iter() {
+        if let AgentEvent::Done { status, .. } = e {
+            assert_eq!(*status, DoneStatus::Completed, "{evs:?}");
+        }
+    }
+    // The steer landed mid-merged-turn: its "turn" (starved, settled by the
+    // cost frame) took at least the foreground command's remaining runtime.
+    let steer_sent_at = steer_sent_at.expect("steer timer ran");
+    let starved_turn = done_times[1].duration_since(steer_sent_at);
+    assert!(
+        starved_turn > Duration::from_secs(8),
+        "steer settled in {starved_turn:?} — too fast to have landed inside \
+         the self-continued turn; the starve shape did not reproduce"
+    );
+    // And the settle tracked the agent's actual finish (last streamed text),
+    // not a watchdog window: cost-frame grace is 1s, allow scheduling slack.
+    let last_text_at = events
+        .iter()
+        .filter(|(_, e)| matches!(e, AgentEvent::TextDelta { .. }))
+        .map(|(t, _)| *t)
+        .next_back()
+        .expect("streamed text exists");
+    let settle_gap = done_times[1].duration_since(last_text_at);
+    assert!(
+        settle_gap < Duration::from_secs(5),
+        "final Done lagged the last content by {settle_gap:?} — the settle \
+         should ride the turn-end cost frame (~1s)"
+    );
+}

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -1227,3 +1227,72 @@ async fn steer_into_self_continuation_cancels_before_prompting() {
         .expect("dones asserted above");
     assert!(first_done < steered, "{events:?}");
 }
+
+/// Claude's native busy-steer path: a steer into a self-continued turn goes
+/// out as a PLAIN prompt (the fixture hard-fails on any session/cancel —
+/// cancelling would kill the agent's in-flight work). The CLI folds the
+/// message into the running turn natively; the adapter drops the prompt's
+/// reply; the cost-frame settle closes the turn ~1s after the merged turn
+/// really ends — well before the fixture's held-open stream EOF.
+#[tokio::test]
+async fn claude_busy_steer_rides_native_queueing_and_the_cost_frame() {
+    let (controls, steer, _token) = controls();
+    let harness = AcpHarness::claude().with_executable(fixture_path());
+    let started = std::time::Instant::now();
+    let stream = harness
+        .run(request("scenario:native-busy-steer"), controls)
+        .await
+        .expect("run starts");
+    let (events, done2_at) = tokio::time::timeout(Duration::from_secs(15), async move {
+        let mut events = Vec::new();
+        let mut done2_at = None;
+        let mut dones_seen = 0usize;
+        let mut stream = stream;
+        let mut steer = Some(steer);
+        while let Some(ev) = stream.next().await {
+            let ev = ev.expect("stream event");
+            if matches!(&ev, AgentEvent::ToolCall { id, .. } if id == "sc-2")
+                && let Some(tx) = steer.take()
+            {
+                tx.send(SteerMessage {
+                    prompt: "what about now".into(),
+                    message_id: None,
+                })
+                .await
+                .expect("steer sent");
+            }
+            if matches!(ev, AgentEvent::Done { .. }) {
+                dones_seen += 1;
+                if dones_seen == 2 {
+                    done2_at = Some(started.elapsed());
+                }
+            }
+            events.push(ev);
+        }
+        (events, done2_at)
+    })
+    .await
+    .expect("run finished in time");
+
+    assert_eq!(
+        dones(&events),
+        vec![(DoneStatus::Completed, None), (DoneStatus::Completed, None)],
+        "{events:?}"
+    );
+    // The merged turn's folded output streamed through (nothing cancelled)…
+    assert!(events.contains(&AgentEvent::TextDelta {
+        text: "merged reply".into()
+    }));
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TextDelta { text } if text.contains("CANCELLED"))),
+        "the native path must never cancel self-continued work: {events:?}"
+    );
+    // …and the settle rode the cost frame, not the 6s stream EOF.
+    let done2_at = done2_at.expect("second done asserted above");
+    assert!(
+        done2_at < Duration::from_secs(5),
+        "settle at {done2_at:?} — should ride the cost frame (~1s), not EOF"
+    );
+}

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -1011,3 +1011,49 @@ async fn starved_prompt_recovers_via_no_running_turn_evidence() {
         "the dead turn settles before the promoted boundary: {events:?}"
     );
 }
+
+/// The dropped-reply turn end with no steer involved: the adapter emits the
+/// turn's terminal cost frame (`usage_update` with `cost`) but never the
+/// prompt response. The claude spec must settle the turn off that evidence
+/// within its 1s grace — Working clears in about a second, not never (and
+/// not only after a watchdog window).
+#[tokio::test]
+async fn dropped_reply_settles_fast_off_the_turn_end_cost_frame() {
+    let (controls, _steer, _token) = controls();
+    let harness = AcpHarness::claude().with_executable(fixture_path());
+    let started = std::time::Instant::now();
+    let stream = harness
+        .run(request("scenario:cost-starve"), controls)
+        .await
+        .expect("run starts");
+    let (events, done_at) = tokio::time::timeout(Duration::from_secs(10), async move {
+        let mut events = Vec::new();
+        let mut done_at = None;
+        let mut stream = stream;
+        while let Some(ev) = stream.next().await {
+            let ev = ev.expect("stream event");
+            if matches!(ev, AgentEvent::Done { .. }) && done_at.is_none() {
+                done_at = Some(started.elapsed());
+            }
+            events.push(ev);
+        }
+        (events, done_at)
+    })
+    .await
+    .expect("run finished in time");
+
+    assert_eq!(
+        dones(&events),
+        vec![(DoneStatus::Completed, None)],
+        "{events:?}"
+    );
+    // The fixture holds its stream open for 6s after the cost frame; the
+    // Done must come from the 1s cost-hint grace, not stream EOF (margin
+    // sized for parallel-suite load).
+    let done_at = done_at.expect("dones asserted above");
+    assert!(
+        done_at < Duration::from_secs(4),
+        "Done at {done_at:?} — should be ~1s after the cost frame, well \
+         before the fixture's 6s exit"
+    );
+}

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -1061,9 +1061,10 @@ async fn dropped_reply_settles_fast_off_the_turn_end_cost_frame() {
 /// Full-stack verification of the 2026-08-12 starve fix against the REAL
 /// adapter + CLI: prompt#1 backgrounds a task and ends; the CLI
 /// self-continues on its notification and runs a 20s foreground command; a
-/// steer lands mid-way (becoming a session/prompt the adapter drops the
-/// reply for); the harness must settle off the turn-end cost frame within
-/// seconds of the agent finishing. Costs a few small prompts. Run explicitly:
+/// steer lands mid-way. With prevention in place the harness cancels the
+/// unowned turn and prompts fresh (no starve to recover from); the turn
+/// must settle promptly either way — never strand, never wait for a
+/// watchdog. Costs a few small prompts. Run explicitly:
 /// `cargo test -p comet-harness --test acp -- --ignored real_claude_starve`
 #[tokio::test]
 #[ignore = "needs the claude CLI authenticated + network; costs a few small prompts"]
@@ -1140,14 +1141,15 @@ async fn real_claude_starve_settles_off_the_cost_frame() {
             assert_eq!(*status, DoneStatus::Completed, "{evs:?}");
         }
     }
-    // The steer landed mid-merged-turn: its "turn" (starved, settled by the
-    // cost frame) took at least the foreground command's remaining runtime.
+    // Prevention path: the steer landed mid self-continued turn, was
+    // preceded by a cancel, and its fresh prompt settled promptly — well
+    // under the quiet/watchdog windows it used to need.
     let steer_sent_at = steer_sent_at.expect("steer timer ran");
-    let starved_turn = done_times[1].duration_since(steer_sent_at);
+    let steer_turn = done_times[1].duration_since(steer_sent_at);
     assert!(
-        starved_turn > Duration::from_secs(8),
-        "steer settled in {starved_turn:?} — too fast to have landed inside \
-         the self-continued turn; the starve shape did not reproduce"
+        steer_turn < Duration::from_secs(25),
+        "steer took {steer_turn:?} to settle — prevention should cancel the \
+         unowned turn and prompt fresh, not starve into a settle window"
     );
     // And the settle tracked the agent's actual finish (last streamed text),
     // not a watchdog window: cost-frame grace is 1s, allow scheduling slack.
@@ -1163,4 +1165,65 @@ async fn real_claude_starve_settles_off_the_cost_frame() {
         "final Done lagged the last content by {settle_gap:?} — the settle \
          should ride the turn-end cost frame (~1s)"
     );
+}
+
+/// Prevention for the interactive starve: a steer arriving while the agent
+/// is mid SELF-CONTINUED turn (open tool call, no prompt outstanding) must
+/// not become a session/prompt — the adapter drops that reply. The harness
+/// cancels the unowned turn first (the fixture asserts session/cancel is on
+/// the wire before any prompt), then dispatches the steer as a fresh prompt
+/// after the flush window.
+#[tokio::test]
+async fn steer_into_self_continuation_cancels_before_prompting() {
+    let (controls, steer, _token) = controls();
+    let harness = harness();
+    let stream = harness
+        .run(request("scenario:busy-steer"), controls)
+        .await
+        .expect("run starts");
+    let events = tokio::time::timeout(Duration::from_secs(15), async move {
+        let mut events = Vec::new();
+        let mut stream = stream;
+        let mut steer = Some(steer);
+        while let Some(ev) = stream.next().await {
+            let ev = ev.expect("stream event");
+            // The self-continued tool call is the busy signal: steer now.
+            if matches!(&ev, AgentEvent::ToolCall { id, .. } if id == "sc-1")
+                && let Some(tx) = steer.take()
+            {
+                tx.send(SteerMessage {
+                    prompt: "what about now".into(),
+                    message_id: None,
+                })
+                .await
+                .expect("steer sent");
+                // Sender dropped here; the mailbox closes so the run can end.
+            }
+            events.push(ev);
+        }
+        events
+    })
+    .await
+    .expect("run finished in time");
+
+    // Two clean turns: the first prompt's, then the promoted steer's —
+    // and the fixture exits with `refusal` if a prompt ever arrives
+    // without the preceding session/cancel.
+    assert_eq!(
+        dones(&events),
+        vec![(DoneStatus::Completed, None), (DoneStatus::Completed, None)],
+        "{events:?}"
+    );
+    assert!(events.contains(&AgentEvent::TextDelta {
+        text: "fresh answer".into()
+    }));
+    let steered = events
+        .iter()
+        .position(|e| matches!(e, AgentEvent::Steered { .. }))
+        .expect("promoted steer must carry a boundary");
+    let first_done = events
+        .iter()
+        .position(|e| matches!(e, AgentEvent::Done { .. }))
+        .expect("dones asserted above");
+    assert!(first_done < steered, "{events:?}");
 }

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -952,3 +952,62 @@ fn hermes_and_pi_descriptor_surfaces_match_registry_expectations() {
         ]
     );
 }
+
+/// The 2026-08-12 stuck-Working wedge, end to end: a prompt whose turn was
+/// consumed by CLI-side self-continuation never gets its response. A steer's
+/// `noRunningTurn` steering outcome is the protocol evidence the pending
+/// prompt can never settle; after the grace the harness closes the dead turn
+/// (Done — never a stranded Working) and promotes the steer to a fresh
+/// prompt, which settles normally.
+#[tokio::test]
+async fn starved_prompt_recovers_via_no_running_turn_evidence() {
+    let (controls, steer, _token) = controls();
+    let harness = harness();
+    let stream = harness
+        .run(request("scenario:starve"), controls)
+        .await
+        .expect("run starts");
+    let events = tokio::time::timeout(Duration::from_secs(15), async move {
+        let mut events = Vec::new();
+        let mut stream = stream;
+        while let Some(ev) = stream.next().await {
+            let ev = ev.expect("stream event");
+            if matches!(ev, AgentEvent::TextDelta { ref text } if text == "working") {
+                steer
+                    .send(SteerMessage {
+                        prompt: "what about now".into(),
+                        message_id: None,
+                    })
+                    .await
+                    .expect("steer sent");
+            }
+            events.push(ev);
+        }
+        events
+    })
+    .await
+    .expect("run finished in time");
+
+    // Two settled turns: the synthesized close of the starved prompt, then
+    // the promoted steer's real turn.
+    assert_eq!(
+        dones(&events),
+        vec![(DoneStatus::Completed, None), (DoneStatus::Completed, None)],
+        "{events:?}"
+    );
+    assert!(events.contains(&AgentEvent::TextDelta {
+        text: "promoted".into()
+    }));
+    let steered = events
+        .iter()
+        .position(|e| matches!(e, AgentEvent::Steered { .. }))
+        .expect("the queued steer must be promoted through a Steered boundary");
+    let first_done = events
+        .iter()
+        .position(|e| matches!(e, AgentEvent::Done { .. }))
+        .expect("dones asserted above");
+    assert!(
+        first_done < steered,
+        "the dead turn settles before the promoted boundary: {events:?}"
+    );
+}

--- a/crates/harness/tests/acp_quiet.rs
+++ b/crates/harness/tests/acp_quiet.rs
@@ -1,0 +1,157 @@
+//! Blanket dropped-reply settle (`COMET_ACP_QUIET_SETTLE_MS`), tested with
+//! the GROK spec so no adapter-specific evidence (Claude's cost frame,
+//! `noRunningTurn` steering reasons) is in play — this is the path every ACP
+//! agent gets. Own test binary: the env knob is process-global, and every
+//! test here shares the one value.
+
+use std::path::PathBuf;
+use std::sync::Once;
+use std::time::Duration;
+
+use futures::StreamExt;
+use tokio::sync::{mpsc, oneshot};
+
+use comet_harness::{
+    AcpHarness, CancellationToken, Harness, HarnessError, RunControls, SteerMessage,
+};
+use comet_proto::{
+    AgentEvent, DoneStatus, RunRequest, SandboxLevel, UserInputAnswer, UserInputQuestion,
+};
+
+const QUIET_MS: u64 = 1200;
+
+fn init_env() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: set before any harness runs in this test process; all
+        // tests in this binary share the one value.
+        unsafe { std::env::set_var("COMET_ACP_QUIET_SETTLE_MS", QUIET_MS.to_string()) };
+    });
+}
+
+fn fixture_path() -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake-acp.sh");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
+    }
+    path
+}
+
+fn request(prompt: &str) -> RunRequest {
+    RunRequest {
+        prompt: prompt.into(),
+        harness: None,
+        model: Some("grok-4.5".into()),
+        reasoning: None,
+        model_options: serde_json::Map::new(),
+        cwd: "/tmp".into(),
+        sandbox: SandboxLevel::WorkspaceWrite,
+        auto_approve: true,
+        attachments: Vec::new(),
+        resume: None,
+    }
+}
+
+fn controls() -> (RunControls, mpsc::Sender<SteerMessage>, CancellationToken) {
+    let (steer_tx, steer_rx) = mpsc::channel(8);
+    let token = CancellationToken::new();
+    let controls = RunControls {
+        request_input: Box::new(move |questions: Vec<UserInputQuestion>| {
+            let (tx, rx) = oneshot::channel();
+            let answers: Vec<UserInputAnswer> = questions
+                .iter()
+                .map(|q| UserInputAnswer {
+                    question_id: q.id.clone(),
+                    labels: vec!["Yes".into()],
+                })
+                .collect();
+            let _ = tx.send(answers);
+            rx
+        }),
+        steering: steer_rx,
+        interrupt: token.clone(),
+    };
+    (controls, steer_tx, token)
+}
+
+async fn run_and_collect(
+    prompt: &str,
+    timeout: Duration,
+) -> Vec<(std::time::Instant, AgentEvent)> {
+    let (controls, _steer, _token) = controls();
+    let harness = AcpHarness::grok().with_executable(fixture_path());
+    let stream = harness.run(request(prompt), controls).await.expect("run starts");
+    tokio::time::timeout(timeout, async move {
+        let mut stream = stream;
+        let mut events = Vec::new();
+        while let Some(ev) = stream.next().await {
+            events.push((std::time::Instant::now(), ev.expect("stream event")));
+        }
+        events
+    })
+    .await
+    .expect("run finished in time")
+}
+
+fn dones(events: &[(std::time::Instant, AgentEvent)]) -> Vec<(DoneStatus, Option<String>)> {
+    events
+        .iter()
+        .filter_map(|(_, e)| match e {
+            AgentEvent::Done { status, error, .. } => Some((*status, error.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A generic agent whose prompt response is dropped: content streamed, no
+/// open tool, then silence. The blanket settle must produce a clean Done off
+/// the quiet window, well before the fixture's held-open stream ends.
+#[tokio::test]
+async fn generic_dropped_reply_settles_off_the_quiet_window() {
+    init_env();
+    let started = std::time::Instant::now();
+    let events = run_and_collect("scenario:quiet-starve", Duration::from_secs(20)).await;
+    assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)], "{events:?}");
+    let done_at = events
+        .iter()
+        .find(|(_, e)| matches!(e, AgentEvent::Done { .. }))
+        .map(|(t, _)| t.duration_since(started))
+        .expect("done asserted above");
+    // Window is 1.2s; the fixture holds the stream open for 8s. The Done
+    // must come from the settle, not EOF (margin sized for suite load).
+    assert!(
+        done_at < Duration::from_secs(6),
+        "Done at {done_at:?} — should ride the {QUIET_MS}ms quiet window, \
+         not the 8s stream EOF"
+    );
+}
+
+/// The guard: an OPEN tool call makes silence legitimate. The fixture is
+/// quiet for ~3x the settle window mid-tool-call, then finishes normally —
+/// exactly one Done, arriving from the real response, never a premature
+/// synthesized one.
+#[tokio::test]
+async fn open_tool_call_holds_the_quiet_settle_off() {
+    init_env();
+    let events = run_and_collect("scenario:quiet-tool-guard", Duration::from_secs(20)).await;
+    assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)], "{events:?}");
+    // The "finished" text (streamed after the quiet stretch) must precede
+    // the single Done — a premature settle would have flipped that order.
+    let finished = events
+        .iter()
+        .position(|(_, e)| matches!(e, AgentEvent::TextDelta { text } if text == "finished"))
+        .expect("post-quiet text must fold into the SAME turn: {events:?}");
+    let done = events
+        .iter()
+        .position(|(_, e)| matches!(e, AgentEvent::Done { .. }))
+        .expect("done asserted above");
+    assert!(
+        finished < done,
+        "the turn must survive the quiet stretch intact: {events:?}"
+    );
+}

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -196,6 +196,27 @@ case "$promptline" in
   fi
   ;;
 
+*scenario:starve*)
+  # The 2026-08-12 wedge: the prompt's turn was consumed by CLI-side
+  # self-continuation and its response NEVER comes. Steering then answers
+  # noRunningTurn — the harness must settle the dead turn after its grace
+  # and promote the queued steer to a fresh session/prompt.
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
+  read -r steerline || exit 1
+  sid=$(rid "$steerline")
+  has "$steerline" '"method":"_session/steering"' || exit 1
+  emit "{\"id\":$sid,\"result\":{\"outcome\":\"promptRequired\",\"reason\":\"noRunningTurn\"}}"
+  # No response to $pid, ever. The next line must be the promoted prompt.
+  read -r followline || exit 1
+  fid=$(rid "$followline")
+  if has "$followline" '"method":"session/prompt"' && has "$followline" 'what about now'; then
+    update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"promoted"}}'
+    emit "{\"id\":$fid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  else
+    emit "{\"id\":$fid,\"result\":{\"stopReason\":\"refusal\"}}"
+  fi
+  ;;
+
 *scenario:interrupt*)
   update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
   read -r intline || exit 1

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -251,6 +251,31 @@ case "$promptline" in
   fi
   ;;
 
+*scenario:native-busy-steer*)
+  # Claude's native path: steer into a self-continued turn must arrive as a
+  # plain session/prompt (NO cancel — the CLI folds it into the running
+  # turn natively). The adapter drops that prompt's reply; the harness must
+  # settle off the turn-end cost frame instead.
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"first"}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  update '{"sessionUpdate":"tool_call","toolCallId":"sc-2","title":"self-continued work","kind":"execute","status":"pending","rawInput":{"command":"make"}}'
+  read -r followline || exit 1
+  if has "$followline" '"method":"session/cancel"'; then
+    # Cancelling would kill the agent's in-flight work: fail loudly.
+    update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"CANCELLED-NATIVE-WORK"}}'
+    exit 1
+  fi
+  fid=$(rid "$followline")
+  { has "$followline" '"method":"session/prompt"' && has "$followline" 'what about now'; } || exit 1
+  # The merged turn finishes: tool resolves, folded reply streams, the
+  # terminal cost frame arrives — and the prompt response NEVER does.
+  update '{"sessionUpdate":"tool_call_update","toolCallId":"sc-2","status":"completed","content":[]}'
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"merged reply"}}'
+  update '{"sessionUpdate":"usage_update","used":30000,"size":1000000,"cost":{"amount":0.02,"currency":"USD"}}'
+  sleep 6
+  exit 0
+  ;;
+
 *scenario:quiet-starve*)
   # Blanket dropped-reply settle, no adapter-specific evidence: content
   # streamed, no open tool, then silence — the response never comes. The

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -217,6 +217,18 @@ case "$promptline" in
   fi
   ;;
 
+*scenario:cost-starve*)
+  # The dropped-reply turn end, no steer involved: the turn's terminal
+  # cost frame arrives but the prompt response never does. The harness
+  # (claude spec) must settle the turn ~1s after the cost frame instead of
+  # stranding Working. Script exits shortly after so the stream ends.
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
+  update '{"sessionUpdate":"usage_update","used":22457,"size":1000000,"cost":{"amount":0.01,"currency":"USD"}}'
+  # No response to $pid, ever.
+  sleep 6
+  exit 0
+  ;;
+
 *scenario:interrupt*)
   update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
   read -r intline || exit 1

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -276,6 +276,24 @@ case "$promptline" in
   exit 0
   ;;
 
+*scenario:steer-cost-noise*)
+  # The injection cost frame (2026-08-13): claude-agent-acp stamps a
+  # cost-bearing usage_update for the injected message itself, MID-turn,
+  # identical in shape to the terminal one. The harness (claude spec) must
+  # not settle off it — the turn continues and ends via its real response:
+  # exactly one Done, all text intact.
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"first"}}'
+  read -r steerline || exit 1
+  sid=$(rid "$steerline")
+  has "$steerline" '"method":"_session/steering"' || exit 1
+  emit "{\"id\":$sid,\"result\":{\"outcome\":\"injected\"}}"
+  update '{"sessionUpdate":"usage_update","used":21429,"size":200000,"cost":{"amount":0.0006,"currency":"USD"},"_meta":{"_claude/origin":{"kind":"human"}}}'
+  sleep 3
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"steered tail"}}'
+  update '{"sessionUpdate":"usage_update","used":21884,"size":200000,"cost":{"amount":0.02,"currency":"USD"},"_meta":{"_claude/origin":{"kind":"human"}}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  ;;
+
 *scenario:quiet-starve*)
   # Blanket dropped-reply settle, no adapter-specific evidence: content
   # streamed, no open tool, then silence — the response never comes. The

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -229,6 +229,28 @@ case "$promptline" in
   exit 0
   ;;
 
+*scenario:quiet-starve*)
+  # Blanket dropped-reply settle, no adapter-specific evidence: content
+  # streamed, no open tool, then silence — the response never comes. The
+  # harness must settle off the generic quiet window (tests set
+  # COMET_ACP_QUIET_SETTLE_MS small), well before this stream's 8s EOF.
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
+  sleep 8
+  exit 0
+  ;;
+
+*scenario:quiet-tool-guard*)
+  # The guard: an OPEN tool call makes silence legitimate. Quiet stretch is
+  # far past the test's settle window, but the pending tool must hold the
+  # settle off; the turn then ends normally — exactly one Done.
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
+  update '{"sessionUpdate":"tool_call","toolCallId":"slow-1","title":"slow build","kind":"execute","status":"pending","rawInput":{"command":"make"}}'
+  sleep 4
+  update '{"sessionUpdate":"tool_call_update","toolCallId":"slow-1","status":"completed","content":[]}'
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"finished"}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  ;;
+
 *scenario:interrupt*)
   update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
   read -r intline || exit 1

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -229,6 +229,28 @@ case "$promptline" in
   exit 0
   ;;
 
+*scenario:busy-steer*)
+  # Prevention: the turn settles, then the agent SELF-CONTINUES (a turn no
+  # prompt started, visible as an open tool call). A steer arriving now
+  # must NOT become a session/prompt (the adapter drops that reply — the
+  # verified starve): the harness cancels the unowned turn first, then
+  # prompts after the flush window.
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"first"}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  update '{"sessionUpdate":"tool_call","toolCallId":"sc-1","title":"self-continued work","kind":"execute","status":"pending","rawInput":{"command":"make"}}'
+  read -r cancelline || exit 1
+  has "$cancelline" '"method":"session/cancel"' || exit 1
+  update '{"sessionUpdate":"tool_call_update","toolCallId":"sc-1","status":"completed","content":[]}'
+  read -r followline || exit 1
+  fid=$(rid "$followline")
+  if has "$followline" '"method":"session/prompt"' && has "$followline" 'what about now'; then
+    update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"fresh answer"}}'
+    emit "{\"id\":$fid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  else
+    emit "{\"id\":$fid,\"result\":{\"stopReason\":\"refusal\"}}"
+  fi
+  ;;
+
 *scenario:quiet-starve*)
   # Blanket dropped-reply settle, no adapter-specific evidence: content
   # streamed, no open tool, then silence — the response never comes. The

--- a/scripts/acp-starve-repro.py
+++ b/scripts/acp-starve-repro.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Reproduce the 2026-08-12 stuck-Working incident against the real claude-agent-acp.
+
+Evidence script for the upstream report: a session/prompt sent while the
+Claude CLI runs a SELF-CONTINUED turn (background-task re-invocation) never
+gets its response from @agentclientprotocol/claude-agent-acp@0.66.0, because
+the adapter does not track turns it did not start (steering answers
+`promptRequired`/`noRunningTurn` while the CLI is visibly busy). Comet-side
+mitigations: engine turn-quiesce watchdog + harness starved-turn recovery.
+
+Needs an authenticated claude CLI; costs a few small prompts.
+
+Speaks newline-delimited JSON-RPC 2.0 over the adapter's stdio, mirroring
+comet's harness. Timeline (mirrors the 2026-08-12 incident):
+
+  1. initialize + session/new
+  2. prompt#1: agent starts a background task (sleep) and ends its turn
+     -> expect response#1 (stopReason) while the task is still running
+  3. the task exits -> the CLI self-continues (a turn no prompt started);
+     the agent is instructed to run a FOREGROUND sleep in that turn
+  4. while that self-continued turn is busy, send prompt#2 ("what about now")
+  5. watch whether response#2 EVER arrives
+
+Every frame in both directions is logged with a monotonic timestamp to
+/tmp/acp_repro/frames.log. Auto-approves any session/request_permission.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+os.makedirs("/tmp/acp_repro/ws", exist_ok=True)
+LOG = open("/tmp/acp_repro/frames.log", "a", buffering=1)
+T0 = time.monotonic()
+
+
+def log(direction, obj):
+    t = time.monotonic() - T0
+    line = json.dumps(obj, separators=(",", ":"))
+    if len(line) > 600:
+        line = line[:600] + f"...({len(line)}b)"
+    print(f"{t:8.3f} {direction} {line}", file=LOG)
+
+
+proc = subprocess.Popen(
+    ["npx", "-y", "@agentclientprotocol/claude-agent-acp@0.66.0"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=open("/tmp/acp_repro/stderr.log", "ab"),
+    text=True,
+    bufsize=1,
+    env={**os.environ},
+)
+
+next_id = 0
+pending = {}          # id -> description
+responses = {}        # id -> (t, payload)
+lock = threading.Lock()
+session_id = None
+notif_count = 0
+
+
+def send_request(method, params, desc):
+    global next_id
+    next_id += 1
+    rid = next_id
+    with lock:
+        pending[rid] = desc
+    msg = {"jsonrpc": "2.0", "id": rid, "method": method, "params": params}
+    log(f">> req#{rid} [{desc}]", msg)
+    proc.stdin.write(json.dumps(msg) + "\n")
+    proc.stdin.flush()
+    return rid
+
+
+def respond(rid, result):
+    msg = {"jsonrpc": "2.0", "id": rid, "result": result}
+    log("<< resp(ours)", msg)
+    proc.stdin.write(json.dumps(msg) + "\n")
+    proc.stdin.flush()
+
+
+def reader():
+    global notif_count
+    for raw in proc.stdout:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            print(f"{time.monotonic()-T0:8.3f} !! non-json: {raw[:200]}", file=LOG)
+            continue
+        mid = msg.get("id")
+        method = msg.get("method")
+        if method is None and mid is not None:
+            with lock:
+                desc = pending.pop(mid, f"UNKNOWN-ID({mid})")
+                responses[mid] = (time.monotonic() - T0, msg)
+            log(f"** RESPONSE to #{mid} [{desc}]", msg)
+        elif method is not None and mid is not None:
+            log(f"?? server-req {method}", msg)
+            if method == "session/request_permission":
+                opts = (msg.get("params") or {}).get("options") or []
+                allow = next(
+                    (o for o in opts if "allow" in (o.get("kind") or "") or "allow" in (o.get("optionId") or "")),
+                    opts[0] if opts else None,
+                )
+                outcome = {"outcome": {"outcome": "selected", "optionId": allow.get("optionId")}} if allow else {"outcome": {"outcome": "cancelled"}}
+                respond(mid, outcome)
+            else:
+                respond(mid, {})
+        else:
+            notif_count += 1
+            log(f".. notif {method}", msg)
+    print(f"{time.monotonic()-T0:8.3f} !! adapter stdout EOF", file=LOG)
+
+
+threading.Thread(target=reader, daemon=True).start()
+
+
+def wait_response(rid, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with lock:
+            if rid in responses:
+                return responses[rid]
+        time.sleep(0.2)
+    return None
+
+
+# ---- 1. initialize + session/new -------------------------------------------
+rid = send_request(
+    "initialize",
+    {
+        "protocolVersion": 1,
+        "clientCapabilities": {"fs": {"readTextFile": False, "writeTextFile": False}},
+    },
+    "initialize",
+)
+assert wait_response(rid, 60), "initialize timed out"
+
+rid = send_request(
+    "session/new",
+    {"cwd": "/tmp/acp_repro/ws", "mcpServers": []},
+    "session/new",
+)
+resp = wait_response(rid, 120)
+assert resp, "session/new timed out"
+session_id = resp[1]["result"]["sessionId"]
+print(f"session: {session_id}")
+
+# ---- 2. prompt#1: background task, end turn ---------------------------------
+PROMPT1 = (
+    "Use the Bash tool exactly twice, then stop.\n"
+    "First call: run the command `sleep 8; echo task-finished` with "
+    "run_in_background set to true.\n"
+    "Then reply with exactly the word: started\n"
+    "IMPORTANT: later, when a task notification about that background task "
+    "arrives, make one FOREGROUND Bash call: `sleep 20; echo waited` (no "
+    "run_in_background), then reply with exactly: done waiting"
+)
+rid1 = send_request(
+    "session/prompt",
+    {"sessionId": session_id, "prompt": [{"type": "text", "text": PROMPT1}]},
+    "PROMPT#1",
+)
+resp1 = wait_response(rid1, 240)
+print(f"prompt#1 response: {json.dumps(resp1[1].get('result')) if resp1 else 'NEVER ARRIVED'}")
+if not resp1:
+    sys.exit(1)
+
+# ---- 3. wait for self-continuation (task notification fires ~8s in) ---------
+print("waiting 16s for the background task to exit and the CLI to self-continue...")
+time.sleep(16)
+
+# ---- 4. prompt#2 while the self-continued turn is busy ----------------------
+rid2 = send_request(
+    "session/prompt",
+    {"sessionId": session_id, "prompt": [{"type": "text", "text": "what about now"}]},
+    "PROMPT#2",
+)
+resp2 = wait_response(rid2, 180)
+t = time.monotonic() - T0
+if resp2:
+    print(f"prompt#2 response at t={resp2[0]:.1f}s: {json.dumps(resp2[1].get('result'))}")
+    print("VERDICT: adapter settled prompt#2 — no drop in this shape")
+else:
+    print(f"prompt#2 response NEVER ARRIVED (waited 180s, t={t:.1f}s)")
+    print(f"adapter alive: {proc.poll() is None}, notifications seen: {notif_count}")
+    print("VERDICT: REPRODUCED — the adapter/CLI lost the turn-end reply")
+
+log("-- done --", {"prompt2_settled": bool(resp2)})
+proc.terminate()


### PR DESCRIPTION
## The bug (diagnosed live, 2026-08-12)

A session read **Working for 19 minutes after the agent finished**. Root cause chain, established from the agent's session data, comet's doc journal, and the engine log:

- The engine only settles a turn on the harness's `Done`; for ACP that means the `session/prompt` response. That response was lost upstream (agent finished with `stop_reason: end_turn` at 21:03:32; child idle, zero open sockets, empty queue — no turn-end ever arrived).
- Nothing recovers from a lost turn-end: the liveness heartbeat keeps the session row fresh (so the UI's 45s staleness gate never fires), and there's no per-turn timeout by design. The same symptom was reported on a Codex session — the trap is in the shared engine contract, not one adapter.
- The same incident exposed **transcript content loss**: Claude Code re-invokes itself when background tasks finish (turns no prompt started), and the parked gate dropped that streamed output. "Build finished successfully…" / "Confirmed — Xcode 26.2…" exist in the agent's session data and are absent from the chat doc, exactly in the 20:45:43→20:55:25 parked window.

## The fix (engine-level, harness-agnostic)

**Turn-quiesce watchdog** — when the stream is silent past the window (default 120s; `COMET_TURN_QUIESCE_MS` overrides, `0` disables) and the fold shows nothing in flight (no unresolved tool call — live-plan chip exempt — and no open question), the turn parks exactly like a `Done` would: segment finalized `Complete`, status Idle, child + mailbox warm. It never ends the run or errors anything — this is not the stall timeout the design comment rejects. A false trip costs a brief status dip, because…

**Parked self-continuation** — fresh text or a genuinely new tool call on a parked session now resumes it (new segment, Working) instead of being dropped, and the resumed turn settles again via `Done` or the watchdog. A 1s resume gate keeps a finished turn's tail flush inert (arrives within ms of the park; real self-continuation is a whole new agent round trip — 5 minutes in the incident), and stale tool echoes stay gated via `seen_tools`, so the original eternally-running-session fix holds.

The two changes are mutually load-bearing: resume is only safe because the watchdog guarantees a re-settle; the watchdog is only safe because resume makes a false park lossless.

## Verification — the incident workflow, mocked end-to-end

`crates/engine/tests/turn_quiesce.rs` drives a feed-by-hand harness through the exact observed sequence:

1. `parked_self_continuation_folds_and_requiesces` — turn completes → parks; agent self-continues with no prompt → output folds into the doc as its own Complete entry (this exact text was lost in the incident), Working while it streams, watchdog re-parks.
2. `missing_turn_end_settles_instead_of_working_forever` — steer ("what about now") becomes the next turn, the answer streams, its `Done` is lost → watchdog settles instead of Working-forever; the answer survives in the doc.
3. `open_tool_call_never_quiesces` — an unresolved tool call holds the watchdog off through many windows of silence (the legitimately-quiet case the no-stall-timeout comment protects).
4. `stale_tool_echo_stays_parked` — post-turn noise still never re-arms a parked session.

`cargo test -p comet-engine`: all suites green, including the pre-existing `parked_session_ignores_trailing_frames_and_stays_idle` contract test (the resume gate is what keeps it green). `repos_round_trip_add_branches_worktrees` fails identically on `main` (pre-existing, environmental).

Not addressed here (upstream): the adapter losing the `session/prompt` response for a prompt delivered into a merged turn, and settling prompts while background tasks are pending. This PR makes comet correct and lossless regardless of which layer drops the ball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789169137&installation_model_id=425430&pr_number=59&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F59&signature=ab189d1167f39f605bcce0c8d8ec6dae7cc4389f755306df1e43a55c579333a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->