### PR TITLE
changes: comment a diff line, stage it on the next prompt

### DIFF
--- a/crates/ui/src/badges.rs
+++ b/crates/ui/src/badges.rs
@@ -1,0 +1,112 @@
+//! Message badges: the compact pills that stand in for structured context a
+//! user message carries.
+//!
+//! The whole family shares one shape. Some feature stages context against the
+//! composer, folds it into the outgoing prompt as PLAIN TEXT (there is no
+//! second data model — see `comments.rs` and `attachments.rs`), and registers
+//! a [`Extractor`] here. The composer shows the staged set as a pill while it
+//! is being written; once sent, [`split`] lifts the same block back out of the
+//! transcript's raw text so the message reads as one pill over the bubble
+//! instead of a wall of machine-addressed bullets.
+//!
+//! Adding a second kind of pill means adding an extractor to [`EXTRACTORS`]
+//! and a matching stager on the composer side. Nothing here knows what a diff
+//! comment is.
+
+use gpui::{ParentElement, SharedString, Styled, div, px};
+
+use crate::theme::Theme;
+
+/// One pill: an icon and a short label, both already resolved for display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageBadge {
+    /// An `icons::*` asset name.
+    pub icon: &'static str,
+    pub label: SharedString,
+}
+
+/// Lifts one feature's trailing block out of a sent message. Returns the text
+/// with the block removed plus the pill that replaces it, or `None` when this
+/// message carries nothing of that kind.
+pub type Extractor = fn(&str) -> Option<(String, MessageBadge)>;
+
+/// Every registered extractor, applied in order. Each one sees the text the
+/// previous ones already stripped, so two features can ride the same prompt.
+const EXTRACTORS: &[Extractor] = &[crate::comments::extract_badge];
+
+/// Split every registered badge block back out of a sent user message.
+///
+/// Pure over the text, like `attachments::parse_user_message_images` — the
+/// transcript's row version stays a valid cache key because nothing here
+/// depends on state outside the string.
+pub fn split(text: &str) -> (String, Vec<MessageBadge>) {
+    let mut rest = text.to_string();
+    let mut badges = Vec::new();
+    for extract in EXTRACTORS {
+        if let Some((stripped, badge)) = extract(&rest) {
+            rest = stripped;
+            badges.push(badge);
+        }
+    }
+    (rest, badges)
+}
+
+/// Rendered height of a pill, and of the row that holds one. The composer
+/// sizes its own strip arithmetically, so this has to be a constant.
+pub const BADGE_HEIGHT: f32 = 24.0;
+
+/// The pill itself — one element, so the composer's staged chip and the
+/// transcript's sent chip can never drift apart.
+pub fn render(badge: &MessageBadge, theme: &Theme) -> gpui::Div {
+    div()
+        .h(px(BADGE_HEIGHT))
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap(px(6.0))
+        .px(px(8.0))
+        .rounded(px(8.0))
+        .bg(crate::theme::ink(0.06))
+        .text_size(px(12.0))
+        .font_weight(gpui::FontWeight::MEDIUM)
+        .text_color(theme.text_muted)
+        .child(
+            crate::icons::icon(badge.icon)
+                .size(px(12.0))
+                .text_color(theme.text_muted.opacity(0.7)),
+        )
+        .child(badge.label.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::comments::{CommentSide, DiffComment, with_comments};
+
+    #[test]
+    fn a_plain_message_carries_no_badges() {
+        let (text, badges) = split("just a prompt");
+        assert_eq!(text, "just a prompt");
+        assert!(badges.is_empty());
+    }
+
+    #[test]
+    fn a_sent_comment_block_becomes_one_pill() {
+        let staged = vec![
+            DiffComment::new("a.rs", CommentSide::New, 3, "fix"),
+            DiffComment::new("b.rs", CommentSide::Old, 9, "why"),
+        ];
+        let (text, badges) = split(&with_comments("do", &staged));
+        assert_eq!(text, "do");
+        assert_eq!(badges.len(), 1);
+        assert_eq!(badges[0].label.as_ref(), "2 comments");
+    }
+
+    #[test]
+    fn a_comment_only_send_keeps_its_stand_in_body() {
+        let staged = vec![DiffComment::new("a.rs", CommentSide::New, 3, "fix")];
+        let (text, badges) = split(&with_comments("", &staged));
+        assert_eq!(text, crate::comments::COMMENT_ONLY_TEXT);
+        assert_eq!(badges[0].label.as_ref(), "1 comment");
+    }
+}

--- a/crates/ui/src/badges.rs
+++ b/crates/ui/src/badges.rs
@@ -1,44 +1,46 @@
-//! Message badges: the compact pills that stand in for structured context a
-//! user message carries.
+//! Message badges: pills standing in for structured context a user message
+//! carries.
 //!
-//! The whole family shares one shape. Some feature stages context against the
-//! composer, folds it into the outgoing prompt as PLAIN TEXT (there is no
-//! second data model — see `comments.rs` and `attachments.rs`), and registers
-//! a [`Extractor`] here. The composer shows the staged set as a pill while it
-//! is being written; once sent, [`split`] lifts the same block back out of the
-//! transcript's raw text so the message reads as one pill over the bubble
-//! instead of a wall of machine-addressed bullets.
-//!
-//! Adding a second kind of pill means adding an extractor to [`EXTRACTORS`]
-//! and a matching stager on the composer side. Nothing here knows what a diff
-//! comment is.
+//! A feature stages context on the composer, folds it into the prompt as plain
+//! text, and registers an [`Extractor`]. [`split`] lifts that block back out of
+//! the sent message so the transcript draws a pill instead of the bullets the
+//! agent reads. Nothing here knows what a diff comment is.
 
-use gpui::{ParentElement, SharedString, Styled, div, px};
+use std::sync::Arc;
+use std::time::Duration;
+
+use gpui::{Context, IntoElement, Render, SharedString, Window, div, prelude::*, px};
 
 use crate::theme::Theme;
 
-/// One pill: an icon and a short label, both already resolved for display.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MessageBadge {
     /// An `icons::*` asset name.
     pub icon: &'static str,
     pub label: SharedString,
+    /// Empty means the label says everything and the pill carries no card.
+    pub details: Vec<BadgeDetail>,
 }
 
-/// Lifts one feature's trailing block out of a sent message. Returns the text
-/// with the block removed plus the pill that replaces it, or `None` when this
-/// message carries nothing of that kind.
+/// One row of a hover card. Three generic slots, so a new badge kind fills them
+/// without this module learning what it cites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BadgeDetail {
+    /// `src/main.rs:42`, a URL, a commit subject.
+    pub location: SharedString,
+    /// `L`/`R` for a diff side, a status, a count.
+    pub tag: Option<SharedString>,
+    pub body: SharedString,
+}
+
+/// Returns the text with this feature's block removed, plus the pill replacing
+/// it. `None` when the message carries nothing of that kind.
 pub type Extractor = fn(&str) -> Option<(String, MessageBadge)>;
 
-/// Every registered extractor, applied in order. Each one sees the text the
-/// previous ones already stripped, so two features can ride the same prompt.
 const EXTRACTORS: &[Extractor] = &[crate::comments::extract_badge];
 
-/// Split every registered badge block back out of a sent user message.
-///
-/// Pure over the text, like `attachments::parse_user_message_images` — the
-/// transcript's row version stays a valid cache key because nothing here
-/// depends on state outside the string.
+/// Each extractor sees what the previous ones left behind, so two features can
+/// ride the same prompt.
 pub fn split(text: &str) -> (String, Vec<MessageBadge>) {
     let mut rest = text.to_string();
     let mut badges = Vec::new();
@@ -51,31 +53,133 @@ pub fn split(text: &str) -> (String, Vec<MessageBadge>) {
     (rest, badges)
 }
 
-/// Rendered height of a pill, and of the row that holds one. The composer
-/// sizes its own strip arithmetically, so this has to be a constant.
+/// The composer sizes its strip arithmetically, so this cannot be a
+/// measurement.
 pub const BADGE_HEIGHT: f32 = 24.0;
 
-/// The pill itself — one element, so the composer's staged chip and the
-/// transcript's sent chip can never drift apart.
-pub fn render(badge: &MessageBadge, theme: &Theme) -> gpui::Div {
+const PILL_RADIUS: f32 = 8.0;
+const ICON_SIZE: f32 = 12.0;
+const TEXT_SIZE: f32 = 12.0;
+const CARD_WIDTH: f32 = 320.0;
+const HOVER_DELAY: Duration = Duration::from_millis(280);
+
+/// `id` scopes the hover card and must be stable per rendered pill.
+pub fn render(
+    id: impl Into<gpui::ElementId>,
+    badge: &MessageBadge,
+    theme: &Theme,
+) -> gpui::Stateful<gpui::Div> {
     div()
+        .id(id)
         .h(px(BADGE_HEIGHT))
         .flex()
         .flex_row()
         .items_center()
         .gap(px(6.0))
         .px(px(8.0))
-        .rounded(px(8.0))
+        .rounded(px(PILL_RADIUS))
         .bg(crate::theme::ink(0.06))
-        .text_size(px(12.0))
+        .text_size(px(TEXT_SIZE))
         .font_weight(gpui::FontWeight::MEDIUM)
         .text_color(theme.text_muted)
         .child(
             crate::icons::icon(badge.icon)
-                .size(px(12.0))
+                .size(px(ICON_SIZE))
                 .text_color(theme.text_muted.opacity(0.7)),
         )
         .child(badge.label.clone())
+        .when(!badge.details.is_empty(), |el| {
+            let details = Arc::new(badge.details.clone());
+            el.tooltip(move |_, cx| {
+                cx.new(|_| BadgeCard {
+                    details: details.clone(),
+                })
+                .into()
+            })
+            .tooltip_show_delay(HOVER_DELAY)
+        })
+}
+
+struct BadgeCard {
+    details: Arc<Vec<BadgeDetail>>,
+}
+
+impl BadgeCard {
+    fn row(detail: &BadgeDetail, theme: &Theme) -> gpui::Div {
+        div()
+            .flex()
+            .flex_row()
+            .gap(px(8.0))
+            .p(px(8.0))
+            .rounded(px(6.0))
+            .bg(crate::theme::ink(0.05))
+            .child(
+                div()
+                    .flex_none()
+                    .w(px(2.0))
+                    .rounded(px(1.0))
+                    .bg(theme.solid.opacity(0.35)),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .flex()
+                    .flex_col()
+                    .gap(px(4.0))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap(px(6.0))
+                            .font_family(theme.font_mono.clone())
+                            .text_size(px(10.0))
+                            .text_color(theme.text_faint)
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .child(detail.location.clone()),
+                            )
+                            .children(detail.tag.clone().map(|tag| {
+                                div()
+                                    .flex_none()
+                                    .px(px(4.0))
+                                    .rounded(px(3.0))
+                                    .bg(crate::theme::ink(0.10))
+                                    .child(tag)
+                            })),
+                    )
+                    .child(
+                        div()
+                            .min_w_0()
+                            .text_size(px(TEXT_SIZE))
+                            .line_height(px(16.0))
+                            .text_color(theme.text)
+                            .child(detail.body.clone()),
+                    ),
+            )
+    }
+}
+
+impl Render for BadgeCard {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = Theme::of(cx);
+        let card = crate::popover::popover_card(theme)
+            .w(px(CARD_WIDTH))
+            .p(px(6.0))
+            .flex()
+            .flex_col()
+            .gap(px(4.0))
+            .children(self.details.iter().map(|detail| Self::row(detail, theme)));
+        // `frosted` is load-bearing beyond the blur: it gives the card its own
+        // scene layer. Sharing the transcript's layer let the bubble's text
+        // paint over the card, since equal draw orders render quads before
+        // text.
+        crate::frost::frosted(crate::popover::CARD_RADIUS, crate::frost::MENU_BLUR, card)
+    }
 }
 
 #[cfg(test)]
@@ -100,6 +204,42 @@ mod tests {
         assert_eq!(text, "do");
         assert_eq!(badges.len(), 1);
         assert_eq!(badges[0].label.as_ref(), "2 comments");
+    }
+
+    #[test]
+    fn the_card_carries_one_row_per_comment() {
+        let staged = vec![
+            DiffComment::new("src/main.rs", CommentSide::New, 42, "early-return here"),
+            DiffComment::new("src/lib.rs", CommentSide::Old, 7, "why was this dropped?"),
+        ];
+        let (_, badges) = split(&with_comments("look", &staged));
+        let details = &badges[0].details;
+        assert_eq!(details.len(), 2);
+        assert_eq!(details[0].location.as_ref(), "src/main.rs:42");
+        assert_eq!(details[0].tag.as_deref(), Some("R"));
+        assert_eq!(details[0].body.as_ref(), "early-return here");
+        assert_eq!(details[1].location.as_ref(), "src/lib.rs:7");
+        assert_eq!(details[1].tag.as_deref(), Some("L"));
+    }
+
+    #[test]
+    fn a_multiline_body_rejoins_its_continuation_lines() {
+        let staged = vec![DiffComment::new(
+            "a.rs",
+            CommentSide::New,
+            3,
+            "first\nsecond",
+        )];
+        let (_, badges) = split(&with_comments("x", &staged));
+        assert_eq!(badges[0].details[0].body.as_ref(), "first\nsecond");
+    }
+
+    #[test]
+    fn a_path_with_a_colon_still_splits_on_the_side_marker() {
+        let staged = vec![DiffComment::new("odd:name.rs", CommentSide::New, 5, "hm")];
+        let (_, badges) = split(&with_comments("x", &staged));
+        assert_eq!(badges[0].details[0].location.as_ref(), "odd:name.rs:5");
+        assert_eq!(badges[0].details[0].body.as_ref(), "hm");
     }
 
     #[test]

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -1052,7 +1052,14 @@ struct HoverRow {
 }
 
 struct CommentDraft {
+    /// Composer the note will stage onto, captured when the card opened. A
+    /// draft belongs to the checkout it was written over, so it must not
+    /// follow the user onto whatever chat is selected by commit time.
+    key: String,
     path: String,
+    /// The file's pre-rename path, when it moved — carried onto the comment so
+    /// an `Old`-side citation names the file that line lives in.
+    old_path: Option<String>,
     side: CommentSide,
     line: u32,
     input: Entity<ComposerInput>,
@@ -1597,6 +1604,7 @@ impl Changes {
 
     /// Reconcile parsed content with the currently-active diff.
     fn sync(&mut self, cx: &mut Context<Self>) {
+        self.discard_stale_draft(cx);
         // The watch follows the selected chat's host device (idempotent when
         // the target is unchanged); a boot-deferred attempt retries here too.
         self.ensure_watch(cx);
@@ -1906,6 +1914,29 @@ impl Changes {
             .collect()
     }
 
+    /// The parsed diff's pre-rename path for `path`, when the file moved.
+    fn old_path_of(&self, path: &str) -> Option<String> {
+        self.parsed
+            .as_ref()?
+            .files
+            .iter()
+            .find(|file| file.path == path)?
+            .old_path
+            .clone()
+    }
+
+    /// A draft belongs to the checkout it was opened over. Chat navigation
+    /// swaps both the diff under it and the composer it would stage onto, so
+    /// the half-written note is dropped rather than following the user across.
+    fn discard_stale_draft(&mut self, cx: &mut Context<Self>) {
+        let key = self.state.read(cx).composer_key();
+        if self.draft.as_ref().is_some_and(|draft| draft.key != key) {
+            self.draft = None;
+            self.sync_comment_rows(cx);
+            cx.notify();
+        }
+    }
+
     fn draft_anchor(&self) -> Option<(String, CommentSide, u32)> {
         self.draft
             .as_ref()
@@ -2011,8 +2042,12 @@ impl Changes {
             _ => {}
         });
         let handle = input.read(cx).focus_handle(cx);
+        let key = self.state.read(cx).composer_key();
+        let old_path = self.old_path_of(&path);
         self.draft = Some(CommentDraft {
+            key,
             path,
+            old_path,
             side,
             line,
             input,
@@ -2039,9 +2074,12 @@ impl Changes {
             cx.notify();
             return;
         }
-        let comment = DiffComment::new(draft.path, draft.side, draft.line, body);
+        let comment =
+            DiffComment::new(draft.path, draft.side, draft.line, body).renamed_from(draft.old_path);
+        // `draft.key`, not the live one: the note stages onto the composer it
+        // was written against even if the selection moved under it.
+        let key = draft.key;
         self.state.update(cx, |state, cx| {
-            let key = state.composer_key();
             state.add_diff_comment(&key, comment);
             cx.notify();
         });
@@ -2394,8 +2432,10 @@ impl Changes {
                     .as_ref()
                     .filter(|draft| draft.path == file_diff.path)
                 {
+                    // Header cites the same path the staged card and the
+                    // prompt bullet will.
                     Some(draft) => render_comment_draft(
-                        &draft.path,
+                        draft_cite_path(draft),
                         draft.line,
                         draft.input.clone(),
                         &theme,
@@ -3333,6 +3373,14 @@ fn render_comment_card(comment: &DiffComment, theme: &Theme, cx: &Context<Change
 
 fn comment_accent_bar(color: gpui::Hsla) -> gpui::Div {
     div().w(px(ACCENT_BAR_WIDTH)).h_full().flex_none().bg(color)
+}
+
+/// Mirrors [`DiffComment::cite_path`] for the not-yet-staged note.
+fn draft_cite_path(draft: &CommentDraft) -> &str {
+    match draft.side {
+        CommentSide::Old => draft.old_path.as_deref().unwrap_or(&draft.path),
+        CommentSide::New => &draft.path,
+    }
 }
 
 /// Fixed height, so an open draft never fights the fold tween.

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -446,9 +446,6 @@ pub fn body_height(file: &FileDiff) -> f32 {
     body_height_with(file, &[], None)
 }
 
-/// Body height including the comment cards and open draft that hang inside
-/// it. Analytic like everything else here — it walks the same row model the
-/// renderer draws.
 pub fn body_height_with(
     file: &FileDiff,
     comments: &[DiffComment],
@@ -460,9 +457,8 @@ pub fn body_height_with(
         .sum()
 }
 
-/// Which side/number a rendered diff row hangs its comments off: deletions
-/// only exist in the pre-change file, everything else is cited against the
-/// post-change file (what the agent will actually edit).
+/// A deletion only exists in the pre-change file; everything else is cited
+/// against the post-change file, which is what the agent edits.
 pub fn line_anchor(line: &DiffLine) -> Option<(CommentSide, u32)> {
     match line.kind {
         LineKind::Meta => None,
@@ -646,13 +642,10 @@ pub fn apply_diff_frame(diffs: &mut Vec<CheckoutDiff>, value: serde_json::Value)
     }
 }
 
-/// Fingerprint of everything the row model folds in beyond the patch itself:
-/// the staged comments (ids are unique and bodies immutable once staged) and
-/// the open draft's anchor.
 fn comment_state_key(comments: &[DiffComment], draft: Option<&(String, CommentSide, u32)>) -> u64 {
     let mut parts: Vec<String> = comments.iter().map(|comment| comment.id.clone()).collect();
     if let Some((path, side, line)) = draft {
-        parts.push(format!("draft:{path}:{}:{line}", side_tag(*side)));
+        parts.push(format!("draft:{path}:{}:{line}", side.tag()));
     }
     let refs: Vec<&str> = parts.iter().map(String::as_str).collect();
     hash64(&refs)
@@ -857,13 +850,11 @@ pub enum DiffRow {
         /// Flat index across the file's hunks — keys into the highlight slot.
         flat: u32,
     },
-    /// A staged comment card under its anchor line. `card` indexes the
-    /// file's own staged-comment slice, in staged order.
+    /// `card` indexes the file's own staged-comment slice, in staged order.
     CommentCard {
         file: u32,
         card: u32,
     },
-    /// The one open comment draft, under its anchor line.
     CommentDraft {
         file: u32,
     },
@@ -880,10 +871,8 @@ pub enum DiffRow {
 }
 
 impl DiffRow {
-    /// Analytic height of one steady-state row. `comments` is the same
-    /// per-file slice `body_rows` indexed `CommentCard::card` into.
-    /// `FoldingBody` stand-ins are height-animated, not analytic — they
-    /// report 0 here and never appear in a height sum.
+    /// `FoldingBody` is height-animated, so it reports 0 and never lands in a
+    /// height sum.
     fn height(self, comments: &[DiffComment]) -> f32 {
         match self {
             DiffRow::FileHeader { .. } => FILE_HEADER_HEIGHT,
@@ -901,15 +890,12 @@ impl DiffRow {
     }
 }
 
-/// Rows an expanded body contributes (notices + hunk headers + lines + pad),
-/// before comment cards — a capacity hint, not the exact count.
+/// Capacity hint only — comment cards are not counted.
 pub fn body_row_count(file: &FileDiff) -> usize {
     let lines: usize = file.hunks.iter().map(|h| h.lines.len()).sum();
     file_notices(file).len() + file.hunks.len() + lines + 1
 }
 
-/// The steady-state body rows of one expanded file, with this file's staged
-/// comment cards (and the open draft) parked under the lines they anchor to.
 pub fn body_rows(
     file_ix: u32,
     file: &FileDiff,
@@ -968,8 +954,8 @@ pub fn body_rows(
 
 /// Flatten all files into rows + each file's row span (header at
 /// `range.start`, body rows after it). `collapsed(ix)` folds a file to just
-/// its header. `comments` is the whole staged set — each file takes its own
-/// path's slice; `draft` names the file its card hangs in by path.
+/// its header. `comments` is the whole staged set; each file takes its own
+/// path's slice.
 pub fn flatten_rows(
     files: &[FileDiff],
     comments: &[DiffComment],
@@ -1058,7 +1044,6 @@ struct RefMenu {
     _search_events: Subscription,
 }
 
-/// The diff line the pointer is on — the only line that draws a `+`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct HoverRow {
     path: String,
@@ -1066,7 +1051,6 @@ struct HoverRow {
     line: u32,
 }
 
-/// A comment being written: where it will land plus the input holding it.
 struct CommentDraft {
     path: String,
     side: CommentSide,
@@ -1117,14 +1101,10 @@ pub struct Changes {
     scoped_task: Option<Task<()>>,
     scope_menu: Popup<()>,
     ref_menu: Popup<RefMenu>,
-    /// The one open comment draft, if any. Only ever one — a second `+` click
-    /// moves the card rather than stacking two half-written notes.
+    /// Only ever one: a second `+` moves the card rather than stacking two
+    /// half-written notes.
     draft: Option<CommentDraft>,
-    /// The diff line the pointer is on. Exactly one `+` exists at a time.
     hover: Option<HoverRow>,
-    /// Fingerprint of (staged comments, draft anchor) the current row
-    /// model was built with — [`Changes::sync_comment_rows`] splices bodies
-    /// only when it changes.
     comment_key: u64,
     history: Option<Entity<GitHistory>>,
     history_count: Option<Entity<GitHistoryCount>>,
@@ -1642,8 +1622,6 @@ impl Changes {
         };
         let key = self.parse_key(&diff);
         if self.parsed.as_ref().is_some_and(|p| p.key == key) {
-            // Same patch, but the staged comments / draft may have
-            // moved under us (the composer purges comments on send).
             self.sync_comment_rows(cx);
             return;
         }
@@ -1714,8 +1692,31 @@ impl Changes {
         };
         let body = range.start + 1..range.end;
         let delta = new_body.len() as isize - body.len() as isize;
-        self.list.splice(body.clone(), new_body.len());
-        self.rows.splice(body, new_body);
+        // Only splice the rows that moved: `ListState::splice` clamps the
+        // scroll anchor to the range start when the anchored row is inside it,
+        // so replacing a whole body jumped the pane to the top of the file.
+        let (prefix, suffix) = {
+            let old = &self.rows[body.clone()];
+            let prefix = old
+                .iter()
+                .zip(&new_body)
+                .take_while(|(a, b)| a == b)
+                .count();
+            let suffix = old[prefix..]
+                .iter()
+                .rev()
+                .zip(new_body[prefix..].iter().rev())
+                .take_while(|(a, b)| a == b)
+                .count();
+            (prefix, suffix)
+        };
+        if delta == 0 && prefix + suffix >= body.len() {
+            return;
+        }
+        let changed = body.start + prefix..body.end - suffix;
+        let mid: Vec<DiffRow> = new_body[prefix..new_body.len() - suffix].to_vec();
+        self.list.splice(changed.clone(), mid.len());
+        self.rows.splice(changed, mid);
         self.row_ranges[file_ix] = range.start..(range.end as isize + delta) as usize;
         for r in &mut self.row_ranges[file_ix + 1..] {
             *r = (r.start as isize + delta) as usize..(r.end as isize + delta) as usize;
@@ -1892,16 +1893,12 @@ impl Changes {
         cx.notify();
     }
 
-    // ---- diff comments ----
-
-    /// The comments staged for the chat this pane is showing. Cloned because
-    /// rendering borrows `self` mutably a moment later.
+    /// Cloned because rendering borrows `self` mutably a moment later.
     fn staged_comments(&self, cx: &App) -> Vec<DiffComment> {
         let state = self.state.read(cx);
         state.diff_comments(&state.composer_key()).to_vec()
     }
 
-    /// One file's staged comments, in the order `body_rows` indexes them.
     fn comments_for(&self, path: &str, cx: &App) -> Vec<DiffComment> {
         self.staged_comments(cx)
             .into_iter()
@@ -1922,9 +1919,6 @@ impl Changes {
             .map(|draft| (draft.side, draft.line))
     }
 
-    /// Splice every expanded file's body when the staged comments or the open
-    /// draft changed — splices keep the list's scroll anchor, a full reset
-    /// would jump the pane to the top on every comment.
     fn sync_comment_rows(&mut self, cx: &mut Context<Self>) {
         if self.parsed.is_none() {
             return;
@@ -1942,8 +1936,7 @@ impl Changes {
         let files = parsed.files.clone();
         for file_ix in (0..self.row_ranges.len().min(files.len())).rev() {
             let file = &files[file_ix];
-            // Collapsed bodies have no rows to refresh, and a mid-tween
-            // stand-in is the settle sweep's to replace, not ours.
+            // A mid-tween stand-in is the settle sweep's to replace.
             if self
                 .folds
                 .get(&file.path)
@@ -1975,7 +1968,6 @@ impl Changes {
         cx.notify();
     }
 
-    /// Point the hover `+` at one line, re-rendering only when it moves.
     fn set_hover(
         &mut self,
         path: &str,
@@ -1993,7 +1985,6 @@ impl Changes {
         }
     }
 
-    /// Drop the `+` when the pointer leaves the row that owns it.
     fn clear_hover_at(&mut self, path: &str, side: CommentSide, line: u32, cx: &mut Context<Self>) {
         if self
             .hover
@@ -2013,7 +2004,6 @@ impl Changes {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // "Composer" context: ⏎ commits the comment, ⇧⏎ adds a line.
         let input = cx.new(|cx| ComposerInput::new("Request a change…", cx));
         let events = cx.subscribe(&input, |this: &mut Self, _, event, cx| match event {
             ComposerInputEvent::Submitted => this.commit_draft(cx),
@@ -2039,8 +2029,6 @@ impl Changes {
         cx.notify();
     }
 
-    /// Stage the open draft. An empty body just closes the card — a blank
-    /// comment would ride the prompt as a bullet with nothing after the colon.
     fn commit_draft(&mut self, cx: &mut Context<Self>) {
         let Some(draft) = self.draft.take() else {
             return;
@@ -3206,24 +3194,10 @@ fn diff_line_row(
         .into_any_element()
 }
 
-/// Stable per-side token for element ids (`L`/`R`, matching how the comment
-/// cites its line in the prompt).
-fn side_tag(side: CommentSide) -> &'static str {
-    match side {
-        CommentSide::Old => "L",
-        CommentSide::New => "R",
-    }
-}
-
-/// Size of the `+` button, and where it sits.
 pub const COMMENT_ADDER_SIZE: f32 = 16.0;
 
-/// Left inset of the hover `+` for a row: centred over the line-number column
-/// the comment will cite, so the button lands on the very number that ends up
-/// in the prompt.
-///
 /// A row carries both gutters side by side, and a deletion numbers in the
-/// first one.
+/// first.
 pub fn comment_adder_left(side: CommentSide, gutter_px: f32) -> f32 {
     let column = match side {
         CommentSide::Old => 0.0,
@@ -3232,7 +3206,6 @@ pub fn comment_adder_left(side: CommentSide, gutter_px: f32) -> f32 {
     ACCENT_BAR_WIDTH + column + (gutter_px - COMMENT_ADDER_SIZE) / 2.0
 }
 
-/// The `+` plate, parked over the line-number column of the row it belongs to.
 fn positioned_adder(left: f32, adder: AnyElement) -> gpui::Div {
     div()
         .absolute()
@@ -3244,10 +3217,6 @@ fn positioned_adder(left: f32, adder: AnyElement) -> gpui::Div {
         .child(adder)
 }
 
-/// The hover `+` on a diff line: a solid plate over the line number, invisible
-/// until the row is hovered, so a quiet diff stays quiet. `solid`/`on_solid`
-/// are the neutral primary pair — near-white on dark, near-black on light —
-/// not an accent hue.
 fn render_comment_adder(
     path: &str,
     side: CommentSide,
@@ -3259,7 +3228,7 @@ fn render_comment_adder(
     div()
         .id(SharedString::from(format!(
             "cmt-add-{path}-{}-{line}",
-            side_tag(side)
+            side.tag()
         )))
         .size(px(COMMENT_ADDER_SIZE))
         .flex()
@@ -3269,8 +3238,6 @@ fn render_comment_adder(
         .bg(theme.solid)
         .cursor_pointer()
         .on_click(cx.listener(move |this, _, window, cx| {
-            // A second `+` replaces the open draft rather than stacking two
-            // half-written notes.
             this.open_draft(target.clone(), side, line, window, cx);
         }))
         .child(
@@ -3281,22 +3248,19 @@ fn render_comment_adder(
         .into_any_element()
 }
 
-/// A staged comment parked under its line: mono location, body, and a
-/// hover-revealed remove. Deliberately not a thread — it is one note that
-/// rides the next prompt and then stops existing.
 fn render_comment_card(comment: &DiffComment, theme: &Theme, cx: &Context<Changes>) -> AnyElement {
     let group: SharedString = format!("cmt-card-{}", comment.id).into();
     let id = comment.id.clone();
     div()
         .group(group.clone())
         .h(px(comments::card_height(&comment.body)))
+        .w_full()
         .flex_none()
         .flex()
         .flex_row()
         .bg(crate::theme::ink(0.05))
-        // A real bar, not a border: it has to be the same ACCENT_BAR_WIDTH as
-        // the +/− bars on the diff rows above and below, or the card's edge
-        // steps in and out of the column (user report).
+        // A bar, not a border: it must match ACCENT_BAR_WIDTH exactly or the
+        // card's edge steps in and out of the column.
         .child(comment_accent_bar(theme.solid.opacity(0.35)))
         .child(
             div()
@@ -3355,9 +3319,8 @@ fn render_comment_card(comment: &DiffComment, theme: &Theme, cx: &Context<Change
                     div()
                         .flex_1()
                         .min_h_0()
-                        // The card's height is analytic (comments::card_height);
-                        // an unexpectedly long body clips inside the card
-                        // instead of pushing the file body past its fold height.
+                        // Height is analytic, so an over-long body clips
+                        // inside the card rather than past the fold height.
                         .overflow_hidden()
                         .text_size(px(12.0))
                         .line_height(px(comments::CARD_LINE_HEIGHT))
@@ -3368,14 +3331,11 @@ fn render_comment_card(comment: &DiffComment, theme: &Theme, cx: &Context<Change
         .into_any_element()
 }
 
-/// The card's left edge: the same solid bar, at the same width, as the +/−
-/// accent bars on the diff rows it sits between.
 fn comment_accent_bar(color: gpui::Hsla) -> gpui::Div {
     div().w(px(ACCENT_BAR_WIDTH)).h_full().flex_none().bg(color)
 }
 
-/// The open draft card: input plus Cancel / Comment. Fixed height so an open
-/// draft never fights the fold tween.
+/// Fixed height, so an open draft never fights the fold tween.
 fn render_comment_draft(
     path: &str,
     line: u32,
@@ -3385,6 +3345,7 @@ fn render_comment_draft(
 ) -> AnyElement {
     div()
         .h(px(comments::DRAFT_CARD_HEIGHT))
+        .w_full()
         .flex_none()
         .flex()
         .flex_row()
@@ -3452,7 +3413,6 @@ fn render_comment_draft(
         .into_any_element()
 }
 
-/// One button on the draft card. `primary` is the filled Comment action.
 fn comment_action(
     id: &'static str,
     label: &'static str,
@@ -3469,8 +3429,6 @@ fn comment_action(
         .text_size(px(11.0))
         .font_weight(gpui::FontWeight::MEDIUM)
         .cursor_pointer()
-        // The neutral primary plate (theme.solid / on_solid), same pair the
-        // send button uses — no accent hue anywhere in the comment surface.
         .when(primary, |el| el.bg(theme.solid).text_color(theme.on_solid))
         .when(!primary, |el| {
             el.text_color(motion::hover_blend(id, theme.text_muted, theme.text))

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -35,6 +35,7 @@ use gpui::{
 use zeron_proto::{Chat, CheckoutDiff, GitHistoryCommit};
 use zeron_rpc::methods;
 
+use crate::comments::{self, CommentSide, DiffComment};
 use crate::composer::{ComposerInput, ComposerInputEvent};
 use crate::history::{GitHistory, GitHistoryCount, GitHistoryEvent, GitHistoryFetchButton};
 use crate::markdown::render;
@@ -442,10 +443,32 @@ pub fn truncate_file_lines(file: &mut FileDiff, max_lines: usize) {
 /// Analytic expanded-body height — drives the 180 ms fold tween without
 /// measurement.
 pub fn body_height(file: &FileDiff) -> f32 {
-    let notices = file_notices(file).len() as f32 * NOTICE_HEIGHT;
-    let hunks = file.hunks.len() as f32 * HUNK_HEADER_HEIGHT;
-    let lines: usize = file.hunks.iter().map(|h| h.lines.len()).sum();
-    notices + hunks + lines as f32 * DIFF_LINE_HEIGHT + BODY_BOTTOM_PAD
+    body_height_with(file, &[], None)
+}
+
+/// Body height including the comment cards and open draft that hang inside
+/// it. Analytic like everything else here — it walks the same row model the
+/// renderer draws.
+pub fn body_height_with(
+    file: &FileDiff,
+    comments: &[DiffComment],
+    draft: Option<(CommentSide, u32)>,
+) -> f32 {
+    body_rows(0, file, comments, draft)
+        .iter()
+        .map(|row| row.height(comments))
+        .sum()
+}
+
+/// Which side/number a rendered diff row hangs its comments off: deletions
+/// only exist in the pre-change file, everything else is cited against the
+/// post-change file (what the agent will actually edit).
+pub fn line_anchor(line: &DiffLine) -> Option<(CommentSide, u32)> {
+    match line.kind {
+        LineKind::Meta => None,
+        LineKind::Del => line.old_no.map(|no| (CommentSide::Old, no)),
+        _ => line.new_no.map(|no| (CommentSide::New, no)),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -621,6 +644,18 @@ pub fn apply_diff_frame(diffs: &mut Vec<CheckoutDiff>, value: serde_json::Value)
             false
         }
     }
+}
+
+/// Fingerprint of everything the row model folds in beyond the patch itself:
+/// the staged comments (ids are unique and bodies immutable once staged) and
+/// the open draft's anchor.
+fn comment_state_key(comments: &[DiffComment], draft: Option<&(String, CommentSide, u32)>) -> u64 {
+    let mut parts: Vec<String> = comments.iter().map(|comment| comment.id.clone()).collect();
+    if let Some((path, side, line)) = draft {
+        parts.push(format!("draft:{path}:{}:{line}", side_tag(*side)));
+    }
+    let refs: Vec<&str> = parts.iter().map(String::as_str).collect();
+    hash64(&refs)
 }
 
 fn hash64(parts: &[&str]) -> u64 {
@@ -822,6 +857,16 @@ pub enum DiffRow {
         /// Flat index across the file's hunks — keys into the highlight slot.
         flat: u32,
     },
+    /// A staged comment card under its anchor line. `card` indexes the
+    /// file's own staged-comment slice, in staged order.
+    CommentCard {
+        file: u32,
+        card: u32,
+    },
+    /// The one open comment draft, under its anchor line.
+    CommentDraft {
+        file: u32,
+    },
     /// Trailing pad closing an expanded body ([`BODY_BOTTOM_PAD`]).
     BodyPad {
         file: u32,
@@ -834,14 +879,65 @@ pub enum DiffRow {
     },
 }
 
-/// Rows an expanded body contributes (notices + hunk headers + lines + pad).
+impl DiffRow {
+    /// Analytic height of one steady-state row. `comments` is the same
+    /// per-file slice `body_rows` indexed `CommentCard::card` into.
+    /// `FoldingBody` stand-ins are height-animated, not analytic — they
+    /// report 0 here and never appear in a height sum.
+    fn height(self, comments: &[DiffComment]) -> f32 {
+        match self {
+            DiffRow::FileHeader { .. } => FILE_HEADER_HEIGHT,
+            DiffRow::Notice { .. } => NOTICE_HEIGHT,
+            DiffRow::HunkHeader { .. } => HUNK_HEADER_HEIGHT,
+            DiffRow::Line { .. } => DIFF_LINE_HEIGHT,
+            DiffRow::CommentCard { card, .. } => comments
+                .get(card as usize)
+                .map(|comment| comments::card_height(&comment.body))
+                .unwrap_or(0.0),
+            DiffRow::CommentDraft { .. } => comments::DRAFT_CARD_HEIGHT,
+            DiffRow::BodyPad { .. } => BODY_BOTTOM_PAD,
+            DiffRow::FoldingBody { .. } => 0.0,
+        }
+    }
+}
+
+/// Rows an expanded body contributes (notices + hunk headers + lines + pad),
+/// before comment cards — a capacity hint, not the exact count.
 pub fn body_row_count(file: &FileDiff) -> usize {
     let lines: usize = file.hunks.iter().map(|h| h.lines.len()).sum();
     file_notices(file).len() + file.hunks.len() + lines + 1
 }
 
-/// The steady-state body rows of one expanded file.
-pub fn body_rows(file_ix: u32, file: &FileDiff) -> Vec<DiffRow> {
+/// The steady-state body rows of one expanded file, with this file's staged
+/// comment cards (and the open draft) parked under the lines they anchor to.
+pub fn body_rows(
+    file_ix: u32,
+    file: &FileDiff,
+    comments: &[DiffComment],
+    draft: Option<(CommentSide, u32)>,
+) -> Vec<DiffRow> {
+    fn push_cards(
+        rows: &mut Vec<DiffRow>,
+        file_ix: u32,
+        comments: &[DiffComment],
+        draft: Option<(CommentSide, u32)>,
+        anchors: &[Option<(CommentSide, u32)>],
+    ) {
+        for anchor in anchors.iter().flatten() {
+            for (ix, comment) in comments.iter().enumerate() {
+                if comment.anchor() == *anchor {
+                    rows.push(DiffRow::CommentCard {
+                        file: file_ix,
+                        card: ix as u32,
+                    });
+                }
+            }
+            if draft == Some(*anchor) {
+                rows.push(DiffRow::CommentDraft { file: file_ix });
+            }
+        }
+    }
+
     let mut rows = Vec::with_capacity(body_row_count(file));
     for notice in 0..file_notices(file).len() {
         rows.push(DiffRow::Notice {
@@ -849,21 +945,22 @@ pub fn body_rows(file_ix: u32, file: &FileDiff) -> Vec<DiffRow> {
             notice: notice as u32,
         });
     }
-    let mut flat = 0u32;
+    let mut hunk_flat = 0u32;
     for (hunk_ix, hunk) in file.hunks.iter().enumerate() {
         rows.push(DiffRow::HunkHeader {
             file: file_ix,
             hunk: hunk_ix as u32,
         });
-        for line_ix in 0..hunk.lines.len() {
+        for (line_ix, line) in hunk.lines.iter().enumerate() {
             rows.push(DiffRow::Line {
                 file: file_ix,
                 hunk: hunk_ix as u32,
                 line: line_ix as u32,
-                flat,
+                flat: hunk_flat + line_ix as u32,
             });
-            flat += 1;
+            push_cards(&mut rows, file_ix, comments, draft, &[line_anchor(line)]);
         }
+        hunk_flat += hunk.lines.len() as u32;
     }
     rows.push(DiffRow::BodyPad { file: file_ix });
     rows
@@ -871,9 +968,12 @@ pub fn body_rows(file_ix: u32, file: &FileDiff) -> Vec<DiffRow> {
 
 /// Flatten all files into rows + each file's row span (header at
 /// `range.start`, body rows after it). `collapsed(ix)` folds a file to just
-/// its header.
+/// its header. `comments` is the whole staged set — each file takes its own
+/// path's slice; `draft` names the file its card hangs in by path.
 pub fn flatten_rows(
     files: &[FileDiff],
+    comments: &[DiffComment],
+    draft: Option<(&str, CommentSide, u32)>,
     mut collapsed: impl FnMut(usize) -> bool,
 ) -> (Vec<DiffRow>, Vec<std::ops::Range<usize>>) {
     let mut rows = Vec::new();
@@ -882,7 +982,15 @@ pub fn flatten_rows(
         let start = rows.len();
         rows.push(DiffRow::FileHeader { file: ix as u32 });
         if !collapsed(ix) {
-            rows.extend(body_rows(ix as u32, file));
+            let file_comments: Vec<DiffComment> = comments
+                .iter()
+                .filter(|comment| comment.path == file.path)
+                .cloned()
+                .collect();
+            let file_draft = draft
+                .filter(|(path, _, _)| *path == file.path)
+                .map(|(_, side, line)| (side, line));
+            rows.extend(body_rows(ix as u32, file, &file_comments, file_draft));
         }
         ranges.push(start..rows.len());
     }
@@ -950,6 +1058,23 @@ struct RefMenu {
     _search_events: Subscription,
 }
 
+/// The diff line the pointer is on — the only line that draws a `+`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HoverRow {
+    path: String,
+    side: CommentSide,
+    line: u32,
+}
+
+/// A comment being written: where it will land plus the input holding it.
+struct CommentDraft {
+    path: String,
+    side: CommentSide,
+    line: u32,
+    input: Entity<ComposerInput>,
+    _events: Subscription,
+}
+
 /// The Changes pane entity. Lazy: no RPC until [`Changes::ensure_watch`] runs
 /// (the shell calls it when the pane first opens).
 pub struct Changes {
@@ -992,6 +1117,15 @@ pub struct Changes {
     scoped_task: Option<Task<()>>,
     scope_menu: Popup<()>,
     ref_menu: Popup<RefMenu>,
+    /// The one open comment draft, if any. Only ever one — a second `+` click
+    /// moves the card rather than stacking two half-written notes.
+    draft: Option<CommentDraft>,
+    /// The diff line the pointer is on. Exactly one `+` exists at a time.
+    hover: Option<HoverRow>,
+    /// Fingerprint of (staged comments, draft anchor) the current row
+    /// model was built with — [`Changes::sync_comment_rows`] splices bodies
+    /// only when it changes.
+    comment_key: u64,
     history: Option<Entity<GitHistory>>,
     history_count: Option<Entity<GitHistoryCount>>,
     history_fetch_button: Option<Entity<GitHistoryFetchButton>>,
@@ -1042,6 +1176,9 @@ impl Changes {
             scoped_task: None,
             scope_menu: Popup::default(),
             ref_menu: Popup::default(),
+            draft: None,
+            hover: None,
+            comment_key: 0,
             history: None,
             history_count: None,
             history_fetch_button: None,
@@ -1505,6 +1642,9 @@ impl Changes {
         };
         let key = self.parse_key(&diff);
         if self.parsed.as_ref().is_some_and(|p| p.key == key) {
+            // Same patch, but the staged comments / draft may have
+            // moved under us (the composer purges comments on send).
+            self.sync_comment_rows(cx);
             return;
         }
         // Parse off the render path — patches run to megabytes.
@@ -1531,7 +1671,17 @@ impl Changes {
                 };
                 changes.folds.clear();
                 changes.highlights.clear();
-                let (rows, ranges) = flatten_rows(&files, |_| false);
+                let staged = changes.staged_comments(cx);
+                let draft = changes.draft_anchor();
+                let (rows, ranges) = flatten_rows(
+                    &files,
+                    &staged,
+                    draft
+                        .as_ref()
+                        .map(|(path, side, line)| (path.as_str(), *side, *line)),
+                    |_| false,
+                );
+                changes.comment_key = comment_state_key(&staged, draft.as_ref());
                 // The uniform hint keeps offsets for never-rendered rows
                 // sane (most rows ARE lines); real heights land as rows
                 // render.
@@ -1579,7 +1729,11 @@ impl Changes {
         let Some(file) = parsed.files.get(file_ix) else {
             return;
         };
-        let expanded_height = body_height(file);
+        let expanded_height = body_height_with(
+            file,
+            &self.comments_for(&file.path, cx),
+            self.draft_anchor_in(&file.path),
+        );
         let fold = self.folds.entry(file.path.clone()).or_default();
         let currently_collapsed = fold.collapsed;
         fold.from = if currently_collapsed {
@@ -1656,7 +1810,12 @@ impl Changes {
             let body = if fold.collapsed {
                 Vec::new()
             } else {
-                body_rows(file_ix as u32, file)
+                body_rows(
+                    file_ix as u32,
+                    file,
+                    &self.comments_for(&file.path, cx),
+                    self.draft_anchor_in(&file.path),
+                )
             };
             self.replace_file_body(file_ix, body);
         }
@@ -1694,21 +1853,221 @@ impl Changes {
             fold.collapsed = collapse;
             fold.toggled_at = None;
         }
+        let staged = self.staged_comments(cx);
+        let draft = self.draft_anchor();
         for file_ix in (0..self.row_ranges.len().min(files.len())).rev() {
             let range = &self.row_ranges[file_ix];
             let body = range.start + 1..range.end;
             let new_len = if collapse {
                 0
             } else {
-                body_row_count(&files[file_ix])
+                let file = &files[file_ix];
+                let comments: Vec<DiffComment> = staged
+                    .iter()
+                    .filter(|comment| comment.path == file.path)
+                    .cloned()
+                    .collect();
+                body_rows(
+                    file_ix as u32,
+                    file,
+                    &comments,
+                    self.draft_anchor_in(&file.path),
+                )
+                .len()
             };
             if body.len() != new_len {
                 self.list.splice(body, new_len);
             }
         }
-        let (rows, ranges) = flatten_rows(&files, |_| collapse);
+        let (rows, ranges) = flatten_rows(
+            &files,
+            &staged,
+            draft
+                .as_ref()
+                .map(|(path, side, line)| (path.as_str(), *side, *line)),
+            |_| collapse,
+        );
         self.rows = rows;
         self.row_ranges = ranges;
+        cx.notify();
+    }
+
+    // ---- diff comments ----
+
+    /// The comments staged for the chat this pane is showing. Cloned because
+    /// rendering borrows `self` mutably a moment later.
+    fn staged_comments(&self, cx: &App) -> Vec<DiffComment> {
+        let state = self.state.read(cx);
+        state.diff_comments(&state.composer_key()).to_vec()
+    }
+
+    /// One file's staged comments, in the order `body_rows` indexes them.
+    fn comments_for(&self, path: &str, cx: &App) -> Vec<DiffComment> {
+        self.staged_comments(cx)
+            .into_iter()
+            .filter(|comment| comment.path == path)
+            .collect()
+    }
+
+    fn draft_anchor(&self) -> Option<(String, CommentSide, u32)> {
+        self.draft
+            .as_ref()
+            .map(|draft| (draft.path.clone(), draft.side, draft.line))
+    }
+
+    fn draft_anchor_in(&self, path: &str) -> Option<(CommentSide, u32)> {
+        self.draft
+            .as_ref()
+            .filter(|draft| draft.path == path)
+            .map(|draft| (draft.side, draft.line))
+    }
+
+    /// Splice every expanded file's body when the staged comments or the open
+    /// draft changed — splices keep the list's scroll anchor, a full reset
+    /// would jump the pane to the top on every comment.
+    fn sync_comment_rows(&mut self, cx: &mut Context<Self>) {
+        if self.parsed.is_none() {
+            return;
+        }
+        let staged = self.staged_comments(cx);
+        let draft = self.draft_anchor();
+        let key = comment_state_key(&staged, draft.as_ref());
+        if key == self.comment_key {
+            return;
+        }
+        self.comment_key = key;
+        let Some(parsed) = &self.parsed else {
+            return;
+        };
+        let files = parsed.files.clone();
+        for file_ix in (0..self.row_ranges.len().min(files.len())).rev() {
+            let file = &files[file_ix];
+            // Collapsed bodies have no rows to refresh, and a mid-tween
+            // stand-in is the settle sweep's to replace, not ours.
+            if self
+                .folds
+                .get(&file.path)
+                .is_some_and(|fold| fold.collapsed)
+            {
+                continue;
+            }
+            let range = &self.row_ranges[file_ix];
+            if self.rows.get(range.start + 1)
+                == Some(&DiffRow::FoldingBody {
+                    file: file_ix as u32,
+                })
+            {
+                continue;
+            }
+            let comments: Vec<DiffComment> = staged
+                .iter()
+                .filter(|comment| comment.path == file.path)
+                .cloned()
+                .collect();
+            let body = body_rows(
+                file_ix as u32,
+                file,
+                &comments,
+                self.draft_anchor_in(&file.path),
+            );
+            self.replace_file_body(file_ix, body);
+        }
+        cx.notify();
+    }
+
+    /// Point the hover `+` at one line, re-rendering only when it moves.
+    fn set_hover(
+        &mut self,
+        path: &str,
+        anchor: Option<(CommentSide, u32)>,
+        cx: &mut Context<Self>,
+    ) {
+        let next = anchor.map(|(side, line)| HoverRow {
+            path: path.to_string(),
+            side,
+            line,
+        });
+        if next != self.hover {
+            self.hover = next;
+            cx.notify();
+        }
+    }
+
+    /// Drop the `+` when the pointer leaves the row that owns it.
+    fn clear_hover_at(&mut self, path: &str, side: CommentSide, line: u32, cx: &mut Context<Self>) {
+        if self
+            .hover
+            .as_ref()
+            .is_some_and(|hover| hover.path == path && hover.side == side && hover.line == line)
+        {
+            self.hover = None;
+            cx.notify();
+        }
+    }
+
+    fn open_draft(
+        &mut self,
+        path: String,
+        side: CommentSide,
+        line: u32,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // "Composer" context: ⏎ commits the comment, ⇧⏎ adds a line.
+        let input = cx.new(|cx| ComposerInput::new("Request a change…", cx));
+        let events = cx.subscribe(&input, |this: &mut Self, _, event, cx| match event {
+            ComposerInputEvent::Submitted => this.commit_draft(cx),
+            ComposerInputEvent::Edited => cx.notify(),
+            _ => {}
+        });
+        let handle = input.read(cx).focus_handle(cx);
+        self.draft = Some(CommentDraft {
+            path,
+            side,
+            line,
+            input,
+            _events: events,
+        });
+        window.focus(&handle, cx);
+        self.sync_comment_rows(cx);
+        cx.notify();
+    }
+
+    fn cancel_draft(&mut self, cx: &mut Context<Self>) {
+        self.draft = None;
+        self.sync_comment_rows(cx);
+        cx.notify();
+    }
+
+    /// Stage the open draft. An empty body just closes the card — a blank
+    /// comment would ride the prompt as a bullet with nothing after the colon.
+    fn commit_draft(&mut self, cx: &mut Context<Self>) {
+        let Some(draft) = self.draft.take() else {
+            return;
+        };
+        let body = draft.input.read(cx).text().trim().to_string();
+        if body.is_empty() {
+            self.sync_comment_rows(cx);
+            cx.notify();
+            return;
+        }
+        let comment = DiffComment::new(draft.path, draft.side, draft.line, body);
+        self.state.update(cx, |state, cx| {
+            let key = state.composer_key();
+            state.add_diff_comment(&key, comment);
+            cx.notify();
+        });
+        self.sync_comment_rows(cx);
+        cx.notify();
+    }
+
+    fn remove_comment(&mut self, id: &str, cx: &mut Context<Self>) {
+        self.state.update(cx, |state, cx| {
+            let key = state.composer_key();
+            state.remove_diff_comment(&key, id);
+            cx.notify();
+        });
+        self.sync_comment_rows(cx);
         cx.notify();
     }
 
@@ -1996,7 +2355,66 @@ impl Changes {
                     .as_deref()
                     .map(|highlights| highlights.spans(line))
                     .unwrap_or(&[]);
-                diff_line_row(line, spans, &theme, gutter_width(file_diff))
+                let gutter_px = gutter_width(file_diff);
+                let row = diff_line_row(line, spans, &theme, gutter_px);
+                let Some((side, line_no)) = line_anchor(line) else {
+                    return row;
+                };
+                let path = file_diff.path.clone();
+                let hovered = self.hover.as_ref().is_some_and(|hover| {
+                    hover.path == path && hover.side == side && hover.line == line_no
+                });
+                let move_path = path.clone();
+                let leave_path = path.clone();
+                div()
+                    .id(("diff-line", ix))
+                    .w_full()
+                    .relative()
+                    .child(row)
+                    .when(hovered, |el| {
+                        el.child(positioned_adder(
+                            comment_adder_left(side, gutter_px),
+                            render_comment_adder(&path, side, line_no, &theme, cx),
+                        ))
+                    })
+                    .on_mouse_move(cx.listener(move |this, _, _, cx| {
+                        this.set_hover(&move_path, Some((side, line_no)), cx);
+                    }))
+                    .on_hover(cx.listener(move |this, hovered: &bool, _, cx| {
+                        if !*hovered {
+                            this.clear_hover_at(&leave_path, side, line_no, cx);
+                        }
+                    }))
+                    .into_any_element()
+            }
+            DiffRow::CommentCard { file, card } => {
+                let Some(file_diff) = files.get(file as usize) else {
+                    return gpui::Empty.into_any_element();
+                };
+                let comments = self.comments_for(&file_diff.path, cx);
+                match comments.get(card as usize) {
+                    Some(comment) => render_comment_card(comment, &theme, cx),
+                    None => gpui::Empty.into_any_element(),
+                }
+            }
+            DiffRow::CommentDraft { file } => {
+                let Some(file_diff) = files.get(file as usize) else {
+                    return gpui::Empty.into_any_element();
+                };
+                match self
+                    .draft
+                    .as_ref()
+                    .filter(|draft| draft.path == file_diff.path)
+                {
+                    Some(draft) => render_comment_draft(
+                        &draft.path,
+                        draft.line,
+                        draft.input.clone(),
+                        &theme,
+                        cx,
+                    ),
+                    None => gpui::Empty.into_any_element(),
+                }
             }
             DiffRow::BodyPad { .. } => div().w_full().h(px(BODY_BOTTOM_PAD)).into_any_element(),
             DiffRow::FoldingBody { file } => {
@@ -2788,6 +3206,284 @@ fn diff_line_row(
         .into_any_element()
 }
 
+/// Stable per-side token for element ids (`L`/`R`, matching how the comment
+/// cites its line in the prompt).
+fn side_tag(side: CommentSide) -> &'static str {
+    match side {
+        CommentSide::Old => "L",
+        CommentSide::New => "R",
+    }
+}
+
+/// Size of the `+` button, and where it sits.
+pub const COMMENT_ADDER_SIZE: f32 = 16.0;
+
+/// Left inset of the hover `+` for a row: centred over the line-number column
+/// the comment will cite, so the button lands on the very number that ends up
+/// in the prompt.
+///
+/// A row carries both gutters side by side, and a deletion numbers in the
+/// first one.
+pub fn comment_adder_left(side: CommentSide, gutter_px: f32) -> f32 {
+    let column = match side {
+        CommentSide::Old => 0.0,
+        CommentSide::New => gutter_px,
+    };
+    ACCENT_BAR_WIDTH + column + (gutter_px - COMMENT_ADDER_SIZE) / 2.0
+}
+
+/// The `+` plate, parked over the line-number column of the row it belongs to.
+fn positioned_adder(left: f32, adder: AnyElement) -> gpui::Div {
+    div()
+        .absolute()
+        .left(px(left))
+        .top(px(0.0))
+        .h_full()
+        .flex()
+        .items_center()
+        .child(adder)
+}
+
+/// The hover `+` on a diff line: a solid plate over the line number, invisible
+/// until the row is hovered, so a quiet diff stays quiet. `solid`/`on_solid`
+/// are the neutral primary pair — near-white on dark, near-black on light —
+/// not an accent hue.
+fn render_comment_adder(
+    path: &str,
+    side: CommentSide,
+    line: u32,
+    theme: &Theme,
+    cx: &Context<Changes>,
+) -> AnyElement {
+    let target = path.to_string();
+    div()
+        .id(SharedString::from(format!(
+            "cmt-add-{path}-{}-{line}",
+            side_tag(side)
+        )))
+        .size(px(COMMENT_ADDER_SIZE))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(4.0))
+        .bg(theme.solid)
+        .cursor_pointer()
+        .on_click(cx.listener(move |this, _, window, cx| {
+            // A second `+` replaces the open draft rather than stacking two
+            // half-written notes.
+            this.open_draft(target.clone(), side, line, window, cx);
+        }))
+        .child(
+            crate::icons::icon(crate::icons::PLUS)
+                .size(px(11.0))
+                .text_color(theme.on_solid),
+        )
+        .into_any_element()
+}
+
+/// A staged comment parked under its line: mono location, body, and a
+/// hover-revealed remove. Deliberately not a thread — it is one note that
+/// rides the next prompt and then stops existing.
+fn render_comment_card(comment: &DiffComment, theme: &Theme, cx: &Context<Changes>) -> AnyElement {
+    let group: SharedString = format!("cmt-card-{}", comment.id).into();
+    let id = comment.id.clone();
+    div()
+        .group(group.clone())
+        .h(px(comments::card_height(&comment.body)))
+        .flex_none()
+        .flex()
+        .flex_row()
+        .bg(crate::theme::ink(0.05))
+        // A real bar, not a border: it has to be the same ACCENT_BAR_WIDTH as
+        // the +/− bars on the diff rows above and below, or the card's edge
+        // steps in and out of the column (user report).
+        .child(comment_accent_bar(theme.solid.opacity(0.35)))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .flex()
+                .flex_col()
+                .px(px(Theme::SPACE_LG))
+                .py(px(comments::CARD_PAD_V / 2.0))
+                .child(
+                    div()
+                        .h(px(comments::CARD_HEADER_HEIGHT))
+                        .flex_none()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap(px(6.0))
+                        .child(
+                            crate::icons::icon(crate::icons::CHAT_ROUND_LINE)
+                                .size(px(12.0))
+                                .text_color(theme.text_faint),
+                        )
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .truncate()
+                                .font_family(theme.font_mono.clone())
+                                .text_size(px(11.0))
+                                .text_color(theme.text_faint)
+                                .child(SharedString::from(comment.location())),
+                        )
+                        .child(
+                            div()
+                                .id(SharedString::from(format!("cmt-remove-{}", comment.id)))
+                                .flex_none()
+                                .size(px(16.0))
+                                .flex()
+                                .items_center()
+                                .justify_center()
+                                .rounded(px(4.0))
+                                .cursor_pointer()
+                                .opacity(0.0)
+                                .group_hover(group, |s| s.opacity(1.0))
+                                .on_click(
+                                    cx.listener(move |this, _, _, cx| this.remove_comment(&id, cx)),
+                                )
+                                .child(
+                                    crate::icons::icon(crate::icons::CLOSE_CIRCLE)
+                                        .size(px(12.0))
+                                        .text_color(theme.text_muted),
+                                ),
+                        ),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .min_h_0()
+                        // The card's height is analytic (comments::card_height);
+                        // an unexpectedly long body clips inside the card
+                        // instead of pushing the file body past its fold height.
+                        .overflow_hidden()
+                        .text_size(px(12.0))
+                        .line_height(px(comments::CARD_LINE_HEIGHT))
+                        .text_color(theme.text_dim)
+                        .child(SharedString::from(comment.body.clone())),
+                ),
+        )
+        .into_any_element()
+}
+
+/// The card's left edge: the same solid bar, at the same width, as the +/−
+/// accent bars on the diff rows it sits between.
+fn comment_accent_bar(color: gpui::Hsla) -> gpui::Div {
+    div().w(px(ACCENT_BAR_WIDTH)).h_full().flex_none().bg(color)
+}
+
+/// The open draft card: input plus Cancel / Comment. Fixed height so an open
+/// draft never fights the fold tween.
+fn render_comment_draft(
+    path: &str,
+    line: u32,
+    input: Entity<ComposerInput>,
+    theme: &Theme,
+    cx: &Context<Changes>,
+) -> AnyElement {
+    div()
+        .h(px(comments::DRAFT_CARD_HEIGHT))
+        .flex_none()
+        .flex()
+        .flex_row()
+        .bg(crate::theme::ink(0.08))
+        .child(comment_accent_bar(theme.solid.opacity(0.7)))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .flex()
+                .flex_col()
+                .px(px(Theme::SPACE_LG))
+                .py(px(10.0))
+                .child(
+                    div()
+                        .h(px(comments::CARD_HEADER_HEIGHT))
+                        .flex_none()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap(px(6.0))
+                        .child(
+                            crate::icons::icon(crate::icons::CHAT_ROUND_LINE)
+                                .size(px(12.0))
+                                .text_color(theme.text_faint),
+                        )
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .truncate()
+                                .font_family(theme.font_mono.clone())
+                                .text_size(px(11.0))
+                                .text_color(theme.text_faint)
+                                .child(SharedString::from(format!("{path}:{line}"))),
+                        ),
+                )
+                .child(
+                    div()
+                        .h(px(46.0))
+                        .flex_none()
+                        .overflow_hidden()
+                        .text_size(px(12.0))
+                        .child(input.into_any_element()),
+                )
+                .child(
+                    div()
+                        .h(px(28.0))
+                        .flex_none()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .justify_end()
+                        .gap(px(6.0))
+                        .child(
+                            comment_action("cmt-cancel", "Cancel", false, theme)
+                                .on_click(cx.listener(|this, _, _, cx| this.cancel_draft(cx))),
+                        )
+                        .child(
+                            comment_action("cmt-commit", "Comment", true, theme)
+                                .on_click(cx.listener(|this, _, _, cx| this.commit_draft(cx))),
+                        ),
+                ),
+        )
+        .into_any_element()
+}
+
+/// One button on the draft card. `primary` is the filled Comment action.
+fn comment_action(
+    id: &'static str,
+    label: &'static str,
+    primary: bool,
+    theme: &Theme,
+) -> gpui::Stateful<gpui::Div> {
+    div()
+        .id(id)
+        .h(px(22.0))
+        .px(px(10.0))
+        .flex()
+        .items_center()
+        .rounded(px(6.0))
+        .text_size(px(11.0))
+        .font_weight(gpui::FontWeight::MEDIUM)
+        .cursor_pointer()
+        // The neutral primary plate (theme.solid / on_solid), same pair the
+        // send button uses — no accent hue anywhere in the comment surface.
+        .when(primary, |el| el.bg(theme.solid).text_color(theme.on_solid))
+        .when(!primary, |el| {
+            el.text_color(motion::hover_blend(id, theme.text_muted, theme.text))
+                .bg(motion::hover_blend(
+                    id,
+                    gpui::transparent_black(),
+                    theme.element_hover,
+                ))
+                .on_hover(motion::hover_listener(id))
+        })
+        .child(SharedString::from(label))
+}
+
 /// The expanded body of one file section: notices, hunk headers, +/-/context
 /// lines with a coloured accent bar, dual line-number gutters, a marker
 /// column, and paint-only syntax runs (zeron checkout-diff-sidebar).
@@ -3162,7 +3858,7 @@ rename to new_name.rs
     #[test]
     fn rows_flatten_to_line_granularity() {
         let files = parse_patch(PATCH);
-        let (rows, ranges) = flatten_rows(&files, |_| false);
+        let (rows, ranges) = flatten_rows(&files, &[], None, |_| false);
         assert_eq!(ranges.len(), files.len());
         // Every file's span starts with its header…
         for (ix, range) in ranges.iter().enumerate() {
@@ -3189,7 +3885,7 @@ rename to new_name.rs
         assert_eq!(*main_rows.last().unwrap(), DiffRow::BodyPad { file: 0 });
 
         // A collapsed file contributes its header row only.
-        let (rows, ranges) = flatten_rows(&files, |ix| ix == 0);
+        let (rows, ranges) = flatten_rows(&files, &[], None, |ix| ix == 0);
         assert_eq!(ranges[0].len(), 1);
         assert_eq!(rows[ranges[1].start], DiffRow::FileHeader { file: 1 });
 

--- a/crates/ui/src/comments.rs
+++ b/crates/ui/src/comments.rs
@@ -1,0 +1,226 @@
+//! Diff comments: notes pinned to an exact line of the changes pane, staged in
+//! the composer and folded into the next prompt.
+//!
+//! The transport is deliberately the same shape as `attachments.rs`: the
+//! comments ride the user message as PLAIN TEXT (see [`with_comments`]). There
+//! is no second data model — nothing to persist, nothing to sync, and the
+//! agent reads `path:line` in the prompt exactly as a human would. The
+//! composer projects the staged set to one chip while it is being composed;
+//! once sent, the message is ordinary text and the transcript renders it as
+//! such, the same way file mentions carry their own Markdown.
+
+use std::collections::HashMap;
+
+/// Which column of the diff a comment's line number came from. A comment on a
+/// deleted line can only ever cite the pre-change file, so the side has to
+/// travel with the number — `path:42` alone would send the agent to the wrong
+/// line whenever a hunk shifts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CommentSide {
+    Old,
+    New,
+}
+
+/// One staged comment. `id` is client-minted and only ever used to remove the
+/// row again — it never leaves the process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffComment {
+    pub id: String,
+    /// Display path of the file, as the patch header spells it.
+    pub path: String,
+    pub side: CommentSide,
+    pub line: u32,
+    pub body: String,
+}
+
+impl DiffComment {
+    pub fn new(
+        path: impl Into<String>,
+        side: CommentSide,
+        line: u32,
+        body: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            path: path.into(),
+            side,
+            line,
+            body: body.into(),
+        }
+    }
+
+    /// The anchor a rendered diff row matches itself against.
+    pub fn anchor(&self) -> (CommentSide, u32) {
+        (self.side, self.line)
+    }
+
+    /// `file.rs:42` — how the comment cites its line to the agent, and what
+    /// the card shows in its header.
+    pub fn location(&self) -> String {
+        format!("{}:{}", self.path, self.line)
+    }
+}
+
+/// Body used when the user stages comments and sends with an empty prompt —
+/// mirrors `attachments::ATTACHMENT_ONLY_TEXT`.
+pub const COMMENT_ONLY_TEXT: &str = "Address the review comments below.";
+
+/// How comments ride the prompt: a trailing block of `path:line` bullets.
+///
+/// Multi-line bodies are indented under their bullet so the block stays
+/// unambiguous when the agent re-reads it, and `L`/`R` marks which side of the
+/// diff the number indexes (`R` = the post-change file, the common case).
+pub fn with_comments(text: &str, comments: &[DiffComment]) -> String {
+    if comments.is_empty() {
+        return text.to_string();
+    }
+    let bullets: Vec<String> = comments
+        .iter()
+        .map(|comment| {
+            let side = match comment.side {
+                CommentSide::Old => "L",
+                CommentSide::New => "R",
+            };
+            // Continuation lines are indented to the bullet's text column; an
+            // unindented second line would read as a new comment.
+            let body = comment.body.trim().replace('\n', "\n  ");
+            format!("- {}:{} ({side}): {body}", comment.path, comment.line)
+        })
+        .collect();
+    let body = if text.is_empty() {
+        COMMENT_ONLY_TEXT
+    } else {
+        text
+    };
+    format!(
+        "{body}\n\nComments on the diff (each cites the file and line it belongs to; L = line number in the original file, R = in the changed file):\n{}",
+        bullets.join("\n")
+    )
+}
+
+/// Composer chip label — "1 comment" / "4 comments".
+pub fn chip_label(count: usize) -> String {
+    if count == 1 {
+        "1 comment".to_string()
+    } else {
+        format!("{count} comments")
+    }
+}
+
+/// Group a chat's staged comments by file path for rendering — the changes
+/// pane walks one file at a time and needs its comments in line order.
+pub fn by_path(comments: &[DiffComment]) -> HashMap<&str, Vec<&DiffComment>> {
+    let mut map: HashMap<&str, Vec<&DiffComment>> = HashMap::new();
+    for comment in comments {
+        map.entry(comment.path.as_str()).or_default().push(comment);
+    }
+    map
+}
+
+pub const CARD_PAD_V: f32 = 20.0;
+pub const CARD_HEADER_HEIGHT: f32 = 22.0;
+pub const CARD_LINE_HEIGHT: f32 = 18.0;
+pub const CARD_GAP: f32 = 6.0;
+/// Characters a card body fits per line at the pane's usual width. Only used
+/// to guess soft wraps — see [`card_height`].
+const CARD_WRAP_COLUMNS: usize = 64;
+/// Ceiling on rendered body lines. A pasted essay clips inside its own card
+/// rather than pushing the whole file body out of its fold height.
+const CARD_MAX_LINES: usize = 8;
+
+/// Rendered height of a comment card.
+///
+/// Analytic, because the changes pane sizes file bodies by arithmetic to drive
+/// the fold tween (`changes::body_height`) — a measured card would desync it,
+/// and the fold clips to the analytic number. That means soft wraps have to be
+/// *guessed* here (the pure function has no width): each hard line is charged
+/// one row per [`CARD_WRAP_COLUMNS`] characters, and the total is capped.
+pub fn card_body_lines(body: &str) -> usize {
+    body.lines()
+        .map(|line| line.chars().count().div_ceil(CARD_WRAP_COLUMNS).max(1))
+        .sum::<usize>()
+        .clamp(1, CARD_MAX_LINES)
+}
+
+pub fn card_height(body: &str) -> f32 {
+    CARD_PAD_V + CARD_HEADER_HEIGHT + card_body_lines(body) as f32 * CARD_LINE_HEIGHT + CARD_GAP
+}
+
+/// The draft card is a fixed two-row affair (input + actions) — its height is
+/// constant so an open draft never fights the fold tween.
+pub const DRAFT_CARD_HEIGHT: f32 = 116.0;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn comment(path: &str, side: CommentSide, line: u32, body: &str) -> DiffComment {
+        DiffComment::new(path, side, line, body)
+    }
+
+    #[test]
+    fn empty_set_leaves_the_prompt_untouched() {
+        assert_eq!(with_comments("ship it", &[]), "ship it");
+    }
+
+    #[test]
+    fn comments_append_as_located_bullets() {
+        let staged = vec![
+            comment("src/main.rs", CommentSide::New, 42, "early-return here"),
+            comment("src/lib.rs", CommentSide::Old, 7, "why was this dropped?"),
+        ];
+        let out = with_comments("look at these", &staged);
+        assert!(out.starts_with("look at these\n\n"));
+        assert!(out.contains("- src/main.rs:42 (R): early-return here"));
+        assert!(out.contains("- src/lib.rs:7 (L): why was this dropped?"));
+    }
+
+    #[test]
+    fn comment_only_send_gets_a_body() {
+        let staged = vec![comment("a.rs", CommentSide::New, 1, "fix")];
+        assert!(with_comments("", &staged).starts_with(COMMENT_ONLY_TEXT));
+    }
+
+    #[test]
+    fn multiline_bodies_indent_under_their_bullet() {
+        let staged = vec![comment("a.rs", CommentSide::New, 3, "first\nsecond")];
+        assert!(with_comments("x", &staged).contains("- a.rs:3 (R): first\n  second"));
+    }
+
+    #[test]
+    fn chip_label_pluralizes() {
+        assert_eq!(chip_label(1), "1 comment");
+        assert_eq!(chip_label(2), "2 comments");
+        assert_eq!(chip_label(0), "0 comments");
+    }
+
+    #[test]
+    fn grouping_keeps_per_file_order() {
+        let staged = vec![
+            comment("a.rs", CommentSide::New, 9, "x"),
+            comment("b.rs", CommentSide::New, 1, "y"),
+            comment("a.rs", CommentSide::New, 2, "z"),
+        ];
+        let grouped = by_path(&staged);
+        assert_eq!(grouped["a.rs"].len(), 2);
+        assert_eq!(grouped["a.rs"][0].line, 9);
+        assert_eq!(grouped["a.rs"][1].line, 2);
+        assert_eq!(grouped["b.rs"].len(), 1);
+    }
+
+    #[test]
+    fn card_height_grows_with_body_lines() {
+        assert!(card_height("two\nlines") > card_height("one"));
+        // An empty body still reserves one line — the card is never zero-tall.
+        assert_eq!(card_height(""), card_height("one"));
+    }
+
+    #[test]
+    fn long_lines_are_charged_for_their_soft_wraps() {
+        assert_eq!(card_body_lines("short"), 1);
+        assert_eq!(card_body_lines(&"x".repeat(CARD_WRAP_COLUMNS)), 1);
+        assert_eq!(card_body_lines(&"x".repeat(CARD_WRAP_COLUMNS + 1)), 2);
+        // Capped, so a pasted essay can't blow out the fold height.
+        assert_eq!(card_body_lines(&"line\n".repeat(200)), CARD_MAX_LINES);
+    }
+}

--- a/crates/ui/src/comments.rs
+++ b/crates/ui/src/comments.rs
@@ -6,8 +6,9 @@
 //! is no second data model — nothing to persist, nothing to sync, and the
 //! agent reads `path:line` in the prompt exactly as a human would. The
 //! composer projects the staged set to one chip while it is being composed;
-//! once sent, the message is ordinary text and the transcript renders it as
-//! such, the same way file mentions carry their own Markdown.
+//! once sent, [`extract_badge`] lifts the same block back out for the
+//! transcript (see `badges.rs`), so the reader sees that one chip again
+//! rather than the bullets the agent reads.
 
 use std::collections::HashMap;
 
@@ -92,10 +93,44 @@ pub fn with_comments(text: &str, comments: &[DiffComment]) -> String {
     } else {
         text
     };
-    format!(
-        "{body}\n\nComments on the diff (each cites the file and line it belongs to; L = line number in the original file, R = in the changed file):\n{}",
-        bullets.join("\n")
-    )
+    format!("{body}\n\n{COMMENT_BLOCK_HEADER}\n{}", bullets.join("\n"))
+}
+
+/// The line that opens the appended block. Exact, and shared with
+/// [`extract_badge`] — the transcript finds the block by matching this string,
+/// so the two can never drift.
+pub const COMMENT_BLOCK_HEADER: &str = "Comments on the diff (each cites the file and line it belongs to; L = line number in the original file, R = in the changed file):";
+
+/// [`crate::badges::Extractor`] for the comment block: strip the trailing
+/// bullets off a sent message and report them as one pill.
+///
+/// The header is matched at a paragraph break at the very end of the message,
+/// which is the only place [`with_comments`] ever writes it — a prompt that
+/// merely quotes the sentence mid-body is left alone.
+pub fn extract_badge(text: &str) -> Option<(String, crate::badges::MessageBadge)> {
+    let marker = format!("\n\n{COMMENT_BLOCK_HEADER}\n");
+    let at = text.rfind(&marker)?;
+    let bullets = &text[at + marker.len()..];
+    // The block is bullets and their indented continuation lines, nothing
+    // else — anything else means this is not a block we wrote, and the text
+    // stays untouched rather than being silently truncated.
+    let count = bullets
+        .lines()
+        .filter(|line| line.starts_with("- "))
+        .count();
+    let well_formed = bullets
+        .lines()
+        .all(|line| line.starts_with("- ") || line.starts_with("  "));
+    if count == 0 || !well_formed {
+        return None;
+    }
+    Some((
+        text[..at].to_string(),
+        crate::badges::MessageBadge {
+            icon: crate::icons::CHAT_ROUND_LINE,
+            label: chip_label(count).into(),
+        },
+    ))
 }
 
 /// Composer chip label — "1 comment" / "4 comments".

--- a/crates/ui/src/comments.rs
+++ b/crates/ui/src/comments.rs
@@ -1,33 +1,27 @@
-//! Diff comments: notes pinned to an exact line of the changes pane, staged in
-//! the composer and folded into the next prompt.
+//! Diff comments: notes pinned to a line of the changes pane, staged on the
+//! composer and folded into the next prompt as plain text.
 //!
-//! The transport is deliberately the same shape as `attachments.rs`: the
-//! comments ride the user message as PLAIN TEXT (see [`with_comments`]). There
-//! is no second data model — nothing to persist, nothing to sync, and the
-//! agent reads `path:line` in the prompt exactly as a human would. The
-//! composer projects the staged set to one chip while it is being composed;
-//! once sent, [`extract_badge`] lifts the same block back out for the
-//! transcript (see `badges.rs`), so the reader sees that one chip again
-//! rather than the bullets the agent reads.
+//! [`with_comments`] appends them; [`extract_badge`] reads the same block back
+//! out for the transcript. There is no second data model.
 
-use std::collections::HashMap;
-
-/// Which column of the diff a comment's line number came from. A comment on a
-/// deleted line can only ever cite the pre-change file, so the side has to
-/// travel with the number — `path:42` alone would send the agent to the wrong
-/// line whenever a hunk shifts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CommentSide {
     Old,
     New,
 }
 
-/// One staged comment. `id` is client-minted and only ever used to remove the
-/// row again — it never leaves the process.
+impl CommentSide {
+    pub fn tag(self) -> &'static str {
+        match self {
+            Self::Old => "L",
+            Self::New => "R",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiffComment {
     pub id: String,
-    /// Display path of the file, as the patch header spells it.
     pub path: String,
     pub side: CommentSide,
     pub line: u32,
@@ -50,27 +44,23 @@ impl DiffComment {
         }
     }
 
-    /// The anchor a rendered diff row matches itself against.
     pub fn anchor(&self) -> (CommentSide, u32) {
         (self.side, self.line)
     }
 
-    /// `file.rs:42` — how the comment cites its line to the agent, and what
-    /// the card shows in its header.
     pub fn location(&self) -> String {
         format!("{}:{}", self.path, self.line)
     }
 }
 
-/// Body used when the user stages comments and sends with an empty prompt —
-/// mirrors `attachments::ATTACHMENT_ONLY_TEXT`.
 pub const COMMENT_ONLY_TEXT: &str = "Address the review comments below.";
 
-/// How comments ride the prompt: a trailing block of `path:line` bullets.
-///
-/// Multi-line bodies are indented under their bullet so the block stays
-/// unambiguous when the agent re-reads it, and `L`/`R` marks which side of the
-/// diff the number indexes (`R` = the post-change file, the common case).
+pub const COMMENT_BLOCK_HEADER: &str = "Comments on the diff (each cites the file and line it belongs to; L = line number in the original file, R = in the changed file):";
+
+fn side_marker(side: CommentSide) -> String {
+    format!(" ({}): ", side.tag())
+}
+
 pub fn with_comments(text: &str, comments: &[DiffComment]) -> String {
     if comments.is_empty() {
         return text.to_string();
@@ -78,14 +68,12 @@ pub fn with_comments(text: &str, comments: &[DiffComment]) -> String {
     let bullets: Vec<String> = comments
         .iter()
         .map(|comment| {
-            let side = match comment.side {
-                CommentSide::Old => "L",
-                CommentSide::New => "R",
-            };
-            // Continuation lines are indented to the bullet's text column; an
-            // unindented second line would read as a new comment.
             let body = comment.body.trim().replace('\n', "\n  ");
-            format!("- {}:{} ({side}): {body}", comment.path, comment.line)
+            format!(
+                "- {}{}{body}",
+                comment.location(),
+                side_marker(comment.side)
+            )
         })
         .collect();
     let body = if text.is_empty() {
@@ -96,44 +84,63 @@ pub fn with_comments(text: &str, comments: &[DiffComment]) -> String {
     format!("{body}\n\n{COMMENT_BLOCK_HEADER}\n{}", bullets.join("\n"))
 }
 
-/// The line that opens the appended block. Exact, and shared with
-/// [`extract_badge`] — the transcript finds the block by matching this string,
-/// so the two can never drift.
-pub const COMMENT_BLOCK_HEADER: &str = "Comments on the diff (each cites the file and line it belongs to; L = line number in the original file, R = in the changed file):";
-
-/// [`crate::badges::Extractor`] for the comment block: strip the trailing
-/// bullets off a sent message and report them as one pill.
-///
-/// The header is matched at a paragraph break at the very end of the message,
-/// which is the only place [`with_comments`] ever writes it — a prompt that
-/// merely quotes the sentence mid-body is left alone.
+/// [`crate::badges::Extractor`] for the comment block. Matched only as a whole
+/// trailing block, so a prompt quoting the header mid-body is left alone.
 pub fn extract_badge(text: &str) -> Option<(String, crate::badges::MessageBadge)> {
     let marker = format!("\n\n{COMMENT_BLOCK_HEADER}\n");
     let at = text.rfind(&marker)?;
-    let bullets = &text[at + marker.len()..];
-    // The block is bullets and their indented continuation lines, nothing
-    // else — anything else means this is not a block we wrote, and the text
-    // stays untouched rather than being silently truncated.
-    let count = bullets
-        .lines()
-        .filter(|line| line.starts_with("- "))
-        .count();
-    let well_formed = bullets
-        .lines()
-        .all(|line| line.starts_with("- ") || line.starts_with("  "));
-    if count == 0 || !well_formed {
+    let block = &text[at + marker.len()..];
+    if block.is_empty()
+        || !block
+            .lines()
+            .all(|line| line.starts_with("- ") || line.starts_with("  "))
+    {
+        return None;
+    }
+    let details = parse_bullets(block);
+    if details.is_empty() {
         return None;
     }
     Some((
         text[..at].to_string(),
         crate::badges::MessageBadge {
             icon: crate::icons::CHAT_ROUND_LINE,
-            label: chip_label(count).into(),
+            label: chip_label(details.len()).into(),
+            details,
         },
     ))
 }
 
-/// Composer chip label — "1 comment" / "4 comments".
+fn parse_bullets(block: &str) -> Vec<crate::badges::BadgeDetail> {
+    let mut details: Vec<crate::badges::BadgeDetail> = Vec::new();
+    for line in block.lines() {
+        let Some(bullet) = line.strip_prefix("- ") else {
+            if let (Some(indented), Some(last)) = (line.strip_prefix("  "), details.last_mut()) {
+                last.body = format!("{}\n{indented}", last.body).into();
+            }
+            continue;
+        };
+        // Earliest marker wins: a body may contain "(L): " itself, and matching
+        // that would swallow the body into the location.
+        let split = [CommentSide::Old, CommentSide::New]
+            .into_iter()
+            .filter_map(|side| {
+                let marker = side_marker(side);
+                bullet.find(&marker).map(|at| (at, marker.len(), side))
+            })
+            .min_by_key(|(at, _, _)| *at);
+        let Some((at, marker_len, side)) = split else {
+            continue;
+        };
+        details.push(crate::badges::BadgeDetail {
+            location: bullet[..at].into(),
+            tag: Some(side.tag().into()),
+            body: bullet[at + marker_len..].into(),
+        });
+    }
+    details
+}
+
 pub fn chip_label(count: usize) -> String {
     if count == 1 {
         "1 comment".to_string()
@@ -142,34 +149,16 @@ pub fn chip_label(count: usize) -> String {
     }
 }
 
-/// Group a chat's staged comments by file path for rendering — the changes
-/// pane walks one file at a time and needs its comments in line order.
-pub fn by_path(comments: &[DiffComment]) -> HashMap<&str, Vec<&DiffComment>> {
-    let mut map: HashMap<&str, Vec<&DiffComment>> = HashMap::new();
-    for comment in comments {
-        map.entry(comment.path.as_str()).or_default().push(comment);
-    }
-    map
-}
-
 pub const CARD_PAD_V: f32 = 20.0;
 pub const CARD_HEADER_HEIGHT: f32 = 22.0;
 pub const CARD_LINE_HEIGHT: f32 = 18.0;
-pub const CARD_GAP: f32 = 6.0;
-/// Characters a card body fits per line at the pane's usual width. Only used
-/// to guess soft wraps — see [`card_height`].
+pub const DRAFT_CARD_HEIGHT: f32 = 116.0;
+const CARD_GAP: f32 = 6.0;
 const CARD_WRAP_COLUMNS: usize = 64;
-/// Ceiling on rendered body lines. A pasted essay clips inside its own card
-/// rather than pushing the whole file body out of its fold height.
 const CARD_MAX_LINES: usize = 8;
 
-/// Rendered height of a comment card.
-///
-/// Analytic, because the changes pane sizes file bodies by arithmetic to drive
-/// the fold tween (`changes::body_height`) — a measured card would desync it,
-/// and the fold clips to the analytic number. That means soft wraps have to be
-/// *guessed* here (the pure function has no width): each hard line is charged
-/// one row per [`CARD_WRAP_COLUMNS`] characters, and the total is capped.
+/// Wraps are guessed, not measured: the changes pane sizes bodies by arithmetic
+/// to drive the fold tween, and a measured card would desync it.
 pub fn card_body_lines(body: &str) -> usize {
     body.lines()
         .map(|line| line.chars().count().div_ceil(CARD_WRAP_COLUMNS).max(1))
@@ -180,10 +169,6 @@ pub fn card_body_lines(body: &str) -> usize {
 pub fn card_height(body: &str) -> f32 {
     CARD_PAD_V + CARD_HEADER_HEIGHT + card_body_lines(body) as f32 * CARD_LINE_HEIGHT + CARD_GAP
 }
-
-/// The draft card is a fixed two-row affair (input + actions) — its height is
-/// constant so an open draft never fights the fold tween.
-pub const DRAFT_CARD_HEIGHT: f32 = 116.0;
 
 #[cfg(test)]
 mod tests {
@@ -230,23 +215,24 @@ mod tests {
     }
 
     #[test]
-    fn grouping_keeps_per_file_order() {
-        let staged = vec![
-            comment("a.rs", CommentSide::New, 9, "x"),
-            comment("b.rs", CommentSide::New, 1, "y"),
-            comment("a.rs", CommentSide::New, 2, "z"),
-        ];
-        let grouped = by_path(&staged);
-        assert_eq!(grouped["a.rs"].len(), 2);
-        assert_eq!(grouped["a.rs"][0].line, 9);
-        assert_eq!(grouped["a.rs"][1].line, 2);
-        assert_eq!(grouped["b.rs"].len(), 1);
+    fn a_body_quoting_a_side_marker_survives_the_round_trip() {
+        let staged = vec![comment(
+            "a.rs",
+            CommentSide::New,
+            5,
+            "see (L): the other one",
+        )];
+        let (text, badge) = extract_badge(&with_comments("x", &staged)).unwrap();
+        assert_eq!(text, "x");
+        assert_eq!(badge.details.len(), 1);
+        assert_eq!(badge.details[0].location.as_ref(), "a.rs:5");
+        assert_eq!(badge.details[0].tag.as_deref(), Some("R"));
+        assert_eq!(badge.details[0].body.as_ref(), "see (L): the other one");
     }
 
     #[test]
     fn card_height_grows_with_body_lines() {
         assert!(card_height("two\nlines") > card_height("one"));
-        // An empty body still reserves one line — the card is never zero-tall.
         assert_eq!(card_height(""), card_height("one"));
     }
 
@@ -255,7 +241,6 @@ mod tests {
         assert_eq!(card_body_lines("short"), 1);
         assert_eq!(card_body_lines(&"x".repeat(CARD_WRAP_COLUMNS)), 1);
         assert_eq!(card_body_lines(&"x".repeat(CARD_WRAP_COLUMNS + 1)), 2);
-        // Capped, so a pasted essay can't blow out the fold height.
         assert_eq!(card_body_lines(&"line\n".repeat(200)), CARD_MAX_LINES);
     }
 }

--- a/crates/ui/src/comments.rs
+++ b/crates/ui/src/comments.rs
@@ -22,7 +22,12 @@ impl CommentSide {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiffComment {
     pub id: String,
+    /// The diff's own path — post-rename when the file moved. This is the
+    /// grouping key the changes pane looks cards up by, NOT necessarily the
+    /// path the citation names (see [`DiffComment::cite_path`]).
     pub path: String,
+    /// Pre-rename path, when the file moved. `None` otherwise.
+    pub old_path: Option<String>,
     pub side: CommentSide,
     pub line: u32,
     pub body: String,
@@ -38,18 +43,36 @@ impl DiffComment {
         Self {
             id: uuid::Uuid::new_v4().to_string(),
             path: path.into(),
+            old_path: None,
             side,
             line,
             body: body.into(),
         }
     }
 
+    /// Tag the comment with the file's pre-rename path so an `Old`-side line
+    /// cites where that line actually lives.
+    pub fn renamed_from(mut self, old_path: Option<impl Into<String>>) -> Self {
+        self.old_path = old_path.map(Into::into);
+        self
+    }
+
     pub fn anchor(&self) -> (CommentSide, u32) {
         (self.side, self.line)
     }
 
+    /// The path the line number is valid in. An `Old`-side line only exists in
+    /// the pre-rename file, so citing `path` there points the agent at a line
+    /// of a file that never held it.
+    pub fn cite_path(&self) -> &str {
+        match self.side {
+            CommentSide::Old => self.old_path.as_deref().unwrap_or(&self.path),
+            CommentSide::New => &self.path,
+        }
+    }
+
     pub fn location(&self) -> String {
-        format!("{}:{}", self.path, self.line)
+        format!("{}:{}", self.cite_path(), self.line)
     }
 }
 
@@ -228,6 +251,31 @@ mod tests {
         assert_eq!(badge.details[0].location.as_ref(), "a.rs:5");
         assert_eq!(badge.details[0].tag.as_deref(), Some("R"));
         assert_eq!(badge.details[0].body.as_ref(), "see (L): the other one");
+    }
+
+    #[test]
+    fn a_renamed_file_cites_the_side_the_line_lives_in() {
+        let old = comment("new_name.rs", CommentSide::Old, 7, "why dropped?")
+            .renamed_from(Some("old_name.rs"));
+        let new =
+            comment("new_name.rs", CommentSide::New, 12, "nit").renamed_from(Some("old_name.rs"));
+        // The grouping key stays the diff's own path either way.
+        assert_eq!(old.path, "new_name.rs");
+        assert_eq!(new.path, "new_name.rs");
+        let out = with_comments("x", &[old, new]);
+        assert!(out.contains("- old_name.rs:7 (L): why dropped?"));
+        assert!(out.contains("- new_name.rs:12 (R): nit"));
+    }
+
+    #[test]
+    fn an_unrenamed_file_cites_its_only_path_on_both_sides() {
+        let staged = vec![
+            comment("a.rs", CommentSide::Old, 3, "gone"),
+            comment("a.rs", CommentSide::New, 4, "here"),
+        ];
+        let out = with_comments("x", &staged);
+        assert!(out.contains("- a.rs:3 (L): gone"));
+        assert!(out.contains("- a.rs:4 (R): here"));
     }
 
     #[test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -377,6 +377,13 @@ pub enum SendButtonMode {
     Stop,
 }
 
+/// What the composer holds that a send could carry. A staged image or diff
+/// comment counts: both synthesize their own prompt body, so either alone is
+/// a legal send — and during a live run has to read as Steer, not Stop.
+pub fn composer_has_content(text: &str, attachments: usize, comments: usize) -> bool {
+    !text.trim().is_empty() || attachments > 0 || comments > 0
+}
+
 pub fn send_button_mode(run_live: bool, has_text: bool) -> SendButtonMode {
     match (run_live, has_text) {
         (false, _) => SendButtonMode::Send,
@@ -4405,9 +4412,11 @@ impl Composer {
     }
 
     fn button_mode(&self, cx: &App) -> SendButtonMode {
-        // A staged image counts as content: image-only sends are legal
-        // (the prompt body becomes "See the attached image(s).").
-        let has_text = !self.input.read(cx).text().trim().is_empty() || !self.staged().is_empty();
+        let has_text = composer_has_content(
+            self.input.read(cx).text(),
+            self.staged().len(),
+            self.staged_comments(cx).len(),
+        );
         send_button_mode(self.run_live(cx), has_text)
     }
 
@@ -4423,7 +4432,7 @@ impl Composer {
         }
         let text = self.input.read(cx).text().trim().to_string();
         let no_content =
-            text.is_empty() && self.staged().is_empty() && self.staged_comments(cx).is_empty();
+            !composer_has_content(&text, self.staged().len(), self.staged_comments(cx).len());
         match self.button_mode(cx) {
             SendButtonMode::Stop => self.interrupt(cx),
             _ if no_content => {}
@@ -6294,6 +6303,30 @@ mod tests {
         assert_eq!(m.progress(180.0), 1.0);
         let mid = m.progress(90.0);
         assert!(mid > 0.0 && mid < 1.0);
+    }
+
+    #[test]
+    fn staged_comments_alone_are_content() {
+        assert!(!composer_has_content("   ", 0, 0));
+        assert!(composer_has_content("hi", 0, 0));
+        assert!(composer_has_content("", 1, 0));
+        assert!(composer_has_content("", 0, 1));
+    }
+
+    #[test]
+    fn a_comment_only_stage_steers_a_live_run_instead_of_stopping_it() {
+        let live = true;
+        let comment_only = composer_has_content("", 0, 2);
+        assert_eq!(
+            send_button_mode(live, comment_only),
+            SendButtonMode::Steer,
+            "comment-only submit must steer, not interrupt the run"
+        );
+        // Nothing staged at all is still the stop square.
+        assert_eq!(
+            send_button_mode(live, composer_has_content("", 0, 0)),
+            SendButtonMode::Stop
+        );
     }
 
     #[test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -210,16 +210,14 @@ pub fn attachment_strip_height(count: usize, inner_width: f32) -> f32 {
     STRIP_PAD_TOP + rows as f32 * STRIP_THUMB + (rows - 1) as f32 * STRIP_GAP
 }
 
-/// The staged-comments chip row: one 24px pill on its own line above the
-/// input, same top inset as the attachment strip. Constant, because the chip
-/// collapses every staged comment into a single "N comments" label.
-pub const COMMENT_CHIP_HEIGHT: f32 = 24.0;
-
+/// The staged-badge chip row: one pill on its own line above the input, same
+/// top inset as the attachment strip. Constant, because each badge collapses
+/// its whole staged set into a single label.
 pub fn comment_strip_height(count: usize) -> f32 {
     if count == 0 {
         return 0.0;
     }
-    STRIP_PAD_TOP + COMMENT_CHIP_HEIGHT
+    STRIP_PAD_TOP + crate::badges::BADGE_HEIGHT
 }
 
 /// Compact↔expanded flip morph (round 9): the flip used to snap between the
@@ -3599,26 +3597,13 @@ impl Composer {
                 .flex_row()
                 .px(px(STRIP_PAD_X))
                 .pt(px(STRIP_PAD_TOP))
-                .child(
-                    div()
-                        .h(px(COMMENT_CHIP_HEIGHT))
-                        .flex()
-                        .flex_row()
-                        .items_center()
-                        .gap(px(6.0))
-                        .px(px(8.0))
-                        .rounded(px(8.0))
-                        .bg(crate::theme::ink(0.06))
-                        .text_size(px(12.0))
-                        .font_weight(gpui::FontWeight::MEDIUM)
-                        .text_color(theme.text_muted)
-                        .child(
-                            crate::icons::icon(crate::icons::CHAT_ROUND_LINE)
-                                .size(px(12.0))
-                                .text_color(theme.text_muted.opacity(0.7)),
-                        )
-                        .child(SharedString::from(crate::comments::chip_label(count))),
-                ),
+                .child(crate::badges::render(
+                    &crate::badges::MessageBadge {
+                        icon: crate::icons::CHAT_ROUND_LINE,
+                        label: crate::comments::chip_label(count).into(),
+                    },
+                    theme,
+                )),
         )
     }
 

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -210,9 +210,6 @@ pub fn attachment_strip_height(count: usize, inner_width: f32) -> f32 {
     STRIP_PAD_TOP + rows as f32 * STRIP_THUMB + (rows - 1) as f32 * STRIP_GAP
 }
 
-/// The staged-badge chip row: one pill on its own line above the input, same
-/// top inset as the attachment strip. Constant, because each badge collapses
-/// its whole staged set into a single label.
 pub fn comment_strip_height(count: usize) -> f32 {
     if count == 0 {
         return 0.0;
@@ -3572,9 +3569,7 @@ impl Composer {
         });
     }
 
-    /// Diff comments staged for the chat the composer is aimed at. They live
-    /// in `AppState` because the changes pane writes them — the composer only
-    /// shows the count and folds them into the next prompt.
+    /// Staged in `AppState` because the changes pane writes them.
     fn staged_comments(&self, cx: &App) -> Vec<crate::comments::DiffComment> {
         self.state
             .read(cx)
@@ -3582,10 +3577,6 @@ impl Composer {
             .to_vec()
     }
 
-    /// The "N comments" chip: a read-only ghost pill above the input, the same
-    /// tone as the footer picker chips. It reports what will ride the next
-    /// prompt; the comments themselves are edited in the changes pane, so
-    /// there is nothing to click here.
     fn render_comments_chip(&self, theme: &Theme, cx: &App) -> Option<gpui::Div> {
         let count = self.staged_comments(cx).len();
         if count == 0 {
@@ -3598,9 +3589,13 @@ impl Composer {
                 .px(px(STRIP_PAD_X))
                 .pt(px(STRIP_PAD_TOP))
                 .child(crate::badges::render(
+                    "composer-comments",
                     &crate::badges::MessageBadge {
                         icon: crate::icons::CHAT_ROUND_LINE,
                         label: crate::comments::chip_label(count).into(),
+                        // The staged set is already on screen in the changes
+                        // pane, so a hover card would only repeat it.
+                        details: Vec::new(),
                     },
                     theme,
                 )),
@@ -4509,9 +4504,7 @@ impl Composer {
             .attachments
             .remove(&self.current_key)
             .unwrap_or_default();
-        // Diff comments ride the prompt as plain text and clear on the same
-        // beat — the chip empties the instant the message carrying them goes
-        // out. `typed` keeps the user's own words for the failure hand-back:
+        // `typed` keeps the user's own words for the failure hand-back below:
         // restoring the folded prompt would paste the comment block into the
         // input as literal text.
         let key = self.current_key.clone();
@@ -4805,10 +4798,9 @@ impl Composer {
                     composer.state.update(cx, |s, cx| {
                         s.remove_echo(&err_chat_id, &err_message_id);
                         s.end_pending_send(&err_chat_id, &err_message_id);
-                        // Comments back on the stage, under the chat's key —
-                        // a new chat's send has already re-keyed the composer
-                        // to the minted id by now, exactly like the staged
-                        // files below.
+                        // Re-staged under the chat's key: a new chat's send has
+                        // already re-keyed the composer to the minted id by
+                        // now, exactly like the staged files below.
                         for comment in &comments {
                             s.add_diff_comment(&err_chat_id, comment.clone());
                         }
@@ -5491,7 +5483,6 @@ impl Render for Composer {
         let staged_count = self.staged().len();
         let strip_width_hint = if last_width > 0.0 { last_width } else { 720.0 };
         let strip_h = attachment_strip_height(staged_count, strip_width_hint);
-        // Staged diff comments add one chip row on the same terms.
         let comment_strip_h = comment_strip_height(self.staged_comments(cx).len());
         let base_height = if expanded {
             composer_total_height(content_height)
@@ -5542,8 +5533,7 @@ impl Render for Composer {
                     .text_color(theme.text_muted),
             );
         // Staged-thumbnail strip (attachment-ui.tsx AttachmentStrip), above
-        // the input inside the pill in both modes. The comments chip sits
-        // above it — comments are about the diff, images about the prompt.
+        // the input inside the pill in both modes.
         let strip = self.render_attachment_strip(&theme, cx);
         let comments_chip = self.render_comments_chip(&theme, cx);
 

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -210,6 +210,18 @@ pub fn attachment_strip_height(count: usize, inner_width: f32) -> f32 {
     STRIP_PAD_TOP + rows as f32 * STRIP_THUMB + (rows - 1) as f32 * STRIP_GAP
 }
 
+/// The staged-comments chip row: one 24px pill on its own line above the
+/// input, same top inset as the attachment strip. Constant, because the chip
+/// collapses every staged comment into a single "N comments" label.
+pub const COMMENT_CHIP_HEIGHT: f32 = 24.0;
+
+pub fn comment_strip_height(count: usize) -> f32 {
+    if count == 0 {
+        return 0.0;
+    }
+    STRIP_PAD_TOP + COMMENT_CHIP_HEIGHT
+}
+
 /// Compact↔expanded flip morph (round 9): the flip used to snap between the
 /// two pill layouts. The original has no height transition (its shell carries
 /// only `transition-colors`), so this is a native nicety: ONE committed flip
@@ -3555,8 +3567,59 @@ impl Composer {
 
     /// Drop a deleted chat's per-chat composer state — staged attachments hold
     /// raw image bytes, and a deleted chat's stage could never be sent again.
-    pub fn purge_chat(&mut self, chat_id: &str) {
+    pub fn purge_chat(&mut self, chat_id: &str, cx: &mut Context<Self>) {
         self.attachments.remove(chat_id);
+        self.state.update(cx, |state, _| {
+            state.purge_diff_comments(chat_id);
+        });
+    }
+
+    /// Diff comments staged for the chat the composer is aimed at. They live
+    /// in `AppState` because the changes pane writes them — the composer only
+    /// shows the count and folds them into the next prompt.
+    fn staged_comments(&self, cx: &App) -> Vec<crate::comments::DiffComment> {
+        self.state
+            .read(cx)
+            .diff_comments(&self.current_key)
+            .to_vec()
+    }
+
+    /// The "N comments" chip: a read-only ghost pill above the input, the same
+    /// tone as the footer picker chips. It reports what will ride the next
+    /// prompt; the comments themselves are edited in the changes pane, so
+    /// there is nothing to click here.
+    fn render_comments_chip(&self, theme: &Theme, cx: &App) -> Option<gpui::Div> {
+        let count = self.staged_comments(cx).len();
+        if count == 0 {
+            return None;
+        }
+        Some(
+            div()
+                .flex()
+                .flex_row()
+                .px(px(STRIP_PAD_X))
+                .pt(px(STRIP_PAD_TOP))
+                .child(
+                    div()
+                        .h(px(COMMENT_CHIP_HEIGHT))
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap(px(6.0))
+                        .px(px(8.0))
+                        .rounded(px(8.0))
+                        .bg(crate::theme::ink(0.06))
+                        .text_size(px(12.0))
+                        .font_weight(gpui::FontWeight::MEDIUM)
+                        .text_color(theme.text_muted)
+                        .child(
+                            crate::icons::icon(crate::icons::CHAT_ROUND_LINE)
+                                .size(px(12.0))
+                                .text_color(theme.text_muted.opacity(0.7)),
+                        )
+                        .child(SharedString::from(crate::comments::chip_label(count))),
+                ),
+        )
     }
 
     /// The staged-thumbnail strip (attachment-ui.tsx AttachmentStrip):
@@ -4379,9 +4442,11 @@ impl Composer {
             return;
         }
         let text = self.input.read(cx).text().trim().to_string();
+        let no_content =
+            text.is_empty() && self.staged().is_empty() && self.staged_comments(cx).is_empty();
         match self.button_mode(cx) {
             SendButtonMode::Stop => self.interrupt(cx),
-            _ if text.is_empty() && self.staged().is_empty() => {}
+            _ if no_content => {}
             _ if self.send_blocked(cx) => {}
             SendButtonMode::Send => self.send(text, false, cx),
             SendButtonMode::Steer => self.send(text, true, cx),
@@ -4459,6 +4524,21 @@ impl Composer {
             .attachments
             .remove(&self.current_key)
             .unwrap_or_default();
+        // Diff comments ride the prompt as plain text and clear on the same
+        // beat — the chip empties the instant the message carrying them goes
+        // out. `typed` keeps the user's own words for the failure hand-back:
+        // restoring the folded prompt would paste the comment block into the
+        // input as literal text.
+        let key = self.current_key.clone();
+        let comments = self.state.update(cx, |state, cx| {
+            let taken = state.take_diff_comments(&key);
+            if !taken.is_empty() {
+                cx.notify();
+            }
+            taken
+        });
+        let typed = text.clone();
+        let text = crate::comments::with_comments(&text, &comments);
         self.preview = None;
         let message_id = uuid::Uuid::new_v4().to_string();
         let created_at = chrono::Utc::now().timestamp_millis();
@@ -4521,7 +4601,7 @@ impl Composer {
         cx.notify();
 
         let steer_cmd = steer && !is_new;
-        let restore_text = text.clone();
+        let restore_text = typed;
         let err_chat_id = chat_id.clone();
         let err_message_id = message_id.clone();
         self.send_task = Some(cx.spawn(async move |this, cx| {
@@ -4740,6 +4820,13 @@ impl Composer {
                     composer.state.update(cx, |s, cx| {
                         s.remove_echo(&err_chat_id, &err_message_id);
                         s.end_pending_send(&err_chat_id, &err_message_id);
+                        // Comments back on the stage, under the chat's key —
+                        // a new chat's send has already re-keyed the composer
+                        // to the minted id by now, exactly like the staged
+                        // files below.
+                        for comment in &comments {
+                            s.add_diff_comment(&err_chat_id, comment.clone());
+                        }
                         cx.notify();
                     });
                     composer.input.update(cx, |input, cx| input.set_text(restore_text, cx));
@@ -5419,12 +5506,14 @@ impl Render for Composer {
         let staged_count = self.staged().len();
         let strip_width_hint = if last_width > 0.0 { last_width } else { 720.0 };
         let strip_h = attachment_strip_height(staged_count, strip_width_hint);
+        // Staged diff comments add one chip row on the same terms.
+        let comment_strip_h = comment_strip_height(self.staged_comments(cx).len());
         let base_height = if expanded {
             composer_total_height(content_height)
         } else {
             COMPACT_TOTAL_HEIGHT
         };
-        let target_height = base_height + strip_h;
+        let target_height = base_height + strip_h + comment_strip_h;
         let (pill_height, morph_t, morphing) = match self.flip_morph {
             Some(m) if !m.done(now_ms) => {
                 (m.height(target_height, now_ms), m.progress(now_ms), true)
@@ -5468,8 +5557,10 @@ impl Render for Composer {
                     .text_color(theme.text_muted),
             );
         // Staged-thumbnail strip (attachment-ui.tsx AttachmentStrip), above
-        // the input inside the pill in both modes.
+        // the input inside the pill in both modes. The comments chip sits
+        // above it — comments are about the diff, images about the prompt.
         let strip = self.render_attachment_strip(&theme, cx);
+        let comments_chip = self.render_comments_chip(&theme, cx);
 
         // The pill chrome (zeron composer.tsx): `rounded-[26px] border
         // border-white/[0.08] bg-white/[0.03] shadow-xl` — a floating pill with
@@ -5507,6 +5598,7 @@ impl Render for Composer {
                 .relative()
                 .flex()
                 .flex_col()
+                .children(comments_chip)
                 .children(strip)
                 .child(
                     div()
@@ -5559,6 +5651,7 @@ impl Render for Composer {
                 .flex()
                 .flex_col()
                 .justify_end()
+                .children(comments_chip)
                 .children(strip)
                 .child(
                     div()

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -16,6 +16,7 @@ pub mod app_menus;
 pub mod appearance;
 pub mod attachments;
 pub mod changes;
+pub mod comments;
 pub mod composer;
 pub mod edge_fade;
 pub mod frost;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod app_menus;
 pub mod appearance;
 pub mod attachments;
+pub mod badges;
 pub mod changes;
 pub mod comments;
 pub mod composer;

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -300,11 +300,15 @@ pub fn classify_key(key: &str, cmd: bool, ctrl: bool) -> MenuKey {
 /// [`crate::frost::MENU_BLUR`] blur from the mount helpers below, plus the
 /// same hairline + baked-in shadow. Opaque platforms keep the near-opaque
 /// tone the reference composites to on the dark panels (~#161616).
+/// Corner radius of every floating card. The frost wrapper masks its backdrop
+/// blur to the same value, so the two must agree.
+pub const CARD_RADIUS: f32 = 12.0;
+
 pub fn popover_card(theme: &Theme) -> gpui::Div {
     let card = div()
         .border_1()
         .border_color(hairline(0.10))
-        .rounded(px(12.0))
+        .rounded(px(CARD_RADIUS))
         .shadow_lg()
         .p(px(4.0))
         .overflow_hidden()
@@ -362,7 +366,7 @@ fn exit_progress(since: std::time::Instant) -> f32 {
 /// hold full strength through the fade and pop off at unmount.
 fn frosted_menu(exit: Option<f32>, content: AnyElement) -> AnyElement {
     let blur = crate::frost::MENU_BLUR * (1.0 - exit.unwrap_or(0.0));
-    crate::frost::frosted(12.0, blur, content).into_any_element()
+    crate::frost::frosted(CARD_RADIUS, blur, content).into_any_element()
 }
 
 /// Entrance or exit motion for a popover layer. While exiting (the [`Popup`]

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -2020,7 +2020,7 @@ impl Shell {
             self.state.update(cx, |s, cx| s.select_chat(None, cx));
         }
         self.composer
-            .update(cx, |composer, _| composer.purge_chat(&chat_id));
+            .update(cx, |composer, cx| composer.purge_chat(&chat_id, cx));
         self.mutate(
             serde_json::json!({ "op": "deleteChat", "chatId": chat_id }),
             cx,

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -27,6 +27,7 @@ use gpui::{App, Context, Entity, Task};
 use gpui_tokio::Tokio;
 use serde::de::DeserializeOwned;
 
+use crate::comments::DiffComment;
 use zeron_doc::{SessionMessageEntry, TranscriptDesync, TranscriptFrame};
 use zeron_engine::{Engine, EngineConfig, EngineRuntime, InstanceLock, rpc::AuthRpc};
 use zeron_proto::{
@@ -606,6 +607,10 @@ pub struct AppState {
     /// Send-in-flight overlay per chat id: a queued doc command the host
     /// hasn't executed yet (see [`Self::begin_pending_send`]).
     pending_sends: HashMap<String, PendingSend>,
+    /// Diff comments staged per composer key. The changes pane writes them,
+    /// the composer reads them for its chip and folds them into the next
+    /// prompt — AppState is the only thing both views already share.
+    diff_comments: HashMap<String, Vec<DiffComment>>,
     /// This engine's device id (best-effort `LocalDevice` probe; `None` until
     /// the engine serves it — views degrade gracefully).
     pub local_device_id: Option<String>,
@@ -642,6 +647,7 @@ impl AppState {
             transcript: Vec::new(),
             echoes: HashMap::new(),
             pending_sends: HashMap::new(),
+            diff_comments: HashMap::new(),
             local_device_id: None,
             update: None,
             data_dir: None,
@@ -652,6 +658,50 @@ impl AppState {
             chats_synced: false,
             spaces_synced: false,
         }
+    }
+
+    // ---- diff comments (pure) ----
+
+    /// The key both the changes pane and the composer stage under: the
+    /// selected chat, or `""` on the new-chat canvas — identical to the
+    /// composer's own per-chat attachment/draft key, so a comment written
+    /// before the first send survives the chat being minted.
+    pub fn composer_key(&self) -> String {
+        self.selected_chat.clone().unwrap_or_default()
+    }
+
+    pub fn diff_comments(&self, key: &str) -> &[DiffComment] {
+        self.diff_comments
+            .get(key)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    pub fn add_diff_comment(&mut self, key: &str, comment: DiffComment) {
+        self.diff_comments
+            .entry(key.to_string())
+            .or_default()
+            .push(comment);
+    }
+
+    pub fn remove_diff_comment(&mut self, key: &str, id: &str) {
+        if let Some(list) = self.diff_comments.get_mut(key) {
+            list.retain(|c| c.id != id);
+            if list.is_empty() {
+                self.diff_comments.remove(key);
+            }
+        }
+    }
+
+    /// Snapshot-and-clear on send (`attachments` does the same): the chip
+    /// empties the instant the prompt carrying the comments goes out.
+    pub fn take_diff_comments(&mut self, key: &str) -> Vec<DiffComment> {
+        self.diff_comments.remove(key).unwrap_or_default()
+    }
+
+    /// Drop a deleted chat's stage — its comments could never be sent again.
+    pub fn purge_diff_comments(&mut self, key: &str) {
+        self.diff_comments.remove(key);
     }
 
     // ---- reducers (pure) ----

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -607,9 +607,7 @@ pub struct AppState {
     /// Send-in-flight overlay per chat id: a queued doc command the host
     /// hasn't executed yet (see [`Self::begin_pending_send`]).
     pending_sends: HashMap<String, PendingSend>,
-    /// Diff comments staged per composer key. The changes pane writes them,
-    /// the composer reads them for its chip and folds them into the next
-    /// prompt — AppState is the only thing both views already share.
+    /// Written by the changes pane, read by the composer.
     diff_comments: HashMap<String, Vec<DiffComment>>,
     /// This engine's device id (best-effort `LocalDevice` probe; `None` until
     /// the engine serves it — views degrade gracefully).
@@ -660,12 +658,9 @@ impl AppState {
         }
     }
 
-    // ---- diff comments (pure) ----
-
-    /// The key both the changes pane and the composer stage under: the
-    /// selected chat, or `""` on the new-chat canvas — identical to the
-    /// composer's own per-chat attachment/draft key, so a comment written
-    /// before the first send survives the chat being minted.
+    /// The selected chat, or `""` on the new-chat canvas. Identical to the
+    /// composer's own attachment/draft key, so a comment written before the
+    /// first send survives the chat being minted.
     pub fn composer_key(&self) -> String {
         self.selected_chat.clone().unwrap_or_default()
     }
@@ -693,13 +688,10 @@ impl AppState {
         }
     }
 
-    /// Snapshot-and-clear on send (`attachments` does the same): the chip
-    /// empties the instant the prompt carrying the comments goes out.
     pub fn take_diff_comments(&mut self, key: &str) -> Vec<DiffComment> {
         self.diff_comments.remove(key).unwrap_or_default()
     }
 
-    /// Drop a deleted chat's stage — its comments could never be sent again.
     pub fn purge_diff_comments(&mut self, key: &str) {
         self.diff_comments.remove(key);
     }

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -498,6 +498,10 @@ pub enum RowKind {
         /// Image refs parsed out of the message text (message-attachments.ts):
         /// thumbnails load from the owning device via ReadAttachmentChunk.
         attachments: Arc<Vec<crate::attachments::UserImageAttachment>>,
+        /// Structured context the prompt folded in as text — diff comments and
+        /// anything else registered in `badges` — lifted back out and shown as
+        /// pills over the bubble instead of raw bullets.
+        badges: Arc<Vec<crate::badges::MessageBadge>>,
         /// Optimistic echo not yet confirmed by a doc frame.
         pending: bool,
     },
@@ -663,9 +667,13 @@ pub fn rows_for_entry(
         // File mentions render as chips here too, not just in the composer.
         // The projection is pure over the text, so the raw-length row version
         // below stays a valid cache/diff key.
-        let (text, mentions) = match crate::composer::sent_mention_display(&parsed.text) {
+        // Badge blocks (diff comments today) ride the same plain text; lift
+        // them out before the mention projection so a comment body's own
+        // Markdown never lands in the bubble.
+        let (body, badges) = crate::badges::split(&parsed.text);
+        let (text, mentions) = match crate::composer::sent_mention_display(&body) {
             Some((display, spans)) => (display, spans),
-            None => (parsed.text, Vec::new()),
+            None => (body, Vec::new()),
         };
         return vec![Row {
             id: entry.id.clone().into(),
@@ -675,6 +683,7 @@ pub fn rows_for_entry(
                 text: text.into(),
                 mentions: Arc::new(mentions),
                 attachments: Arc::new(parsed.attachments),
+                badges: Arc::new(badges),
                 pending,
             },
             entry_id,
@@ -2744,9 +2753,11 @@ impl Transcript {
                 text,
                 mentions,
                 attachments,
+                badges,
                 pending,
             } => {
                 let attachments = attachments.clone();
+                let badges = badges.clone();
                 let text = text.clone();
                 let mentions = mentions.clone();
                 let pending = *pending;
@@ -2756,6 +2767,28 @@ impl Transcript {
                 let mut column = div().w_full().flex().flex_col();
                 if !attachments.is_empty() {
                     column = column.child(self.render_user_attachments(&row.id, &attachments, cx));
+                }
+                // Badge pills sit between the thumbnails and the bubble, on
+                // the same right-aligned axis — the composer shows the very
+                // same pill while the prompt is being written, so sending one
+                // reads as the chip moving into the transcript.
+                if !badges.is_empty() {
+                    column = column.child(
+                        div()
+                            .w_full()
+                            .flex()
+                            .flex_row()
+                            .flex_wrap()
+                            .justify_end()
+                            .items_center()
+                            .gap(px(6.0))
+                            .pb(px(6.0))
+                            .children(
+                                badges
+                                    .iter()
+                                    .map(|badge| crate::badges::render(badge, &theme)),
+                            ),
+                    );
                 }
                 if !text.is_empty() {
                     // `min_w_0` is load-bearing: gpui text answers min/max-content

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -3696,6 +3696,8 @@ fn detail_body(
 ) -> AnyElement {
     let body = div().w_full().min_w_0().flex().flex_col().overflow_hidden();
     match detail {
+        // No comment layer: an inline tool diff is a record of what the
+        // agent already did, not a review surface.
         ToolDetail::Diff { file, .. } => body
             .child(crate::changes::render_file_body_with_syntax(
                 file,

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -498,9 +498,7 @@ pub enum RowKind {
         /// Image refs parsed out of the message text (message-attachments.ts):
         /// thumbnails load from the owning device via ReadAttachmentChunk.
         attachments: Arc<Vec<crate::attachments::UserImageAttachment>>,
-        /// Structured context the prompt folded in as text — diff comments and
-        /// anything else registered in `badges` — lifted back out and shown as
-        /// pills over the bubble instead of raw bullets.
+        /// Context the prompt folded in as text, lifted back out by `badges`.
         badges: Arc<Vec<crate::badges::MessageBadge>>,
         /// Optimistic echo not yet confirmed by a doc frame.
         pending: bool,
@@ -667,8 +665,7 @@ pub fn rows_for_entry(
         // File mentions render as chips here too, not just in the composer.
         // The projection is pure over the text, so the raw-length row version
         // below stays a valid cache/diff key.
-        // Badge blocks (diff comments today) ride the same plain text; lift
-        // them out before the mention projection so a comment body's own
+        // Lifted before the mention projection, so a comment body's own
         // Markdown never lands in the bubble.
         let (body, badges) = crate::badges::split(&parsed.text);
         let (text, mentions) = match crate::composer::sent_mention_display(&body) {
@@ -2768,10 +2765,6 @@ impl Transcript {
                 if !attachments.is_empty() {
                     column = column.child(self.render_user_attachments(&row.id, &attachments, cx));
                 }
-                // Badge pills sit between the thumbnails and the bubble, on
-                // the same right-aligned axis — the composer shows the very
-                // same pill while the prompt is being written, so sending one
-                // reads as the chip moving into the transcript.
                 if !badges.is_empty() {
                     column = column.child(
                         div()
@@ -2783,11 +2776,13 @@ impl Transcript {
                             .items_center()
                             .gap(px(6.0))
                             .pb(px(6.0))
-                            .children(
-                                badges
-                                    .iter()
-                                    .map(|badge| crate::badges::render(badge, &theme)),
-                            ),
+                            .children(badges.iter().enumerate().map(|(bix, badge)| {
+                                crate::badges::render(
+                                    SharedString::from(format!("{}#badge{bix}", row.id)),
+                                    badge,
+                                    &theme,
+                                )
+                            })),
                     );
                 }
                 if !text.is_empty() {


### PR DESCRIPTION
Adds line comments to the changes pane. Hover any diff line, hit `+`, write a note; it stages against the composer and rides the next prompt.

### How it travels

The comment ships as plain text, the same way `attachments.rs` ships image refs — no second data model, nothing to persist or sync. `with_comments` appends a block of `path:line (L|R): body` bullets; the agent reads the citation exactly as a human would.

```
Address the review comments below.

Comments on the diff (each cites the file and line it belongs to; ...):
- crates/ui/src/changes.rs:3292 (R): why is this cloned?
```

`L`/`R` is load-bearing: a comment on a deleted line can only cite the pre-change file, so `path:42` alone lands on the wrong line once a hunk shifts.

### The pill

Once sent, the reader should not see that block. `badges.rs` lifts it back out and draws one pill over the bubble, the same pill the composer showed while the prompt was being written. Hovering it opens a card listing each note — same accent bar and mono location header as the staged card in the diff pane, so it reads as the same object in both places.

`badges.rs` knows nothing about diff comments. A badge is `{ icon, label, details }`, and a detail is three neutral slots (`location`, optional `tag`, `body`). Adding another kind of pill is one `Extractor` in `EXTRACTORS` plus a stager on the composer side. No click handlers or action hooks yet — those are speculative until there's a second badge to shape them against.

### Notes for review

- `Changes::replace_file_body` now splices only the rows that moved. `ListState::splice` clamps the scroll anchor to the range start when the anchored row falls inside it, so replacing a whole file body jumped the pane to the top every time a comment card opened.
- The hover card is wrapped in `frost::frosted`. That is not only the blur: it also gives the card its own scene layer. Sharing the transcript's layer let the bubble's text paint over the card, since equal draw orders render quads before text.
- `popover::CARD_RADIUS` replaces the `12.0` that was hardcoded in the card, the frost mask, and `frosted_menu`.

Comment cards are not threads — one note that rides the next prompt and then stops existing.

### Testing

437 tests pass; 9 new, covering the prompt round trip (including a body that itself contains `(L): `), multi-line bodies, paths containing a colon, and the card-height arithmetic the fold tween depends on. Exercised by hand in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789333465&installation_model_id=425430&pr_number=83&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F83&signature=ae1a8286c910bfe857c8ce6d706915eef5936a95a097e145712bf7fdc0fe91d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->