### PR TITLE
linux: window controls under client-side decorations

### DIFF
--- a/crates/ui/assets/icons/window-maximize.svg
+++ b/crates/ui/assets/icons/window-maximize.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none"><rect x="4.75" y="4.75" width="6.5" height="6.5" rx="1.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/></svg>

--- a/crates/ui/assets/icons/window-minimize.svg
+++ b/crates/ui/assets/icons/window-minimize.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none"><path d="M4.75 8h6.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/></svg>

--- a/crates/ui/assets/icons/window-restore.svg
+++ b/crates/ui/assets/icons/window-restore.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none"><rect x="4.75" y="6.25" width="5" height="5" rx="1.25" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/><path d="M7.25 4.75h2.5a1.5 1.5 0 0 1 1.5 1.5v2.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/></svg>

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -122,6 +122,13 @@ icon_assets![
     (TERMINAL, "terminal"),
     (PLUS, "plus"),
     (CLOSE, "close"),
+    // Hand-drawn Linux caption glyphs (minimize dash, maximize square,
+    // restore stacked squares) in the same style as `close` — drawn for the
+    // client-side-decoration window controls; no system glyph font exists on
+    // Linux the way Segoe Fluent Icons does on Windows.
+    (WINDOW_MINIMIZE, "window-minimize"),
+    (WINDOW_MAXIMIZE, "window-maximize"),
+    (WINDOW_RESTORE, "window-restore"),
     (STOP, "stop"),
     (CHECK, "check"),
     (COPY, "copy"),

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -222,6 +222,18 @@ fn open_main_window(state: gpui::Entity<state::AppState>, boot: EngineBootConfig
             // Drag + start_window_move) — mark the content view app-owned
             // so AppKit neither dead-zones the strip nor delays clicks.
             app_owns_titlebar_drag: true,
+            // Linux: request client-side decorations — zeron draws its own
+            // unified titlebar and (under CSD) its own caption buttons
+            // (shell.rs `render_linux_caption_controls`). Leaving this unset
+            // requests SERVER decorations, which stacked a compositor
+            // titlebar on top of the app's chrome under sway/KDE, while
+            // compositors without SSD support (GNOME) went client-side
+            // anyway — frameless, and before the shell drew caption buttons,
+            // with no window controls at all. The compositor can still
+            // override via xdg-decoration negotiation; the shell re-resolves
+            // what to draw every frame.
+            window_decorations: cfg!(target_os = "linux")
+                .then_some(gpui::WindowDecorations::Client),
             // Frosted shell (macOS): blur the desktop behind the window; the
             // shell paints its frost surface translucent so the sidebar reads
             // as glass (shell.rs root). Elsewhere blur support is compositor

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -85,10 +85,24 @@ pub fn titlebar_spacer_width(is_macos: bool, fullscreen: bool, container_pad: f3
 /// back/forward: three 24px buttons, 2px gaps).
 pub const CLUSTER_BUTTONS_WIDTH: f32 = 24.0 * 3.0 + 2.0 * 2.0;
 
+/// Width of a row of `count` Linux caption buttons, drawn at the cluster's
+/// own 24px-button / 2px-gap rhythm.
+pub fn caption_buttons_width(count: usize) -> f32 {
+    if count == 0 {
+        return 0.0;
+    }
+    count as f32 * 24.0 + (count as f32 - 1.0) * 2.0
+}
+
 /// Where the cluster's first button starts, from the window's left edge.
-pub fn cluster_buttons_start(is_macos: bool, fullscreen: bool) -> f32 {
+/// `linux_left_captions` is the number of caption buttons zeron draws at the
+/// top-left on Linux (GNOME `close:…` layouts) — the app cluster follows them
+/// at the shared 2px rhythm.
+pub fn cluster_buttons_start(is_macos: bool, fullscreen: bool, linux_left_captions: usize) -> f32 {
     if is_macos {
         titlebar_cluster_start(fullscreen)
+    } else if linux_left_captions > 0 {
+        10.0 + caption_buttons_width(linux_left_captions) + 2.0
     } else {
         10.0
     }
@@ -96,8 +110,14 @@ pub fn cluster_buttons_start(is_macos: bool, fullscreen: bool) -> f32 {
 
 /// Left clearance a full-bleed header (collapsed sidebar) needs so its content
 /// starts past the overlay cluster, given the header's own `container_pad`.
-pub fn cluster_clearance(is_macos: bool, fullscreen: bool, container_pad: f32) -> f32 {
-    (cluster_buttons_start(is_macos, fullscreen) + CLUSTER_BUTTONS_WIDTH + 8.0 - container_pad)
+pub fn cluster_clearance(
+    is_macos: bool,
+    fullscreen: bool,
+    linux_left_captions: usize,
+    container_pad: f32,
+) -> f32 {
+    (cluster_buttons_start(is_macos, fullscreen, linux_left_captions) + CLUSTER_BUTTONS_WIDTH + 8.0
+        - container_pad)
         .max(0.0)
 }
 
@@ -689,6 +709,15 @@ pub struct Shell {
     /// Armed by mouse-down on a titlebar strip; the next mouse-move hands the
     /// drag to the compositor (zed's platform-titlebar pattern).
     titlebar_should_move: bool,
+    /// The caption buttons zeron itself draws on Linux under client-side
+    /// decorations, per side, already filtered to what the compositor
+    /// supports — `None` off Linux or under server decorations (where the WM
+    /// draws real buttons). Re-resolved every frame at the top of `render`.
+    linux_captions: Option<gpui::WindowButtonLayout>,
+    /// Re-renders when the desktop's button layout changes (GNOME
+    /// `button-layout` gsetting). Registered on first paint — [`Shell::new`]
+    /// has no window.
+    button_layout_sub: Option<Subscription>,
     /// Clears the height tween once it completes (so a closed panel unmounts).
     terminal_tween_task: Option<Task<()>>,
     /// Height-drag anchor: (pointer y, height) at mouse-down on the handle.
@@ -868,6 +897,8 @@ impl Shell {
             fullscreen: None,
             titlebar_tween: None,
             titlebar_should_move: false,
+            linux_captions: None,
+            button_layout_sub: None,
             terminal_tween_task: None,
             terminal_drag_anchor: None,
             reduced_motion: false,
@@ -2007,7 +2038,7 @@ impl Shell {
         let is_macos = cfg!(target_os = "macos");
         let cluster = self.eval_tween(
             self.titlebar_tween,
-            cluster_buttons_start(is_macos, fullscreen),
+            cluster_buttons_start(is_macos, fullscreen, self.linux_left_caption_count()),
         );
         cluster + CLUSTER_BUTTONS_WIDTH + 10.0
     }
@@ -2025,10 +2056,7 @@ impl Shell {
                     .items_center()
                     .pt(px(Theme::TITLEBAR_TOP_PAD))
                     .pl(px(self.title_bar_content_start()))
-                    .pr(px(titlebar_right_padding(
-                        cfg!(target_os = "windows"),
-                        Theme::SPACE_LG,
-                    )));
+                    .pr(px(self.titlebar_right_pad(Theme::SPACE_LG)));
                 let bar = div().h(px(Theme::TITLEBAR_HEIGHT)).flex_none().child(inner);
                 self.titlebar_drag_region("settings-header-titlebar", bar, cx)
                     .into_any_element()
@@ -2119,6 +2147,15 @@ impl Shell {
             .gap(px(2.0))
             .px(px(10.0))
             .children(self.titlebar_spacer(12.0))
+            // Left-side Linux captions (GNOME `close:…` layouts): the
+            // root-level caption overlay owns the buttons; the cluster row
+            // just starts past them, at the shared 2px rhythm.
+            .children((self.linux_left_caption_count() > 0).then(|| {
+                div()
+                    .flex_none()
+                    .h_full()
+                    .w(px(caption_buttons_width(self.linux_left_caption_count())))
+            }))
             .child(window_control_button(
                 "toggle-sidebar",
                 icons::SIDEBAR_MINIMALISTIC_LEFT,
@@ -2210,6 +2247,140 @@ impl Shell {
                 ))
                 .into_any_element(),
         )
+    }
+
+    /// Which caption buttons zeron itself must draw on Linux: under
+    /// client-side decorations (the Wayland default) nobody else will —
+    /// without these the window has NO minimize/maximize/close at all.
+    /// Server-side decorations (X11 WMs, KDE with SSD) already draw real
+    /// buttons, so `None` there. The desktop's layout (GNOME's
+    /// `button-layout` gsetting via `cx.button_layout()`) decides side and
+    /// order — min/max/close on the right by default; controls the
+    /// compositor can't do (e.g. minimize on some Wayland compositors) drop
+    /// out, close always stays.
+    #[cfg(target_os = "linux")]
+    fn resolve_linux_captions(window: &Window, cx: &App) -> Option<gpui::WindowButtonLayout> {
+        use gpui::{MAX_BUTTONS_PER_SIDE, WindowButton, WindowButtonLayout};
+        if !matches!(
+            window.window_decorations(),
+            gpui::Decorations::Client { .. }
+        ) {
+            return None;
+        }
+        let layout = cx
+            .button_layout()
+            .unwrap_or_else(WindowButtonLayout::linux_default);
+        let supported = window.window_controls();
+        let filter_side = |side: [Option<WindowButton>; MAX_BUTTONS_PER_SIDE]| {
+            let mut out = [None; MAX_BUTTONS_PER_SIDE];
+            let mut i = 0;
+            for button in side.into_iter().flatten() {
+                let keep = match button {
+                    WindowButton::Minimize => supported.minimize,
+                    WindowButton::Maximize => supported.maximize,
+                    WindowButton::Close => true,
+                };
+                if keep {
+                    out[i] = Some(button);
+                    i += 1;
+                }
+            }
+            out
+        };
+        let layout = WindowButtonLayout {
+            left: filter_side(layout.left),
+            right: filter_side(layout.right),
+        };
+        (layout.left[0].is_some() || layout.right[0].is_some()).then_some(layout)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn resolve_linux_captions(_window: &Window, _cx: &App) -> Option<gpui::WindowButtonLayout> {
+        None
+    }
+
+    pub(super) fn linux_left_caption_count(&self) -> usize {
+        self.linux_captions
+            .map_or(0, |l| l.left.iter().flatten().count())
+    }
+
+    pub(super) fn linux_right_caption_count(&self) -> usize {
+        self.linux_captions
+            .map_or(0, |l| l.right.iter().flatten().count())
+    }
+
+    /// Right padding titlebar content needs to clear the platform's caption
+    /// controls (native Windows cluster / zeron-drawn Linux buttons).
+    pub(super) fn titlebar_right_pad(&self, base: f32) -> f32 {
+        titlebar_right_padding(
+            cfg!(target_os = "windows"),
+            self.linux_right_caption_count(),
+            base,
+        )
+    }
+
+    /// Zeron-drawn Linux caption controls, one overlay per populated side.
+    /// Shell-level chrome like the Windows cluster: mounted at the root so
+    /// they stay above the splash and every auth/org/error gate.
+    fn render_linux_caption_controls(&self, window: &Window, cx: &App) -> Vec<AnyElement> {
+        let Some(layout) = self.linux_captions else {
+            return Vec::new();
+        };
+        let theme = Theme::of(cx);
+        let is_maximized = window.is_maximized();
+        // Ids can be per-button (not per-side): the layout parser dedups, so
+        // a button never appears on both sides at once.
+        let strip = |buttons: &[Option<gpui::WindowButton>]| {
+            div()
+                .absolute()
+                .top_0()
+                .h(px(Theme::TITLEBAR_HEIGHT))
+                .flex()
+                .flex_row()
+                .items_center()
+                .pt(px(Theme::TITLEBAR_TOP_PAD))
+                .gap(px(2.0))
+                .px(px(10.0))
+                .children(buttons.iter().flatten().map(|button| {
+                    match button {
+                        gpui::WindowButton::Minimize => linux_caption_button(
+                            "window-minimize",
+                            icons::WINDOW_MINIMIZE,
+                            false,
+                            theme,
+                            |_, window, _| window.minimize_window(),
+                        )
+                        .into_any_element(),
+                        gpui::WindowButton::Maximize => {
+                            let (id, icon_path) = if is_maximized {
+                                ("window-restore", icons::WINDOW_RESTORE)
+                            } else {
+                                ("window-maximize", icons::WINDOW_MAXIMIZE)
+                            };
+                            linux_caption_button(id, icon_path, false, theme, |_, window, _| {
+                                window.zoom_window()
+                            })
+                            .into_any_element()
+                        }
+                        gpui::WindowButton::Close => linux_caption_button(
+                            "window-close",
+                            icons::CLOSE,
+                            true,
+                            theme,
+                            |_, window, _| window.remove_window(),
+                        )
+                        .into_any_element(),
+                    }
+                }))
+        };
+        let mut out = Vec::new();
+        if layout.left[0].is_some() {
+            out.push(strip(&layout.left).left_0().into_any_element());
+        }
+        if layout.right[0].is_some() {
+            out.push(strip(&layout.right).right_0().into_any_element());
+        }
+        out
     }
 
     fn render_sidebar(&mut self, cx: &mut Context<Self>) -> AnyElement {
@@ -4665,9 +4836,14 @@ fn window_control_button(
 const WINDOWS_CAPTION_BUTTON_WIDTH: f32 = 36.0;
 const WINDOWS_CAPTION_WIDTH: f32 = WINDOWS_CAPTION_BUTTON_WIDTH * 3.0;
 
-fn titlebar_right_padding(is_windows: bool, base: f32) -> f32 {
+/// Right padding for titlebar content: past the native Windows caption
+/// cluster, or past zeron's own Linux caption buttons (10px edge inset +
+/// the button row) when the layout puts any on the right.
+fn titlebar_right_padding(is_windows: bool, linux_right_captions: usize, base: f32) -> f32 {
     base + if is_windows {
         WINDOWS_CAPTION_WIDTH
+    } else if linux_right_captions > 0 {
+        10.0 + caption_buttons_width(linux_right_captions)
     } else {
         0.0
     }
@@ -4713,6 +4889,54 @@ fn windows_caption_button(
         .occlude()
         .window_control_area(area)
         .child(glyph)
+}
+
+/// A Linux caption button in zeron's own cluster style (24px, rounded-6,
+/// 16px linear icon). gpui's `WindowControlArea` hit-testing is inert on
+/// Linux, so unlike the Windows cluster these carry explicit click handlers
+/// (`minimize_window` / `zoom_window` / `remove_window`), the same calls
+/// zed's Linux titlebar makes. `occlude` + `prevent_default` keep them out
+/// of the drag strip's event surface (see [`window_control_button`]).
+fn linux_caption_button(
+    id: &'static str,
+    icon_path: &'static str,
+    close: bool,
+    theme: &Theme,
+    on_click: impl Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    let (muted, hover_bg, hover_fg) = if close {
+        let red: gpui::Hsla = gpui::rgb(0xe81123).into();
+        (theme.text_muted, red, gpui::white())
+    } else {
+        (theme.text_muted, theme.glass_hover(), theme.text)
+    };
+    div()
+        .id(id)
+        // gpui svgs don't inherit the div's text color — recolor the glyph
+        // on hover through the group instead (zed's WindowControl idiom).
+        .group("linux-caption-button")
+        .size(px(24.0))
+        .flex_none()
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(6.0))
+        .cursor_pointer()
+        .hover(move |style| style.bg(hover_bg))
+        .occlude()
+        .on_mouse_down(MouseButton::Left, |_, window, _| window.prevent_default())
+        .on_click(move |event, window, cx| {
+            cx.stop_propagation();
+            on_click(event, window, cx)
+        })
+        .child(
+            icon(icon_path)
+                .size(px(16.0))
+                .text_color(muted)
+                .group_hover("linux-caption-button", move |style| {
+                    style.text_color(hover_fg)
+                }),
+        )
 }
 
 /// A titlebar history button (zeron window-controls.tsx): enabled it is a
@@ -4815,6 +5039,14 @@ impl Render for Shell {
                 ));
             }
             self.fullscreen = Some(fullscreen);
+        }
+        // Linux CSD: (re-)resolve which caption buttons we draw and on which
+        // side — decorations can flip server↔client at runtime and the
+        // desktop's button layout is user configuration.
+        self.linux_captions = Self::resolve_linux_captions(window, cx);
+        if cfg!(target_os = "linux") && self.button_layout_sub.is_none() {
+            self.button_layout_sub =
+                Some(cx.observe_button_layout_changed(window, |_, _, cx| cx.notify()));
         }
         // Manual tween drive bookkeeping for this pass (see [`WidthTween`]).
         self.reduced_motion = motion::reduced_motion(cx);
@@ -5071,24 +5303,31 @@ impl Render for Shell {
 
         // Caption controls are shell-level chrome, not Ready-page content:
         // keep them above the splash and every auth/org/error gate as well as
-        // the full application. Gate pages also need a native drag surface
-        // because they do not render the unified tabs/settings titlebar.
+        // the full application. Gate pages also need a drag surface because
+        // they do not render the unified tabs/settings titlebar — on Windows
+        // the native `Drag` control area, on Linux the explicit
+        // `start_window_move` strip (the control-area hit-test is inert
+        // there); macOS drags gate windows natively.
         let root = if (!restart_required && matches!(gate, GatePhase::Ready))
-            || !cfg!(target_os = "windows")
+            || cfg!(target_os = "macos")
         {
             root
         } else {
             root.child(
-                div()
-                    .absolute()
-                    .top_0()
-                    .left_0()
-                    .right_0()
-                    .h(px(Theme::TITLEBAR_HEIGHT))
-                    .window_control_area(WindowControlArea::Drag),
+                self.titlebar_drag_region(
+                    "gate-titlebar-drag",
+                    div()
+                        .absolute()
+                        .top_0()
+                        .left_0()
+                        .right_0()
+                        .h(px(Theme::TITLEBAR_HEIGHT)),
+                    cx,
+                ),
             )
         };
         root.children(self.render_windows_caption_controls(window, cx))
+            .children(self.render_linux_caption_controls(window, cx))
     }
 }
 
@@ -5330,24 +5569,46 @@ mod tests {
 
     #[test]
     fn windows_caption_controls_reserve_titlebar_space() {
-        assert_eq!(titlebar_right_padding(true, 16.0), 124.0);
-        assert_eq!(titlebar_right_padding(false, 16.0), 16.0);
+        assert_eq!(titlebar_right_padding(true, 0, 16.0), 124.0);
+        assert_eq!(titlebar_right_padding(false, 0, 16.0), 16.0);
+    }
+
+    #[test]
+    fn linux_caption_controls_reserve_titlebar_space() {
+        // 24px buttons on the cluster's 2px rhythm.
+        assert_eq!(caption_buttons_width(0), 0.0);
+        assert_eq!(caption_buttons_width(1), 24.0);
+        assert_eq!(caption_buttons_width(3), 76.0);
+        // Right-side captions (the Linux default: minimize,maximize,close):
+        // content pads past the 10px edge inset + the button row.
+        assert_eq!(titlebar_right_padding(false, 3, 16.0), 16.0 + 10.0 + 76.0);
+        // GNOME-vanilla ":close" — a single right button.
+        assert_eq!(titlebar_right_padding(false, 1, 16.0), 16.0 + 10.0 + 24.0);
+        // Left-side captions ("close:…" layouts) shift the app cluster right
+        // by the button row + one 2px gap.
+        assert_eq!(cluster_buttons_start(false, false, 0), 10.0);
+        assert_eq!(cluster_buttons_start(false, false, 1), 10.0 + 24.0 + 2.0);
+        assert_eq!(cluster_buttons_start(false, false, 3), 10.0 + 76.0 + 2.0);
+        // macOS ignores the Linux caption count entirely.
+        assert_eq!(cluster_buttons_start(true, false, 3), 88.0);
     }
 
     #[test]
     fn cluster_clearance_clears_the_overlay_buttons() {
         // Linux: buttons at 10..86; a 16px-padded header needs 78 more px to
         // put content at 86 + 8 breathing room.
-        assert_eq!(cluster_clearance(false, false, 16.0), 78.0);
-        assert_eq!(cluster_clearance(false, false, 10.0), 84.0);
+        assert_eq!(cluster_clearance(false, false, 0, 16.0), 78.0);
+        assert_eq!(cluster_clearance(false, false, 0, 10.0), 84.0);
+        // Linux with a left-side close caption: everything shifts one slot.
+        assert_eq!(cluster_clearance(false, false, 1, 16.0), 78.0 + 26.0);
         // macOS: buttons start at the 88px traffic-light cluster start.
         assert_eq!(
-            cluster_clearance(true, false, 16.0),
+            cluster_clearance(true, false, 0, 16.0),
             88.0 + 76.0 + 8.0 - 16.0
         );
         // macOS fullscreen: cluster reclaims the inset (starts at 12).
         assert_eq!(
-            cluster_clearance(true, true, 16.0),
+            cluster_clearance(true, true, 0, 16.0),
             12.0 + 76.0 + 8.0 - 16.0
         );
     }

--- a/crates/ui/src/shell/tabs.rs
+++ b/crates/ui/src/shell/tabs.rs
@@ -148,7 +148,7 @@ impl Shell {
             None
         } else if self.right_pane_open(cx) {
             let right_now = self.eval_tween(self.right_tween, self.right_target(cx));
-            let pr = titlebar_right_padding(cfg!(target_os = "windows"), Theme::SPACE_LG);
+            let pr = self.titlebar_right_pad(Theme::SPACE_LG);
             // The row's own left padding is part of its content box: a strip
             // wider than what's left after it overflows and clips at the right
             // edge (flex_none never shrinks) — cap to the available width. The
@@ -221,10 +221,7 @@ impl Shell {
             .pt(px(Theme::TITLEBAR_TOP_PAD))
             .gap(px(8.0))
             .pl(px(row_left))
-            .pr(px(titlebar_right_padding(
-                cfg!(target_os = "windows"),
-                Theme::SPACE_LG,
-            )))
+            .pr(px(self.titlebar_right_pad(Theme::SPACE_LG)))
             // In panel takeover the header strip spans the whole band — the
             // title would sit UNDER it (both flex_none, the row overflows and
             // paint order stacks them), so it hides for the duration.


### PR DESCRIPTION
## Problem

On Linux the window had **no minimize/maximize/close buttons at all** whenever the compositor put us in client-side-decoration mode — which is the norm: GNOME/Mutter has no server-side decoration support, and gpui's Wayland backend defaults to client mode when the protocol is absent. The Windows caption cluster never applied because `WindowControlArea` hit-testing is Windows-only, and macOS has native traffic lights — Linux just fell through.

On top of that, zeron left `WindowOptions.window_decorations` unset, which makes gpui request **server** decorations — so on compositors that do support SSD (sway, labwc, KDE) a foreign titlebar was stacked on top of zeron's own unified chrome:

![before: compositor titlebar stacked on the app chrome](https://github.com/user-attachments/assets/1f56a2bf-a81e-447e-84d4-5d5436d2c443)

## Fix

- **Request client decorations on Linux** — matches the unified-titlebar design (and Zed's default). The compositor can still override via xdg-decoration negotiation; the shell re-resolves what to draw every frame.
- **Draw zeron-styled caption buttons** in the titlebar (24px cluster rhythm, hand-drawn linear glyphs matching the existing `close`/`plus` set) with explicit handlers — `minimize_window` / `zoom_window` / `remove_window` — since the native control-area hit-test is inert on Linux. They mount at the shell root like the Windows cluster, so they stay above the splash and the auth/org gates.
- **Follow the desktop's button layout** (`cx.button_layout()`, GNOME's `button-layout` gsetting via the settings portal, with `observe_button_layout_changed` re-rendering on change): min/max/close on the **right** by default; `close:…` layouts put buttons on the **left** and the sidebar/nav cluster shifts past them at the shared 2px rhythm. Controls the compositor can't do (per `wm_capabilities`) drop out; close always stays.
- **Reserve titlebar space**: the tab strip, changes-pane header, and settings bar pad right past the caption strip (`titlebar_right_pad`), mirroring the existing Windows caption budget; `cluster_buttons_start`/`title_bar_content_start` budget the left side.
- **Gate/splash pages get a real drag strip** on Linux/Windows (`titlebar_drag_region`) — the bare `WindowControlArea::Drag` surface those pages relied on is dead on Linux.

## After

Unified titlebar with zeron's own controls, no compositor chrome (labwc, client-side decorations):

![after: unified titlebar with min/max/close top-right](https://github.com/user-attachments/assets/bcee27c5-0b15-4a8c-ad42-d23ef431f05c)

The changes-pane toggle keeps its spot left of the caption cluster (it is git-gated, so it only shows when the session's project has git), and with the pane open its header controls clear the captions too:

![changes pane open next to the caption cluster](https://github.com/user-attachments/assets/1108accb-37b4-4fb1-878c-536eb8e58242)

Close hover gets the caption-red wash:

![close hover](https://github.com/user-attachments/assets/b7519ecf-5228-443a-8e23-e72421e6a570)

Maximized: the middle glyph flips to restore, and `zoom_window` round-trips:

![maximized with restore glyph](https://github.com/user-attachments/assets/df578a92-00cd-4c4a-b739-5edc6c486f6b)

GNOME `button-layout "close:"` — the close button moves to the **left** and the window-control cluster shifts over, verified end-to-end through `xdg-desktop-portal-gtk`:

![left-side close per GNOME button-layout](https://github.com/user-attachments/assets/9aaafd71-2ee4-4b73-b33b-3e0917e52657)

Server-side decorations (sway, tiled) still work and we draw **nothing** — no double controls; the compositor owns the buttons:

![sway SSD: compositor titlebar, no in-app duplicates](https://github.com/user-attachments/assets/92197064-ecb4-4546-a41c-d2abfaaa0edf)

## Verification

- Rig-tested under **labwc** (headless, CSD): clicked all three buttons via virtual pointer — minimize unmaps the window (process stays alive), maximize fills the output and flips to the restore glyph, restore returns to the floating size, close exits the app cleanly.
- **sway** (SSD): decoration negotiation traced with `WAYLAND_DEBUG` — we request client mode, sway configures server mode, the shell adapts and draws nothing.
- Left-side layout served by a real portal chain (`dbus` session + `xdg-desktop-portal` + `-gtk` + `gsettings button-layout "close:"`).
- `cargo test -p zeron-ui`: 423 passed, including new coverage for the caption width/clearance math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789359661&installation_model_id=425430&pr_number=97&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F97&signature=73e93ed571c3af48b1cf466709595fceaa74a9ac3e6255251331ee84706320c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
