### PR TITLE
feat(ui): make mounted volumes reachable from the project picker

### DIFF
--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -3858,33 +3858,33 @@ mod tests {
         assert_eq!(breadcrumbs("/").len(), 1);
 
         let home = browser_location_breadcrumbs(
-            "/Users/kalan/github/zeron",
-            Some("/Users/kalan"),
+            "/Users/developer/projects/comet",
+            Some("/Users/developer"),
             "MacBook",
         );
         assert_eq!(
             home,
             [
                 ("MacBook".into(), "/".into()),
-                ("Home".into(), "/Users/kalan".into()),
-                ("github".into(), "/Users/kalan/github".into()),
-                ("zeron".into(), "/Users/kalan/github/zeron".into()),
+                ("Home".into(), "/Users/developer".into()),
+                ("projects".into(), "/Users/developer/projects".into()),
+                ("comet".into(), "/Users/developer/projects/comet".into()),
             ]
         );
 
         // External mounts must not disappear into the folded home crumb.
         let volume =
-            browser_location_breadcrumbs("/Volumes/Kalan", Some("/Users/kalan"), "MacBook");
+            browser_location_breadcrumbs("/Volumes/External", Some("/Users/developer"), "MacBook");
         assert_eq!(
             volume,
             [
                 ("MacBook".into(), "/".into()),
                 ("Volumes".into(), "/Volumes".into()),
-                ("Kalan".into(), "/Volumes/Kalan".into()),
+                ("External".into(), "/Volumes/External".into()),
             ]
         );
         assert_eq!(
-            browser_location_breadcrumbs("/", Some("/Users/kalan"), "MacBook"),
+            browser_location_breadcrumbs("/", Some("/Users/developer"), "MacBook"),
             [("MacBook".into(), "/".into())]
         );
     }

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -322,6 +322,40 @@ pub fn breadcrumbs(path: &str) -> Vec<(String, String)> {
     out
 }
 
+/// Breadcrumbs for the folder browser's location bar. The device label is the
+/// filesystem root, while a distinct `Home` crumb folds the usually-noisy
+/// home prefix. Paths outside home (notably macOS `/Volumes`) stay fully
+/// visible and reachable from the always-present device/root crumb.
+pub fn browser_location_breadcrumbs(
+    path: &str,
+    home: Option<&str>,
+    device_label: &str,
+) -> Vec<(String, String)> {
+    let path = if path.is_empty() { "/" } else { path };
+    let mut out = vec![(device_label.to_string(), "/".to_string())];
+    if path == "/" {
+        return out;
+    }
+
+    let home = home
+        .map(|home| home.trim_end_matches('/'))
+        .filter(|h| !h.is_empty());
+    let inside_home = home.filter(|home| path == *home || path.starts_with(&format!("{home}/")));
+    if let Some(home) = inside_home {
+        out.push(("Home".to_string(), home.to_string()));
+        let mut full = home.to_string();
+        for segment in path[home.len()..].split('/').filter(|s| !s.is_empty()) {
+            full.push('/');
+            full.push_str(segment);
+            out.push((segment.to_string(), full.clone()));
+        }
+        return out;
+    }
+
+    out.extend(breadcrumbs(path).into_iter().skip(1));
+    out
+}
+
 /// Directory rows of a listing (files never render in the browser).
 pub fn browser_rows(listing: &FolderListing) -> Vec<&zeron_proto::FolderEntry> {
     listing.entries.iter().filter(|e| e.is_dir).collect()
@@ -3822,6 +3856,37 @@ mod tests {
         assert_eq!(labels, ["/", "home", "w", "dev"]);
         assert_eq!(crumbs[2].1, "/home/w");
         assert_eq!(breadcrumbs("/").len(), 1);
+
+        let home = browser_location_breadcrumbs(
+            "/Users/kalan/github/zeron",
+            Some("/Users/kalan"),
+            "MacBook",
+        );
+        assert_eq!(
+            home,
+            [
+                ("MacBook".into(), "/".into()),
+                ("Home".into(), "/Users/kalan".into()),
+                ("github".into(), "/Users/kalan/github".into()),
+                ("zeron".into(), "/Users/kalan/github/zeron".into()),
+            ]
+        );
+
+        // External mounts must not disappear into the folded home crumb.
+        let volume =
+            browser_location_breadcrumbs("/Volumes/Kalan", Some("/Users/kalan"), "MacBook");
+        assert_eq!(
+            volume,
+            [
+                ("MacBook".into(), "/".into()),
+                ("Volumes".into(), "/Volumes".into()),
+                ("Kalan".into(), "/Volumes/Kalan".into()),
+            ]
+        );
+        assert_eq!(
+            browser_location_breadcrumbs("/", Some("/Users/kalan"), "MacBook"),
+            [("MacBook".into(), "/".into())]
+        );
     }
 
     #[test]

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -9,7 +9,9 @@
 //! Child module of `shell` so it renders straight off `Shell`'s private state.
 
 use super::*;
-use crate::pickers::{breadcrumbs, browser_rows, completion_prefix_len, parent_path};
+use crate::pickers::{
+    browser_location_breadcrumbs, browser_rows, completion_prefix_len, parent_path,
+};
 use gpui::FocusHandle;
 use zeron_proto::{ChatIndicator, Device, FolderListing, Space};
 
@@ -1485,23 +1487,19 @@ impl Shell {
                     .child(SharedString::from("esc")),
             );
 
-        // ── breadcrumbs ("MacBook Pro / Projects / zeron"): the quiet mono
-        //    path voice, `/` separators. The device crumb stands in for home —
-        //    everything up to the resolved home path folds into it; below
-        //    home the full path shows. Ancestors (device crumb included) are
-        //    clickable.
+        // ── breadcrumbs ("MacBook Pro / Home / Projects / zeron"): the
+        //    quiet mono path voice. The device crumb is the filesystem root,
+        //    so external mounts such as `/Volumes` are always one click away;
+        //    Home is a separate fold for the otherwise noisy `/Users/name`
+        //    prefix. Every ancestor remains clickable.
         let crumbs: AnyElement = match &listing {
             Some(listing) => {
-                let segments = breadcrumbs(&listing.path);
+                let segments = browser_location_breadcrumbs(
+                    &listing.path,
+                    home.as_deref(),
+                    device_name.as_ref(),
+                );
                 let last = segments.len().saturating_sub(1);
-                // Root "/" chip always folds; the home segments fold too when
-                // the browsed path sits at/under home.
-                let at_home = home.as_deref() == Some(listing.path.as_str());
-                let folded = 1 + home
-                    .as_deref()
-                    .filter(|h| listing.path == *h || listing.path.starts_with(&format!("{h}/")))
-                    .map(|h| h.split('/').filter(|s| !s.is_empty()).count())
-                    .unwrap_or(0);
                 div()
                     .flex()
                     .flex_row()
@@ -1512,72 +1510,46 @@ impl Shell {
                     .pb(px(2.0))
                     .text_size(px(11.0))
                     .font_family(theme.font_mono.clone())
-                    .child({
-                        let crumb = div()
-                            .id("add-space-crumb-device")
-                            .px(px(3.0))
-                            .rounded(px(4.0))
-                            .child(device_name.clone());
-                        if at_home {
-                            // Standing at home — the device crumb IS the
-                            // current folder.
-                            crumb
-                                .text_color(theme.text.opacity(0.85))
-                                .into_any_element()
-                        } else {
-                            crumb
-                                .text_color(theme.text_muted.opacity(0.55))
-                                .cursor_pointer()
-                                .hover(|s| s.text_color(theme.text))
-                                .on_click(cx.listener(|this, _, _, cx| {
-                                    if let Some(flow) = this.add_space.as_mut() {
-                                        flow.browser_repo = false;
-                                    }
-                                    this.load_space_folders(None, cx);
-                                }))
-                                .into_any_element()
-                        }
-                    })
-                    .children(segments.into_iter().enumerate().skip(folded).map(
-                        |(ix, (label, full))| {
-                            let is_last = ix == last;
-                            div()
-                                .flex()
-                                .flex_row()
-                                .items_center()
-                                .child(
+                    .children(segments.into_iter().enumerate().map(|(ix, (label, full))| {
+                        let is_last = ix == last;
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .when(ix > 0, |el| {
+                                el.child(
                                     div()
                                         .text_color(theme.text_faint.opacity(0.7))
                                         .child(SharedString::from("/")),
                                 )
-                                .child({
-                                    let crumb = div()
-                                        .id(("add-space-crumb", ix))
-                                        .px(px(3.0))
-                                        .rounded(px(4.0))
-                                        .text_color(if is_last {
-                                            theme.text.opacity(0.85)
-                                        } else {
-                                            theme.text_muted.opacity(0.55)
-                                        })
-                                        .child(SharedString::from(label));
-                                    if is_last {
-                                        crumb.into_any_element()
+                            })
+                            .child({
+                                let crumb = div()
+                                    .id(("add-space-crumb", ix))
+                                    .px(px(3.0))
+                                    .rounded(px(4.0))
+                                    .text_color(if is_last {
+                                        theme.text.opacity(0.85)
                                     } else {
-                                        crumb
-                                            .cursor_pointer()
-                                            .hover(|s| s.text_color(theme.text))
-                                            .on_click(cx.listener(move |this, _, _, cx| {
-                                                if let Some(flow) = this.add_space.as_mut() {
-                                                    flow.browser_repo = false;
-                                                }
-                                                this.load_space_folders(Some(full.clone()), cx);
-                                            }))
-                                            .into_any_element()
-                                    }
-                                })
-                        },
-                    ))
+                                        theme.text_muted.opacity(0.55)
+                                    })
+                                    .child(SharedString::from(label));
+                                if is_last {
+                                    crumb.into_any_element()
+                                } else {
+                                    crumb
+                                        .cursor_pointer()
+                                        .hover(|s| s.text_color(theme.text))
+                                        .on_click(cx.listener(move |this, _, _, cx| {
+                                            if let Some(flow) = this.add_space.as_mut() {
+                                                flow.browser_repo = false;
+                                            }
+                                            this.load_space_folders(Some(full.clone()), cx);
+                                        }))
+                                        .into_any_element()
+                                }
+                            })
+                    }))
                     .into_any_element()
             }
             None => div().pt(px(6.0)).into_any_element(),


### PR DESCRIPTION
## Problem

I store projects on an external SSD, but the project picker does not provide a visible way to navigate outside the home directory. As a result, projects on mounted volumes cannot be selected.

This PR makes the device breadcrumb navigate to the filesystem root, allowing users to reach /Volumes and select projects stored on external drives.

## Summary

- make the device breadcrumb navigate to filesystem root
- retain a separate Home breadcrumb for compact home-directory paths
- expose macOS mounted drives under /Volumes in the Add Project picker
- cover root, home, and mounted-volume breadcrumb behavior

## Testing

- cargo test -p zeron-ui --lib (423 passed)
- manually navigated to /Volumes and verified the mounted folders are listed

### Video

https://github.com/user-attachments/assets/d2b5f63c-dbaa-4a27-858e-d4a32d2b7fed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789349434&installation_model_id=425430&pr_number=89&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F89&signature=5d29b9160e97238c0530d87630f9251bb0c359c81c447f84b2f0feaa8c418c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
