### PR TITLE
Use landing screenshot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Control your coding agents (Claude Code, Codex, Cursor, Grok, Hermes, Pi) from
 any of your devices.
 
-![Zeron running a Claude Code session](docs/screenshot.png)
+![Zeron driving a Claude Code session with a live branch diff sidebar](apps/landing/public/assets/app-screenshot.jpg)
 
 Every device runs a small engine that keeps your sessions in sync: start an
 agent on one machine, follow and drive it from another. Install the engine as


### PR DESCRIPTION
## What changed

- Updated the root README to use the same application screenshot displayed on the landing page.
- Updated the image alt text to describe the current screenshot.

## Why

This keeps the GitHub project presentation consistent with the landing page.

## Validation

- `git diff --check`
- Confirmed the referenced image exists at `apps/landing/public/assets/app-screenshot.jpg`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789195426&installation_model_id=425430&pr_number=60&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F60&signature=3e69161f446340a522b58eae4d3f9048c0a916f01237e0d21beae53c03f49011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->