### PR TITLE
Transcript: accurate rail during runway, smooth surround on chip toggles

### DIFF
--- a/crates/ui/src/rail.rs
+++ b/crates/ui/src/rail.rs
@@ -433,7 +433,26 @@ impl Transcript {
             return gpui::Empty.into_any_element();
         }
         let tick_rows: Vec<usize> = pairs.iter().map(|(_, row)| *row).collect();
-        let top_row = self.list_state().logical_scroll_top().item_ix;
+        // Active detection reads from the READING line, not the raw clip top:
+        // the titlebar overlays the list, so a row whose top sits within that
+        // chrome band is what you're reading — the sliver of the previous row
+        // above it is behind the blur. Concretely, the own-turn hold parks the
+        // newest prompt exactly at the chrome inset, and crediting the row at
+        // the raw clip top kept the PREVIOUS tick lit for the whole runway
+        // (user report). Walk forward over measured rows whose tops are at or
+        // above the reading line; unmeasured rows (None bounds) stop the walk,
+        // leaving the raw top row — the pre-fix behavior.
+        let mut top_row = self.list_state().logical_scroll_top().item_ix;
+        let read_top = f32::from(self.list_state().viewport_bounds().top())
+            + crate::transcript::OWN_SEND_TOP_INSET_PX
+            + 0.5;
+        while let Some(bounds) = self.list_state().bounds_for_item(top_row + 1) {
+            if f32::from(bounds.top()) <= read_top {
+                top_row += 1;
+            } else {
+                break;
+            }
+        }
         let active = active_tick(&tick_rows, top_row);
         let hover = self.rail_hover();
         let theme = Theme::of(cx).clone();

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -113,7 +113,7 @@ pub const GLIDE_MAX_VIEWPORTS: f32 = 2.5;
 /// A freshly-sent prompt rests this far below the transcript viewport's top.
 /// The titlebar overlays the full-height list, so its height is part of the
 /// inset; the extra 10px matches the first row's breathing room.
-const OWN_SEND_TOP_INSET_PX: f32 = Theme::TITLEBAR_HEIGHT + 10.0;
+pub(crate) const OWN_SEND_TOP_INSET_PX: f32 = Theme::TITLEBAR_HEIGHT + 10.0;
 /// Epsilon of extra height under the reservation. The runway ends AT the
 /// app's bottom — this is not scroll room (24px of it read as a janky
 /// overshoot-and-fight zone, user report) — it exists only to keep the held
@@ -3228,6 +3228,7 @@ impl Transcript {
                         .toggled_at
                         .is_some_and(|at| at.elapsed() < FOLD_TWEEN_WINDOW);
                 let toggle_key = key.clone();
+                let group_key = row_id.clone();
                 let mut card = div()
                     .my(px((CHIP_HEIGHT - CHIP_CARD_HEIGHT) / 2.0))
                     .ml(px(12.0))
@@ -3252,6 +3253,23 @@ impl Transcript {
                                 entry.open = Some(!currently_open);
                                 entry.epoch += 1;
                                 entry.toggled_at = Some(Instant::now());
+                                // Arm the GROUP body's height tween too (open
+                                // state untouched): the body's height is
+                                // analytic over the final detail state, so
+                                // without a tween the row snaps to the target
+                                // height while the card is still mid-tween —
+                                // content below teleported on expand and the
+                                // shrinking card clipped on collapse (user
+                                // report). `open_height` was computed with
+                                // the detail still in its pre-click state,
+                                // which is exactly the tween's start; both
+                                // tweens share the click instant and the
+                                // RESIZE curve, so the row tracks the card's
+                                // bottom edge frame-for-frame.
+                                let group = this.folds.entry(group_key.clone()).or_default();
+                                group.from = open_height;
+                                group.epoch += 1;
+                                group.toggled_at = Some(Instant::now());
                                 cx.notify();
                             }))
                             .child(chip_header(tool, open, theme)),


### PR DESCRIPTION
Two user-reported follow-ups to the runway rework (#74).

## Rail inaccurate while the runway is active

The own-turn hold parks the newest prompt `TITLEBAR_HEIGHT + 10` px below the viewport top, but the rail's active-tick detection used `logical_scroll_top().item_ix` — the row at the raw clip top, i.e. the tail of the *previous* turn. Result: the previous prompt's tick stayed lit the entire time you were held on the newest one.

Fix: active detection reads from the **reading line** (viewport top + chrome inset). Measured rows whose tops sit within the titlebar band count as the top row — the sliver of the row above is behind the blur anyway. Unmeasured rows stop the walk, degrading to the old behavior. Not runway-special-cased; manual scrolling gets the same slightly earlier, more truthful tick flips.

## Individual chip expand/collapse jumps the content around it

The chip card tweens its height over 200ms, but the group body containing it renders at an analytic height computed from the **final** detail state — so the row snapped instantly. On expand: text below teleported down, leaving a blank gap under the chips while the card caught up. On collapse: the row snapped short and clipped the still-shrinking card. (Group toggles never had this problem because they tween the body itself.)

Fix: a chip toggle also arms the group body's height tween (open state untouched) from the pre-click height. Both tweens share the click instant and the `RESIZE` curve, so the row's bottom edge tracks the card frame-for-frame and content below glides in sync.

Verified by eye in a dev build against live sessions: held-runway rail tick correct while streaming, chip expand/collapse glides the text below with zero clipping, group fold unchanged. 402 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789279219&installation_model_id=425430&pr_number=76&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F76&signature=49d49c2b5e87558c609abb81360b6d0179445354a49abb75ba97d887812e90d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->