### PR TITLE
Skip the 15s heartbeat on parked or settled folds

### DIFF
--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -1202,6 +1202,20 @@ fn expand_home(cwd: &str) -> String {
     }
 }
 
+/// Unresolved tools (except the live-plan chip) and unanswered questions.
+/// The live-plan chip is a singleton that never resolves.
+fn fold_has_in_flight_work(folded: &[MessagePart]) -> bool {
+    folded.iter().any(|part| match part {
+        MessagePart::Tool {
+            id,
+            resolved: false,
+            ..
+        } => id != zeron_proto::LIVE_PLAN_TOOL_ID,
+        MessagePart::Input { resolved: false, .. } => true,
+        _ => false,
+    })
+}
+
 /// Resume bookkeeping for one run task: which user entry the run answers (so
 /// the startup-crash retry re-dispatches idempotently against the same doc
 /// entry), whether `dispatch` injected the resume id itself (only
@@ -1384,7 +1398,15 @@ async fn drive_run(
                 session_id: None,
             },
             _ = live_heartbeat.tick() => {
-                inner.touch_session(&chat_id);
+                // A parked persistent session is already Idle. A live turn
+                // whose fold has completed output and nothing in flight
+                // (the dropped-reply / mid-run hang shape) must be allowed
+                // to age out of the UI's 45s Working gate instead of being
+                // kept fresh by this tick. Open tools and questions still
+                // get the heartbeat — those silences are real work.
+                if idle_since.is_none() && fold_has_in_flight_work(&folded) {
+                    inner.touch_session(&chat_id);
+                }
                 continue;
             }
             // Idle reaper (zeron SESSION_IDLE_MS): a parked persistent session
@@ -1472,13 +1494,7 @@ async fn drive_run(
                 && idle_since.is_none()
                 && !interrupted
                 && steerable
-                && !folded.iter().any(|p| match p {
-                    MessagePart::Tool { id, resolved: false, .. } => {
-                        id != zeron_proto::LIVE_PLAN_TOOL_ID
-                    }
-                    MessagePart::Input { resolved: false, .. } => true,
-                    _ => false,
-                }) =>
+                && !fold_has_in_flight_work(&folded) =>
             {
                 tracing::warn!(
                     chat = %chat_id,
@@ -2125,3 +2141,72 @@ mod subagent_id_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod fold_liveness_tests {
+    use super::fold_has_in_flight_work;
+    use zeron_doc::MessagePart;
+    use zeron_proto::{LIVE_PLAN_TOOL_ID, ToolCall, UserInputQuestion};
+
+    fn open_tool(id: &str) -> MessagePart {
+        MessagePart::Tool {
+            id: id.into(),
+            call: ToolCall::Exec {
+                command: "make".into(),
+            },
+            is_error: false,
+            resolved: false,
+            output: None,
+            diff: None,
+            output_ref: None,
+            output_bytes: None,
+            diff_ref: None,
+            diff_stats: None,
+            subagent_ref: None,
+            subagent_status: None,
+            subagent_tail: None,
+        }
+    }
+
+    fn text(t: &str) -> MessagePart {
+        MessagePart::Text {
+            id: "t0".into(),
+            text: t.into(),
+        }
+    }
+
+    #[test]
+    fn completed_text_fold_has_no_in_flight_work() {
+        assert!(!fold_has_in_flight_work(&[text("done")]));
+        assert!(!fold_has_in_flight_work(&[]));
+    }
+
+    #[test]
+    fn open_tool_and_question_still_need_the_heartbeat() {
+        assert!(fold_has_in_flight_work(&[
+            text("working"),
+            open_tool("build-1")
+        ]));
+        assert!(fold_has_in_flight_work(&[MessagePart::Input {
+            id: "q0".into(),
+            request_id: "r0".into(),
+            questions: vec![UserInputQuestion {
+                id: "q".into(),
+                header: "ok?".into(),
+                question: "continue?".into(),
+                options: vec![],
+                multi_select: false,
+            }],
+            resolved: false,
+        }]));
+    }
+
+    #[test]
+    fn live_plan_chip_alone_is_not_in_flight_work() {
+        assert!(!fold_has_in_flight_work(&[
+            text("plan updated"),
+            open_tool(LIVE_PLAN_TOOL_ID)
+        ]));
+    }
+}
+


### PR DESCRIPTION
## Summary

- skip the 15s session liveness heartbeat when the run is parked (`idle_since`) or the current fold has completed output and nothing in flight
- keep the heartbeat for unresolved tools and unanswered questions
- treat the live-plan chip as chrome, not in-flight work

I reviewed the full diff; this stops a finished turn from looking Working forever just because the heartbeat kept `updated_at` fresh.

## Why this approach

The heartbeat exists so a silent-but-alive child stays inside the UI's 45s Working window. That is right for an open tool or a parked question. It is wrong once the fold already has completed text and no open work: each tick resets freshness, so the 45s staleness gate never fires.

## Tradeoff

Thinking that still emits deltas stays fresh through the event path. A silent think with no open tool and no question will now age out of Working after 45s even though the child is still alive. That is the intended cost of letting the dropped-reply / mid-run hang shape settle.

## Testing

- `cargo test -p zeron-engine fold_liveness`
  - completed text / empty fold → no heartbeat
  - open tool + unanswered question → heartbeat
  - live-plan chip alone → no heartbeat

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789353964&installation_model_id=425430&pr_number=94&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F94&signature=d5bde85e385bf61412502f828596209d421e9bf0635c1b8099ea46444b09bc4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->