### PR TITLE
Settle self-continued turns: adapter turn-end extension + short quiesce window

### DIFF
--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -1139,6 +1139,28 @@ async fn drive_run(
         None => Some(std::time::Duration::from_secs(120)),
     };
     let mut last_stream_activity = tokio::time::Instant::now();
+    // SELF-CONTINUED turns get a much SHORTER quiesce window. A turn the
+    // agent starts on its own (background-task wake) can never receive a
+    // harness Done: the adapter has no `session/prompt` outstanding to
+    // settle — verified in claude-agent-acp's autonomous-result lane, which
+    // consumes the SDK's turn-end without emitting anything; codex shows
+    // the same shape. The watchdog is that turn shape's ONLY settle path,
+    // so the default 120s window read as 2min of stuck-Working after every
+    // background notification (user report 2026-08-13). The in-flight
+    // fold gate below still protects running tools; reasoning heartbeats
+    // push the window during real thinking. `COMET_SELF_TURN_QUIESCE_MS`
+    // overrides; 0 falls back to the normal window. An explicit
+    // `COMET_TURN_QUIESCE_MS=0` still disables the watchdog entirely.
+    let self_quiesce_after: Option<std::time::Duration> =
+        match std::env::var("COMET_SELF_TURN_QUIESCE_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+        {
+            Some(0) => None,
+            Some(ms) => Some(std::time::Duration::from_millis(ms)),
+            None => Some(std::time::Duration::from_secs(20)),
+        };
+    let mut self_continued_turn = false;
 
     let final_status = loop {
         let event: AgentEvent = tokio::select! {
@@ -1232,9 +1254,13 @@ async fn drive_run(
             // fold still arms — a Steered boundary that no output ever
             // follows is one of the wedge shapes — it just parks without
             // writing a segment (an empty finalize would leave a stub entry).
-            _ = tokio::time::sleep_until(
-                last_stream_activity + quiesce_after.unwrap_or_default()
-            ), if quiesce_after.is_some()
+            _ = tokio::time::sleep_until({
+                let mut window = quiesce_after.unwrap_or_default();
+                if self_continued_turn && let Some(short) = self_quiesce_after {
+                    window = window.min(short);
+                }
+                last_stream_activity + window
+            }), if quiesce_after.is_some()
                 && idle_since.is_none()
                 && !interrupted
                 && steerable
@@ -1271,6 +1297,7 @@ async fn drive_run(
                 entry_id = new_id();
                 segment_started = now_ms();
                 idle_since = Some(tokio::time::Instant::now());
+                self_continued_turn = false;
                 inner.set_status(&chat_id, SessionStatus::Idle, false);
                 continue;
             }
@@ -1346,6 +1373,7 @@ async fn drive_run(
                     "parked session resumed by self-continued agent output"
                 );
                 idle_since = None;
+                self_continued_turn = true;
                 // The park cleared the fold; rotate to a fresh entry and
                 // fall through — this event is the new segment's first part.
                 entry_id = new_id();
@@ -1482,6 +1510,9 @@ async fn drive_run(
         } = &event
         {
             inner.publish(&chat_id, &event);
+            // A steer boundary means a real prompt owns the turn again — its
+            // Done will come; the short self-continued window stands down.
+            self_continued_turn = false;
             if let Err(err) = finish_segment(
                 doc_ref,
                 writer.take(),
@@ -1624,6 +1655,7 @@ async fn drive_run(
                 // Resume-retry is strictly a first-turn concern.
                 saw_session_started = true;
                 idle_since = Some(tokio::time::Instant::now());
+                self_continued_turn = false;
                 inner.set_status(&chat_id, SessionStatus::Idle, false);
                 continue;
             }

--- a/crates/engine/tests/self_continued_quiesce.rs
+++ b/crates/engine/tests/self_continued_quiesce.rs
@@ -1,0 +1,310 @@
+//! The SHORT quiesce window for self-continued turns (2026-08-13 incident:
+//! "stuck in working after you finished watching the build").
+//!
+//! A turn the agent starts on its own — a background-task wake — can never
+//! receive a harness Done: the adapter has no `session/prompt` outstanding to
+//! settle, so the quiesce watchdog is that turn shape's ONLY settle path.
+//! With the shared 120s window every background notification ended in ~2min
+//! of phantom Working. Self-continued turns now use a much shorter window
+//! (`COMET_SELF_TURN_QUIESCE_MS`); prompt/steer turns keep the normal one.
+//!
+//! This file exists separately from `turn_quiesce.rs` because the env knobs
+//! are process-global: here the NORMAL window is set far beyond the test
+//! horizon, so a fast park can only have come through the short path.
+
+use std::sync::{Arc, Once};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use tokio::sync::{Mutex, mpsc};
+
+use comet_engine::{EngineCore, HarnessRegistry};
+use comet_harness::{Harness, HarnessError, RunControls};
+use comet_proto::{
+    AgentEvent, DoneStatus, HarnessId, Model, ReasoningLevel, RunRequest, SandboxLevel,
+    SessionStatus, SteeringMode,
+};
+
+const CHAT: &str = "chat-self-quiesce";
+/// Normal window: far beyond the test horizon — any park inside the test
+/// window must have come through the self-continued path.
+const QUIESCE_MS: u64 = 600_000;
+/// Short window under test.
+const SELF_QUIESCE_MS: u64 = 400;
+
+fn init_env() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: called before any engine (and thus any reader of the vars)
+        // exists in this test process.
+        unsafe {
+            std::env::set_var("COMET_TURN_QUIESCE_MS", QUIESCE_MS.to_string());
+            std::env::set_var("COMET_SELF_TURN_QUIESCE_MS", SELF_QUIESCE_MS.to_string());
+        }
+    });
+}
+
+fn run_request(prompt: &str) -> RunRequest {
+    RunRequest {
+        prompt: prompt.into(),
+        harness: None,
+        model: None,
+        reasoning: None,
+        model_options: Default::default(),
+        cwd: "/tmp".into(),
+        sandbox: SandboxLevel::WorkspaceWrite,
+        auto_approve: true,
+        attachments: Vec::new(),
+        resume: None,
+    }
+}
+
+fn done(status: DoneStatus) -> AgentEvent {
+    AgentEvent::Done {
+        status,
+        result: None,
+        error: None,
+        session_id: Some("hs-sq".into()),
+    }
+}
+
+fn session_started() -> AgentEvent {
+    AgentEvent::SessionStarted {
+        harness: HarnessId::Mock,
+        model: "mock-1".into(),
+        tools: vec![],
+        cwd: "/tmp".into(),
+        session_id: "hs-sq".into(),
+        assistant_message_id: "a-sq".into(),
+    }
+}
+
+fn text(t: &str) -> AgentEvent {
+    AgentEvent::TextDelta { text: t.into() }
+}
+
+/// Feed-by-hand harness (see `turn_quiesce.rs`): the test pushes events
+/// through a channel; accepted steers confirm with a `Steered` boundary.
+struct FeedHarness {
+    main_prompt: String,
+    feed: Mutex<Option<mpsc::UnboundedReceiver<AgentEvent>>>,
+}
+
+#[async_trait]
+impl Harness for FeedHarness {
+    fn id(&self) -> HarnessId {
+        HarnessId::Mock
+    }
+    fn display_name(&self) -> &str {
+        "Feed"
+    }
+    fn supports_steering(&self) -> bool {
+        true
+    }
+    fn steering_mode(&self) -> SteeringMode {
+        SteeringMode::StepBoundary
+    }
+    fn reasoning_levels(&self) -> &[ReasoningLevel] {
+        &[ReasoningLevel::Medium]
+    }
+    async fn models(&self) -> Result<Vec<Model>, HarnessError> {
+        Ok(vec![])
+    }
+    async fn run(
+        &self,
+        request: RunRequest,
+        mut controls: RunControls,
+    ) -> Result<BoxStream<'static, Result<AgentEvent, HarnessError>>, HarnessError> {
+        if request.prompt != self.main_prompt {
+            let events = vec![Ok(done(DoneStatus::Completed))];
+            return Ok(futures::stream::iter(events).boxed());
+        }
+        let mut feed = self
+            .feed
+            .lock()
+            .await
+            .take()
+            .expect("FeedHarness serves the main dispatch once per test");
+        let (tx, rx) = mpsc::channel::<Result<AgentEvent, HarnessError>>(64);
+        tokio::spawn(async move {
+            let mut steering_open = true;
+            loop {
+                tokio::select! {
+                    biased;
+                    steer = controls.steering.recv(), if steering_open => match steer {
+                        Some(_) => {
+                            let boundary = AgentEvent::Steered {
+                                assistant_message_id: None,
+                                next_assistant_message_id: None,
+                            };
+                            if tx.send(Ok(boundary)).await.is_err() {
+                                return;
+                            }
+                        }
+                        None => steering_open = false,
+                    },
+                    event = feed.recv() => match event {
+                        Some(event) => {
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
+                            }
+                        }
+                        None => return,
+                    },
+                }
+            }
+        });
+        Ok(futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|event| (event, rx))
+        })
+        .boxed())
+    }
+}
+
+struct Rig {
+    core: EngineCore,
+    feed: mpsc::UnboundedSender<AgentEvent>,
+    _dir: tempfile::TempDir,
+}
+
+fn assemble(main_prompt: &str) -> Rig {
+    init_env();
+    let (feed, rx) = mpsc::unbounded_channel();
+    let registry = HarnessRegistry::new();
+    registry.register(Arc::new(FeedHarness {
+        main_prompt: main_prompt.into(),
+        feed: Mutex::new(Some(rx)),
+    }));
+    let dir = tempfile::tempdir().unwrap();
+    let core = EngineCore::assemble(dir.path(), Arc::new(registry), HarnessId::Mock, None)
+        .expect("engine core assembles");
+    Rig {
+        core,
+        feed,
+        _dir: dir,
+    }
+}
+
+fn status(core: &EngineCore) -> Option<SessionStatus> {
+    core.sessions.session_status(CHAT).map(|s| s.status)
+}
+
+async fn wait_for<F>(mut predicate: F, what: &str)
+where
+    F: FnMut() -> bool,
+{
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while !predicate() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for {what}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn self_continued_turn_parks_on_the_short_window() {
+    let rig = assemble("watch the build");
+    rig.core
+        .sessions
+        .dispatch(CHAT, HarnessId::Mock, run_request("watch the build"), None)
+        .await
+        .expect("dispatch");
+
+    // Turn 1 completes normally → parked Idle.
+    rig.feed.send(session_started()).unwrap();
+    rig.feed.send(text("I will watch the build.")).unwrap();
+    rig.feed.send(done(DoneStatus::Completed)).unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "park after Done",
+    )
+    .await;
+
+    // Background wake: self-continued output past the resume gate.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    rig.feed.send(text("The build is green. Released.")).unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Working),
+        "self-continued output resumes Working",
+    )
+    .await;
+
+    // The short window parks it well inside the 10s wait_for horizon — the
+    // normal window (10 min here) could not have.
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "short quiesce parks the self-continued turn",
+    )
+    .await;
+
+    rig.core.sessions.shutdown().await;
+}
+
+#[tokio::test]
+async fn steered_turn_keeps_the_normal_window() {
+    let rig = assemble("watch the build again");
+    rig.core
+        .sessions
+        .dispatch(
+            CHAT,
+            HarnessId::Mock,
+            run_request("watch the build again"),
+            None,
+        )
+        .await
+        .expect("dispatch");
+
+    rig.feed.send(session_started()).unwrap();
+    rig.feed.send(text("Watching.")).unwrap();
+    rig.feed.send(done(DoneStatus::Completed)).unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "park after Done",
+    )
+    .await;
+
+    // Background wake resumes the session (short window armed)…
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    rig.feed.send(text("Build done.")).unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Working),
+        "self-continued output resumes Working",
+    )
+    .await;
+
+    // …then a real steer takes the turn over: the short window must stand
+    // down. The steered turn's reply streams and goes quiet — with the
+    // normal window at 10 minutes, the session must STAY Working well past
+    // the short window (its Done is genuinely coming).
+    rig.core
+        .sessions
+        .steer(CHAT, "and then?", None)
+        .await
+        .expect("steer accepted");
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Working),
+        "steered turn is Working",
+    )
+    .await;
+    rig.feed.send(text("Answering the steer.")).unwrap();
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert_eq!(
+        status(&rig.core),
+        Some(SessionStatus::Working),
+        "a steered (prompt-owned) turn must not park on the short window"
+    );
+
+    // Clean turn end.
+    rig.feed.send(done(DoneStatus::Completed)).unwrap();
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Idle),
+        "steered turn parks at its Done",
+    )
+    .await;
+
+    rig.core.sessions.shutdown().await;
+}

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -2320,6 +2320,30 @@ async fn run_session(session: Session) {
                     // tolerated by design.
                     let events = if method == "session/update" {
                         session_update_events(&params, &session_id)
+                    } else if method == "_session/turn_ended" {
+                        // Autonomous turn-end (claude-agent-acp extension,
+                        // `_`-prefixed like `_session/steering`): a turn the
+                        // agent started on its own — a background-task wake —
+                        // has no `session/prompt` to settle, so its SDK-side
+                        // turn-end previously vanished at the adapter and the
+                        // engine's quiesce watchdog was the only settle path
+                        // (≤2min of phantom Working per notification, user
+                        // report 2026-08-13). Gated to BETWEEN prompts: a
+                        // live turn settles through its own response.
+                        if turn.is_none()
+                            && !interrupted
+                            && params.get("sessionId").and_then(Value::as_str)
+                                == Some(session_id.as_str())
+                        {
+                            vec![AgentEvent::Done {
+                                status: DoneStatus::Completed,
+                                result: None,
+                                error: None,
+                                session_id: Some(session_id.clone()),
+                            }]
+                        } else {
+                            Vec::new()
+                        }
                     } else {
                         cursor_notification_events(&method, &params)
                     };

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -1484,3 +1484,42 @@ async fn injection_cost_frame_never_settles_a_steered_turn() {
         .expect("done asserted above");
     assert!(tail < done, "{events:?}");
 }
+
+#[tokio::test]
+async fn autonomous_turn_ended_extension_settles_between_prompts() {
+    // A background-task wake makes the agent stream a turn no prompt started;
+    // its SDK-side turn-end has no `session/prompt` to settle, so the adapter
+    // forwards the `_session/turn_ended` extension instead — which must map
+    // to a completed Done exactly once, only for this session, and only
+    // between prompts (the engine's quiesce watchdog then stays a backstop,
+    // not the settle path).
+    let (controls, _steer, _token) = controls();
+    let events = run_to_end(&harness(), request("scenario:autonomous-end"), controls).await;
+
+    let d = dones(&events);
+    assert_eq!(d.len(), 2, "prompt turn + autonomous turn, no third: {events:?}");
+    assert!(
+        d.iter().all(|(s, e)| *s == DoneStatus::Completed && e.is_none()),
+        "{events:?}"
+    );
+
+    // The self-continued output sits BETWEEN the two Dones.
+    let first_done = events
+        .iter()
+        .position(|e| matches!(e, AgentEvent::Done { .. }))
+        .unwrap();
+    let last_done = events
+        .iter()
+        .rposition(|e| matches!(e, AgentEvent::Done { .. }))
+        .unwrap();
+    let background = events
+        .iter()
+        .position(
+            |e| matches!(e, AgentEvent::TextDelta { text } if text == "background finished"),
+        )
+        .expect("self-continued output surfaces: {events:?}");
+    assert!(
+        first_done < background && background < last_done,
+        "{events:?}"
+    );
+}

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -94,6 +94,20 @@ case "$promptline" in
   emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
   ;;
 
+*scenario:autonomous-end*)
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"on it"}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  # Background-task wake: a self-continued cycle streams real output with no
+  # prompt in flight, then announces its end with the turn-ended extension.
+  # The sleep orders it AFTER the prompt response settles (responses resolve
+  # through a different channel than notifications and can race).
+  sleep 1
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"background finished"}}'
+  emit "{\"method\":\"_session/turn_ended\",\"params\":{\"sessionId\":\"$SID\",\"stopReason\":\"end_turn\"}}"
+  # Another session's marker must map to nothing.
+  emit "{\"method\":\"_session/turn_ended\",\"params\":{\"sessionId\":\"other\",\"stopReason\":\"end_turn\"}}"
+  ;;
+
 *scenario:happy*)
   update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello"}}'
   update '{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking"}}'


### PR DESCRIPTION
Root-caused live from this dogfood session (the "stuck in Working after watching the build" report): a turn the agent starts on its own — a background-task wake — **can never receive a harness Done**. The adapter has no `session/prompt` outstanding to settle; claude-agent-acp's autonomous-result lane consumes the SDK's turn-end without emitting anything (verified in its source), and codex shows the same shape. The 120s quiesce watchdog was that turn shape's *only* settle path, so every background notification ended in ~2 minutes of phantom Working (engine log: resumed 21:16:17 → quiesced 21:18:36, +120s exactly).

## Two complementary fixes

**Harness (claude, precise)** — map the adapter's new `_session/turn_ended` extension notification to a completed `Done`, gated to between prompts and to this session's id. The Done rides the existing park path, so status settles the moment the agent finishes. Companion adapter PR: agentclientprotocol/claude-agent-acp (out-of-turn `extNotification` from the autonomous-result lane, `_`-prefixed per ACP extension conventions — clients that don't know it ignore it).

**Engine (generic — covers codex and any harness)** — self-continued turns quiesce on a much shorter window (`COMET_SELF_TURN_QUIESCE_MS`, default 20s), tracked from the self-continued resume until a Steered boundary or Done hands the turn back to a prompt. The unresolved-tool fold gate still protects running commands; `COMET_TURN_QUIESCE_MS=0` still disables the watchdog entirely.

## Verification

- Harness test: fake-acp scenario proves the extension maps to exactly one Done, session-gated, between prompts only.
- Engine tests: the short window parks a self-continued turn where the normal window is set to 10 minutes; a steer handback keeps the normal window (prompt-owned turns never park early).
- **Live E2E** against the real claude CLI with the patched adapter (`CLAUDE_ACP_EXECUTABLE`): background `sleep 8` task → turn 1 Done → wake → "finished" → **Done via the extension, zero "turn quiesced" lines** in the engine log. Journal tail: `textDelta "finished"` immediately followed by `done completed` — the event that was missing from the production incident's journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789251873&installation_model_id=425430&pr_number=69&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F69&signature=3f7a64013cb93e8ba93492b909ceba0b188c72da59f58e1770efddd683626b90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->