### PR TITLE
Add device-local drag-and-drop reordering for sidebar sessions

### DIFF
--- a/crates/ui/assets/icons/pin.svg
+++ b/crates/ui/assets/icons/pin.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3h6l-1 6l3 3v2H7v-2l3-3z"/><path d="M12 14v7"/></g></svg>

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -94,6 +94,8 @@ icon_assets![
     (ADD_CIRCLE, "add-circle"),
     (TUNING, "tuning"),
     (PAPERCLIP, "paperclip"),
+    // Hand-drawn pushpin in the Solar Linear style for local sidebar pins.
+    (PIN, "pin"),
     (PEN, "pen"),
     (ARCHIVE_MINIMALISTIC, "archive-minimalistic"),
     (TRASH_BIN_MINIMALISTIC, "trash-bin-minimalistic"),

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -65,6 +65,10 @@ pub struct UiSettings {
     /// Sidebar session filter: a space id, or `None` for "All spaces".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub space_filter: Option<String>,
+    /// Device-local visual order for sidebar sessions. This never enters the
+    /// synced workspace; an empty list preserves the untouched recency order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sidebar_session_order: Vec<String>,
     /// Legacy: per-space tab order, from when tabs were the selected space's
     /// non-archived sessions. Kept for file compatibility; no longer read.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
@@ -105,6 +109,7 @@ impl Default for UiSettings {
             last_space_id: None,
             open_tabs: None,
             space_filter: None,
+            sidebar_session_order: Vec::new(),
             tab_order: std::collections::HashMap::new(),
             space_order: Vec::new(),
             sound_enabled: true,
@@ -370,6 +375,7 @@ mod tests {
             last_space_id: Some("space-1".into()),
             open_tabs: Some(vec!["b".to_string(), "a".to_string()]),
             space_filter: Some("space-1".into()),
+            sidebar_session_order: vec!["chat-2".to_string(), "chat-1".to_string()],
             tab_order: std::collections::HashMap::from([(
                 "space-1".to_string(),
                 vec!["b".to_string(), "a".to_string()],
@@ -406,6 +412,7 @@ mod tests {
         let loaded = UiSettings::load(dir.path());
         assert_eq!(loaded.appearance, crate::appearance::AppearanceMode::System);
         assert_eq!(loaded.sidebar_width, 300.0);
+        assert!(loaded.sidebar_session_order.is_empty());
         assert!(!loaded.sound_enabled, "other keys still parse");
         assert!(
             loaded.notifications_enabled,

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -69,6 +69,10 @@ pub struct UiSettings {
     /// synced workspace; an empty list preserves the untouched recency order.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sidebar_session_order: Vec<String>,
+    /// Device-local set of sessions promoted into the pinned sidebar section.
+    /// Archived ids remain here so restoring a session also restores its pin.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sidebar_pinned_session_ids: Vec<String>,
     /// Legacy: per-space tab order, from when tabs were the selected space's
     /// non-archived sessions. Kept for file compatibility; no longer read.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
@@ -110,6 +114,7 @@ impl Default for UiSettings {
             open_tabs: None,
             space_filter: None,
             sidebar_session_order: Vec::new(),
+            sidebar_pinned_session_ids: Vec::new(),
             tab_order: std::collections::HashMap::new(),
             space_order: Vec::new(),
             sound_enabled: true,
@@ -376,6 +381,7 @@ mod tests {
             open_tabs: Some(vec!["b".to_string(), "a".to_string()]),
             space_filter: Some("space-1".into()),
             sidebar_session_order: vec!["chat-2".to_string(), "chat-1".to_string()],
+            sidebar_pinned_session_ids: vec!["chat-2".to_string()],
             tab_order: std::collections::HashMap::from([(
                 "space-1".to_string(),
                 vec!["b".to_string(), "a".to_string()],
@@ -413,6 +419,7 @@ mod tests {
         assert_eq!(loaded.appearance, crate::appearance::AppearanceMode::System);
         assert_eq!(loaded.sidebar_width, 300.0);
         assert!(loaded.sidebar_session_order.is_empty());
+        assert!(loaded.sidebar_pinned_session_ids.is_empty());
         assert!(!loaded.sound_enabled, "other keys still parse");
         assert!(
             loaded.notifications_enabled,

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -1268,6 +1268,22 @@ impl Shell {
             self.settings.space_filter = None;
             self.schedule_save(cx);
         }
+        // Sidebar order is presentation-only. Keep archived ids so a restore
+        // returns to the same local slot; only hard-deleted chats are pruned.
+        if state.read(cx).chats_synced && !self.settings.sidebar_session_order.is_empty() {
+            let known_chat_ids = state
+                .read(cx)
+                .chats
+                .iter()
+                .map(|chat| chat.id.clone())
+                .collect();
+            if spaces::retain_known_sessions(
+                &mut self.settings.sidebar_session_order,
+                &known_chat_ids,
+            ) {
+                self.schedule_save(cx);
+            }
+        }
         // Chat switch: restore THAT chat's panel state (per-session open flags;
         // snap, no tween — the panels belong to the destination chat).
         let selected = state.read(cx).selected_chat.clone().unwrap_or_default();

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -385,6 +385,10 @@ const SIDEBAR_LIST_GAP: f32 = 2.0;
 
 /// Fixed vertical slot occupied by one active sidebar card.
 const SIDEBAR_SESSION_SLOT: f32 = CHAT_ROW_HEIGHT + SIDEBAR_LIST_GAP;
+/// Divider box between pinned and regular sessions. With the list's 2px gaps,
+/// its centered 1px hairline has 8px of air on each side.
+const SIDEBAR_PINNED_DIVIDER_HEIGHT: f32 = 13.0;
+const SIDEBAR_PINNED_DIVIDER_KEY: &str = "sidebar-pinned-divider";
 
 /// Ramp height of the sidebar's scroll-edge fade (the gpui
 /// [`gpui::EdgeFade`] scope — per-primitive, so text fades per glyph).
@@ -425,6 +429,9 @@ struct SidebarSessionDrag {
     chat_id: String,
     visible_ids: std::sync::Arc<Vec<String>>,
     filter: Option<String>,
+    section_start: usize,
+    section_len: usize,
+    section_offset_y: f32,
 }
 
 /// Live destination for a sidebar session drag. The real row remains clipped
@@ -437,11 +444,21 @@ struct SidebarSessionDragState {
     prev_over: usize,
     epoch: usize,
     filter: Option<String>,
+    section_start: usize,
+    section_len: usize,
+    section_offset_y: f32,
     pointer_y: Option<f32>,
     viewport_top: f32,
     viewport_bottom: f32,
     generation: u64,
     autoscroll_active: bool,
+}
+
+type SidebarKeyedRow = (String, f32, AnyElement);
+
+struct SidebarSessionRows {
+    rows: Vec<SidebarKeyedRow>,
+    pinned_count: usize,
 }
 
 /// Ghost chip following the pointer while a surface tab drags.
@@ -1309,19 +1326,28 @@ impl Shell {
             self.settings.space_filter = None;
             self.schedule_save(cx);
         }
-        // Sidebar order is presentation-only. Keep archived ids so a restore
-        // returns to the same local slot; only hard-deleted chats are pruned.
-        if state.read(cx).chats_synced && !self.settings.sidebar_session_order.is_empty() {
+        // Sidebar order and pins are presentation-only. Keep archived ids so
+        // a restore returns to the same local slot and pinned section; only
+        // hard-deleted chats are pruned.
+        if state.read(cx).chats_synced
+            && (!self.settings.sidebar_session_order.is_empty()
+                || !self.settings.sidebar_pinned_session_ids.is_empty())
+        {
             let known_chat_ids = state
                 .read(cx)
                 .chats
                 .iter()
                 .map(|chat| chat.id.clone())
                 .collect();
-            if spaces::retain_known_sessions(
+            let order_changed = spaces::retain_known_sessions(
                 &mut self.settings.sidebar_session_order,
                 &known_chat_ids,
-            ) {
+            );
+            let pins_changed = spaces::retain_known_sessions(
+                &mut self.settings.sidebar_pinned_session_ids,
+                &known_chat_ids,
+            );
+            if order_changed || pins_changed {
                 self.schedule_save(cx);
             }
         }
@@ -2074,6 +2100,34 @@ impl Shell {
 
     fn archive_chat(&mut self, chat_id: String, cx: &mut Context<Self>) {
         self.set_chat_archived(chat_id, true, cx);
+    }
+
+    fn set_chat_pinned(&mut self, chat_id: String, pinned: bool, cx: &mut Context<Self>) {
+        self.close_chat_menu(cx);
+        self.cancel_sidebar_session_drag(cx);
+        let changed = if pinned {
+            if self
+                .settings
+                .sidebar_pinned_session_ids
+                .iter()
+                .any(|id| id == &chat_id)
+            {
+                false
+            } else {
+                self.settings.sidebar_pinned_session_ids.push(chat_id);
+                true
+            }
+        } else {
+            let before = self.settings.sidebar_pinned_session_ids.len();
+            self.settings
+                .sidebar_pinned_session_ids
+                .retain(|id| id != &chat_id);
+            self.settings.sidebar_pinned_session_ids.len() != before
+        };
+        if changed {
+            self.schedule_save(cx);
+        }
+        cx.notify();
     }
 
     pub(super) fn set_chat_archived(
@@ -3357,6 +3411,49 @@ impl Shell {
             .into_any_element()
     }
 
+    fn render_sidebar_session_group(
+        id: &'static str,
+        items: Vec<AnyElement>,
+        section_start: usize,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let section_len = items.len();
+        div()
+            .id(id)
+            .flex()
+            .flex_col()
+            .gap(px(SIDEBAR_LIST_GAP))
+            .on_drag_move::<SidebarSessionDrag>(cx.listener(
+                move |this, event: &gpui::DragMoveEvent<SidebarSessionDrag>, _, cx| {
+                    let payload = event.drag(cx).clone();
+                    if payload.section_start != section_start || payload.section_len != section_len
+                    {
+                        return;
+                    }
+                    let rel_y = f32::from(event.event.position.y) - f32::from(event.bounds.top());
+                    if let Some(over) = spaces::sidebar_session_section_drop_index(
+                        rel_y,
+                        section_start,
+                        section_len,
+                    ) {
+                        this.update_sidebar_session_drag(&payload, over, cx);
+                    }
+                },
+            ))
+            .on_drop::<SidebarSessionDrag>(cx.listener(
+                move |this, payload: &SidebarSessionDrag, _, cx| {
+                    if payload.section_start == section_start && payload.section_len == section_len
+                    {
+                        this.commit_sidebar_session_drag(payload, cx);
+                    } else {
+                        this.cancel_sidebar_session_drag(cx);
+                    }
+                },
+            ))
+            .children(items)
+            .into_any_element()
+    }
+
     /// Chat-mode sidebar (spaces overhaul): window-control strip, the Spaces
     /// section (folder + device rows, add-space), the global Active sessions
     /// list, the notice strip, and the UserMenu (§1.6).
@@ -3376,7 +3473,10 @@ impl Shell {
         // Keyed rows: (stable key, estimated height, element) — the key + height
         // list drives the §1.6 resort FLIP diff below (attention-bucket
         // promotions glide; cleared rows just go).
-        let keyed: Vec<(String, f32, AnyElement)> = self.render_active_rows(theme, cx);
+        let session_rows = self.render_active_rows(theme, cx);
+        let pinned_count = session_rows.pinned_count;
+        let has_pinned_divider = pinned_count > 0 && pinned_count < session_rows.rows.len();
+        let keyed = session_rows.rows;
 
         // Resort glide (§1.6 View Transitions parity): when the ORDER of a live
         // list changes (new activity resort, grouping flip), surviving rows
@@ -3385,7 +3485,17 @@ impl Shell {
         // over 260ms cubic-bezier(0.22,1,0.36,1). New rows fade in; removals
         // just go (matching the original). First fill and chat switches (which
         // don't reorder) never animate.
-        let order: Vec<(String, f32)> = keyed.iter().map(|(k, h, _)| (k.clone(), *h)).collect();
+        let mut order: Vec<(String, f32)> =
+            Vec::with_capacity(keyed.len() + usize::from(has_pinned_divider));
+        for (ix, (key, height, _)) in keyed.iter().enumerate() {
+            if has_pinned_divider && ix == pinned_count {
+                order.push((
+                    SIDEBAR_PINNED_DIVIDER_KEY.to_string(),
+                    SIDEBAR_PINNED_DIVIDER_HEIGHT,
+                ));
+            }
+            order.push((key.clone(), *height));
+        }
         if self.sidebar_session_drag.is_none() && self.sidebar_prev_order != order {
             if !self.sidebar_prev_order.is_empty() {
                 let offsets = resort_offsets(&self.sidebar_prev_order, &order, SIDEBAR_LIST_GAP);
@@ -3507,27 +3617,38 @@ impl Shell {
         let filter_row = self.render_spaces_filter(theme, cx);
         let active_count = list_items.len();
         let active_list = if active_count > 0 {
+            let mut pinned_items = list_items;
+            let regular_items = pinned_items.split_off(pinned_count);
+            let pinned_group = (!pinned_items.is_empty()).then(|| {
+                Self::render_sidebar_session_group("sidebar-pinned-sessions", pinned_items, 0, cx)
+            });
+            let regular_group = (!regular_items.is_empty()).then(|| {
+                Self::render_sidebar_session_group(
+                    "sidebar-regular-sessions",
+                    regular_items,
+                    pinned_count,
+                    cx,
+                )
+            });
             div()
                 .id("sidebar-active-sessions")
                 .flex()
                 .flex_col()
                 .gap(px(SIDEBAR_LIST_GAP))
                 .pb(px(Theme::SPACE_SM))
-                .on_drag_move::<SidebarSessionDrag>(cx.listener(
-                    move |this, event: &gpui::DragMoveEvent<SidebarSessionDrag>, _, cx| {
-                        let payload = event.drag(cx).clone();
-                        let rel_y =
-                            f32::from(event.event.position.y) - f32::from(event.bounds.top());
-                        let over = spaces::sidebar_session_drop_index(rel_y, active_count);
-                        this.update_sidebar_session_drag(&payload, over, cx);
-                    },
-                ))
-                .on_drop::<SidebarSessionDrag>(cx.listener(
-                    |this, payload: &SidebarSessionDrag, _, cx| {
-                        this.commit_sidebar_session_drag(payload, cx);
-                    },
-                ))
-                .children(list_items)
+                .when_some(pinned_group, |el, group| el.child(group))
+                .when(has_pinned_divider, |el| {
+                    el.child(
+                        div()
+                            .id(SIDEBAR_PINNED_DIVIDER_KEY)
+                            .h(px(SIDEBAR_PINNED_DIVIDER_HEIGHT))
+                            .px(px(10.0))
+                            .flex()
+                            .items_center()
+                            .child(div().h(px(1.0)).w_full().bg(theme.border.opacity(0.6))),
+                    )
+                })
+                .when_some(regular_group, |el, group| el.child(group))
                 .into_any_element()
         } else {
             div()
@@ -3578,7 +3699,6 @@ impl Shell {
                                         f32::from(event.event.position.y),
                                         f32::from(event.bounds.top()),
                                         f32::from(event.bounds.bottom()),
-                                        active_count,
                                         cx,
                                     );
                                 },
@@ -4362,7 +4482,13 @@ impl Shell {
 
         if let Some((chat_id, position)) = self.chat_menu.get().cloned() {
             let chat_menu_closing = self.chat_menu.closing_since();
+            let is_pinned = self
+                .settings
+                .sidebar_pinned_session_ids
+                .iter()
+                .any(|id| id == &chat_id);
             let rename_id = chat_id.clone();
+            let pin_id = chat_id.clone();
             let archive_id = chat_id.clone();
             let delete_id = chat_id.clone();
             let menu = popover::popover_card(&theme)
@@ -4380,6 +4506,15 @@ impl Shell {
                         }))
                         .child(icon(icons::PEN).size(px(16.0)).text_color(theme.text_muted))
                         .child(SharedString::from("Rename…")),
+                )
+                .child(
+                    popover::menu_row(&theme, false, format!("chat-menu-pin-{chat_id}"))
+                        .id("chat-menu-pin")
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.set_chat_pinned(pin_id.clone(), !is_pinned, cx)
+                        }))
+                        .child(icon(icons::PIN).size(px(16.0)).text_color(theme.text_muted))
+                        .child(SharedString::from(if is_pinned { "Unpin" } else { "Pin" })),
                 )
                 .child(
                     popover::menu_row(&theme, false, format!("chat-menu-archive-{chat_id}"))

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -383,6 +383,9 @@ const CHAT_ROW_HEIGHT: f32 = 61.0;
 /// Flex gap between sidebar list items.
 const SIDEBAR_LIST_GAP: f32 = 2.0;
 
+/// Fixed vertical slot occupied by one active sidebar card.
+const SIDEBAR_SESSION_SLOT: f32 = CHAT_ROW_HEIGHT + SIDEBAR_LIST_GAP;
+
 /// Ramp height of the sidebar's scroll-edge fade (the gpui
 /// [`gpui::EdgeFade`] scope — per-primitive, so text fades per glyph).
 const SIDEBAR_GLASS_FADE_BAND: f32 = 32.0;
@@ -407,6 +410,70 @@ struct RightTabDragState {
     over: usize,
     epoch: usize,
     prev_over: usize,
+}
+
+/// Device-local active-session reorder payload. The visible ids are shared by
+/// every row payload in a frame, so a drag can freeze one filtered projection
+/// without cloning the whole list per card.
+struct SidebarSessionDrag {
+    chat_id: String,
+    title: SharedString,
+    space_name: SharedString,
+    visible_ids: std::sync::Arc<Vec<String>>,
+}
+
+/// Live destination for a sidebar session drag. The dragged row stays in the
+/// layout as a spacer while siblings slide toward its current gap.
+struct SidebarSessionDragState {
+    chat_id: String,
+    visible_ids: std::sync::Arc<Vec<String>>,
+    from: usize,
+    over: usize,
+    prev_over: usize,
+    epoch: usize,
+}
+
+/// Compact card ghost following the pointer during sidebar reordering.
+struct SidebarSessionGhost {
+    title: SharedString,
+    space_name: SharedString,
+    width: f32,
+}
+
+impl Render for SidebarSessionGhost {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = Theme::of(cx);
+        div()
+            .h(px(CHAT_ROW_HEIGHT))
+            .w(px(self.width))
+            .px(px(Theme::SPACE_SM))
+            .py(px(6.0))
+            .flex()
+            .flex_col()
+            .gap(px(2.0))
+            .rounded(px(8.0))
+            .bg(theme.surface_raised)
+            .border_1()
+            .border_color(theme.border_strong)
+            .shadow_lg()
+            .opacity(0.92)
+            .child(
+                div()
+                    .truncate()
+                    .text_size(px(11.0))
+                    .line_height(px(14.0))
+                    .text_color(theme.text_muted)
+                    .child(self.space_name.clone()),
+            )
+            .child(
+                div()
+                    .truncate()
+                    .text_size(px(13.0))
+                    .line_height(px(17.0))
+                    .text_color(theme.text)
+                    .child(self.title.clone()),
+            )
+    }
 }
 
 /// Ghost chip following the pointer while a surface tab drags.
@@ -822,6 +889,8 @@ pub struct Shell {
     chat_status_hover: Option<String>,
     /// Scroll position of the sidebar lists region (drives its edge fades).
     sidebar_scroll: gpui::ScrollHandle,
+    /// In-flight active-session reorder. Purely local presentation state.
+    sidebar_session_drag: Option<SidebarSessionDragState>,
     /// `settings.last_space_id` applied once after the first spaces frame.
     space_boot_applied: bool,
     /// Last seen session status per chat — the chime trigger compares against
@@ -1046,6 +1115,7 @@ impl Shell {
             spaces_menu: popover::Popup::default(),
             chat_status_hover: None,
             sidebar_scroll: gpui::ScrollHandle::new(),
+            sidebar_session_drag: None,
             space_boot_applied: false,
             sound_prev: std::collections::HashMap::new(),
             user_menu: popover::Popup::default(),
@@ -3017,6 +3087,7 @@ impl Shell {
         status: zeron_proto::ChatIndicator,
         selected: bool,
         archived: bool,
+        drag: Option<SidebarSessionDrag>,
         theme: &Theme,
         cx: &mut Context<Self>,
     ) -> AnyElement {
@@ -3208,6 +3279,17 @@ impl Shell {
                     cx.notify();
                 }),
             )
+            .when_some(drag, |el, payload| {
+                let ghost_width = (self.settings.sidebar_width - 2.0 * Theme::SPACE_SM).max(1.0);
+                el.on_drag(payload, move |payload, _point, _, cx| {
+                    cx.stop_propagation();
+                    cx.new(|_| SidebarSessionGhost {
+                        title: payload.title.clone(),
+                        space_name: payload.space_name.clone(),
+                        width: ghost_width,
+                    })
+                })
+            })
             // Line 1: "project @ device", status word / time-ago right.
             .child(
                 div()
@@ -3293,6 +3375,11 @@ impl Shell {
     /// section (folder + device rows, add-space), the global Active sessions
     /// list, the notice strip, and the UserMenu (§1.6).
     fn render_chat_sidebar(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+        // A release outside the active-list drop target ends GPUI's drag but
+        // never calls our drop handler. Heal the ephemeral spacer state here.
+        if self.sidebar_session_drag.is_some() && !cx.has_active_drag() {
+            self.sidebar_session_drag = None;
+        }
         let (user, workspace_scope) = {
             let state = self.state.read(cx);
             (state.auth_user().cloned(), state.workspace_scope)
@@ -3311,7 +3398,7 @@ impl Shell {
         // just go (matching the original). First fill and chat switches (which
         // don't reorder) never animate.
         let order: Vec<(String, f32)> = keyed.iter().map(|(k, h, _)| (k.clone(), *h)).collect();
-        if self.sidebar_prev_order != order {
+        if self.sidebar_session_drag.is_none() && self.sidebar_prev_order != order {
             if !self.sidebar_prev_order.is_empty() {
                 let offsets = resort_offsets(&self.sidebar_prev_order, &order, SIDEBAR_LIST_GAP);
                 let prev_keys: std::collections::HashSet<&str> = self
@@ -3333,9 +3420,45 @@ impl Shell {
             self.sidebar_prev_order = order;
         }
         let epoch = self.resort_epoch;
+        let session_drag = self
+            .sidebar_session_drag
+            .as_ref()
+            .map(|drag| (drag.from, drag.over, drag.prev_over, drag.epoch));
         let list_items: Vec<AnyElement> = keyed
             .into_iter()
-            .map(|(key, _, element)| {
+            .enumerate()
+            .map(|(ix, (key, _, element))| {
+                if let Some((from, over, prev_over, drag_epoch)) = session_drag {
+                    if ix == from {
+                        return div()
+                            .h(px(CHAT_ROW_HEIGHT))
+                            .w_full()
+                            .flex_none()
+                            .into_any_element();
+                    }
+                    let target =
+                        crate::terminal::panel::slide_offset(ix, from, over) * SIDEBAR_SESSION_SLOT;
+                    let start = crate::terminal::panel::slide_offset(ix, from, prev_over)
+                        * SIDEBAR_SESSION_SLOT;
+                    if self.reduced_motion {
+                        return div()
+                            .relative()
+                            .top(px(target))
+                            .child(element)
+                            .into_any_element();
+                    }
+                    return div()
+                        .child(element)
+                        .with_animation(
+                            (
+                                "sidebar-session-slide",
+                                (ix as u64) | ((drag_epoch as u64) << 32),
+                            ),
+                            TAB_SLIDE.animation(),
+                            move |el, t| el.relative().top(px(motion::lerp(start, target, t))),
+                        )
+                        .into_any_element();
+                }
                 if let Some(dy) = self.sidebar_resort.get(&key).copied() {
                     let id = SharedString::from(format!("resort-{epoch}-{key}"));
                     div()
@@ -3392,6 +3515,42 @@ impl Shell {
         // The space filter lives ABOVE the scroll region (fixed) so its
         // dropdown can float without being clipped by the list's overflow.
         let filter_row = self.render_spaces_filter(theme, cx);
+        let active_count = list_items.len();
+        let active_list = if active_count > 0 {
+            div()
+                .id("sidebar-active-sessions")
+                .flex()
+                .flex_col()
+                .gap(px(SIDEBAR_LIST_GAP))
+                .pb(px(Theme::SPACE_SM))
+                .on_drag_move::<SidebarSessionDrag>(cx.listener(
+                    move |this, event: &gpui::DragMoveEvent<SidebarSessionDrag>, _, cx| {
+                        let (chat_id, visible_ids) = {
+                            let payload = event.drag(cx);
+                            (payload.chat_id.clone(), payload.visible_ids.clone())
+                        };
+                        let rel_y =
+                            f32::from(event.event.position.y) - f32::from(event.bounds.top());
+                        let over = spaces::sidebar_session_drop_index(rel_y, active_count);
+                        this.update_sidebar_session_drag(chat_id, visible_ids, over, cx);
+                    },
+                ))
+                .on_drop::<SidebarSessionDrag>(cx.listener(
+                    |this, payload: &SidebarSessionDrag, _, cx| {
+                        this.commit_sidebar_session_drag(payload, cx);
+                    },
+                ))
+                .children(list_items)
+                .into_any_element()
+        } else {
+            div()
+                .px(px(Theme::SPACE_SM))
+                .pb(px(Theme::SPACE_SM))
+                .text_size(px(12.0))
+                .text_color(theme.text_faint)
+                .child(SharedString::from("No sessions yet"))
+                .into_any_element()
+        };
 
         div()
             .w(px(self.settings.sidebar_width))
@@ -3427,23 +3586,7 @@ impl Shell {
                             // No "Sessions" header (user request) — the list
                             // is the whole column; a little air stands in.
                             .pt(px(4.0))
-                            .child(if !list_items.is_empty() {
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(px(2.0))
-                                    .pb(px(Theme::SPACE_SM))
-                                    .children(list_items)
-                                    .into_any_element()
-                            } else {
-                                div()
-                                    .px(px(Theme::SPACE_SM))
-                                    .pb(px(Theme::SPACE_SM))
-                                    .text_size(px(12.0))
-                                    .text_color(theme.text_faint)
-                                    .child(SharedString::from("No sessions yet"))
-                                    .into_any_element()
-                            })
+                            .child(active_list)
                             .children(archived_section),
                     ),
                 )

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -389,6 +389,11 @@ const SIDEBAR_SESSION_SLOT: f32 = CHAT_ROW_HEIGHT + SIDEBAR_LIST_GAP;
 /// Ramp height of the sidebar's scroll-edge fade (the gpui
 /// [`gpui::EdgeFade`] scope — per-primitive, so text fades per glyph).
 const SIDEBAR_GLASS_FADE_BAND: f32 = 32.0;
+/// Pointer band and per-frame cap for session-card edge autoscroll.
+const SIDEBAR_DRAG_SCROLL_BAND: f32 = 48.0;
+const SIDEBAR_DRAG_SCROLL_MAX: f32 = 12.0;
+const SIDEBAR_DRAG_SCROLL_FRAME_MS: u64 = 16;
+const SIDEBAR_LIST_PAD_TOP: f32 = 4.0;
 
 /// Drag marker for the sidebar resize handle.
 struct SidebarResize;
@@ -415,11 +420,13 @@ struct RightTabDragState {
 /// Device-local active-session reorder payload. The visible ids are shared by
 /// every row payload in a frame, so a drag can freeze one filtered projection
 /// without cloning the whole list per card.
+#[derive(Clone)]
 struct SidebarSessionDrag {
     chat_id: String,
     title: SharedString,
     space_name: SharedString,
     visible_ids: std::sync::Arc<Vec<String>>,
+    filter: Option<String>,
 }
 
 /// Live destination for a sidebar session drag. The dragged row stays in the
@@ -431,6 +438,12 @@ struct SidebarSessionDragState {
     over: usize,
     prev_over: usize,
     epoch: usize,
+    filter: Option<String>,
+    pointer_y: Option<f32>,
+    viewport_top: f32,
+    viewport_bottom: f32,
+    generation: u64,
+    autoscroll_active: bool,
 }
 
 /// Compact card ghost following the pointer during sidebar reordering.
@@ -891,6 +904,7 @@ pub struct Shell {
     sidebar_scroll: gpui::ScrollHandle,
     /// In-flight active-session reorder. Purely local presentation state.
     sidebar_session_drag: Option<SidebarSessionDragState>,
+    sidebar_session_drag_generation: u64,
     /// `settings.last_space_id` applied once after the first spaces frame.
     space_boot_applied: bool,
     /// Last seen session status per chat — the chime trigger compares against
@@ -1116,6 +1130,7 @@ impl Shell {
             chat_status_hover: None,
             sidebar_scroll: gpui::ScrollHandle::new(),
             sidebar_session_drag: None,
+            sidebar_session_drag_generation: 0,
             space_boot_applied: false,
             sound_prev: std::collections::HashMap::new(),
             user_menu: popover::Popup::default(),
@@ -1353,6 +1368,9 @@ impl Shell {
             ) {
                 self.schedule_save(cx);
             }
+        }
+        if !self.sidebar_session_drag_is_valid(cx) {
+            self.cancel_sidebar_session_drag(cx);
         }
         // Chat switch: restore THAT chat's panel state (per-session open flags;
         // snap, no tween — the panels belong to the destination chat).
@@ -3210,10 +3228,11 @@ impl Shell {
                 .items_center()
                 .cursor_pointer()
                 .when(corner_hovered, |el| {
-                    el.on_click(cx.listener(move |this, _, _, cx| {
-                        cx.stop_propagation();
-                        this.set_chat_archived(archive_id.clone(), !archived, cx);
-                    }))
+                    el.on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            cx.stop_propagation();
+                            this.set_chat_archived(archive_id.clone(), !archived, cx);
+                        }))
                 })
                 .child(corner_body)
                 .into_any_element()
@@ -3377,8 +3396,10 @@ impl Shell {
     fn render_chat_sidebar(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
         // A release outside the active-list drop target ends GPUI's drag but
         // never calls our drop handler. Heal the ephemeral spacer state here.
-        if self.sidebar_session_drag.is_some() && !cx.has_active_drag() {
-            self.sidebar_session_drag = None;
+        if self.sidebar_session_drag.is_some()
+            && (!cx.has_active_drag() || !self.sidebar_session_drag_is_valid(cx))
+        {
+            self.cancel_sidebar_session_drag(cx);
         }
         let (user, workspace_scope) = {
             let state = self.state.read(cx);
@@ -3525,14 +3546,11 @@ impl Shell {
                 .pb(px(Theme::SPACE_SM))
                 .on_drag_move::<SidebarSessionDrag>(cx.listener(
                     move |this, event: &gpui::DragMoveEvent<SidebarSessionDrag>, _, cx| {
-                        let (chat_id, visible_ids) = {
-                            let payload = event.drag(cx);
-                            (payload.chat_id.clone(), payload.visible_ids.clone())
-                        };
+                        let payload = event.drag(cx).clone();
                         let rel_y =
                             f32::from(event.event.position.y) - f32::from(event.bounds.top());
                         let over = spaces::sidebar_session_drop_index(rel_y, active_count);
-                        this.update_sidebar_session_drag(chat_id, visible_ids, over, cx);
+                        this.update_sidebar_session_drag(&payload, over, cx);
                     },
                 ))
                 .on_drop::<SidebarSessionDrag>(cx.listener(
@@ -3580,12 +3598,28 @@ impl Shell {
                             .size_full()
                             .overflow_y_scroll()
                             .track_scroll(&self.sidebar_scroll)
+                            .on_drag_move::<SidebarSessionDrag>(cx.listener(
+                                move |this,
+                                      event: &gpui::DragMoveEvent<SidebarSessionDrag>,
+                                      _,
+                                      cx| {
+                                    let payload = event.drag(cx).clone();
+                                    this.track_sidebar_session_drag_pointer(
+                                        payload,
+                                        f32::from(event.event.position.y),
+                                        f32::from(event.bounds.top()),
+                                        f32::from(event.bounds.bottom()),
+                                        active_count,
+                                        cx,
+                                    );
+                                },
+                            ))
                             .px(px(Theme::SPACE_SM))
                             .flex()
                             .flex_col()
                             // No "Sessions" header (user request) — the list
                             // is the whole column; a little air stands in.
-                            .pt(px(4.0))
+                            .pt(px(SIDEBAR_LIST_PAD_TOP))
                             .child(active_list)
                             .children(archived_section),
                     ),

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -423,14 +423,12 @@ struct RightTabDragState {
 #[derive(Clone)]
 struct SidebarSessionDrag {
     chat_id: String,
-    title: SharedString,
-    space_name: SharedString,
     visible_ids: std::sync::Arc<Vec<String>>,
     filter: Option<String>,
 }
 
-/// Live destination for a sidebar session drag. The dragged row stays in the
-/// layout as a spacer while siblings slide toward its current gap.
+/// Live destination for a sidebar session drag. The real row remains clipped
+/// to the sidebar and slides between slots with its siblings.
 struct SidebarSessionDragState {
     chat_id: String,
     visible_ids: std::sync::Arc<Vec<String>>,
@@ -444,49 +442,6 @@ struct SidebarSessionDragState {
     viewport_bottom: f32,
     generation: u64,
     autoscroll_active: bool,
-}
-
-/// Compact card ghost following the pointer during sidebar reordering.
-struct SidebarSessionGhost {
-    title: SharedString,
-    space_name: SharedString,
-    width: f32,
-}
-
-impl Render for SidebarSessionGhost {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = Theme::of(cx);
-        div()
-            .h(px(CHAT_ROW_HEIGHT))
-            .w(px(self.width))
-            .px(px(Theme::SPACE_SM))
-            .py(px(6.0))
-            .flex()
-            .flex_col()
-            .gap(px(2.0))
-            .rounded(px(8.0))
-            .bg(theme.surface_raised)
-            .border_1()
-            .border_color(theme.border_strong)
-            .shadow_lg()
-            .opacity(0.92)
-            .child(
-                div()
-                    .truncate()
-                    .text_size(px(11.0))
-                    .line_height(px(14.0))
-                    .text_color(theme.text_muted)
-                    .child(self.space_name.clone()),
-            )
-            .child(
-                div()
-                    .truncate()
-                    .text_size(px(13.0))
-                    .line_height(px(17.0))
-                    .text_color(theme.text)
-                    .child(self.title.clone()),
-            )
-    }
 }
 
 /// Ghost chip following the pointer while a surface tab drags.
@@ -516,7 +471,8 @@ impl Render for SurfaceTabGhost {
 /// Drag marker for the terminal-panel height handle.
 struct TerminalResize;
 
-/// Invisible drag ghost — resize drags render nothing at the cursor.
+/// Invisible drag ghost — resize drags and contained sidebar reorders render
+/// nothing at the cursor.
 struct DragGhost;
 
 impl Render for DragGhost {
@@ -1805,6 +1761,22 @@ impl Shell {
         self.sidebar_tween = None; // live drag tracks the pointer directly
         self.schedule_save(cx);
         cx.notify();
+    }
+
+    fn contain_sidebar_session_drag(
+        &mut self,
+        event: &gpui::DragMoveEvent<SidebarSessionDrag>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let inside_window = event.bounds.contains(&event.event.position);
+        let pointer_x = f32::from(event.event.position.x);
+        let sidebar_left = f32::from(event.bounds.left());
+        let inside_sidebar =
+            pointer_x >= sidebar_left && pointer_x <= sidebar_left + self.settings.sidebar_width;
+        if !inside_window || !inside_sidebar {
+            self.cancel_sidebar_session_drag(cx);
+        }
     }
 
     fn on_right_pane_drag(
@@ -3299,14 +3271,9 @@ impl Shell {
                 }),
             )
             .when_some(drag, |el, payload| {
-                let ghost_width = (self.settings.sidebar_width - 2.0 * Theme::SPACE_SM).max(1.0);
-                el.on_drag(payload, move |payload, _point, _, cx| {
+                el.on_drag(payload, move |_, _point, _, cx| {
                     cx.stop_propagation();
-                    cx.new(|_| SidebarSessionGhost {
-                        title: payload.title.clone(),
-                        space_name: payload.space_name.clone(),
-                        width: ghost_width,
-                    })
+                    cx.new(|_| DragGhost)
                 })
             })
             // Line 1: "project @ device", status word / time-ago right.
@@ -3450,17 +3417,19 @@ impl Shell {
             .enumerate()
             .map(|(ix, (key, _, element))| {
                 if let Some((from, over, prev_over, drag_epoch)) = session_drag {
-                    if ix == from {
-                        return div()
-                            .h(px(CHAT_ROW_HEIGHT))
-                            .w_full()
-                            .flex_none()
-                            .into_any_element();
-                    }
-                    let target =
-                        crate::terminal::panel::slide_offset(ix, from, over) * SIDEBAR_SESSION_SLOT;
-                    let start = crate::terminal::panel::slide_offset(ix, from, prev_over)
-                        * SIDEBAR_SESSION_SLOT;
+                    let (start, target) = if ix == from {
+                        (
+                            (prev_over as f32 - from as f32) * SIDEBAR_SESSION_SLOT,
+                            (over as f32 - from as f32) * SIDEBAR_SESSION_SLOT,
+                        )
+                    } else {
+                        (
+                            crate::terminal::panel::slide_offset(ix, from, prev_over)
+                                * SIDEBAR_SESSION_SLOT,
+                            crate::terminal::panel::slide_offset(ix, from, over)
+                                * SIDEBAR_SESSION_SLOT,
+                        )
+                    };
                     if self.reduced_motion {
                         return div()
                             .relative()
@@ -6396,6 +6365,7 @@ impl Render for Shell {
             .text_color(text)
             .font_family(font)
             .text_size(px(14.0))
+            .on_drag_move::<SidebarSessionDrag>(cx.listener(Self::contain_sidebar_session_drag))
             .on_drag_move(cx.listener(Self::on_sidebar_drag))
             .on_drag_move(cx.listener(Self::on_right_pane_drag))
             .on_drag_move(cx.listener(Self::on_terminal_drag))

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -11,7 +11,83 @@
 use super::*;
 use crate::pickers::{breadcrumbs, browser_rows, completion_prefix_len, parent_path};
 use gpui::FocusHandle;
+use std::collections::HashSet;
 use zeron_proto::{ChatIndicator, Device, FolderListing, Space};
+
+/// Merge active sessions in recency order with the device-local manual order.
+/// New active ids lead; saved ids (including archived rows) retain their slots.
+pub(super) fn materialize_local_order(recency_ids: &[String], saved_ids: &[String]) -> Vec<String> {
+    if saved_ids.is_empty() {
+        let mut seen = HashSet::new();
+        return recency_ids
+            .iter()
+            .filter(|id| seen.insert(id.as_str()))
+            .cloned()
+            .collect();
+    }
+
+    let saved: HashSet<&str> = saved_ids.iter().map(String::as_str).collect();
+    let mut seen = HashSet::new();
+    recency_ids
+        .iter()
+        .filter(|id| !saved.contains(id.as_str()))
+        .chain(saved_ids.iter())
+        .filter(|id| seen.insert(id.as_str()))
+        .cloned()
+        .collect()
+}
+
+/// Active projection of [`materialize_local_order`]. A missing preference is
+/// exactly the current recency order; archived saved ids remain stored but do
+/// not enter this projection.
+pub(super) fn project_local_order(recency_ids: &[String], saved_ids: &[String]) -> Vec<String> {
+    let active: HashSet<&str> = recency_ids.iter().map(String::as_str).collect();
+    materialize_local_order(recency_ids, saved_ids)
+        .into_iter()
+        .filter(|id| active.contains(id.as_str()))
+        .collect()
+}
+
+/// Move within a filtered projection while preserving every hidden global
+/// slot. Callers materialize all currently visible ids before invoking this.
+pub(super) fn reorder_visible_projection(
+    global_ids: &[String],
+    visible_ids: &[String],
+    from: usize,
+    to: usize,
+) -> Vec<String> {
+    if from >= visible_ids.len() || to >= visible_ids.len() || from == to {
+        return global_ids.to_vec();
+    }
+
+    let mut reordered = visible_ids.to_vec();
+    let moved = reordered.remove(from);
+    reordered.insert(to, moved);
+    let visible: HashSet<&str> = visible_ids.iter().map(String::as_str).collect();
+    let mut replacements = reordered.into_iter();
+    global_ids
+        .iter()
+        .map(|id| {
+            if visible.contains(id.as_str()) {
+                replacements.next().unwrap_or_else(|| id.clone())
+            } else {
+                id.clone()
+            }
+        })
+        .collect()
+}
+
+/// Remove only ids absent from the workspace. Archived chats remain known so
+/// unarchiving restores their device-local position.
+pub(super) fn retain_known_sessions(
+    saved_ids: &mut Vec<String>,
+    known_chat_ids: &HashSet<String>,
+) -> bool {
+    let before = saved_ids.len();
+    let mut seen = HashSet::new();
+    saved_ids.retain(|id| known_chat_ids.contains(id) && seen.insert(id.clone()));
+    saved_ids.len() != before
+}
 
 /// The space-filter dropdown, `Some` while open. The same searchable-menu
 /// recipe as the composer's ref picker: filter input on top
@@ -2118,5 +2194,73 @@ impl Shell {
         }
 
         overlays
+    }
+}
+
+#[cfg(test)]
+mod local_order_tests {
+    use super::{
+        materialize_local_order, project_local_order, reorder_visible_projection,
+        retain_known_sessions,
+    };
+    use std::collections::HashSet;
+
+    fn ids(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn sidebar_session_order_empty_preserves_recency() {
+        assert_eq!(
+            project_local_order(&ids(&["c", "b", "a"]), &[]),
+            ids(&["c", "b", "a"])
+        );
+    }
+
+    #[test]
+    fn sidebar_session_order_new_rows_lead_and_saved_rows_stay_stable() {
+        let saved = ids(&["a", "b", "archived"]);
+        assert_eq!(
+            materialize_local_order(&ids(&["new-2", "b", "new-1", "a"]), &saved),
+            ids(&["new-2", "new-1", "a", "b", "archived"])
+        );
+        assert_eq!(
+            project_local_order(&ids(&["new-2", "b", "new-1", "a"]), &saved),
+            ids(&["new-2", "new-1", "a", "b"])
+        );
+    }
+
+    #[test]
+    fn sidebar_session_order_deduplicates_inputs() {
+        assert_eq!(
+            materialize_local_order(&ids(&["new", "new", "a"]), &ids(&["a", "a", "old"])),
+            ids(&["new", "a", "old"])
+        );
+    }
+
+    #[test]
+    fn sidebar_session_order_reorders_only_visible_slots() {
+        let global = ids(&["a1", "b1", "a2", "archived", "b2"]);
+        let visible = ids(&["a1", "a2"]);
+        assert_eq!(
+            reorder_visible_projection(&global, &visible, 0, 1),
+            ids(&["a2", "b1", "a1", "archived", "b2"])
+        );
+    }
+
+    #[test]
+    fn sidebar_session_order_invalid_move_is_a_noop() {
+        let global = ids(&["a", "b"]);
+        assert_eq!(reorder_visible_projection(&global, &global, 0, 0), global);
+        assert_eq!(reorder_visible_projection(&global, &global, 8, 0), global);
+    }
+
+    #[test]
+    fn sidebar_session_order_retains_archived_and_prunes_deleted() {
+        let mut saved = ids(&["active", "archived", "deleted", "active"]);
+        let known = HashSet::from(["active".to_string(), "archived".to_string()]);
+        assert!(retain_known_sessions(&mut saved, &known));
+        assert_eq!(saved, ids(&["active", "archived"]));
+        assert!(!retain_known_sessions(&mut saved, &known));
     }
 }

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -89,6 +89,57 @@ pub(super) fn retain_known_sessions(
     saved_ids.len() != before
 }
 
+/// Edge-scroll speed is proportional inside the band and capped per frame.
+pub(super) fn sidebar_drag_scroll_delta(
+    pointer_y: f32,
+    viewport_top: f32,
+    viewport_bottom: f32,
+) -> f32 {
+    if viewport_bottom <= viewport_top {
+        return 0.0;
+    }
+    if pointer_y < viewport_top + super::SIDEBAR_DRAG_SCROLL_BAND {
+        let penetration = ((viewport_top + super::SIDEBAR_DRAG_SCROLL_BAND - pointer_y)
+            / super::SIDEBAR_DRAG_SCROLL_BAND)
+            .clamp(0.0, 1.0);
+        -super::SIDEBAR_DRAG_SCROLL_MAX * penetration
+    } else if pointer_y > viewport_bottom - super::SIDEBAR_DRAG_SCROLL_BAND {
+        let penetration = ((pointer_y - (viewport_bottom - super::SIDEBAR_DRAG_SCROLL_BAND))
+            / super::SIDEBAR_DRAG_SCROLL_BAND)
+            .clamp(0.0, 1.0);
+        super::SIDEBAR_DRAG_SCROLL_MAX * penetration
+    } else {
+        0.0
+    }
+}
+
+/// Return the next logical scroll top, or `None` when a frame loop should stop.
+pub(super) fn sidebar_drag_scroll_step(
+    drag_active: bool,
+    loop_generation: u64,
+    drag_generation: u64,
+    current: f32,
+    max: f32,
+    delta: f32,
+) -> Option<f32> {
+    if !drag_active || loop_generation != drag_generation || delta == 0.0 {
+        return None;
+    }
+    let next = (current + delta).clamp(0.0, max.max(0.0));
+    (next != current).then_some(next)
+}
+
+/// A frozen drag remains valid when all snapshotted rows are still active in
+/// the same filter. Newly arrived rows are deliberately allowed.
+pub(super) fn sidebar_drag_snapshot_is_valid(
+    dragged_id: &str,
+    snapshot_ids: &[String],
+    current_ids: &HashSet<String>,
+) -> bool {
+    snapshot_ids.iter().any(|id| id == dragged_id)
+        && snapshot_ids.iter().all(|id| current_ids.contains(id))
+}
+
 /// Quantize a pointer position within the active list into a card slot.
 pub(super) fn sidebar_session_drop_index(rel_y: f32, count: usize) -> usize {
     if count == 0 {
@@ -195,6 +246,9 @@ impl Shell {
     /// new-session canvas the space context follows the filter — the canvas
     /// default is "the space you're looking at".
     pub(super) fn set_space_filter(&mut self, filter: Option<String>, cx: &mut Context<Self>) {
+        if self.settings.space_filter != filter {
+            self.cancel_sidebar_session_drag(cx);
+        }
         self.settings.space_filter = filter.clone();
         if let Some(space_id) = filter
             && self.state.read(cx).selected_chat.is_none()
@@ -220,6 +274,7 @@ impl Shell {
     /// Land in a just-added space: filter the sidebar to it and open the
     /// new-session canvas there.
     pub(super) fn land_in_space(&mut self, space_id: String, cx: &mut Context<Self>) {
+        self.cancel_sidebar_session_drag(cx);
         self.route = Route::Chat;
         self.settings.space_filter = Some(space_id.clone());
         self.settings.last_space_id = Some(space_id.clone());
@@ -235,34 +290,197 @@ impl Shell {
 
     pub(super) fn update_sidebar_session_drag(
         &mut self,
-        chat_id: String,
-        visible_ids: std::sync::Arc<Vec<String>>,
+        payload: &SidebarSessionDrag,
         over: usize,
         cx: &mut Context<Self>,
     ) {
-        let Some(from) = visible_ids.iter().position(|id| id == &chat_id) else {
-            self.sidebar_session_drag = None;
+        let Some(from) = payload
+            .visible_ids
+            .iter()
+            .position(|id| id == &payload.chat_id)
+        else {
+            self.cancel_sidebar_session_drag(cx);
             return;
         };
         match &mut self.sidebar_session_drag {
-            Some(drag) if drag.chat_id == chat_id && drag.over != over => {
+            Some(drag)
+                if drag.chat_id == payload.chat_id
+                    && drag.filter == payload.filter
+                    && drag.over != over =>
+            {
                 drag.prev_over = drag.over;
                 drag.over = over;
                 drag.epoch = drag.epoch.wrapping_add(1);
                 cx.notify();
             }
-            Some(drag) if drag.chat_id == chat_id => {}
+            Some(drag) if drag.chat_id == payload.chat_id && drag.filter == payload.filter => {}
             _ => {
+                self.sidebar_session_drag_generation =
+                    self.sidebar_session_drag_generation.wrapping_add(1);
                 self.sidebar_session_drag = Some(SidebarSessionDragState {
-                    chat_id,
-                    visible_ids,
+                    chat_id: payload.chat_id.clone(),
+                    visible_ids: payload.visible_ids.clone(),
                     from,
                     over,
                     prev_over: from,
                     epoch: 0,
+                    filter: payload.filter.clone(),
+                    pointer_y: None,
+                    viewport_top: 0.0,
+                    viewport_bottom: 0.0,
+                    generation: self.sidebar_session_drag_generation,
+                    autoscroll_active: false,
                 });
                 cx.notify();
             }
+        }
+    }
+
+    pub(super) fn track_sidebar_session_drag_pointer(
+        &mut self,
+        payload: SidebarSessionDrag,
+        pointer_y: f32,
+        viewport_top: f32,
+        viewport_bottom: f32,
+        active_count: usize,
+        cx: &mut Context<Self>,
+    ) {
+        let scroll_top = -f32::from(self.sidebar_scroll.offset().y);
+        let rel_y = pointer_y - viewport_top + scroll_top - super::SIDEBAR_LIST_PAD_TOP;
+        let active_height =
+            active_count as f32 * super::SIDEBAR_SESSION_SLOT - super::SIDEBAR_LIST_GAP;
+        if active_count == 0 || rel_y < 0.0 || rel_y > active_height {
+            if let Some(drag) = self.sidebar_session_drag.as_mut() {
+                drag.pointer_y = None;
+                drag.autoscroll_active = false;
+            }
+            return;
+        }
+
+        let over = sidebar_session_drop_index(rel_y, active_count);
+        self.update_sidebar_session_drag(&payload, over, cx);
+        let delta = sidebar_drag_scroll_delta(pointer_y, viewport_top, viewport_bottom);
+        let Some(drag) = self.sidebar_session_drag.as_mut() else {
+            return;
+        };
+        drag.pointer_y = Some(pointer_y);
+        drag.viewport_top = viewport_top;
+        drag.viewport_bottom = viewport_bottom;
+        let should_start = delta != 0.0 && !drag.autoscroll_active;
+        let generation = drag.generation;
+        if should_start {
+            drag.autoscroll_active = true;
+            self.start_sidebar_session_autoscroll(generation, cx);
+        }
+    }
+
+    fn start_sidebar_session_autoscroll(&mut self, generation: u64, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(std::time::Duration::from_millis(
+                        super::SIDEBAR_DRAG_SCROLL_FRAME_MS,
+                    ))
+                    .await;
+                let keep_running = this
+                    .update(cx, |shell, cx| {
+                        shell.sidebar_session_autoscroll_tick(generation, cx)
+                    })
+                    .unwrap_or(false);
+                if !keep_running {
+                    break;
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn sidebar_session_autoscroll_tick(&mut self, generation: u64, cx: &mut Context<Self>) -> bool {
+        let Some(drag) = self.sidebar_session_drag.as_ref() else {
+            return false;
+        };
+        if drag.generation != generation || !cx.has_active_drag() {
+            if let Some(drag) = self.sidebar_session_drag.as_mut() {
+                drag.autoscroll_active = false;
+            }
+            return false;
+        }
+        let Some(pointer_y) = drag.pointer_y else {
+            if let Some(drag) = self.sidebar_session_drag.as_mut() {
+                drag.autoscroll_active = false;
+            }
+            return false;
+        };
+        let viewport_top = drag.viewport_top;
+        let viewport_bottom = drag.viewport_bottom;
+        let active_count = drag.visible_ids.len();
+        let delta = sidebar_drag_scroll_delta(pointer_y, viewport_top, viewport_bottom);
+        let scroll_top = -f32::from(self.sidebar_scroll.offset().y);
+        let max_scroll = f32::from(self.sidebar_scroll.max_offset().y);
+        let Some(next_scroll) = sidebar_drag_scroll_step(
+            true,
+            generation,
+            drag.generation,
+            scroll_top,
+            max_scroll,
+            delta,
+        ) else {
+            if let Some(drag) = self.sidebar_session_drag.as_mut() {
+                drag.autoscroll_active = false;
+            }
+            return false;
+        };
+
+        let rel_y = pointer_y - viewport_top + next_scroll - super::SIDEBAR_LIST_PAD_TOP;
+        let active_height =
+            active_count as f32 * super::SIDEBAR_SESSION_SLOT - super::SIDEBAR_LIST_GAP;
+        if active_count == 0 || rel_y < 0.0 || rel_y > active_height {
+            if let Some(drag) = self.sidebar_session_drag.as_mut() {
+                drag.autoscroll_active = false;
+            }
+            return false;
+        }
+
+        let offset = self.sidebar_scroll.offset();
+        self.sidebar_scroll
+            .set_offset(gpui::point(offset.x, px(-next_scroll)));
+        let over = sidebar_session_drop_index(rel_y, active_count);
+        if let Some(drag) = self.sidebar_session_drag.as_mut()
+            && drag.over != over
+        {
+            drag.prev_over = drag.over;
+            drag.over = over;
+            drag.epoch = drag.epoch.wrapping_add(1);
+        }
+        cx.notify();
+        true
+    }
+
+    pub(super) fn sidebar_session_drag_is_valid(&self, cx: &App) -> bool {
+        let Some(drag) = self.sidebar_session_drag.as_ref() else {
+            return true;
+        };
+        if drag.filter != self.settings.space_filter {
+            return false;
+        }
+        let state = self.state.read(cx);
+        let current_ids: HashSet<String> = state
+            .overview_chats(Utc::now())
+            .into_iter()
+            .filter(|(_, chat)| match &drag.filter {
+                Some(space_id) => chat.space_id.as_deref() == Some(space_id.as_str()),
+                None => true,
+            })
+            .map(|(_, chat)| chat.id.clone())
+            .collect();
+        sidebar_drag_snapshot_is_valid(&drag.chat_id, drag.visible_ids.as_ref(), &current_ids)
+    }
+
+    pub(super) fn cancel_sidebar_session_drag(&mut self, cx: &mut Context<Self>) {
+        if self.sidebar_session_drag.take().is_some() {
+            self.sidebar_session_drag_generation =
+                self.sidebar_session_drag_generation.wrapping_add(1);
+            cx.notify();
         }
     }
 
@@ -271,10 +489,18 @@ impl Shell {
         payload: &SidebarSessionDrag,
         cx: &mut Context<Self>,
     ) {
+        if !self.sidebar_session_drag_is_valid(cx) {
+            self.cancel_sidebar_session_drag(cx);
+            return;
+        }
         let Some(drag) = self.sidebar_session_drag.take() else {
             return;
         };
-        if drag.chat_id != payload.chat_id {
+        self.sidebar_session_drag_generation = self.sidebar_session_drag_generation.wrapping_add(1);
+        if drag.chat_id != payload.chat_id
+            || drag.filter != payload.filter
+            || drag.visible_ids.as_ref() != payload.visible_ids.as_ref()
+        {
             cx.notify();
             return;
         }
@@ -815,6 +1041,7 @@ impl Shell {
                     title: title.clone(),
                     space_name: space_name.clone(),
                     visible_ids: visible_ids.clone(),
+                    filter: filter.clone(),
                 };
                 let element = self.render_chat_row(
                     chat.id.clone(),
@@ -2318,7 +2545,8 @@ impl Shell {
 mod local_order_tests {
     use super::{
         materialize_local_order, project_local_order, reorder_visible_projection,
-        retain_known_sessions, sidebar_session_drop_index,
+        retain_known_sessions, sidebar_drag_scroll_delta, sidebar_drag_scroll_step,
+        sidebar_drag_snapshot_is_valid, sidebar_session_drop_index,
     };
     use std::collections::HashSet;
 
@@ -2415,5 +2643,55 @@ mod local_order_tests {
         assert_eq!(sidebar_session_drop_index(63.0, 3), 1);
         assert_eq!(sidebar_session_drop_index(500.0, 3), 2);
         assert_eq!(sidebar_session_drop_index(10.0, 0), 0);
+    }
+
+    #[test]
+    fn sidebar_session_order_edge_scroll_is_proportional_and_capped() {
+        let top = 100.0;
+        let bottom = 300.0;
+        assert_eq!(sidebar_drag_scroll_delta(200.0, top, bottom), 0.0);
+        assert_eq!(sidebar_drag_scroll_delta(124.0, top, bottom), -6.0);
+        assert_eq!(sidebar_drag_scroll_delta(276.0, top, bottom), 6.0);
+        assert_eq!(sidebar_drag_scroll_delta(0.0, top, bottom), -12.0);
+        assert_eq!(sidebar_drag_scroll_delta(400.0, top, bottom), 12.0);
+    }
+
+    #[test]
+    fn sidebar_session_order_edge_scroll_stops_with_drag_lifecycle() {
+        assert_eq!(
+            sidebar_drag_scroll_step(true, 4, 4, 20.0, 100.0, 6.0),
+            Some(26.0)
+        );
+        assert_eq!(
+            sidebar_drag_scroll_step(false, 4, 4, 20.0, 100.0, 6.0),
+            None
+        );
+        assert_eq!(sidebar_drag_scroll_step(true, 3, 4, 20.0, 100.0, 6.0), None);
+        assert_eq!(
+            sidebar_drag_scroll_step(true, 4, 4, 100.0, 100.0, 6.0),
+            None
+        );
+        assert_eq!(sidebar_drag_scroll_step(true, 4, 4, 0.0, 100.0, -6.0), None);
+    }
+
+    #[test]
+    fn sidebar_session_order_drag_snapshot_allows_additions_but_not_removals() {
+        let snapshot = ids(&["a", "b"]);
+        let with_new = HashSet::from(["new".to_string(), "a".to_string(), "b".to_string()]);
+        assert!(sidebar_drag_snapshot_is_valid("a", &snapshot, &with_new));
+
+        let without_dragged = HashSet::from(["b".to_string()]);
+        assert!(!sidebar_drag_snapshot_is_valid(
+            "a",
+            &snapshot,
+            &without_dragged
+        ));
+
+        let without_sibling = HashSet::from(["a".to_string()]);
+        assert!(!sidebar_drag_snapshot_is_valid(
+            "a",
+            &snapshot,
+            &without_sibling
+        ));
     }
 }

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -646,8 +646,9 @@ impl Shell {
     }
 
     /// The sidebar's Sessions list: every session (idle included) of the
-    /// filter space — or all spaces under "All" — attention-sorted. Rows are
-    /// keyed for the FLIP resort glide.
+    /// filter space — or all spaces under "All". Untouched settings preserve
+    /// recency; a device-local manual order keeps known rows stable and lets
+    /// new sessions lead. Rows stay keyed for the FLIP resort glide.
     pub(super) fn render_active_rows(
         &mut self,
         theme: &Theme,
@@ -657,9 +658,21 @@ impl Shell {
         let filter = self.settings.space_filter.clone();
         let rows: Vec<(ChatIndicator, zeron_proto::Chat, String, Option<String>)> = {
             let state = self.state.read(cx);
-            state
-                .overview_chats(now)
+            let overview = state.overview_chats(now);
+            let recency_ids: Vec<String> =
+                overview.iter().map(|(_, chat)| chat.id.clone()).collect();
+            let ordered_ids =
+                project_local_order(&recency_ids, &self.settings.sidebar_session_order);
+            let mut rows_by_id: std::collections::HashMap<
+                String,
+                (ChatIndicator, &zeron_proto::Chat),
+            > = overview
                 .into_iter()
+                .map(|(status, chat)| (chat.id.clone(), (status, chat)))
+                .collect();
+            ordered_ids
+                .into_iter()
+                .filter_map(|id| rows_by_id.remove(&id))
                 .filter(|(_, chat)| match &filter {
                     Some(space_id) => chat.space_id.as_deref() == Some(space_id.as_str()),
                     None => true,
@@ -2228,6 +2241,32 @@ mod local_order_tests {
             project_local_order(&ids(&["new-2", "b", "new-1", "a"]), &saved),
             ids(&["new-2", "new-1", "a", "b"])
         );
+    }
+
+    #[test]
+    fn sidebar_session_order_ignores_new_activity_for_saved_rows() {
+        let saved = ids(&["a", "b", "c"]);
+        assert_eq!(project_local_order(&ids(&["c", "b", "a"]), &saved), saved);
+    }
+
+    #[test]
+    fn sidebar_session_order_filters_are_consistent_projections() {
+        let ordered = project_local_order(
+            &ids(&["b2", "a2", "b1", "a1"]),
+            &ids(&["a1", "b1", "a2", "b2"]),
+        );
+        let project_a: Vec<String> = ordered
+            .iter()
+            .filter(|id| id.starts_with('a'))
+            .cloned()
+            .collect();
+        let project_b: Vec<String> = ordered
+            .iter()
+            .filter(|id| id.starts_with('b'))
+            .cloned()
+            .collect();
+        assert_eq!(project_a, ids(&["a1", "a2"]));
+        assert_eq!(project_b, ids(&["b1", "b2"]));
     }
 
     #[test]

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -148,6 +148,28 @@ pub(super) fn sidebar_session_drop_index(rel_y: f32, count: usize) -> usize {
     ((rel_y / super::SIDEBAR_SESSION_SLOT).floor().max(0.0) as usize).min(count - 1)
 }
 
+/// Resolve a pointer inside one reorderable section to its index in the full
+/// pinned-first projection. Divider and sibling-section positions return none.
+pub(super) fn sidebar_session_section_drop_index(
+    rel_y: f32,
+    section_start: usize,
+    section_len: usize,
+) -> Option<usize> {
+    if section_len == 0 {
+        return None;
+    }
+    let section_height = section_len as f32 * super::SIDEBAR_SESSION_SLOT - super::SIDEBAR_LIST_GAP;
+    (rel_y >= 0.0 && rel_y <= section_height)
+        .then(|| section_start + sidebar_session_drop_index(rel_y, section_len))
+}
+
+/// A single pinned row has nowhere to move, so do not start GPUI's drag
+/// lifecycle for it. Regular rows remain draggable so their existing
+/// contained-reorder behavior is unchanged.
+fn sidebar_session_row_is_draggable(in_pinned_section: bool, section_len: usize) -> bool {
+    !in_pinned_section || section_len > 1
+}
+
 /// The space-filter dropdown, `Some` while open. The same searchable-menu
 /// recipe as the composer's ref picker: filter input on top
 /// (`PaletteSearch` context so ↑↓/⏎ bubble to the card), ranked substring
@@ -302,10 +324,22 @@ impl Shell {
             self.cancel_sidebar_session_drag(cx);
             return;
         };
+        let section_end = payload.section_start.saturating_add(payload.section_len);
+        if payload.section_len == 0
+            || section_end > payload.visible_ids.len()
+            || !(payload.section_start..section_end).contains(&from)
+            || !(payload.section_start..section_end).contains(&over)
+        {
+            self.cancel_sidebar_session_drag(cx);
+            return;
+        }
         match &mut self.sidebar_session_drag {
             Some(drag)
                 if drag.chat_id == payload.chat_id
                     && drag.filter == payload.filter
+                    && drag.visible_ids.as_ref() == payload.visible_ids.as_ref()
+                    && drag.section_start == payload.section_start
+                    && drag.section_len == payload.section_len
                     && drag.over != over =>
             {
                 drag.prev_over = drag.over;
@@ -313,7 +347,12 @@ impl Shell {
                 drag.epoch = drag.epoch.wrapping_add(1);
                 cx.notify();
             }
-            Some(drag) if drag.chat_id == payload.chat_id && drag.filter == payload.filter => {}
+            Some(drag)
+                if drag.chat_id == payload.chat_id
+                    && drag.filter == payload.filter
+                    && drag.visible_ids.as_ref() == payload.visible_ids.as_ref()
+                    && drag.section_start == payload.section_start
+                    && drag.section_len == payload.section_len => {}
             _ => {
                 self.sidebar_session_drag_generation =
                     self.sidebar_session_drag_generation.wrapping_add(1);
@@ -325,6 +364,9 @@ impl Shell {
                     prev_over: from,
                     epoch: 0,
                     filter: payload.filter.clone(),
+                    section_start: payload.section_start,
+                    section_len: payload.section_len,
+                    section_offset_y: payload.section_offset_y,
                     pointer_y: None,
                     viewport_top: 0.0,
                     viewport_bottom: 0.0,
@@ -342,22 +384,22 @@ impl Shell {
         pointer_y: f32,
         viewport_top: f32,
         viewport_bottom: f32,
-        active_count: usize,
         cx: &mut Context<Self>,
     ) {
         let scroll_top = -f32::from(self.sidebar_scroll.offset().y);
-        let rel_y = pointer_y - viewport_top + scroll_top - super::SIDEBAR_LIST_PAD_TOP;
-        let active_height =
-            active_count as f32 * super::SIDEBAR_SESSION_SLOT - super::SIDEBAR_LIST_GAP;
-        if active_count == 0 || rel_y < 0.0 || rel_y > active_height {
+        let rel_y = pointer_y - viewport_top + scroll_top
+            - super::SIDEBAR_LIST_PAD_TOP
+            - payload.section_offset_y;
+        let Some(over) =
+            sidebar_session_section_drop_index(rel_y, payload.section_start, payload.section_len)
+        else {
             if let Some(drag) = self.sidebar_session_drag.as_mut() {
                 drag.pointer_y = None;
                 drag.autoscroll_active = false;
             }
             return;
-        }
+        };
 
-        let over = sidebar_session_drop_index(rel_y, active_count);
         self.update_sidebar_session_drag(&payload, over, cx);
         let delta = sidebar_drag_scroll_delta(pointer_y, viewport_top, viewport_bottom);
         let Some(drag) = self.sidebar_session_drag.as_mut() else {
@@ -413,7 +455,6 @@ impl Shell {
         };
         let viewport_top = drag.viewport_top;
         let viewport_bottom = drag.viewport_bottom;
-        let active_count = drag.visible_ids.len();
         let delta = sidebar_drag_scroll_delta(pointer_y, viewport_top, viewport_bottom);
         let scroll_top = -f32::from(self.sidebar_scroll.offset().y);
         let max_scroll = f32::from(self.sidebar_scroll.max_offset().y);
@@ -431,20 +472,21 @@ impl Shell {
             return false;
         };
 
-        let rel_y = pointer_y - viewport_top + next_scroll - super::SIDEBAR_LIST_PAD_TOP;
-        let active_height =
-            active_count as f32 * super::SIDEBAR_SESSION_SLOT - super::SIDEBAR_LIST_GAP;
-        if active_count == 0 || rel_y < 0.0 || rel_y > active_height {
+        let rel_y = pointer_y - viewport_top + next_scroll
+            - super::SIDEBAR_LIST_PAD_TOP
+            - drag.section_offset_y;
+        let Some(over) =
+            sidebar_session_section_drop_index(rel_y, drag.section_start, drag.section_len)
+        else {
             if let Some(drag) = self.sidebar_session_drag.as_mut() {
                 drag.autoscroll_active = false;
             }
             return false;
-        }
+        };
 
         let offset = self.sidebar_scroll.offset();
         self.sidebar_scroll
             .set_offset(gpui::point(offset.x, px(-next_scroll)));
-        let over = sidebar_session_drop_index(rel_y, active_count);
         if let Some(drag) = self.sidebar_session_drag.as_mut()
             && drag.over != over
         {
@@ -500,6 +542,8 @@ impl Shell {
         if drag.chat_id != payload.chat_id
             || drag.filter != payload.filter
             || drag.visible_ids.as_ref() != payload.visible_ids.as_ref()
+            || drag.section_start != payload.section_start
+            || drag.section_len != payload.section_len
         {
             cx.notify();
             return;
@@ -525,13 +569,7 @@ impl Shell {
         let next = reorder_visible_projection(&global, drag.visible_ids.as_ref(), from, to);
         if next != self.settings.sidebar_session_order {
             self.settings.sidebar_session_order = next;
-            let mut visible = drag.visible_ids.as_ref().clone();
-            let moved = visible.remove(from);
-            visible.insert(to, moved);
-            self.sidebar_prev_order = visible
-                .iter()
-                .map(|id| (format!("c:{id}"), super::CHAT_ROW_HEIGHT))
-                .collect();
+            self.sidebar_prev_order.clear();
             self.sidebar_resort.clear();
             self.sidebar_new_keys.clear();
             self.schedule_save(cx);
@@ -962,12 +1000,13 @@ impl Shell {
     /// The sidebar's Sessions list: every session (idle included) of the
     /// filter space — or all spaces under "All". Untouched settings preserve
     /// recency; a device-local manual order keeps known rows stable and lets
-    /// new sessions lead. Rows stay keyed for the FLIP resort glide.
+    /// new sessions lead. Locally pinned rows form a stable section above the
+    /// regular projection. Rows stay keyed for the FLIP resort glide.
     pub(super) fn render_active_rows(
         &mut self,
         theme: &Theme,
         cx: &mut Context<Self>,
-    ) -> Vec<(String, f32, AnyElement)> {
+    ) -> SidebarSessionRows {
         let now = Utc::now();
         let filter = self.settings.space_filter.clone();
         let frozen_visible = self
@@ -1021,43 +1060,82 @@ impl Shell {
                 })
                 .collect()
         };
+        let pinned_ids: HashSet<&str> = self
+            .settings
+            .sidebar_pinned_session_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let (mut pinned, regular): (Vec<_>, Vec<_>) = rows
+            .into_iter()
+            .partition(|(_, chat, _, _)| pinned_ids.contains(chat.id.as_str()));
+        let pinned_count = pinned.len();
+        let regular_count = regular.len();
+        pinned.extend(regular);
+        let rows = pinned;
         let visible_ids: std::sync::Arc<Vec<String>> =
             std::sync::Arc::new(rows.iter().map(|(_, chat, _, _)| chat.id.clone()).collect());
+        let has_divider = pinned_count > 0 && regular_count > 0;
+        let regular_offset_y = if has_divider {
+            pinned_count as f32 * super::SIDEBAR_SESSION_SLOT
+                + super::SIDEBAR_PINNED_DIVIDER_HEIGHT
+                + super::SIDEBAR_LIST_GAP
+        } else {
+            0.0
+        };
         let selected = self.state.read(cx).selected_chat.clone();
-        rows.into_iter()
-            .map(|(status, chat, folder, branch)| {
-                let time_ago: SharedString =
-                    format_time_ago(chat.last_message_at.unwrap_or(chat.created_at), now).into();
-                let is_selected = selected.as_deref() == Some(chat.id.as_str());
-                let height = super::CHAT_ROW_HEIGHT;
-                let harness = chat.config.as_ref().map(|c| c.harness);
-                let title: SharedString = transcript::single_line(
-                    &chat.title.clone().unwrap_or_else(|| "New session".into()),
-                )
-                .into();
-                let space_name: SharedString = folder.into();
-                let drag = SidebarSessionDrag {
-                    chat_id: chat.id.clone(),
-                    visible_ids: visible_ids.clone(),
-                    filter: filter.clone(),
-                };
-                let element = self.render_chat_row(
-                    chat.id.clone(),
-                    title,
-                    time_ago,
-                    space_name,
-                    branch.map(SharedString::from),
-                    harness,
-                    status,
-                    is_selected,
-                    false,
-                    Some(drag),
-                    theme,
-                    cx,
-                );
-                (format!("c:{}", chat.id), height, element)
-            })
-            .collect()
+        let rows =
+            rows.into_iter()
+                .enumerate()
+                .map(|(ix, (status, chat, folder, branch))| {
+                    let time_ago: SharedString =
+                        format_time_ago(chat.last_message_at.unwrap_or(chat.created_at), now)
+                            .into();
+                    let is_selected = selected.as_deref() == Some(chat.id.as_str());
+                    let height = super::CHAT_ROW_HEIGHT;
+                    let harness = chat.config.as_ref().map(|c| c.harness);
+                    let title: SharedString = transcript::single_line(
+                        &chat.title.clone().unwrap_or_else(|| "New session".into()),
+                    )
+                    .into();
+                    let space_name: SharedString = folder.into();
+                    let in_pinned_section = ix < pinned_count;
+                    let section_len = if in_pinned_section {
+                        pinned_count
+                    } else {
+                        regular_count
+                    };
+                    let drag = sidebar_session_row_is_draggable(in_pinned_section, section_len)
+                        .then(|| SidebarSessionDrag {
+                            chat_id: chat.id.clone(),
+                            visible_ids: visible_ids.clone(),
+                            filter: filter.clone(),
+                            section_start: if in_pinned_section { 0 } else { pinned_count },
+                            section_len,
+                            section_offset_y: if in_pinned_section {
+                                0.0
+                            } else {
+                                regular_offset_y
+                            },
+                        });
+                    let element = self.render_chat_row(
+                        chat.id.clone(),
+                        title,
+                        time_ago,
+                        space_name,
+                        branch.map(SharedString::from),
+                        harness,
+                        status,
+                        is_selected,
+                        false,
+                        drag,
+                        theme,
+                        cx,
+                    );
+                    (format!("c:{}", chat.id), height, element)
+                })
+                .collect();
+        SidebarSessionRows { rows, pinned_count }
     }
 
     /// The sidebar's archived shelf — a direct port of t3code's settled
@@ -2545,6 +2623,7 @@ mod local_order_tests {
         materialize_local_order, project_local_order, reorder_visible_projection,
         retain_known_sessions, sidebar_drag_scroll_delta, sidebar_drag_scroll_step,
         sidebar_drag_snapshot_is_valid, sidebar_session_drop_index,
+        sidebar_session_row_is_draggable, sidebar_session_section_drop_index,
     };
     use std::collections::HashSet;
 
@@ -2618,6 +2697,20 @@ mod local_order_tests {
     }
 
     #[test]
+    fn sidebar_session_order_reorders_a_pinned_first_projection() {
+        let global = ids(&["p1", "u1", "p2", "u2", "hidden"]);
+        let pinned_first = ids(&["p1", "p2", "u1", "u2"]);
+        assert_eq!(
+            reorder_visible_projection(&global, &pinned_first, 1, 0),
+            ids(&["p2", "p1", "u1", "u2", "hidden"])
+        );
+        assert_eq!(
+            reorder_visible_projection(&global, &pinned_first, 3, 2),
+            ids(&["p1", "p2", "u2", "u1", "hidden"])
+        );
+    }
+
+    #[test]
     fn sidebar_session_order_invalid_move_is_a_noop() {
         let global = ids(&["a", "b"]);
         assert_eq!(reorder_visible_projection(&global, &global, 0, 0), global);
@@ -2641,6 +2734,26 @@ mod local_order_tests {
         assert_eq!(sidebar_session_drop_index(63.0, 3), 1);
         assert_eq!(sidebar_session_drop_index(500.0, 3), 2);
         assert_eq!(sidebar_session_drop_index(10.0, 0), 0);
+    }
+
+    #[test]
+    fn sidebar_session_order_drop_index_stays_inside_its_section() {
+        assert_eq!(sidebar_session_section_drop_index(-1.0, 3, 2), None);
+        assert_eq!(sidebar_session_section_drop_index(0.0, 3, 2), Some(3));
+        assert_eq!(
+            sidebar_session_section_drop_index(super::SIDEBAR_SESSION_SLOT, 3, 2),
+            Some(4)
+        );
+        assert_eq!(sidebar_session_section_drop_index(500.0, 3, 2), None);
+        assert_eq!(sidebar_session_section_drop_index(0.0, 0, 0), None);
+    }
+
+    #[test]
+    fn sidebar_session_order_disables_drag_for_a_single_pinned_row() {
+        assert!(!sidebar_session_row_is_draggable(true, 1));
+        assert!(sidebar_session_row_is_draggable(true, 2));
+        assert!(sidebar_session_row_is_draggable(true, 3));
+        assert!(sidebar_session_row_is_draggable(false, 1));
     }
 
     #[test]

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -1038,8 +1038,6 @@ impl Shell {
                 let space_name: SharedString = folder.into();
                 let drag = SidebarSessionDrag {
                     chat_id: chat.id.clone(),
-                    title: title.clone(),
-                    space_name: space_name.clone(),
                     visible_ids: visible_ids.clone(),
                     filter: filter.clone(),
                 };

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -89,6 +89,14 @@ pub(super) fn retain_known_sessions(
     saved_ids.len() != before
 }
 
+/// Quantize a pointer position within the active list into a card slot.
+pub(super) fn sidebar_session_drop_index(rel_y: f32, count: usize) -> usize {
+    if count == 0 {
+        return 0;
+    }
+    ((rel_y / super::SIDEBAR_SESSION_SLOT).floor().max(0.0) as usize).min(count - 1)
+}
+
 /// The space-filter dropdown, `Some` while open. The same searchable-menu
 /// recipe as the composer's ref picker: filter input on top
 /// (`PaletteSearch` context so ↑↓/⏎ bubble to the card), ranked substring
@@ -224,6 +232,86 @@ impl Shell {
     }
 
     // ---- sidebar sections ----
+
+    pub(super) fn update_sidebar_session_drag(
+        &mut self,
+        chat_id: String,
+        visible_ids: std::sync::Arc<Vec<String>>,
+        over: usize,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(from) = visible_ids.iter().position(|id| id == &chat_id) else {
+            self.sidebar_session_drag = None;
+            return;
+        };
+        match &mut self.sidebar_session_drag {
+            Some(drag) if drag.chat_id == chat_id && drag.over != over => {
+                drag.prev_over = drag.over;
+                drag.over = over;
+                drag.epoch = drag.epoch.wrapping_add(1);
+                cx.notify();
+            }
+            Some(drag) if drag.chat_id == chat_id => {}
+            _ => {
+                self.sidebar_session_drag = Some(SidebarSessionDragState {
+                    chat_id,
+                    visible_ids,
+                    from,
+                    over,
+                    prev_over: from,
+                    epoch: 0,
+                });
+                cx.notify();
+            }
+        }
+    }
+
+    pub(super) fn commit_sidebar_session_drag(
+        &mut self,
+        payload: &SidebarSessionDrag,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(drag) = self.sidebar_session_drag.take() else {
+            return;
+        };
+        if drag.chat_id != payload.chat_id {
+            cx.notify();
+            return;
+        }
+        let Some(from) = drag.visible_ids.iter().position(|id| id == &drag.chat_id) else {
+            cx.notify();
+            return;
+        };
+        let to = drag.over.min(drag.visible_ids.len().saturating_sub(1));
+        if from == to {
+            cx.notify();
+            return;
+        }
+
+        let recency_ids: Vec<String> = self
+            .state
+            .read(cx)
+            .overview_chats(Utc::now())
+            .into_iter()
+            .map(|(_, chat)| chat.id.clone())
+            .collect();
+        let global = materialize_local_order(&recency_ids, &self.settings.sidebar_session_order);
+        let next = reorder_visible_projection(&global, drag.visible_ids.as_ref(), from, to);
+        if next != self.settings.sidebar_session_order {
+            self.settings.sidebar_session_order = next;
+            let mut visible = drag.visible_ids.as_ref().clone();
+            let moved = visible.remove(from);
+            visible.insert(to, moved);
+            self.sidebar_prev_order = visible
+                .iter()
+                .map(|id| (format!("c:{id}"), super::CHAT_ROW_HEIGHT))
+                .collect();
+            self.sidebar_resort.clear();
+            self.sidebar_new_keys.clear();
+            self.schedule_save(cx);
+        }
+        cx.notify();
+    }
 
     /// The filter's display rows: "All projects", then spaces matching the
     /// search (ranked — `popover::filter_indices`), then "New project…".
@@ -656,13 +744,18 @@ impl Shell {
     ) -> Vec<(String, f32, AnyElement)> {
         let now = Utc::now();
         let filter = self.settings.space_filter.clone();
+        let frozen_visible = self
+            .sidebar_session_drag
+            .as_ref()
+            .map(|drag| drag.visible_ids.clone());
         let rows: Vec<(ChatIndicator, zeron_proto::Chat, String, Option<String>)> = {
             let state = self.state.read(cx);
             let overview = state.overview_chats(now);
             let recency_ids: Vec<String> =
                 overview.iter().map(|(_, chat)| chat.id.clone()).collect();
-            let ordered_ids =
-                project_local_order(&recency_ids, &self.settings.sidebar_session_order);
+            let ordered_ids = frozen_visible.as_deref().cloned().unwrap_or_else(|| {
+                project_local_order(&recency_ids, &self.settings.sidebar_session_order)
+            });
             let mut rows_by_id: std::collections::HashMap<
                 String,
                 (ChatIndicator, &zeron_proto::Chat),
@@ -702,6 +795,8 @@ impl Shell {
                 })
                 .collect()
         };
+        let visible_ids: std::sync::Arc<Vec<String>> =
+            std::sync::Arc::new(rows.iter().map(|(_, chat, _, _)| chat.id.clone()).collect());
         let selected = self.state.read(cx).selected_chat.clone();
         rows.into_iter()
             .map(|(status, chat, folder, branch)| {
@@ -710,19 +805,28 @@ impl Shell {
                 let is_selected = selected.as_deref() == Some(chat.id.as_str());
                 let height = super::CHAT_ROW_HEIGHT;
                 let harness = chat.config.as_ref().map(|c| c.harness);
+                let title: SharedString = transcript::single_line(
+                    &chat.title.clone().unwrap_or_else(|| "New session".into()),
+                )
+                .into();
+                let space_name: SharedString = folder.into();
+                let drag = SidebarSessionDrag {
+                    chat_id: chat.id.clone(),
+                    title: title.clone(),
+                    space_name: space_name.clone(),
+                    visible_ids: visible_ids.clone(),
+                };
                 let element = self.render_chat_row(
                     chat.id.clone(),
-                    transcript::single_line(
-                        &chat.title.clone().unwrap_or_else(|| "New session".into()),
-                    )
-                    .into(),
+                    title,
                     time_ago,
-                    folder.into(),
+                    space_name,
                     branch.map(SharedString::from),
                     harness,
                     status,
                     is_selected,
                     false,
+                    Some(drag),
                     theme,
                     cx,
                 );
@@ -2214,7 +2318,7 @@ impl Shell {
 mod local_order_tests {
     use super::{
         materialize_local_order, project_local_order, reorder_visible_projection,
-        retain_known_sessions,
+        retain_known_sessions, sidebar_session_drop_index,
     };
     use std::collections::HashSet;
 
@@ -2301,5 +2405,15 @@ mod local_order_tests {
         assert!(retain_known_sessions(&mut saved, &known));
         assert_eq!(saved, ids(&["active", "archived"]));
         assert!(!retain_known_sessions(&mut saved, &known));
+    }
+
+    #[test]
+    fn sidebar_session_order_drop_index_quantizes_and_clamps() {
+        assert_eq!(sidebar_session_drop_index(-20.0, 3), 0);
+        assert_eq!(sidebar_session_drop_index(0.0, 3), 0);
+        assert_eq!(sidebar_session_drop_index(62.9, 3), 0);
+        assert_eq!(sidebar_session_drop_index(63.0, 3), 1);
+        assert_eq!(sidebar_session_drop_index(500.0, 3), 2);
+        assert_eq!(sidebar_session_drop_index(10.0, 0), 0);
     }
 }


### PR DESCRIPTION
## Summary

Adds live drag-and-drop reordering and device-local pinning for active session cards in the desktop sidebar.

Reordering is contained to the left sidebar: the real card moves between slots inside the clipped list, and no floating card preview follows the pointer outside it. Pinned sessions appear in a reserved section above the regular sessions with a visual divider.

The custom order and pinned session IDs are persisted locally on the current device through `UiSettings` and `ui-settings.json`. Neither the order nor pin state is ever streamed, synchronized, or sent to remote services or other devices.

## Changes

- Persist an ordered list of session IDs and pinned session IDs in `UiSettings`.
- Add `Pin` and `Unpin` actions to the session context menu.
- Render pinned sessions in a reserved section at the top of the sidebar, separated from regular sessions by a divider.
- Allow two or more pinned sessions to be reordered within the pinned section.
- Disable dragging when there is only one pinned session, avoiding a no-op drag glitch.
- Keep regular session reordering within the regular section and pinned session reordering within the pinned section.
- Return unpinned sessions to the regular section without changing synchronized chat data.
- Apply the local order consistently to filtered sidebar projections.
- Preserve recency ordering for new sessions and retain archived sessions in local preferences.
- Remove locally stored IDs only when sessions are permanently deleted.
- Add contained live reorder feedback with:
  - the real card and its siblings sliding between sidebar slots;
  - no floating card preview outside the sidebar;
  - reduced-motion support;
  - edge auto-scrolling.
- Cancel the in-list drag state when the pointer leaves the left sidebar.
- Commit and save the new order only after a valid drop.

## Scope

This change is intentionally desktop-local:

- The order and pin state are never streamed to remote services.
- No synchronized chat data is modified.
- No RPC, engine, edge, or mobile behavior is changed.
- Session tracking remains unchanged.
- Other devices keep their own local ordering and pin state.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p zeron-ui` — 438 tests passed
- `cargo clippy -p zeron-ui --lib --tests`
- Verified that changes are limited to desktop UI settings and sidebar presentation:
  - `crates/ui/src/settings.rs`
  - `crates/ui/src/shell.rs`
  - `crates/ui/src/shell/spaces.rs`
  - `crates/ui/src/icons.rs`
  - `crates/ui/assets/icons/pin.svg`

Clippy reports existing warnings elsewhere in the repository, with no new warning introduced by this change.

## Manual QA

- [ ] Drag regular session cards to different positions within the regular section.
- [ ] Pin sessions from the context menu and verify they move above the divider.
- [ ] Reorder two or more pinned sessions within the pinned section.
- [ ] Verify a single pinned session cannot be dragged.
- [ ] Unpin a session and verify it returns to the regular section.
- [ ] Drag horizontally outside the sidebar and verify that no card preview or tooltip leaves the list and no order is committed.
- [ ] Verify the list remains responsive during dragging.
- [ ] Verify edge auto-scroll near the top and bottom of the sidebar.
- [ ] Verify filtering does not corrupt the saved order or pin state.
- [ ] Restart the app and verify the local order and pin state persist.
- [ ] Verify neither order nor pin state is propagated to another device.
