### PR TITLE
ACP: exempt Claude from the blanket quiet settle (false mid-thought Done + stuck-Working orphan)

### DIFF
--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -2057,18 +2057,33 @@ async fn run_session(session: Session) {
     // the turn has streamed content, every tool call it opened has resolved,
     // no permission/question round-trip is pending, and the stream has been
     // quiet past the window, the turn is settled through the same recovery
-    // arm. A false settle is recoverable by design (the engine folds any
-    // later output as a self-continued segment and re-arms Working; a late
-    // response resolves a dropped channel), which is what makes a tight
-    // window safe where a hard per-turn timeout was rejected.
+    // arm. A false settle is only PARTLY recoverable: the engine folds any
+    // later output as a self-continued segment and re-arms Working, but the
+    // turn is orphaned — the real response resolves a closed channel, no
+    // Done ever comes, and the session strands Working until the engine's
+    // quiesce watchdog parks it.
+    //
+    // Claude is EXEMPT, even from the env knob: claude-agent-acp forwards
+    // no thinking traffic, so a long silent reasoning stretch in exactly
+    // the "looks finished" state (content streamed, every tool resolved)
+    // is indistinguishable from a dropped reply — 30s of quiet falsely
+    // settled live turns mid-thought (2026-08-13), producing both a
+    // premature Done and the stuck-Working orphan above. Claude's
+    // genuinely dropped replies already settle deterministically (the
+    // cost-frame hint above, `noRunningTurn` steering evidence); the
+    // engine watchdog backstops anything left.
     // `COMET_ACP_QUIET_SETTLE_MS` overrides; 0 disables.
-    let quiet_settle: Option<Duration> = match std::env::var("COMET_ACP_QUIET_SETTLE_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-    {
-        Some(0) => None,
-        Some(ms) => Some(Duration::from_millis(ms)),
-        None => Some(Duration::from_secs(30)),
+    let quiet_settle: Option<Duration> = if cost_hint_enabled {
+        None
+    } else {
+        match std::env::var("COMET_ACP_QUIET_SETTLE_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+        {
+            Some(0) => None,
+            Some(ms) => Some(Duration::from_millis(ms)),
+            None => Some(Duration::from_secs(30)),
+        }
     };
     let mut last_update_at = tokio::time::Instant::now();
     let mut turn_content_seen = false;
@@ -2077,7 +2092,8 @@ async fn run_session(session: Session) {
     // message itself, mid-turn, indistinguishable in shape from the
     // terminal one (verified against 0.66.0 — premature Done exactly one
     // grace after injection). Steered turns settle off their real response
-    // (healthy in every trace); the quiet settle stays as their backstop.
+    // (healthy in every trace); the engine's quiesce watchdog backstops
+    // them (the quiet settle used to, before the Claude exemption above).
     let mut steered_this_turn = false;
     let mut open_tools: std::collections::HashSet<String> = std::collections::HashSet::new();
     let open_questions = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/crates/harness/tests/acp_quiet.rs
+++ b/crates/harness/tests/acp_quiet.rs
@@ -80,11 +80,12 @@ fn controls() -> (RunControls, mpsc::Sender<SteerMessage>, CancellationToken) {
 }
 
 async fn run_and_collect(
+    harness: AcpHarness,
     prompt: &str,
     timeout: Duration,
 ) -> Vec<(std::time::Instant, AgentEvent)> {
     let (controls, _steer, _token) = controls();
-    let harness = AcpHarness::grok().with_executable(fixture_path());
+    let harness = harness.with_executable(fixture_path());
     let stream = harness.run(request(prompt), controls).await.expect("run starts");
     tokio::time::timeout(timeout, async move {
         let mut stream = stream;
@@ -115,7 +116,8 @@ fn dones(events: &[(std::time::Instant, AgentEvent)]) -> Vec<(DoneStatus, Option
 async fn generic_dropped_reply_settles_off_the_quiet_window() {
     init_env();
     let started = std::time::Instant::now();
-    let events = run_and_collect("scenario:quiet-starve", Duration::from_secs(20)).await;
+    let events =
+        run_and_collect(AcpHarness::grok(), "scenario:quiet-starve", Duration::from_secs(20)).await;
     assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)], "{events:?}");
     let done_at = events
         .iter()
@@ -138,7 +140,12 @@ async fn generic_dropped_reply_settles_off_the_quiet_window() {
 #[tokio::test]
 async fn open_tool_call_holds_the_quiet_settle_off() {
     init_env();
-    let events = run_and_collect("scenario:quiet-tool-guard", Duration::from_secs(20)).await;
+    let events = run_and_collect(
+        AcpHarness::grok(),
+        "scenario:quiet-tool-guard",
+        Duration::from_secs(20),
+    )
+    .await;
     assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)], "{events:?}");
     // The "finished" text (streamed after the quiet stretch) must precede
     // the single Done — a premature settle would have flipped that order.
@@ -153,5 +160,40 @@ async fn open_tool_call_holds_the_quiet_settle_off() {
     assert!(
         finished < done,
         "the turn must survive the quiet stretch intact: {events:?}"
+    );
+}
+
+/// The 2026-08-13 regression: Claude thinking silently in exactly the
+/// settle's "looks finished" state — content streamed, every tool resolved,
+/// wire quiet far past the window. claude-agent-acp forwards no thinking
+/// traffic, so this is routine mid-turn silence, not a dropped reply; a
+/// false settle here orphans the real turn (premature Done, then the
+/// post-quiet tail folds as self-continued output and the session strands
+/// Working when the real response lands on a closed channel). Claude must
+/// ignore the blanket settle — even with the env knob set, as it is
+/// process-wide in this binary.
+#[tokio::test]
+async fn claude_thinking_silence_never_settles_the_turn() {
+    init_env();
+    let events = run_and_collect(
+        AcpHarness::claude(),
+        "scenario:quiet-thinking",
+        Duration::from_secs(20),
+    )
+    .await;
+    assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)], "{events:?}");
+    // The "finished" text (streamed after the 4s quiet stretch, ~3x the
+    // window) must precede the single Done — a false settle flips the order.
+    let finished = events
+        .iter()
+        .position(|(_, e)| matches!(e, AgentEvent::TextDelta { text } if text == "finished"))
+        .unwrap_or_else(|| panic!("post-quiet text must fold into the SAME turn: {events:?}"));
+    let done = events
+        .iter()
+        .position(|(_, e)| matches!(e, AgentEvent::Done { .. }))
+        .expect("done asserted above");
+    assert!(
+        finished < done,
+        "the turn must survive silent thinking intact: {events:?}"
     );
 }

--- a/crates/harness/tests/acp_quiet.rs
+++ b/crates/harness/tests/acp_quiet.rs
@@ -12,7 +12,7 @@ use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot};
 
 use comet_harness::{
-    AcpHarness, CancellationToken, Harness, HarnessError, RunControls, SteerMessage,
+    AcpHarness, CancellationToken, Harness, RunControls, SteerMessage,
 };
 use comet_proto::{
     AgentEvent, DoneStatus, RunRequest, SandboxLevel, UserInputAnswer, UserInputQuestion,

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -316,6 +316,21 @@ case "$promptline" in
   emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
   ;;
 
+*scenario:quiet-thinking*)
+  # The 2026-08-13 false settle: every tool RESOLVED, then a long silent
+  # thinking stretch (claude-agent-acp forwards no thinking traffic), then
+  # the turn continues and ends normally. This is exactly the "looks
+  # finished" state the blanket settle keys on; Claude must hold through
+  # it — a false settle here orphans the real turn (its response lands on
+  # a closed channel; the session strands Working).
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
+  update '{"sessionUpdate":"tool_call","toolCallId":"th-1","title":"quick read","kind":"read","status":"pending","rawInput":{"path":"/w/src/x.rs"}}'
+  update '{"sessionUpdate":"tool_call_update","toolCallId":"th-1","status":"completed","content":[]}'
+  sleep 4
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"finished"}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  ;;
+
 *scenario:interrupt*)
   update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
   read -r intline || exit 1

--- a/crates/harness/tests/real_quiet_ab.rs
+++ b/crates/harness/tests/real_quiet_ab.rs
@@ -82,6 +82,31 @@ fn brief(ev: &AgentEvent) -> String {
 #[ignore = "real claude CLI + network; run explicitly for the A/B evidence probe"]
 async fn real_claude_quiet_ab_probe() {
     init_env();
+    let runs: usize = std::env::var("AB_RUNS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let mut clean = 0usize;
+    let mut orphaned = 0usize;
+    for run in 1..=runs {
+        let (dones, after, finished) = probe_once(run == 1).await;
+        println!(
+            "RUN {run}/{runs} VERDICT: dones={dones} content_events_after_first_done={after} \
+             finished_text_contains_PROBE_DONE={finished}"
+        );
+        if after == 0 && dones == 1 {
+            clean += 1;
+        } else {
+            orphaned += 1;
+        }
+    }
+    println!(
+        "SUMMARY: runs={runs} clean={clean} orphaned={orphaned} \
+         (clean = one Done, ordered last; orphaned = premature Done, tail after it)"
+    );
+}
+
+async fn probe_once(print_trace: bool) -> (usize, usize, bool) {
     let (controls, steer_tx, _token) = controls();
     let harness = AcpHarness::claude();
     let req = RunRequest {
@@ -140,9 +165,11 @@ async fn real_claude_quiet_ab_probe() {
         }
     }
 
-    println!("--- TRACE (quiet knob = {QUIET_MS}ms) ---");
-    for (at, ev) in &events {
-        println!("{:>8.3}s  {}", at.as_secs_f64(), brief(ev));
+    if print_trace {
+        println!("--- TRACE (quiet knob = {QUIET_MS}ms) ---");
+        for (at, ev) in &events {
+            println!("{:>8.3}s  {}", at.as_secs_f64(), brief(ev));
+        }
     }
     let first_done_idx = events
         .iter()
@@ -173,13 +200,5 @@ async fn real_claude_quiet_ab_probe() {
             _ => None,
         })
         .collect();
-    println!(
-        "VERDICT: dones={dones} content_events_after_first_done={after} \
-         finished_text_contains_PROBE_DONE={}",
-        text.contains("PROBE-DONE")
-    );
-    println!(
-        "VERDICT-MEANING: after==0 && dones==1 → turn survived intact; \
-         after>0 → FALSE SETTLE (premature Done, orphaned tail)"
-    );
+    (dones, after, text.contains("PROBE-DONE"))
 }

--- a/crates/harness/tests/real_quiet_ab.rs
+++ b/crates/harness/tests/real_quiet_ab.rs
@@ -1,0 +1,185 @@
+//! A/B evidence probe for the Claude quiet-settle exemption, against the
+//! REAL stack (claude-agent-acp + claude CLI + live model). Run explicitly:
+//!
+//!   COMET_AB=1 cargo test -p comet-harness --test real_quiet_ab -- --ignored --nocapture
+//!
+//! The knob is set to 800ms — far below routine inference-gap silence
+//! (tool result → next API roundtrip), the same structural ratio as the
+//! production incident (30s window vs 30–120s thinking stretches). On code
+//! where Claude honors the blanket quiet settle, the probe false-settles
+//! mid-turn: a premature Done{completed} with the turn's real tail (tool
+//! calls / text) streaming AFTER it — the orphan signature. On code with
+//! the exemption, the SAME knob setting must produce exactly one Done,
+//! ordered after all content.
+//!
+//! The test asserts nothing: it prints a timestamped trace and a VERDICT
+//! line, and is run on both trees so the traces can be compared.
+
+use std::sync::Once;
+use std::time::Duration;
+
+use futures::StreamExt;
+use tokio::sync::{mpsc, oneshot};
+
+use comet_harness::{AcpHarness, CancellationToken, Harness, RunControls, SteerMessage};
+use comet_proto::{
+    AgentEvent, RunRequest, SandboxLevel, UserInputAnswer, UserInputQuestion,
+};
+
+const QUIET_MS: u64 = 800;
+/// How long to keep observing after the FIRST Done — on unfixed code the
+/// orphaned turn's tail lands in this window.
+const POST_DONE_WINDOW: Duration = Duration::from_secs(25);
+
+fn init_env() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: set before any harness runs in this test process.
+        unsafe { std::env::set_var("COMET_ACP_QUIET_SETTLE_MS", QUIET_MS.to_string()) };
+    });
+}
+
+fn controls() -> (RunControls, mpsc::Sender<SteerMessage>, CancellationToken) {
+    let (steer_tx, steer_rx) = mpsc::channel(8);
+    let token = CancellationToken::new();
+    let controls = RunControls {
+        request_input: Box::new(move |questions: Vec<UserInputQuestion>| {
+            let (tx, rx) = oneshot::channel();
+            let answers: Vec<UserInputAnswer> = questions
+                .iter()
+                .map(|q| UserInputAnswer {
+                    question_id: q.id.clone(),
+                    labels: vec!["Yes".into()],
+                })
+                .collect();
+            let _ = tx.send(answers);
+            rx
+        }),
+        steering: steer_rx,
+        interrupt: token.clone(),
+    };
+    (controls, steer_tx, token)
+}
+
+fn brief(ev: &AgentEvent) -> String {
+    match ev {
+        AgentEvent::SessionStarted { session_id, .. } => format!("SessionStarted({session_id})"),
+        AgentEvent::TextDelta { text } => {
+            format!("TextDelta({:?})", text.chars().take(40).collect::<String>())
+        }
+        AgentEvent::ToolCall { id, .. } => format!("ToolCall({id})"),
+        AgentEvent::ToolResult { id, .. } => format!("ToolResult({id})"),
+        AgentEvent::AssistantMessageCompleted { .. } => "AssistantMessageCompleted".into(),
+        AgentEvent::Done { status, .. } => format!("*** DONE({status:?}) ***"),
+        other => {
+            let dbg = format!("{other:?}");
+            dbg.chars().take(60).collect()
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "real claude CLI + network; run explicitly for the A/B evidence probe"]
+async fn real_claude_quiet_ab_probe() {
+    init_env();
+    let (controls, steer_tx, _token) = controls();
+    let harness = AcpHarness::claude();
+    let req = RunRequest {
+        prompt: "Use your shell tool to run `echo probe-one`. After you see its output, \
+                 run `echo probe-two` as a second separate command. After that, reply \
+                 with exactly the word PROBE-DONE."
+            .into(),
+        harness: None,
+        model: Some("claude-haiku-4-5".into()),
+        reasoning: None,
+        model_options: serde_json::Map::new(),
+        cwd: std::env::var("HOME").unwrap_or_else(|_| "/tmp".into()),
+        sandbox: SandboxLevel::WorkspaceWrite,
+        auto_approve: true,
+        attachments: Vec::new(),
+        resume: None,
+    };
+    let started = std::time::Instant::now();
+    let mut stream = harness.run(req, controls).await.expect("run starts");
+
+    let mut events: Vec<(Duration, AgentEvent)> = Vec::new();
+    let mut steer = Some(steer_tx);
+    let mut first_done_at: Option<std::time::Instant> = None;
+    loop {
+        let budget = match first_done_at {
+            // Post-Done observation: wait out the window, then release the
+            // mailbox so the run can end.
+            Some(at) => {
+                let left = POST_DONE_WINDOW.saturating_sub(at.elapsed());
+                if left.is_zero() && steer.is_some() {
+                    steer = None;
+                }
+                left.max(Duration::from_secs(10))
+            }
+            None => Duration::from_secs(90),
+        };
+        match tokio::time::timeout(budget, stream.next()).await {
+            Ok(Some(ev)) => {
+                let ev = ev.expect("stream event");
+                if matches!(ev, AgentEvent::Done { .. }) && first_done_at.is_none() {
+                    first_done_at = Some(std::time::Instant::now());
+                }
+                events.push((started.elapsed(), ev));
+            }
+            Ok(None) => break,
+            Err(_) => {
+                if steer.is_some() {
+                    steer = None; // release mailbox, drain to stream end
+                } else {
+                    break;
+                }
+            }
+        }
+        if events.len() > 400 {
+            break;
+        }
+    }
+
+    println!("--- TRACE (quiet knob = {QUIET_MS}ms) ---");
+    for (at, ev) in &events {
+        println!("{:>8.3}s  {}", at.as_secs_f64(), brief(ev));
+    }
+    let first_done_idx = events
+        .iter()
+        .position(|(_, e)| matches!(e, AgentEvent::Done { .. }));
+    let dones = events
+        .iter()
+        .filter(|(_, e)| matches!(e, AgentEvent::Done { .. }))
+        .count();
+    let after = first_done_idx
+        .map(|i| {
+            events[i + 1..]
+                .iter()
+                .filter(|(_, e)| {
+                    matches!(
+                        e,
+                        AgentEvent::TextDelta { .. }
+                            | AgentEvent::ToolCall { .. }
+                            | AgentEvent::ToolResult { .. }
+                    )
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    let text: String = events
+        .iter()
+        .filter_map(|(_, e)| match e {
+            AgentEvent::TextDelta { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    println!(
+        "VERDICT: dones={dones} content_events_after_first_done={after} \
+         finished_text_contains_PROBE_DONE={}",
+        text.contains("PROBE-DONE")
+    );
+    println!(
+        "VERDICT-MEANING: after==0 && dones==1 → turn survived intact; \
+         after>0 → FALSE SETTLE (premature Done, orphaned tail)"
+    );
+}

--- a/crates/harness/tests/real_quiet_survey.rs
+++ b/crates/harness/tests/real_quiet_survey.rs
@@ -1,0 +1,240 @@
+//! Production-settings survey across ALL harnesses: does a real multi-tool
+//! turn settle exactly once, at the end, and how close do its silent gaps
+//! come to the 30s blanket quiet-settle window? Run explicitly:
+//!
+//!   SURVEY_RUNS=3 cargo test -p comet-harness --test real_quiet_survey -- --ignored --nocapture
+//!
+//! No env knob is set here — this binary runs the DEFAULTS the app ships:
+//! Claude exempt from the blanket settle, every other adapter on the 30s
+//! window. For each installed+authenticated agent CLI it reports, per run:
+//! the Done count, content events after the first Done (orphan signature),
+//! and the maximum inter-event silent gap — the safety margin against the
+//! window. Uninstalled/unauthenticated agents are skipped by name.
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use tokio::sync::{mpsc, oneshot};
+
+use comet_harness::{AcpHarness, CancellationToken, Harness, RunControls, SteerMessage};
+use comet_proto::{
+    AgentEvent, DoneStatus, RunRequest, SandboxLevel, UserInputAnswer, UserInputQuestion,
+};
+
+const POST_DONE_WINDOW: Duration = Duration::from_secs(20);
+
+fn controls() -> (RunControls, mpsc::Sender<SteerMessage>, CancellationToken) {
+    let (steer_tx, steer_rx) = mpsc::channel(8);
+    let token = CancellationToken::new();
+    let controls = RunControls {
+        request_input: Box::new(move |questions: Vec<UserInputQuestion>| {
+            let (tx, rx) = oneshot::channel();
+            let answers: Vec<UserInputAnswer> = questions
+                .iter()
+                .map(|q| UserInputAnswer {
+                    question_id: q.id.clone(),
+                    labels: vec!["Yes".into()],
+                })
+                .collect();
+            let _ = tx.send(answers);
+            rx
+        }),
+        steering: steer_rx,
+        interrupt: token.clone(),
+    };
+    (controls, steer_tx, token)
+}
+
+struct ProbeOutcome {
+    dones: Vec<(DoneStatus, Option<String>)>,
+    after_first_done: usize,
+    finished: bool,
+    max_gap: Duration,
+    started_err: Option<String>,
+}
+
+async fn probe_once(harness: AcpHarness) -> ProbeOutcome {
+    let (controls, steer_tx, _token) = controls();
+    let req = RunRequest {
+        prompt: "Use your shell tool to run `echo probe-one`. After you see its output, \
+                 run `echo probe-two` as a second separate command. After that, reply \
+                 with exactly the word PROBE-DONE."
+            .into(),
+        harness: None,
+        model: None,
+        reasoning: None,
+        model_options: serde_json::Map::new(),
+        cwd: std::env::var("HOME").unwrap_or_else(|_| "/tmp".into()),
+        sandbox: SandboxLevel::WorkspaceWrite,
+        auto_approve: true,
+        attachments: Vec::new(),
+        resume: None,
+    };
+    let mut stream = match harness.run(req, controls).await {
+        Ok(s) => s,
+        Err(e) => {
+            return ProbeOutcome {
+                dones: Vec::new(),
+                after_first_done: 0,
+                finished: false,
+                max_gap: Duration::ZERO,
+                started_err: Some(e.to_string()),
+            };
+        }
+    };
+    let started = std::time::Instant::now();
+    let mut events: Vec<(Duration, AgentEvent)> = Vec::new();
+    let mut steer = Some(steer_tx);
+    let mut first_done_at: Option<std::time::Instant> = None;
+    loop {
+        let budget = match first_done_at {
+            Some(at) => {
+                let left = POST_DONE_WINDOW.saturating_sub(at.elapsed());
+                if left.is_zero() && steer.is_some() {
+                    steer = None;
+                }
+                left.max(Duration::from_secs(10))
+            }
+            None => Duration::from_secs(120),
+        };
+        match tokio::time::timeout(budget, stream.next()).await {
+            Ok(Some(Ok(ev))) => {
+                if matches!(ev, AgentEvent::Done { .. }) && first_done_at.is_none() {
+                    first_done_at = Some(std::time::Instant::now());
+                }
+                events.push((started.elapsed(), ev));
+            }
+            Ok(Some(Err(e))) => {
+                events.push((
+                    started.elapsed(),
+                    AgentEvent::Done {
+                        status: DoneStatus::Errored,
+                        result: None,
+                        error: Some(e.to_string()),
+                        session_id: None,
+                    },
+                ));
+                break;
+            }
+            Ok(None) => break,
+            Err(_) => {
+                if steer.is_some() {
+                    steer = None;
+                } else {
+                    break;
+                }
+            }
+        }
+        if events.len() > 600 {
+            break;
+        }
+    }
+    let first_done_idx = events
+        .iter()
+        .position(|(_, e)| matches!(e, AgentEvent::Done { .. }));
+    // Max silent gap while the turn is live: consecutive-event gaps from the
+    // first event through the first Done (post-Done observation excluded).
+    let live_end = first_done_idx.unwrap_or(events.len().saturating_sub(1));
+    let max_gap = events[..=live_end.min(events.len().saturating_sub(1))]
+        .windows(2)
+        .map(|w| w[1].0 - w[0].0)
+        .max()
+        .unwrap_or(Duration::ZERO);
+    let after_first_done = first_done_idx
+        .map(|i| {
+            events[i + 1..]
+                .iter()
+                .filter(|(_, e)| {
+                    matches!(
+                        e,
+                        AgentEvent::TextDelta { .. }
+                            | AgentEvent::ToolCall { .. }
+                            | AgentEvent::ToolResult { .. }
+                    )
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    let text: String = events
+        .iter()
+        .filter_map(|(_, e)| match e {
+            AgentEvent::TextDelta { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    ProbeOutcome {
+        dones: events
+            .iter()
+            .filter_map(|(_, e)| match e {
+                AgentEvent::Done { status, error, .. } => Some((*status, error.clone())),
+                _ => None,
+            })
+            .collect(),
+        after_first_done,
+        finished: text.contains("PROBE-DONE"),
+        max_gap,
+        started_err: None,
+    }
+}
+
+fn is_auth_or_missing(o: &ProbeOutcome) -> bool {
+    let msg = o
+        .started_err
+        .clone()
+        .or_else(|| o.dones.iter().find_map(|(_, e)| e.clone()))
+        .unwrap_or_default()
+        .to_lowercase();
+    msg.contains("auth")
+        || msg.contains("login")
+        || msg.contains("not installed")
+        || msg.contains("not found")
+        || msg.contains("no such file")
+}
+
+#[tokio::test]
+#[ignore = "runs every installed+authenticated agent CLI; costs a few small prompts each"]
+async fn real_all_harnesses_quiet_survey() {
+    let runs: usize = std::env::var("SURVEY_RUNS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3);
+    let agents: Vec<(&str, fn() -> AcpHarness)> = vec![
+        ("claude", AcpHarness::claude),
+        ("codex", AcpHarness::codex),
+        ("cursor", AcpHarness::cursor),
+        ("grok", AcpHarness::grok),
+        ("hermes", AcpHarness::hermes),
+        ("pi", AcpHarness::pi),
+    ];
+    let mut failures: Vec<String> = Vec::new();
+    for (name, ctor) in agents {
+        for i in 1..=runs {
+            let o = probe_once(ctor()).await;
+            if is_auth_or_missing(&o) {
+                println!("[{name}] SKIP — not installed / not authenticated");
+                break;
+            }
+            let clean = o.dones.len() == 1
+                && o.dones[0].0 == DoneStatus::Completed
+                && o.after_first_done == 0
+                && o.finished;
+            println!(
+                "[{name}] run {i}/{runs}: dones={:?} after_first_done={} finished={} \
+                 max_live_gap={:.3}s (window margin {:.1}x) → {}",
+                o.dones.iter().map(|(s, _)| format!("{s:?}")).collect::<Vec<_>>(),
+                o.after_first_done,
+                o.finished,
+                o.max_gap.as_secs_f64(),
+                30.0 / o.max_gap.as_secs_f64().max(0.001),
+                if clean { "CLEAN" } else { "VIOLATION" }
+            );
+            if !clean {
+                failures.push(format!(
+                    "[{name}] run {i}: dones={:?} after={} finished={}",
+                    o.dones, o.after_first_done, o.finished
+                ));
+            }
+        }
+    }
+    assert!(failures.is_empty(), "{failures:#?}");
+}


### PR DESCRIPTION
## The incident (2026-08-13, three occurrences in one live session)

The blanket dropped-reply settle added in the turn-quiesce-watchdog merge treats 30s of wire silence — with content streamed, all tools resolved, nothing pending — as a dropped `session/prompt` response. For Claude, that state is **routine mid-turn silence**, not death:

- Recent models default `thinking.display` to `"omitted"`: the API streams signature-only thinking deltas with empty text, and `claude-agent-acp@0.66.0` (correctly) forwards none of them (verified in the adapter source).
- Large-context TTFT and retry backoff add more legitimately silent stretches.

Each false trip is the one failure mode that **destroys the turn** rather than dipping status:

```
09:00:17 WARN comet_harness::acp: turn quiet past the settle window ... quiet_ms=30000   ← premature Done{completed}, UI flips "done" mid-turn
09:00:56 INFO comet_engine::sessions: parked session resumed by self-continued agent output
09:09:33 WARN comet_engine::sessions: turn quiesced ... (suspected missing harness Done) ← 120s watchdog rescues the orphan
```

The false settle drops the turn future, so the turn's **real** response later resolves a closed channel: no Done ever arrives, and the session strands Working after the answer lands until the engine watchdog parks it. Both user-visible bugs — "session said done but it was still working" and "stuck on Working/Scheming after the reply" — are this single defect. The 2026-08-12 starve fixes themselves held: today's logs contain zero starve signatures.

## Fix

Exempt Claude from the blanket quiet settle (even under `COMET_ACP_QUIET_SETTLE_MS` — the heuristic's premise, "live turns make noise", is structurally false for this adapter). Claude turns settle only on deterministic evidence, all pre-existing:

| case | signal | latency |
|---|---|---|
| healthy turn end | real `session/prompt` response | immediate |
| dropped reply, unsteered | turn-end cost frame hint | ~1s |
| dropped reply, steered | `noRunningTurn` steering evidence | next interaction |
| anything else | engine turn-quiesce watchdog (false-trip **safe**: parks status, never ends the run) | 120s backstop |

Other adapters keep the 30s heuristic — they stream thought chunks, so silence genuinely is suspicious there.

## Tests

- New `claude_thinking_silence_never_settles_the_turn` (`acp_quiet.rs`) + `scenario:quiet-thinking` fixture: tool resolves → 4s quiet (3× window) → output resumes → real `end_turn`. Against the unfixed code it reproduces the incident exactly (synthetic Done mid-silence, "finished" streaming after it); with the fix, one Done, correctly ordered.
- `comet-harness` suites: 31 passed / 7 ignored. `comet-engine --test turn_quiesce`: 4 passed. (Pre-existing, unrelated local failure: `shell_env...falls_back_when_interactive_attempt_hangs`, also fails at clean HEAD.)

## Residual (follow-up, not this PR)

A single silent stretch >120s can still false-park via the engine watchdog (safe: status dip only, self-heals on next output). Closing it needs adapter-side turn-lifecycle liveness — upstream issue against `claude-agent-acp`; a naive comet-side keepalive was considered and rejected (heartbeating an unsettled-but-starved turn would disarm the backstop and make a real starve hang forever).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789205912&installation_model_id=425430&pr_number=61&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F61&signature=16fcafc20cd3ce3dc6650e9b14d7b79d42243b98f9f4e282f0a770ab35caa20a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->