### PR TITLE
Exempt Pi from the 30s ACP quiet-settle

### DIFF
--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -2141,14 +2141,24 @@ async fn run_session(session: Session) {
     // Done ever comes, and the session strands Working until the engine's
     // quiesce watchdog parks it.
     //
-    // `ZERON_ACP_QUIET_SETTLE_MS` overrides; 0 disables.
-    let quiet_settle: Option<Duration> = match std::env::var("ZERON_ACP_QUIET_SETTLE_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-    {
-        Some(0) => None,
-        Some(ms) => Some(Duration::from_millis(ms)),
-        None => Some(Duration::from_secs(30)),
+    // Pi is EXEMPT, even from the env knob. Mid-turn compaction and long
+    // reasoning emit no ACP session/update, so a long silent stretch in
+    // exactly the "looks finished" state (content streamed, every tool
+    // resolved) is indistinguishable from a dropped reply — 30s of quiet
+    // forged a clean Completed on a live `session/prompt` (2026-08-15).
+    // Genuinely dropped Pi replies already settle via the engine quiesce
+    // watchdog. `ZERON_ACP_QUIET_SETTLE_MS` overrides; 0 disables.
+    let quiet_settle: Option<Duration> = if harness == HarnessId::Pi {
+        None
+    } else {
+        match std::env::var("ZERON_ACP_QUIET_SETTLE_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+        {
+            Some(0) => None,
+            Some(ms) => Some(Duration::from_millis(ms)),
+            None => Some(Duration::from_secs(30)),
+        }
     };
     let mut last_update_at = tokio::time::Instant::now();
     let mut turn_content_seen = false;
@@ -2158,7 +2168,7 @@ async fn run_session(session: Session) {
     // terminal one (verified against 0.66.0 — premature Done exactly one
     // grace after injection). Steered turns settle off their real response
     // (healthy in every trace); the engine's quiesce watchdog backstops
-    // them (the quiet settle used to, before the Claude exemption above).
+    // them (the quiet settle used to, before the Pi exemption above).
     let mut steered_this_turn = false;
     let mut open_tools: std::collections::HashSet<String> = std::collections::HashSet::new();
     let open_questions = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/crates/harness/tests/acp_quiet.rs
+++ b/crates/harness/tests/acp_quiet.rs
@@ -176,3 +176,36 @@ async fn open_tool_call_holds_the_quiet_settle_off() {
         "the turn must survive the quiet stretch intact: {events:?}"
     );
 }
+
+/// Pi has the same hole as the retired Claude ACP adapter: mid-turn
+/// compaction and long reasoning emit no ACP session/update, so the
+/// "looks finished" quiet window would forge a Completed on a live
+/// prompt. Pi must ignore the blanket settle even with the env knob set.
+#[tokio::test]
+async fn pi_thinking_silence_never_settles_the_turn() {
+    init_env();
+    let events = run_and_collect(
+        AcpHarness::pi(),
+        "scenario:quiet-thinking",
+        Duration::from_secs(20),
+    )
+    .await;
+    assert_eq!(
+        dones(&events),
+        vec![(DoneStatus::Completed, None)],
+        "{events:?}"
+    );
+    let finished = events
+        .iter()
+        .position(|(_, e)| matches!(e, AgentEvent::TextDelta { text } if text == "finished"))
+        .unwrap_or_else(|| panic!("post-quiet text must fold into the SAME turn: {events:?}"));
+    let done = events
+        .iter()
+        .position(|(_, e)| matches!(e, AgentEvent::Done { .. }))
+        .expect("done asserted above");
+    assert!(
+        finished < done,
+        "the turn must survive silent thinking intact: {events:?}"
+    );
+}
+

--- a/crates/harness/tests/real_quiet_survey.rs
+++ b/crates/harness/tests/real_quiet_survey.rs
@@ -5,7 +5,7 @@
 //!   SURVEY_RUNS=3 cargo test -p zeron-harness --test real_quiet_survey -- --ignored --nocapture
 //!
 //! No env knob is set here — this binary runs the DEFAULTS the app ships:
-//! Claude exempt from the blanket settle, every other adapter on the 30s
+//! Pi exempt from the blanket settle, every other adapter on the 30s
 //! window. For each installed+authenticated agent CLI it reports, per run:
 //! the Done count, content events after the first Done (orphan signature),
 //! and the maximum inter-event silent gap — the safety margin against the


### PR DESCRIPTION
## Summary

- Pi joins Claude on the quiet-settle exemption
- mid-turn compaction or silent reasoning no longer forges a clean Completed
- Grok and the other adapters stay on the 30s window
- the engine quiesce watchdog still backstops a genuinely dropped Pi reply

Pi / Oh My Pi emits no ACP `session/update` during compaction and long reasoning. The blanket 30s window treated that silence as a dropped `session/prompt` and killed a live turn.

## Why this approach

Same hole Claude already has. Same exemption. Do not invent a Pi-only heartbeat in the client.

## Testing

- `cargo test -p zeron-harness --test acp_quiet`
  - Pi silent-thinking fixture survives the window
  - Claude exemption still holds
  - Grok dropped-reply still settles off the quiet window
  - open tool still holds the settle off

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789361428&installation_model_id=425430&pr_number=98&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F98&signature=5faebad15a4dff3811d78e0ba08a3ed2b467705cccaf5ffe60a52fb0c408a019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->