### PR TITLE
macOS releases: Developer ID signing + notarization in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,57 @@ jobs:
   # Heads-up: the macOS cfg paths (Keychain in agent_accounts.rs) have never
   # been type-checked against the Apple SDK — this job may surface errors on
   # its first runs. continue-on-error keeps the Linux release shippable.
+  #
+  # Signing/notarization (both optional — absent secrets fall back to an
+  # ad-hoc-signed build):
+  #   MACOS_CERT_P12 / MACOS_CERT_PASSWORD — base64 "Developer ID Application"
+  #     certificate + private key (.p12) and its export password.
+  #   AC_API_KEY_P8 / AC_API_KEY_ID / AC_API_ISSUER_ID — App Store Connect API
+  #     key (raw .p8 contents), for notarytool. All three present → the package
+  #     script notarizes and staples the app + dmg (no Gatekeeper warning).
   macos:
     runs-on: macos-latest # Apple silicon
     continue-on-error: true
+    env:
+      MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      AC_API_KEY_P8: ${{ secrets.AC_API_KEY_P8 }}
+      AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
+      AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
     steps:
       - uses: actions/checkout@v4
       - name: rust toolchain (rust-toolchain.toml)
         run: rustup show active-toolchain || rustup toolchain install
       - uses: Swatinem/rust-cache@v2
+      - name: import Developer ID certificate
+        if: env.MACOS_CERT_P12 != ''
+        run: |
+          keychain="$RUNNER_TEMP/release.keychain-db"
+          pass="$(openssl rand -hex 16)"
+          security create-keychain -p "$pass" "$keychain"
+          security set-keychain-settings -lut 3600 "$keychain"
+          security unlock-keychain -p "$pass" "$keychain"
+          printf '%s' "$MACOS_CERT_P12" | base64 -d >"$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
+            -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign
+          rm -f "$RUNNER_TEMP/cert.p12"
+          # Allow codesign to use the imported key without a UI prompt.
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$pass" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain" login.keychain-db
+          identity="$(security find-identity -v -p codesigning "$keychain" \
+            | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p' | head -1)"
+          [ -n "$identity" ] || { echo "p12 contains no Developer ID Application identity"; exit 1; }
+          echo "CODESIGN_IDENTITY=$identity" >>"$GITHUB_ENV"
+      - name: notary credentials
+        if: env.AC_API_KEY_P8 != ''
+        run: |
+          printf '%s' "$AC_API_KEY_P8" >"$RUNNER_TEMP/ac_api_key.p8"
+          {
+            echo "NOTARY_KEY_PATH=$RUNNER_TEMP/ac_api_key.p8"
+            echo "NOTARY_KEY_ID=$AC_API_KEY_ID"
+            echo "NOTARY_ISSUER_ID=$AC_API_ISSUER_ID"
+          } >>"$GITHUB_ENV"
       - name: package dmg
         run: scripts/package-macos.sh
       - uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target
 **/*.rs.bk
+# Local-only scratch space — holds signing/notary credentials, never commit.
+/ignore/
 *.pdb
 .DS_Store
 .env

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -6,6 +6,9 @@
 #
 # Usage: scripts/package-macos.sh
 # Env:   CODESIGN_IDENTITY="Developer ID Application: …" to sign the bundle.
+#        NOTARY_KEY_PATH + NOTARY_KEY_ID + NOTARY_ISSUER_ID — App Store Connect
+#        API key (.p8) for notarization; all three set → notarize + staple the
+#        app and the dmg, which removes the Gatekeeper warning entirely.
 
 set -euo pipefail
 
@@ -38,11 +41,36 @@ iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/zeron.icns"
 rm -rf "$ICONSET"
 
 if [[ -n "${CODESIGN_IDENTITY:-}" ]]; then
-  codesign --deep --force --options runtime --sign "$CODESIGN_IDENTITY" "$APP"
+  # Hardened runtime + secure timestamp are both notarization requirements.
+  # (No --deep: Apple deprecated it; the bundle is a single Mach-O anyway.)
+  codesign --force --options runtime --timestamp --sign "$CODESIGN_IDENTITY" "$APP"
 else
   # Ad-hoc signature so the app launches on Apple silicon (Gatekeeper still
   # requires right-click → Open on first launch without notarization).
   codesign --deep --force --sign - "$APP"
+fi
+
+# notarize <path>: submit to Apple and wait for the verdict. A rejection may
+# still exit 0 depending on the notarytool version — the `stapler staple` that
+# follows each call has no ticket to attach then, and fails the build for us.
+notarize() {
+  xcrun notarytool submit "$1" \
+    --key "$NOTARY_KEY_PATH" --key-id "$NOTARY_KEY_ID" \
+    --issuer "$NOTARY_ISSUER_ID" --wait
+}
+NOTARIZE=false
+[[ -n "${NOTARY_KEY_PATH:-}" && -n "${NOTARY_KEY_ID:-}" && -n "${NOTARY_ISSUER_ID:-}" ]] && NOTARIZE=true
+
+if $NOTARIZE; then
+  # Staple the bundle BEFORE tarring it: the auto-updater swaps the .app with
+  # no dmg involved, so the tarball copy must carry its own ticket to pass
+  # Gatekeeper offline. The ticket lives inside the bundle, so the tarball's
+  # Zeron.app → Comet.app rename below doesn't disturb it.
+  ZIP="$OUT_DIR/zeron-notarize.zip"
+  ditto -c -k --keepParent "$APP" "$ZIP"
+  notarize "$ZIP"
+  rm -f "$ZIP"
+  xcrun stapler staple "$APP"
 fi
 
 # The auto-updater artifact: keep the historical Comet.app path inside the
@@ -52,4 +80,8 @@ tar -czf "$APP_TARBALL" -s '/^Zeron\.app/Comet.app/' -C "$OUT_DIR" Zeron.app
 echo "packaged: $APP_TARBALL"
 
 hdiutil create -volname Zeron -srcfolder "$APP" -ov -format UDZO "$DMG"
+if $NOTARIZE; then
+  notarize "$DMG"
+  xcrun stapler staple "$DMG"
+fi
 echo "packaged: $DMG"


### PR DESCRIPTION
Signed, notarized, stapled macOS releases — no more Gatekeeper "unverified developer" warning or right-click → Open dance.

## What changed

- **`scripts/package-macos.sh`** — when `CODESIGN_IDENTITY` is set, signs with hardened runtime + secure timestamp (both notarization requirements; drops the deprecated `--deep`). When the three `NOTARY_*` vars are also set, submits to Apple via `notarytool`, staples the ticket onto the app bundle *before* the auto-updater tarball is created (updated installs need their own ticket — the updater swaps the .app with no dmg involved), then notarizes + staples the dmg too. The stapled ticket lives inside the bundle, so the tarball's `Zeron.app` → `Comet.app` compatibility rename is unaffected.
- **`.github/workflows/release.yml`** — the `macos` job imports the Developer ID `.p12` from secrets into a throwaway keychain (random password, auto-locking, codesign granted non-interactive access), extracts the identity, and writes the App Store Connect key to disk for `notarytool`.
- **`.gitignore`** — ignores `/ignore/`, the local scratch dir holding signing credentials (it was not previously ignored).

## Rollout

- All five secrets are already set on this repo: `MACOS_CERT_P12`, `MACOS_CERT_PASSWORD`, `AC_API_KEY_P8`, `AC_API_KEY_ID`, `AC_API_ISSUER_ID`. The p12 was dry-run through the exact CI import sequence locally and yields a valid `Developer ID Application: 1499487 B.C. Ltd. (5XY3M483YQ)` identity; the notary key was verified against Apple's notary service.
- Missing secrets → graceful fallback to the current ad-hoc-signed build, so forks and secret-less runs are unaffected.
- Notarization adds a few minutes of wall-clock to the macOS job (Apple-side scan).
- The cert expires **2027-02-01** (capped to team membership period); already-shipped builds stay valid past that, new releases will need a renewed cert + updated secrets.
- Follow-up once the first signed release lands: consider dropping `continue-on-error: true` from the `macos` job so signing failures block a release instead of silently shipping Linux-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789239546&installation_model_id=425430&pr_number=64&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F64&signature=6709d10ed0889df60fc070186a6fdd505b294bff3067161d2108a5b8ad90942d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->