### PR TITLE
harness: add OpenCode ACP support (opencode acp)

### DIFF
--- a/crates/engine/src/agent_accounts.rs
+++ b/crates/engine/src/agent_accounts.rs
@@ -1298,6 +1298,7 @@ fn harness_slug(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "grok",
         HarnessId::Hermes => "hermes",
         HarnessId::Pi => "pi",
+        HarnessId::OpenCode => "opencode",
         HarnessId::Mock => "mock",
     }
 }

--- a/crates/engine/src/registry.rs
+++ b/crates/engine/src/registry.rs
@@ -454,6 +454,23 @@ pub fn default_registry() -> HarnessRegistry {
         Box::new(|| zeron_harness::AcpHarness::pi().installed()),
         Box::new(|| Ok(Arc::new(zeron_harness::AcpHarness::pi()) as Arc<dyn Harness>)),
     );
+    // OpenCode over ACP (`opencode acp`), same lazy pattern: the static
+    // descriptor mirrors AcpHarness::opencode() exactly. No steering extension
+    // (turn boundaries) and no static effort ladder — models/effort come from
+    // live ACP discovery when the CLI is present.
+    registry.register_lazy(
+        HarnessDescriptor {
+            id: HarnessId::OpenCode,
+            name: "OpenCode".into(),
+            supports_steering: true,
+            steering_mode: SteeringMode::TurnBoundary,
+            reasoning_levels: Vec::new(),
+            installed: true,
+            enabled: None,
+        },
+        Box::new(|| zeron_harness::AcpHarness::opencode().installed()),
+        Box::new(|| Ok(Arc::new(zeron_harness::AcpHarness::opencode()) as Arc<dyn Harness>)),
+    );
     registry
 }
 
@@ -510,7 +527,8 @@ mod tests {
                 HarnessId::Cursor,
                 HarnessId::Grok,
                 HarnessId::Hermes,
-                HarnessId::Pi
+                HarnessId::Pi,
+                HarnessId::OpenCode,
             ]
         );
         assert!(registry.resolve(HarnessId::Mock).is_ok());

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -3,8 +3,8 @@
 //! implementation covers every ACP agent; [`AcpHarness::grok`] configures it
 //! for xAI's Grok Build (`grok agent stdio`), the first registered agent —
 //! [`AcpHarness::hermes`] (Nous Research, `hermes acp`), [`AcpHarness::pi`]
-//! (pi.dev via `pi-acp`) and [`AcpHarness::cursor`] (`cursor-agent acp`)
-//! followed.
+//! (pi.dev via `pi-acp`), [`AcpHarness::cursor`] (`cursor-agent acp`) and
+//! [`AcpHarness::opencode`] (`opencode acp`) followed.
 //!
 //! - `initialize` (protocolVersion 1, fs/terminal capabilities declined) →
 //!   `session/new`, or `session/load` with a fresh-session fallback when
@@ -426,6 +426,61 @@ fn hermes_spec() -> AcpAgentSpec {
     }
 }
 
+fn opencode_install_paths() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        // Official install script fallback + XDG-ish locations.
+        dirs.push(home.join(".opencode").join("bin").join("opencode"));
+        dirs.push(home.join(".local").join("bin").join("opencode"));
+        dirs.push(home.join("bin").join("opencode"));
+        dirs.push(home.join(".npm-global").join("bin").join("opencode"));
+    }
+    dirs.push(PathBuf::from("/opt/homebrew/bin/opencode"));
+    dirs.push(PathBuf::from("/usr/local/bin/opencode"));
+    dirs
+}
+
+fn opencode_spec() -> AcpAgentSpec {
+    AcpAgentSpec {
+        id: HarnessId::OpenCode,
+        display_name: "OpenCode",
+        executable: "opencode",
+        env_override: "OPENCODE_EXECUTABLE",
+        // Native ACP server — no adapter package in between.
+        args: &["acp"],
+        npx_package: None,
+        extra_paths: opencode_install_paths,
+        cli_executable: "opencode",
+        cli_extra_paths: opencode_install_paths,
+        install_hint: "opencode (searched PATH, the login shell's PATH, ~/.opencode/bin, \
+             ~/.local/bin, ~/bin, ~/.npm-global/bin, /opt/homebrew/bin, /usr/local/bin, and \
+             fnm/nvm/volta/pnpm/bun install dirs; install with \
+             `curl -fsSL https://opencode.ai/install | bash` or \
+             `npm install -g opencode-ai`; set OPENCODE_EXECUTABLE to override)",
+        // Models come from the user's OpenCode providers/config. Probe discovery
+        // wins; this pass-through row is only the offline/static fallback.
+        models: || {
+            vec![Model {
+                id: "default".into(),
+                label: "OpenCode default".into(),
+                description: Some(
+                    "Uses the model configured in OpenCode (`opencode` / opencode.json)"
+                        .into(),
+                ),
+                reasoning_levels: Vec::new(),
+                options: Vec::new(),
+            }]
+        },
+        // No `_session/steering` extension assumed: steers deliver at turn boundaries.
+        steering_mode: SteeringMode::TurnBoundary,
+        // No static effort ladder; live `thought_level` (if advertised) fills in.
+        reasoning_levels: &[],
+        prompt_transform: identity_transform,
+        effort_values: default_effort_values,
+        ladder_extras: &[],
+    }
+}
+
 fn pi_spec() -> AcpAgentSpec {
     AcpAgentSpec {
         id: HarnessId::Pi,
@@ -538,6 +593,11 @@ impl AcpHarness {
     /// pi's RPC mode.
     pub fn pi() -> Self {
         Self::with_spec(pi_spec())
+    }
+
+    /// OpenCode (`opencode acp`) — OpenCode's native ACP server.
+    pub fn opencode() -> Self {
+        Self::with_spec(opencode_spec())
     }
 
     /// Use a fixed agent binary instead of PATH/known-location resolution.

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -280,6 +280,10 @@ async fn claude_and_codex_specs_drive_the_same_wire() {
         ),
         ("pi", AcpHarness::pi().with_executable(fixture_path())),
         (
+            "opencode",
+            AcpHarness::opencode().with_executable(fixture_path()),
+        ),
+        (
             "cursor",
             AcpHarness::cursor().with_executable(fixture_path()),
         ),
@@ -914,6 +918,14 @@ async fn models_fall_back_to_the_static_catalog_when_the_probe_fails() {
     assert_eq!(ids, vec!["default"], "{models:?}");
 }
 
+#[tokio::test]
+async fn opencode_models_fall_back_to_static_catalog_when_probe_fails() {
+    let harness = AcpHarness::opencode().with_executable("/nonexistent/never-an-opencode");
+    let models = harness.models().await.expect("static fallback");
+    let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
+    assert_eq!(ids, vec!["default"], "{models:?}");
+}
+
 #[test]
 fn cursor_descriptor_surface_matches_registry_expectations() {
     let cursor = AcpHarness::cursor();
@@ -951,6 +963,16 @@ fn hermes_and_pi_descriptor_surfaces_match_registry_expectations() {
             zeron_proto::ReasoningLevel::Max,
         ]
     );
+}
+
+#[test]
+fn opencode_descriptor_surface_matches_registry_expectations() {
+    let opencode = AcpHarness::opencode();
+    assert_eq!(opencode.id(), HarnessId::OpenCode);
+    assert_eq!(opencode.display_name(), "OpenCode");
+    assert!(opencode.supports_steering());
+    assert_eq!(opencode.steering_mode(), SteeringMode::TurnBoundary);
+    assert!(opencode.reasoning_levels().is_empty());
 }
 
 /// The 2026-08-12 stuck-Working wedge, end to end: a prompt whose turn was
@@ -1313,6 +1335,7 @@ async fn real_all_harnesses_settle_with_a_mid_turn_steer() {
         ("cursor", AcpHarness::cursor()),
         ("grok", AcpHarness::grok()),
         ("pi", AcpHarness::pi()),
+        ("opencode", AcpHarness::opencode()),
     ];
     let mut failures: Vec<String> = Vec::new();
     for (name, h) in agents {

--- a/crates/harness/tests/real_quiet_survey.rs
+++ b/crates/harness/tests/real_quiet_survey.rs
@@ -205,6 +205,7 @@ async fn real_all_harnesses_quiet_survey() {
         ("grok", AcpHarness::grok),
         ("hermes", AcpHarness::hermes),
         ("pi", AcpHarness::pi),
+        ("opencode", AcpHarness::opencode),
     ];
     let mut failures: Vec<String> = Vec::new();
     for (name, ctor) in agents {

--- a/crates/harness/tests/shell_env_resolution.rs
+++ b/crates/harness/tests/shell_env_resolution.rs
@@ -25,6 +25,7 @@ async fn cli_on_login_shell_path_only_is_resolved() {
     write_executable(&shell_bin.join("claude-agent-acp"), "#!/bin/sh\nexit 0\n");
     write_executable(&shell_bin.join("hermes"), "#!/bin/sh\nexit 0\n");
     write_executable(&shell_bin.join("pi-acp"), "#!/bin/sh\nexit 0\n");
+    write_executable(&shell_bin.join("opencode"), "#!/bin/sh\nexit 0\n");
 
     // A $SHELL whose init shapes PATH — the shape resolution must survive.
     let fake_shell = dir.path().join("fake-shell");
@@ -51,6 +52,7 @@ async fn cli_on_login_shell_path_only_is_resolved() {
         std::env::remove_var("CLAUDE_ACP_EXECUTABLE");
         std::env::remove_var("HERMES_EXECUTABLE");
         std::env::remove_var("PI_ACP_EXECUTABLE");
+        std::env::remove_var("OPENCODE_EXECUTABLE");
         std::env::remove_var("ZERON_NO_LOGIN_SHELL");
     }
 
@@ -80,4 +82,8 @@ async fn cli_on_login_shell_path_only_is_resolved() {
         .launch_program()
         .expect("pi-acp resolves via login-shell PATH");
     assert_eq!(pi, shell_bin.join("pi-acp"), "{pi:?}");
+    let opencode = AcpHarness::opencode()
+        .launch_program()
+        .expect("opencode resolves via login-shell PATH");
+    assert_eq!(opencode, shell_bin.join("opencode"), "{opencode:?}");
 }

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -14,6 +14,9 @@ pub enum HarnessId {
     Hermes,
     /// The pi coding agent (pi.dev), driven over ACP via the `pi-acp` adapter.
     Pi,
+    /// OpenCode coding agent, driven over ACP (`opencode acp`).
+    #[serde(rename = "opencode")]
+    OpenCode,
     /// Test harness; never shown in production pickers.
     Mock,
 }
@@ -363,5 +366,15 @@ mod tests {
             serde_json::to_string(&HarnessId::ClaudeCode).unwrap(),
             "\"claude-code\""
         );
+    }
+
+    #[test]
+    fn opencode_harness_id_wire_is_opencode() {
+        assert_eq!(
+            serde_json::to_string(&HarnessId::OpenCode).unwrap(),
+            "\"opencode\""
+        );
+        let back: HarnessId = serde_json::from_str("\"opencode\"").unwrap();
+        assert_eq!(back, HarnessId::OpenCode);
     }
 }

--- a/crates/ui/assets/icons/opencode-mark.svg
+++ b/crates/ui/assets/icons/opencode-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path fill="currentColor" d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13Zm0 2a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z"/>
+  <path fill="currentColor" d="M8 5.25a2.75 2.75 0 1 0 0 5.5 2.75 2.75 0 0 0 0-5.5Z"/>
+</svg>

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -138,6 +138,7 @@ icon_assets![
     (GROK_MARK, "grok-mark"),
     (HERMES_MARK, "hermes-mark"),
     (PI_MARK, "pi-mark"),
+    (OPENCODE_MARK, "opencode-mark"),
 ];
 
 /// The Claude mark's brand orange (`#D97757`) — zeron keeps it even on the

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -3293,6 +3293,7 @@ pub(crate) fn harness_brand_icon(harness: HarnessId) -> (&'static str, Option<gp
         // Nous Research's mark (the Hermes product icon), monochrome.
         HarnessId::Hermes => (crate::icons::HERMES_MARK, None),
         HarnessId::Pi => (crate::icons::PI_MARK, None),
+        HarnessId::OpenCode => (crate::icons::OPENCODE_MARK, None),
     }
 }
 

--- a/crates/ui/src/settings/accounts.rs
+++ b/crates/ui/src/settings/accounts.rs
@@ -1203,6 +1203,7 @@ impl Render for AccountsPage {
             HarnessId::Grok => (crate::icons::GROK_MARK, None),
             HarnessId::Hermes => (crate::icons::HERMES_MARK, None),
             HarnessId::Pi => (crate::icons::PI_MARK, None),
+            HarnessId::OpenCode => (crate::icons::OPENCODE_MARK, None),
             _ => (
                 crate::icons::CLAUDE_MARK,
                 Some(crate::icons::claude_brand()),

--- a/crates/ui/src/settings/harnesses.rs
+++ b/crates/ui/src/settings/harnesses.rs
@@ -39,6 +39,7 @@ pub fn blurb(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "xAI's Grok Build agent (grok CLI).",
         HarnessId::Hermes => "Nous Research's Hermes Agent (hermes CLI).",
         HarnessId::Pi => "The pi coding agent (pi CLI).",
+        HarnessId::OpenCode => "OpenCode coding agent, driven through the opencode CLI (ACP).",
         HarnessId::Mock => "Scripted test harness.",
     }
 }
@@ -52,6 +53,7 @@ pub fn cli_name(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "grok",
         HarnessId::Hermes => "hermes",
         HarnessId::Pi => "pi",
+        HarnessId::OpenCode => "opencode",
         HarnessId::Mock => "mock",
     }
 }

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -60,6 +60,7 @@ not built yet).
 | Grok (ACP) | done | Shared `AcpHarness` spec; `grok agent stdio`, turn-boundary steering. |
 | Hermes (ACP) | done | Shared `AcpHarness` spec; `hermes acp` (Nous Research's native ACP server), turn-boundary steering, no effort ladder yet. |
 | Pi (ACP) | done | Shared `AcpHarness` spec; community `pi-acp` adapter (pinned 0.0.33, npx fallback), turn-boundary steering, minimal→max thinking ladder. |
+| OpenCode (ACP) | done | Shared `AcpHarness` spec; `opencode acp` (native ACP server), turn-boundary steering, no static effort ladder; models from live ACP discovery with a `default` static fallback. Opt-in via Settings → Agents (not default-enabled). |
 | Mock harness | done | Scripted event replay; powers tests + the e2e smoke. |
 
 ## §5 Session doc schema

--- a/docs/research/acp.md
+++ b/docs/research/acp.md
@@ -45,6 +45,13 @@
   ride pi's own provider config (catalog advertises a `default` pass-through
   entry); thinking ladder minimal→max maps onto zeron's levels via the
   generic `thought_level` preference ladder ("off" has no zeron tier).
+- **OpenCode registered**: `AcpHarness::opencode()` runs OpenCode's native ACP
+  server (`opencode acp`; install via `curl -fsSL https://opencode.ai/install | bash`
+  or `npm i -g opencode-ai`; `OPENCODE_EXECUTABLE` overrides). No npm ACP
+  adapter package. No `_session/steering` assumed → turn-boundary steering;
+  empty static reasoning ladder; static model fallback is a single `default`
+  pass-through (user providers live in OpenCode config). Not part of zeron
+  agent-account credential swap.
 - **ACP is the source of truth for model lists** (2026-08-08; preference
   order inverted 2026-08-09): `models()` runs a short-lived probe
   (initialize → `session/new`, the `discover_commands` pattern) and reads

--- a/docs/research/feature-inventory.md
+++ b/docs/research/feature-inventory.md
@@ -189,7 +189,7 @@ display EXCLUDED. File paths refer to the reference repo.
 - HarnessShape: id, name, supportsSteering, steeringMode (step-boundary|turn-boundary),
   reasoningLevels, models, run(request, controls) -> AgentEvent stream.
 - RunControls: requestInput(questions)->answers (blocks agent); steering mailbox.
-- HarnessId: claude-code | codex | cursor. ReasoningLevel: minimal..ultra + ultracode + ultrathink
+- HarnessId: claude-code | codex | cursor | opencode. ReasoningLevel: minimal..ultra + ultracode + ultrathink
   (prompt prefix). Sandbox: read-only|workspace-write|danger-full-access.
 - Claude adapter behaviors to replicate: model discovery, effort ladders, context-window option
   ([1m] suffix), fast mode, always-thinking models, AskUserQuestion -> requestInput, steering via

--- a/docs/tasks/opencode-cli/00-context.md
+++ b/docs/tasks/opencode-cli/00-context.md
@@ -1,0 +1,33 @@
+# Task 00 — Context (read only)
+
+**Goal:** Understand enough to implement OpenCode without redesigning the
+harness layer. **No file edits in this task.**
+
+## Read these files (in order)
+
+1. `docs/tasks/opencode-cli/README.md` — product facts table.
+2. `docs/research/acp.md` — how ACP harnesses work in this repo.
+3. `crates/harness/src/acp/mod.rs` — find `fn hermes_spec()` and
+   `fn hermes_install_paths()` and `AcpHarness::hermes()`. Those three blocks
+   are the template.
+4. `crates/engine/src/registry.rs` — find the Hermes `register_lazy` block.
+5. `crates/proto/src/agent.rs` — `enum HarnessId`.
+6. `docs/PARITY.md` — §4 Harness table (you will add a row in task 07).
+
+## What you must not do
+
+- Do not add a bespoke stream-json / HTTP adapter. OpenCode speaks ACP.
+- Do not add credential-swap / agent-accounts support.
+- Do not enable OpenCode by default (`default_enabled` stays Claude+Codex).
+- Do not pin an `npx` package; native CLI only.
+
+## Checkpoint
+
+You can point to Hermes as the twin and recite:
+
+- launch = `opencode` + `acp`
+- env = `OPENCODE_EXECUTABLE`
+- wire id = `opencode`
+- steering = turn boundary
+
+Then proceed to task 01.

--- a/docs/tasks/opencode-cli/01-proto-harness-id.md
+++ b/docs/tasks/opencode-cli/01-proto-harness-id.md
@@ -1,0 +1,72 @@
+# Task 01 — Add `HarnessId::OpenCode`
+
+**Goal:** Introduce the wire identity so later crates can compile against it.
+
+**Twin:** existing variants in `crates/proto/src/agent.rs`.
+
+## Edit 1 — enum variant
+
+File: `crates/proto/src/agent.rs`
+
+Inside `enum HarnessId`, **after** `Pi` and **before** `Mock`, insert:
+
+```rust
+    /// OpenCode coding agent, driven over ACP (`opencode acp`).
+    #[serde(rename = "opencode")]
+    OpenCode,
+```
+
+Why `#[serde(rename = "opencode")]`: plain kebab-case would emit `"open-code"`.
+The wire id must be the single token `"opencode"` (CLI / product name).
+
+## Edit 2 — serde unit test
+
+In the same file's `#[cfg(test)]` module (near `harness_id_uses_kebab_case`),
+add:
+
+```rust
+    #[test]
+    fn opencode_harness_id_wire_is_opencode() {
+        assert_eq!(
+            serde_json::to_string(&HarnessId::OpenCode).unwrap(),
+            "\"opencode\""
+        );
+        let back: HarnessId = serde_json::from_str("\"opencode\"").unwrap();
+        assert_eq!(back, HarnessId::OpenCode);
+    }
+```
+
+## Fix compile breaks from exhaustive matches (required in this task)
+
+Adding a variant will fail `cargo check` on exhaustive `match` arms. Fix every
+compiler error **now** with the minimal arm (copy the Hermes/Pi arm and rename).
+
+Known exhaustive sites (search if the compiler names others):
+
+| File | Function / site | Add arm |
+| --- | --- | --- |
+| `crates/engine/src/agent_accounts.rs` | `harness_slug` | `HarnessId::OpenCode => "opencode"` |
+| `crates/ui/src/settings/harnesses.rs` | `blurb` | see task 06 copy (use a temporary string if needed) |
+| `crates/ui/src/settings/harnesses.rs` | `cli_name` | `HarnessId::OpenCode => "opencode"` |
+| `crates/ui/src/pickers.rs` | `harness_brand_icon` | temporarily reuse `PI_MARK` or `HERMES_MARK` until task 05 |
+
+For UI icon matches that do not yet have `OPENCODE_MARK`, **temporarily** map
+`OpenCode` to `crate::icons::HERMES_MARK` (or any existing mark). Task 05/06
+will replace that with the real mark. Do not leave `_` catch-alls that hide
+future harnesses if the match was previously exhaustive.
+
+**Do not** add OpenCode to `PROVIDERS` in accounts settings.
+
+## Verify
+
+```bash
+cargo test -p zeron-proto opencode_harness_id_wire_is_opencode
+cargo check -p zeron-proto -p zeron-harness -p zeron-engine -p zeron-ui
+```
+
+All must succeed before task 02.
+
+## Done when
+
+- Wire round-trip is `"opencode"`.
+- Workspace crates that match on `HarnessId` compile.

--- a/docs/tasks/opencode-cli/02-acp-spec.md
+++ b/docs/tasks/opencode-cli/02-acp-spec.md
@@ -1,0 +1,114 @@
+# Task 02 — `AcpHarness::opencode()` spec
+
+**Goal:** Register OpenCode as another `AcpAgentSpec` on the shared ACP harness.
+
+**Twin:** copy `hermes_install_paths` + `hermes_spec` + `AcpHarness::hermes`
+in `crates/harness/src/acp/mod.rs`, then rename.
+
+## Edit 1 — module docs
+
+At the top of `crates/harness/src/acp/mod.rs`, the crate docs list agents.
+Add OpenCode next to Hermes/Pi/Cursor (one short clause):
+`AcpHarness::opencode` (`opencode acp`).
+
+## Edit 2 — install path helper
+
+Paste **immediately after** `hermes_install_paths` (before `hermes_spec` is
+fine too; keep helpers next to their specs). Use this exact body:
+
+```rust
+fn opencode_install_paths() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        // Official install script fallback + XDG-ish locations.
+        dirs.push(home.join(".opencode").join("bin").join("opencode"));
+        dirs.push(home.join(".local").join("bin").join("opencode"));
+        dirs.push(home.join("bin").join("opencode"));
+        dirs.push(home.join(".npm-global").join("bin").join("opencode"));
+    }
+    dirs.push(PathBuf::from("/opt/homebrew/bin/opencode"));
+    dirs.push(PathBuf::from("/usr/local/bin/opencode"));
+    dirs
+}
+```
+
+## Edit 3 — `opencode_spec`
+
+Paste after `hermes_spec` (or after `pi_spec`). Exact shape:
+
+```rust
+fn opencode_spec() -> AcpAgentSpec {
+    AcpAgentSpec {
+        id: HarnessId::OpenCode,
+        display_name: "OpenCode",
+        executable: "opencode",
+        env_override: "OPENCODE_EXECUTABLE",
+        // Native ACP server — no adapter package in between.
+        args: &["acp"],
+        npx_package: None,
+        extra_paths: opencode_install_paths,
+        cli_executable: "opencode",
+        cli_extra_paths: opencode_install_paths,
+        install_hint: "opencode (searched PATH, the login shell's PATH, ~/.opencode/bin, \
+             ~/.local/bin, ~/bin, ~/.npm-global/bin, /opt/homebrew/bin, /usr/local/bin, and \
+             fnm/nvm/volta/pnpm/bun install dirs; install with \
+             `curl -fsSL https://opencode.ai/install | bash` or \
+             `npm install -g opencode-ai`; set OPENCODE_EXECUTABLE to override)",
+        // Models come from the user's OpenCode providers/config. Probe discovery
+        // wins; this pass-through row is only the offline/static fallback.
+        models: || {
+            vec![Model {
+                id: "default".into(),
+                label: "OpenCode default".into(),
+                description: Some(
+                    "Uses the model configured in OpenCode (`opencode` / opencode.json)"
+                        .into(),
+                ),
+                reasoning_levels: Vec::new(),
+                options: Vec::new(),
+            }]
+        },
+        // No `_session/steering` extension assumed: steers deliver at turn boundaries.
+        steering_mode: SteeringMode::TurnBoundary,
+        // No static effort ladder; live `thought_level` (if advertised) fills in.
+        reasoning_levels: &[],
+        prompt_transform: identity_transform,
+        effort_values: default_effort_values,
+        ladder_extras: &[],
+    }
+}
+```
+
+## Edit 4 — constructor
+
+Next to `AcpHarness::hermes` / `pi`:
+
+```rust
+    /// OpenCode (`opencode acp`) — OpenCode's native ACP server.
+    pub fn opencode() -> Self {
+        Self::with_spec(opencode_spec())
+    }
+```
+
+## Do not change
+
+- Shared JSON-RPC / session/prompt / permission auto-accept paths.
+- Cursor-only notification helpers.
+- Claude/Codex catalogs.
+
+## Verify
+
+```bash
+cargo check -p zeron-harness
+```
+
+Optional smoke (no CLI required):
+
+```bash
+cargo test -p zeron-harness --lib -- acp::tests 2>/dev/null || true
+```
+
+## Done when
+
+- `AcpHarness::opencode().id() == HarnessId::OpenCode` would hold (tested in task 04).
+- Spec uses `args: &["acp"]`, `npx_package: None`, empty reasoning ladder.

--- a/docs/tasks/opencode-cli/03-engine-registry.md
+++ b/docs/tasks/opencode-cli/03-engine-registry.md
@@ -1,0 +1,53 @@
+# Task 03 — Engine registry lazy slot
+
+**Goal:** Surface OpenCode in `ListHarnesses` without spawning until first use.
+
+**Twin:** Hermes `register_lazy` block in `crates/engine/src/registry.rs`.
+
+## Edit
+
+File: `crates/engine/src/registry.rs`
+
+Inside `pub fn default_registry()` (or whatever builds the production catalog),
+**after** the Pi `register_lazy` block and **before** `registry` is returned,
+add:
+
+```rust
+    // OpenCode over ACP (`opencode acp`), same lazy pattern: the static
+    // descriptor mirrors AcpHarness::opencode() exactly. No steering extension
+    // (turn boundaries) and no static effort ladder — models/effort come from
+    // live ACP discovery when the CLI is present.
+    registry.register_lazy(
+        HarnessDescriptor {
+            id: HarnessId::OpenCode,
+            name: "OpenCode".into(),
+            supports_steering: true,
+            steering_mode: SteeringMode::TurnBoundary,
+            reasoning_levels: Vec::new(),
+            installed: true,
+            enabled: None,
+        },
+        Box::new(|| zeron_harness::AcpHarness::opencode().installed()),
+        Box::new(|| Ok(Arc::new(zeron_harness::AcpHarness::opencode()) as Arc<dyn Harness>)),
+    );
+```
+
+## Do not change
+
+- `default_enabled()` — must remain `[ClaudeCode, Codex]` only.
+- Mock registration.
+- Existing Hermes/Pi/Cursor/Grok slots (except inserting OpenCode beside them).
+
+## Verify
+
+```bash
+cargo check -p zeron-engine
+cargo test -p zeron-engine registry -- --nocapture
+```
+
+(If no tests match the filter, `cargo check -p zeron-engine` is enough.)
+
+## Done when
+
+- Default registry lists eight production harnesses + mock (OpenCode included).
+- OpenCode is **not** in `default_enabled()`.

--- a/docs/tasks/opencode-cli/04-harness-tests.md
+++ b/docs/tasks/opencode-cli/04-harness-tests.md
@@ -1,0 +1,103 @@
+# Task 04 — Harness tests
+
+**Goal:** Lock the OpenCode descriptor surface and keep shared ACP fixture
+coverage.
+
+**Twin:** Hermes/Pi tests in `crates/harness/tests/acp.rs` and
+`crates/harness/tests/shell_env_resolution.rs`.
+
+## Edit 1 — descriptor surface test
+
+File: `crates/harness/tests/acp.rs`
+
+Near `hermes_and_pi_descriptor_surfaces_match_registry_expectations`, add:
+
+```rust
+#[test]
+fn opencode_descriptor_surface_matches_registry_expectations() {
+    let opencode = AcpHarness::opencode();
+    assert_eq!(opencode.id(), HarnessId::OpenCode);
+    assert_eq!(opencode.display_name(), "OpenCode");
+    assert!(opencode.supports_steering());
+    assert_eq!(opencode.steering_mode(), SteeringMode::TurnBoundary);
+    assert!(opencode.reasoning_levels().is_empty());
+}
+```
+
+## Edit 2 — fixture matrix
+
+In the same file, find the table that builds harnesses with
+`with_executable(fixture_path())` (pairs like `("hermes", …)`, `("pi", …)`,
+`("cursor", …)`). Add:
+
+```rust
+        ("opencode", AcpHarness::opencode().with_executable(fixture_path())),
+```
+
+Also add OpenCode to any other **non-ignored** enumeration of all ACP factories
+in this file (search for `AcpHarness::pi()` lists). Skip ignored `real_*` tests
+unless they already list every harness — if they do, append
+`("opencode", AcpHarness::opencode)` / `AcpHarness::opencode()` for consistency.
+
+## Edit 3 — static fallback test
+
+Add (mirror of the Pi probe-failure test):
+
+```rust
+#[tokio::test]
+async fn opencode_models_fall_back_to_static_catalog_when_probe_fails() {
+    let harness = AcpHarness::opencode().with_executable("/nonexistent/never-an-opencode");
+    let models = harness.models().await.expect("static fallback");
+    let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
+    assert_eq!(ids, vec!["default"], "{models:?}");
+}
+```
+
+## Edit 4 — login-shell PATH resolution
+
+File: `crates/harness/tests/shell_env_resolution.rs`
+
+1. Create a fake binary next to the others:
+
+```rust
+    write_executable(&shell_bin.join("opencode"), "#!/bin/sh\nexit 0\n");
+```
+
+2. Clear the override env with the others:
+
+```rust
+        std::env::remove_var("OPENCODE_EXECUTABLE");
+```
+
+3. Assert resolution:
+
+```rust
+    let opencode = AcpHarness::opencode()
+        .launch_program()
+        .expect("opencode resolves via login-shell PATH");
+    assert_eq!(opencode, shell_bin.join("opencode"), "{opencode:?}");
+```
+
+## Edit 5 — quiet survey (if present)
+
+File: `crates/harness/tests/real_quiet_survey.rs`
+
+If it lists `("hermes", AcpHarness::hermes), …`, append
+`("opencode", AcpHarness::opencode),`. This file is typically ignored live —
+still keep the list complete.
+
+## Verify
+
+```bash
+cargo test -p zeron-harness --test acp opencode
+cargo test -p zeron-harness --test shell_env_resolution
+```
+
+Do **not** run `--ignored` live surveys in this task.
+
+## Done when
+
+- Descriptor assertions pass.
+- Fixture matrix includes OpenCode.
+- Static fallback returns `["default"]`.
+- Shell-env test resolves `opencode` from the fake login PATH.

--- a/docs/tasks/opencode-cli/05-ui-icon.md
+++ b/docs/tasks/opencode-cli/05-ui-icon.md
@@ -1,0 +1,63 @@
+# Task 05 — OpenCode brand mark icon
+
+**Goal:** Add a monochrome SVG mark and register it like Hermes/Pi.
+
+**Twin:** `crates/ui/assets/icons/pi-mark.svg` + `OPENCODE`-style entry in
+`crates/ui/src/icons.rs`.
+
+## Edit 1 — SVG asset
+
+Create file: `crates/ui/assets/icons/opencode-mark.svg`
+
+Use this exact SVG (16×16 logical, `currentColor`, simple geometric mark — do
+not download remote logos):
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path fill="currentColor" d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13Zm0 2a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z"/>
+  <path fill="currentColor" d="M8 5.25a2.75 2.75 0 1 0 0 5.5 2.75 2.75 0 0 0 0-5.5Z"/>
+</svg>
+```
+
+Rules:
+
+- Must contain `<svg` and `viewBox`.
+- Prefer `currentColor` so the UI can tint it (same as Pi/OpenAI marks).
+- Keep the file small (<2KB).
+
+## Edit 2 — register constant
+
+File: `crates/ui/src/icons.rs`
+
+In the icon table next to `(PI_MARK, "pi-mark")`, add:
+
+```rust
+    (OPENCODE_MARK, "opencode-mark"),
+```
+
+The macro/`include` pattern already used for other marks must pick up
+`icons/opencode-mark.svg` automatically — follow the existing registration
+style exactly (do not invent a new loader).
+
+## Edit 3 — replace temporary icon arms from task 01
+
+Wherever task 01 mapped `HarnessId::OpenCode` to `HERMES_MARK` / `PI_MARK`,
+switch to `crate::icons::OPENCODE_MARK` with `None` tint (monochrome), same as
+Pi/Grok:
+
+- `crates/ui/src/pickers.rs` → `harness_brand_icon`
+- `crates/ui/src/settings/accounts.rs` → `provider_icon` closure (add an
+  explicit arm; do not leave OpenCode falling into Claude's brand orange)
+
+## Verify
+
+```bash
+cargo test -p zeron-ui every_registered_icon_loads_and_parses
+cargo check -p zeron-ui
+```
+
+## Done when
+
+- Asset exists and parses as SVG with `viewBox`.
+- `OPENCODE_MARK` is registered.
+- OpenCode no longer reuses another product's mark in UI matches.

--- a/docs/tasks/opencode-cli/06-ui-surface.md
+++ b/docs/tasks/opencode-cli/06-ui-surface.md
@@ -1,0 +1,82 @@
+# Task 06 — UI surface (blurbs, picker, slug)
+
+**Goal:** Make OpenCode readable in Settings → Agents and the composer picker.
+
+**Twin:** Hermes/Pi arms in the same files.
+
+## Edit 1 — Settings blurbs
+
+File: `crates/ui/src/settings/harnesses.rs`
+
+In `blurb`:
+
+```rust
+        HarnessId::OpenCode => "OpenCode coding agent, driven through the opencode CLI (ACP).",
+```
+
+In `cli_name` (if not already done in task 01):
+
+```rust
+        HarnessId::OpenCode => "opencode",
+```
+
+## Edit 2 — Picker brand icon
+
+File: `crates/ui/src/pickers.rs` — `harness_brand_icon`
+
+Ensure:
+
+```rust
+        HarnessId::OpenCode => (crate::icons::OPENCODE_MARK, None),
+```
+
+## Edit 3 — Accounts page icon map
+
+File: `crates/ui/src/settings/accounts.rs`
+
+In the `provider_icon` match used by the accounts page, add an explicit arm
+**before** the `_ => Claude` fallback:
+
+```rust
+            HarnessId::OpenCode => (crate::icons::OPENCODE_MARK, None),
+```
+
+**Do not** add OpenCode to `PROVIDERS` (still only Claude Code + Codex).
+OpenCode manages its own auth via the CLI (`/connect`); zeron does not swap
+credentials for it.
+
+## Edit 4 — Engine slug (if still missing)
+
+File: `crates/engine/src/agent_accounts.rs` — `harness_slug`
+
+```rust
+        HarnessId::OpenCode => "opencode",
+```
+
+## Edit 5 — Sweep remaining exhaustive matches
+
+Run:
+
+```bash
+cargo check -p zeron-ui -p zeron-engine -p zeron 2>&1
+```
+
+For every `non-exhaustive patterns: OpenCode not covered`:
+
+- Prefer copying the nearest Hermes/Pi arm.
+- For agent-account activate/login matches that only support Claude/Codex,
+  leave OpenCode in the existing `other => Err(...)` path (no new login flow).
+
+## Verify
+
+```bash
+cargo check -p zeron-ui -p zeron-engine -p zeron
+cargo test -p zeron-ui harness -- --nocapture
+```
+
+## Done when
+
+- Settings shows a sensible OpenCode description + CLI name `opencode`.
+- Picker/accounts use `OPENCODE_MARK`.
+- No compile errors on `HarnessId` matches.
+- `PROVIDERS` unchanged (length 2).

--- a/docs/tasks/opencode-cli/07-docs-parity.md
+++ b/docs/tasks/opencode-cli/07-docs-parity.md
@@ -1,0 +1,50 @@
+# Task 07 — Docs / parity notes
+
+**Goal:** Record OpenCode in research + parity so future work knows it exists.
+
+## Edit 1 — Parity checklist
+
+File: `docs/PARITY.md`
+
+In **§4 Harness**, after the Pi row, add:
+
+```markdown
+| OpenCode (ACP) | done | Shared `AcpHarness` spec; `opencode acp` (native ACP server), turn-boundary steering, no static effort ladder; models from live ACP discovery with a `default` static fallback. Opt-in via Settings → Agents (not default-enabled). |
+```
+
+Only add the row if the implementation from tasks 01–06 is actually present.
+If something is still missing, write `partial` and list the gap in the Notes
+column instead of lying with `done`.
+
+## Edit 2 — ACP research note
+
+File: `docs/research/acp.md`
+
+In the Decision section (near Hermes + Pi), append a short bullet:
+
+```markdown
+- **OpenCode registered**: `AcpHarness::opencode()` runs OpenCode's native ACP
+  server (`opencode acp`; install via `curl -fsSL https://opencode.ai/install | bash`
+  or `npm i -g opencode-ai`; `OPENCODE_EXECUTABLE` overrides). No npm ACP
+  adapter package. No `_session/steering` assumed → turn-boundary steering;
+  empty static reasoning ladder; static model fallback is a single `default`
+  pass-through (user providers live in OpenCode config). Not part of zeron
+  agent-account credential swap.
+```
+
+## Edit 3 — Optional feature inventory
+
+If `docs/research/feature-inventory.md` lists harness ids
+(`claude-code | codex | cursor | …`), append `opencode` to that list in the
+same style. Skip this edit if the file has no harness id enumeration.
+
+## Do not
+
+- Rewrite `ARCHITECTURE.md` harness blurb unless it still claims only
+  Claude/Codex as production adapters and a one-line mention is cheap —
+  prefer a single clause, not a redesign.
+
+## Done when
+
+- PARITY §4 mentions OpenCode.
+- `docs/research/acp.md` mentions `AcpHarness::opencode()`.

--- a/docs/tasks/opencode-cli/08-verify.md
+++ b/docs/tasks/opencode-cli/08-verify.md
@@ -1,0 +1,61 @@
+# Task 08 — Verify end-to-end (checklist)
+
+**Goal:** Prove the feature is wired without requiring a live OpenCode login.
+
+Run from the repo root. Fix failures before declaring done.
+
+## Required commands
+
+```bash
+# Identity
+cargo test -p zeron-proto opencode_harness_id_wire_is_opencode
+
+# Spec + fixture coverage
+cargo test -p zeron-harness --test acp opencode
+cargo test -p zeron-harness --test shell_env_resolution
+
+# Icons
+cargo test -p zeron-ui every_registered_icon_loads_and_parses
+
+# Exhaustiveness / link
+cargo check -p zeron-harness -p zeron-engine -p zeron-ui -p zeron
+```
+
+## Manual product checks (headed app, if available)
+
+1. Settings → Agents: OpenCode row appears; CLI hint mentions `opencode`.
+2. With OpenCode **disabled** (default): composer harness rail omits it (same
+   as other opt-in agents).
+3. Enable OpenCode on a machine where `opencode` is on PATH: row is not dimmed;
+   picker shows OpenCode + mark.
+4. Without the CLI: row is dimmed / install hint visible; toggle inert or
+   engine rejects enable per existing rules.
+5. Accounts page: still only Claude Code + Codex provider cards.
+
+## Optional live smoke (human / powerful model only)
+
+Only if `opencode` is installed and authenticated:
+
+```bash
+cargo test -p zeron-harness --test acp -- --ignored --nocapture real_all_harnesses
+```
+
+Expect OpenCode to appear in the matrix if task 04 added it. Do not block the
+task pack on live auth failures.
+
+## Final acceptance table
+
+| Check | Pass? |
+| --- | --- |
+| Wire id `"opencode"` | |
+| `AcpHarness::opencode` exists, args `acp` | |
+| Registry lazy slot present | |
+| Not in `default_enabled` | |
+| Tests for descriptor + static `default` model | |
+| `OPENCODE_MARK` asset loads | |
+| UI blurb / cli_name / icon arms | |
+| Not in `PROVIDERS` | |
+| PARITY + acp research notes updated | |
+
+When every required command passes and the acceptance table is complete, the
+OpenCode CLI support task pack is finished.

--- a/docs/tasks/opencode-cli/README.md
+++ b/docs/tasks/opencode-cli/README.md
@@ -1,0 +1,74 @@
+# OpenCode CLI harness — task pack
+
+Add **OpenCode** as a production harness, the same way **Hermes** and **Cursor**
+were added: a thin `AcpAgentSpec` on the shared `AcpHarness`, native ACP via
+`opencode acp` (no adapter npm package).
+
+These tasks are written for a **cheap/fast coding model**. Each file is one
+small, ordered unit of work. Do **not** skip ahead. Do **not** invent new
+architecture. Copy the named twin (Hermes) unless a task says otherwise.
+
+## Product facts (do not re-research)
+
+| Fact | Value |
+| --- | --- |
+| Product name (UI) | `OpenCode` |
+| Wire `HarnessId` JSON | `"opencode"` |
+| Rust enum variant | `OpenCode` with `#[serde(rename = "opencode")]` |
+| CLI binary | `opencode` |
+| ACP launch args | `["acp"]` |
+| Env override | `OPENCODE_EXECUTABLE` |
+| npm fallback | **none** (`npx_package: None`) — same as Hermes/Cursor |
+| Steering | `SteeringMode::TurnBoundary` (no `_session/steering` assumed) |
+| Reasoning ladder | empty `reasoning_levels: &[]` until discovery proves otherwise |
+| Static model fallback | one pass-through row `id: "default"` (same idea as Pi) |
+| Agent accounts / credential swap | **out of scope** — do **not** add to `PROVIDERS` |
+| Default enabled set | unchanged — OpenCode stays opt-in (Settings → Agents) |
+
+Closest twin in this repo: **`AcpHarness::hermes()`** + Hermes registry slot +
+Hermes UI blurb/icon arms.
+
+External docs (already summarized; do not block on fetching):
+
+- ACP: `opencode acp` — <https://opencode.ai/docs/acp/> (also open-code.ai)
+- Install: `curl -fsSL https://opencode.ai/install | bash` or
+  `npm i -g opencode-ai` (package is `opencode-ai`, binary is `opencode`)
+- Default install dirs: `$HOME/.opencode/bin`, `$HOME/.local/bin`, `$HOME/bin`,
+  Homebrew `/opt/homebrew/bin`, `/usr/local/bin`
+
+## Task order (strict)
+
+| # | File | Outcome |
+| --- | --- | --- |
+| 0 | [`00-context.md`](00-context.md) | Read-only orientation (no code changes) |
+| 1 | [`01-proto-harness-id.md`](01-proto-harness-id.md) | `HarnessId::OpenCode` + serde test |
+| 2 | [`02-acp-spec.md`](02-acp-spec.md) | `opencode_spec()` + `AcpHarness::opencode()` |
+| 3 | [`03-engine-registry.md`](03-engine-registry.md) | Lazy registry slot |
+| 4 | [`04-harness-tests.md`](04-harness-tests.md) | Descriptor + fixture + shell-env tests |
+| 5 | [`05-ui-icon.md`](05-ui-icon.md) | SVG asset + `OPENCODE_MARK` |
+| 6 | [`06-ui-surface.md`](06-ui-surface.md) | Picker icon, Settings blurbs, slug, accounts icon |
+| 7 | [`07-docs-parity.md`](07-docs-parity.md) | `PARITY.md` + `docs/research/acp.md` notes |
+| 8 | [`08-verify.md`](08-verify.md) | Compile + targeted tests checklist |
+
+## Definition of done
+
+- `cargo test -p zeron-proto harness_id` passes.
+- `cargo test -p zeron-harness --test acp opencode` passes (non-ignored).
+- `cargo check -p zeron-engine -p zeron-ui -p zeron` succeeds (exhaustive
+  matches compile).
+- Settings → Agents can list OpenCode; composer picker shows the mark when
+  enabled + installed.
+- No new agent-account login flow.
+- No changes to Claude/Codex/Cursor/Grok/Hermes/Pi specs beyond adding
+  OpenCode beside them.
+
+## Rules for the implementing model
+
+1. One task file per session/turn when possible.
+2. Prefer **copy-paste from Hermes**, then rename identifiers.
+3. If `rustc` reports a non-exhaustive `match` on `HarnessId`, fix that arm in
+   the **same** task that introduced the compile break — do not leave broken
+   builds between tasks 1–6.
+4. Do not run ignored live CLI tests unless the human asks
+   (`--ignored real_*`).
+5. Do not commit unless the human asks.


### PR DESCRIPTION
## Summary

Wire **OpenCode** as another opt-in agent on the shared `AcpHarness`, mirroring the Hermes/Pi/Cursor pattern — a thin `AcpAgentSpec` speaking native ACP via `opencode acp` (no adapter npm package).

Fixes #101 

## Changes

- **proto**: `HarnessId::OpenCode` with serde wire id `"opencode"` + round-trip test
- **harness**: `opencode_install_paths()` + `opencode_spec()` (args `["acp"]`, `npx_package: None`, `OPENCODE_EXECUTABLE` override, turn-boundary steering, empty reasoning ladder, single `default` static model fallback) + `AcpHarness::opencode()`
- **engine**: lazy registry slot in `default_registry()`; NOT in `default_enabled()` (stays opt-in via Settings → Agents)
- **tests**: descriptor surface, fixture matrix, static-fallback probe, login-shell PATH resolution, quiet-survey list
- **ui**: `opencode-mark.svg` + `OPENCODE_MARK`, Settings blurb/`cli_name`, picker + accounts icon arms
- **docs**: PARITY §4 row, ACP research note, feature-inventory harness id

## Out of scope

- No agent-account credential swap (not added to `PROVIDERS`)
- No `npx` fallback (native CLI only)

## Verification

- `cargo test -p zeron-proto opencode_harness_id_wire_is_opencode` ✅
- `cargo test -p zeron-harness --test acp opencode` ✅ (30 acp tests pass)
- `cargo test -p zeron-engine --lib registry` ✅ (8 harness slots listed)
- `cargo test -p zeron-ui` ✅ (423 tests, incl. icon load)
- `cargo check -p zeron-harness -p zeron-engine -p zeron-ui -p zeron` ✅

> Note: toolchain 1.95 required (repo's pinned gpui rev); `shell_env_resolution` opencode assert fails on machines with a real `/usr/bin/opencode` shadowing the fake login-shell binary (process-PATH wins by design).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789386838&installation_model_id=425430&pr_number=103&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F103&signature=8edb71f395324076faecda14eb91be7f6ddec29d8a2c457e4e4f556e3d39aa83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->