### PR TITLE
Show an ErrorChip when a prompt turn is force-settled

### DIFF
--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -1146,14 +1146,16 @@ async fn drive_run(
     // that loses a turn's Done — the adapter never settles `session/prompt`
     // even though the agent finished — strands Working forever: the live
     // heartbeat above keeps the row fresh, and there is no per-turn timeout
-    // by design. This is NOT that stall timeout: it never ends the run or
-    // errors anything. When the stream has been silent past the window AND
-    // the fold shows completed output with nothing in flight (no unresolved
-    // tool, no open question), the turn parks exactly like a Done would —
-    // segment finalized Complete, status Idle, child and mailbox warm. A
-    // false trip (the agent was quietly waiting on something invisible)
-    // costs a status dip: the parked-resume path below re-arms Working the
-    // moment output flows again, and nothing is lost. `ZERON_TURN_QUIESCE_MS`
+    // by design. This is NOT that stall timeout: it never ends the run.
+    // When the stream has been silent past the window AND the fold shows
+    // completed output with nothing in flight (no unresolved tool, no open
+    // question), the turn parks: child and mailbox stay warm so a false
+    // trip re-arms Working the moment output flows again. A self-continued
+    // turn (no prompt behind it) has no other settle path — that park is
+    // Idle, same as today. A prompt or steer turn that goes quiet is a
+    // forced settle, not a clean finish: the segment gets an ErrorChip
+    // ("Turn settled — agent went quiet.") and the sidebar reads Failed
+    // until the user looks or the agent speaks again. `ZERON_TURN_QUIESCE_MS`
     // overrides the window; 0 disables.
     let quiesce_after: Option<std::time::Duration> = match std::env::var("ZERON_TURN_QUIESCE_MS")
         .ok()
@@ -1300,9 +1302,21 @@ async fn drive_run(
                 tracing::warn!(
                     chat = %chat_id,
                     quiet_ms = quiesce_after.unwrap_or_default().as_millis() as u64,
+                    self_continued = self_continued_turn,
                     "turn quiesced: stream silent after completed output with no \
                      turn-end; parking (suspected missing harness Done)"
                 );
+                // Prompt/steer turns that go quiet are a forced settle, not a
+                // clean finish. Self-continued turns have no Done coming — that
+                // park stays a silent Idle (the watchdog is their only end).
+                if !self_continued_turn {
+                    fold_event_into_parts(
+                        &mut folded,
+                        &AgentEvent::Error {
+                            message: "Turn settled — agent went quiet.".into(),
+                        },
+                    );
+                }
                 if !folded.is_empty() || writer.is_some() {
                     if let Err(err) = finish_segment(
                         doc_ref,
@@ -1322,8 +1336,13 @@ async fn drive_run(
                 entry_id = new_id();
                 segment_started = now_ms();
                 idle_since = Some(tokio::time::Instant::now());
+                let parked = if self_continued_turn {
+                    SessionStatus::Idle
+                } else {
+                    SessionStatus::Errored
+                };
                 self_continued_turn = false;
-                inner.set_status(&chat_id, SessionStatus::Idle, false);
+                inner.set_status(&chat_id, parked, false);
                 continue;
             }
         };

--- a/crates/engine/tests/turn_quiesce.rs
+++ b/crates/engine/tests/turn_quiesce.rs
@@ -14,8 +14,10 @@
 //!
 //! The fixes under test: parked sessions RESUME on self-continued output
 //! (fold it, show Working), and the quiesce watchdog settles any turn whose
-//! stream goes silent after completed output with nothing in flight —
-//! without ending the run, so a false trip costs a status dip, not content.
+//! stream goes silent after completed output with nothing in flight.
+//! Self-continued parks stay Idle. A prompt or steer turn that goes quiet
+//! is a forced settle: Failed in the sidebar and an ErrorChip in the
+//! transcript, not a clean Completed finish.
 
 use std::sync::{Arc, Once};
 use std::time::Duration;
@@ -304,6 +306,49 @@ async fn parked_self_continuation_folds_and_requiesces() {
     rig.core.sessions.shutdown().await;
 }
 
+/// A first-prompt turn that streams then goes silent (no Done) must not look
+/// like a clean finish. The watchdog parks Failed and stamps the quiet chip.
+#[tokio::test]
+async fn first_prompt_quiet_settle_is_visible() {
+    let rig = assemble("ship the connecting-state fix");
+    rig.core
+        .sessions
+        .dispatch(
+            CHAT,
+            HarnessId::Mock,
+            run_request("ship the connecting-state fix"),
+            None,
+        )
+        .await
+        .expect("dispatch");
+
+    rig.feed.send(session_started()).unwrap();
+    rig.feed.send(text("Working on it.")).unwrap();
+
+    wait_for(
+        || status(&rig.core) == Some(SessionStatus::Errored),
+        "first-prompt quiet settle is Failed, not Idle",
+    )
+    .await;
+    assert!(
+        entries(&rig.core).iter().any(|e| {
+            e.role == MessageRole::Assistant
+                && e.parts.iter().any(|p| {
+                    matches!(
+                        p,
+                        MessagePart::Error { message, .. }
+                            if message == "Turn settled — agent went quiet."
+                    )
+                })
+        }),
+        "forced settle must stamp the quiet ErrorChip, got {:#?}",
+        entries(&rig.core)
+    );
+
+    rig.core.sessions.shutdown().await;
+}
+
+
 /// Step 3 of the incident: a steer becomes the next turn, the agent answers,
 /// and the turn-end reply is LOST. The session must not read Working forever
 /// — the watchdog settles it, and the answer text survives in the doc.
@@ -349,9 +394,10 @@ async fn missing_turn_end_settles_instead_of_working_forever() {
     rig.feed.send(text("Done — here are the results.")).unwrap();
 
     // Old behavior: Working forever (heartbeat keeps the row fresh; no
-    // turn timeout). New behavior: the watchdog settles the turn.
+    // turn timeout). New behavior: the watchdog settles the turn as a
+    // visible failure, not a clean Idle/Completed finish.
     wait_for(
-        || status(&rig.core) == Some(SessionStatus::Idle),
+        || status(&rig.core) == Some(SessionStatus::Errored),
         "watchdog settles the turn whose Done was lost",
     )
     .await;
@@ -361,6 +407,20 @@ async fn missing_turn_end_settles_instead_of_working_forever() {
             t.contains("here are the results") && *s == Some(MessageStatus::Complete)
         }),
         "the lost-Done turn's answer must still finalize in the doc, got {texts:#?}"
+    );
+    assert!(
+        entries(&rig.core).iter().any(|e| {
+            e.role == MessageRole::Assistant
+                && e.parts.iter().any(|p| {
+                    matches!(
+                        p,
+                        MessagePart::Error { message, .. }
+                            if message == "Turn settled — agent went quiet."
+                    )
+                })
+        }),
+        "forced settle must stamp the quiet ErrorChip, got {:#?}",
+        entries(&rig.core)
     );
 
     rig.core.sessions.shutdown().await;


### PR DESCRIPTION
## Summary

- a silent prompt or steer no longer parks as a clean finish
- the transcript gets **Turn settled — agent went quiet.**
- the sidebar reads **Failed**, not Done
- self-continued parks stay Idle — those turns have no prompt to settle

A watchdog guess used to write `Completed` + Idle. Same as a real finish: done-chime, no chip. From the seat it felt like a crash.

## Why this approach

The child and mailbox stay warm. Output still re-arms Working. Only the visible end-state changes: Forced settle is Failed + ErrorChip.

Self-continued turns still park Idle. The watchdog is their only real end.

## Testing

- `cargo test -p zeron-engine --test turn_quiesce --test self_continued_quiesce`
  - first prompt goes quiet → Failed + chip
  - lost steer Done → Failed + chip
  - self-continued park stays Idle
  - open tool still never quiesces

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789361428&installation_model_id=425430&pr_number=99&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F99&signature=4a3539a5a42a0ce350892b3e50ea7f3984326d705646ac15edd7ca6e2fad6561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->