### PR TITLE
Restore window blur on macOS 27

### DIFF
--- a/crates/ui/src/appearance.rs
+++ b/crates/ui/src/appearance.rs
@@ -228,6 +228,85 @@ fn sync_ns_appearance(mode: AppearanceMode) {
 #[cfg(not(target_os = "macos"))]
 fn sync_ns_appearance(_mode: AppearanceMode) {}
 
+/// Restore gpui's behind-window blur on macOS 27.
+///
+/// The pinned gpui fork builds its `BlurredView` with the semantic
+/// `NSVisualEffectMaterialSelection` material. On macOS 27 that material no
+/// longer creates a `CABackdropLayer`; it resolves to an opaque fill instead.
+/// The fork then strips that fill and installs its opaque Mission Control
+/// fallback, leaving the live window looking solid black beneath our frost.
+///
+/// `NSVisualEffectMaterialUnderWindowBackground` is the semantic material for
+/// this exact job and still creates the backdrop/filter hierarchy the fork's
+/// blur tuning expects. Keep the workaround here until the pinned fork changes
+/// its `blurred_view_init_with_frame` material upstream.
+#[cfg(target_os = "macos")]
+fn repair_macos_27_blur_material() {
+    use objc::runtime::{BOOL, Object, YES};
+    use objc::{class, msg_send, sel, sel_impl};
+
+    #[repr(C)]
+    struct OperatingSystemVersion {
+        major: isize,
+        minor: isize,
+        patch: isize,
+    }
+
+    unsafe fn repair_view_tree(view: *mut Object, blurred_view_name: *mut Object) -> usize {
+        unsafe {
+            let class_name: *mut Object = msg_send![view, className];
+            let is_gpui_blur: BOOL = msg_send![class_name, isEqualToString: blurred_view_name];
+            let mut repaired = 0;
+            if is_gpui_blur == YES {
+                // NSVisualEffectMaterialUnderWindowBackground = 21,
+                // NSVisualEffectBlendingModeBehindWindow = 0,
+                // NSVisualEffectStateActive = 1.
+                let _: () = msg_send![view, setMaterial: 21_isize];
+                let _: () = msg_send![view, setBlendingMode: 0_isize];
+                let _: () = msg_send![view, setState: 1_isize];
+                let _: () = msg_send![view, setNeedsDisplay: YES];
+                repaired += 1;
+            }
+
+            let subviews: *mut Object = msg_send![view, subviews];
+            let count: usize = msg_send![subviews, count];
+            for index in 0..count {
+                let child: *mut Object = msg_send![subviews, objectAtIndex: index];
+                repaired += repair_view_tree(child, blurred_view_name);
+            }
+            repaired
+        }
+    }
+
+    unsafe {
+        let process_info: *mut Object = msg_send![class!(NSProcessInfo), processInfo];
+        let version: OperatingSystemVersion = msg_send![process_info, operatingSystemVersion];
+        if version.major < 27 {
+            return;
+        }
+
+        let blurred_view_name: *mut Object = msg_send![
+            class!(NSString),
+            stringWithUTF8String: c"BlurredView".as_ptr()
+        ];
+        let app: *mut Object = msg_send![class!(NSApplication), sharedApplication];
+        let windows: *mut Object = msg_send![app, windows];
+        let count: usize = msg_send![windows, count];
+        let mut repaired = 0;
+        for index in 0..count {
+            let window: *mut Object = msg_send![windows, objectAtIndex: index];
+            let content_view: *mut Object = msg_send![window, contentView];
+            if !content_view.is_null() {
+                repaired += repair_view_tree(content_view, blurred_view_name);
+            }
+        }
+        tracing::trace!(repaired, "appearance: repaired macOS 27 blur material");
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn repair_macos_27_blur_material() {}
+
 /// Push the theme's window background appearance onto every open window.
 pub fn reapply_window_background(cx: &mut App) {
     let Some(wanted) = cx
@@ -243,6 +322,10 @@ pub fn reapply_window_background(cx: &mut App) {
             })
             .ok();
     }
+    // `set_background_appearance(Blurred)` synchronously inserts gpui's
+    // `BlurredView`, so repair its material only after every window has been
+    // updated. This also covers a view recreated after an opaque theme.
+    repair_macos_27_blur_material();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Restore Comet's transparent window appearance on macOS 27 by repairing the `NSVisualEffectView` created by GPUI.

The pinned GPUI fork creates its `BlurredView` with `NSVisualEffectMaterialSelection`. On macOS 27, that semantic material no longer produces the expected `CABackdropLayer`, causing GPUI's opaque fallback to remain visible beneath Comet's frost.

## Changes

- detect macOS 27 and newer at runtime
- find GPUI's `BlurredView` in each AppKit window hierarchy
- switch it to `NSVisualEffectMaterialUnderWindowBackground`
- preserve behind-window blending and the active visual-effect state
- reapply the compatibility fix whenever GPUI updates or recreates the blurred background
- leave macOS 26 and earlier unchanged

## Follow-up

This is a compatibility workaround for the currently pinned GPUI fork. The long-term fix should change the material in GPUI itself; this shim can then be removed after Comet updates to that revision.

## Validation

- `cargo check -p comet-ui`
- `rustfmt --edition 2024 --check crates/ui/src/appearance.rs`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789253655&installation_model_id=425430&pr_number=71&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F71&signature=6fa1aaff5315b1376d189c2b9a5718af717a040066831c69b09d0868e82d664b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->