### PR TITLE
harness: add complete OpenCode ACP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zeron
 
-Control your coding agents (Claude Code, Codex, Cursor, Grok, Hermes, Pi) locally by default, with optional multi-device sync.
+Control your coding agents (Claude Code, Codex, Cursor, Grok, Hermes, Pi, OpenCode) locally by default, with optional multi-device sync.
 
 ![Zeron driving a Claude Code session with a live branch diff sidebar](apps/landing/public/assets/app-screenshot.jpg)
 

--- a/apps/ios/Zeron/Models/HarnessCatalog.swift
+++ b/apps/ios/Zeron/Models/HarnessCatalog.swift
@@ -38,6 +38,7 @@ enum HarnessCatalog {
         "hermes": "Hermes",
         "pi": "Pi",
         "cursor": "Cursor",
+        "opencode": "OpenCode",
         "mock": "Mock",
     ]
 
@@ -71,6 +72,12 @@ enum HarnessCatalog {
                 ModelInfo(id: "default", label: "pi default",
                           description: "Runs the model configured in pi (`pi` settings)",
                           reasoningLevels: ["minimal", "low", "medium", "high", "xhigh", "max"]),
+            ]
+        case "opencode":
+            return [
+                ModelInfo(id: "default", label: "OpenCode default",
+                          description: "Uses the model configured in OpenCode",
+                          reasoningLevels: []),
             ]
         case "codex":
             return [

--- a/apps/zeron/src/main.rs
+++ b/apps/zeron/src/main.rs
@@ -230,14 +230,41 @@ fn engine_config_from_env() -> zeron_engine::EngineConfig {
 /// `ZERON_HARNESS` (kebab-case id) picks the default harness for chats without a
 /// config row — `mock` powers the e2e smoke; default `claude-code`.
 fn harness_from_env() -> zeron_engine::HarnessId {
-    match std::env::var("ZERON_HARNESS").as_deref().map(str::trim) {
-        Ok("mock") => zeron_engine::HarnessId::Mock,
-        Ok("codex") => zeron_engine::HarnessId::Codex,
-        Ok("cursor") => zeron_engine::HarnessId::Cursor,
-        Ok("grok") => zeron_engine::HarnessId::Grok,
-        Ok("hermes") => zeron_engine::HarnessId::Hermes,
-        Ok("pi") => zeron_engine::HarnessId::Pi,
+    harness_from_name(
+        std::env::var("ZERON_HARNESS")
+            .ok()
+            .as_deref()
+            .map(str::trim),
+    )
+}
+
+fn harness_from_name(value: Option<&str>) -> zeron_engine::HarnessId {
+    match value {
+        Some("mock") => zeron_engine::HarnessId::Mock,
+        Some("codex") => zeron_engine::HarnessId::Codex,
+        Some("cursor") => zeron_engine::HarnessId::Cursor,
+        Some("grok") => zeron_engine::HarnessId::Grok,
+        Some("hermes") => zeron_engine::HarnessId::Hermes,
+        Some("pi") => zeron_engine::HarnessId::Pi,
+        Some("opencode") => zeron_engine::HarnessId::OpenCode,
         _ => zeron_engine::HarnessId::ClaudeCode,
+    }
+}
+
+#[cfg(test)]
+mod harness_selection_tests {
+    use super::*;
+
+    #[test]
+    fn opencode_environment_name_selects_opencode() {
+        assert_eq!(
+            harness_from_name(Some("opencode")),
+            zeron_engine::HarnessId::OpenCode
+        );
+        assert_eq!(
+            harness_from_name(Some("unknown")),
+            zeron_engine::HarnessId::ClaudeCode
+        );
     }
 }
 

--- a/crates/engine/src/agent_accounts.rs
+++ b/crates/engine/src/agent_accounts.rs
@@ -1298,6 +1298,7 @@ fn harness_slug(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "grok",
         HarnessId::Hermes => "hermes",
         HarnessId::Pi => "pi",
+        HarnessId::OpenCode => "opencode",
         HarnessId::Mock => "mock",
     }
 }

--- a/crates/engine/src/registry.rs
+++ b/crates/engine/src/registry.rs
@@ -454,6 +454,22 @@ pub fn default_registry() -> HarnessRegistry {
         Box::new(|| zeron_harness::AcpHarness::pi().installed()),
         Box::new(|| Ok(Arc::new(zeron_harness::AcpHarness::pi()) as Arc<dyn Harness>)),
     );
+    // OpenCode's native ACP server (`opencode acp`), same lazy pattern. Its
+    // configured providers and model-dependent effort ladder come from ACP at
+    // runtime; the static descriptor intentionally carries no fake ladder.
+    registry.register_lazy(
+        HarnessDescriptor {
+            id: HarnessId::OpenCode,
+            name: "OpenCode".into(),
+            supports_steering: true,
+            steering_mode: SteeringMode::TurnBoundary,
+            reasoning_levels: Vec::new(),
+            installed: true,
+            enabled: None,
+        },
+        Box::new(|| zeron_harness::AcpHarness::opencode().installed()),
+        Box::new(|| Ok(Arc::new(zeron_harness::AcpHarness::opencode()) as Arc<dyn Harness>)),
+    );
     registry
 }
 
@@ -498,7 +514,7 @@ mod tests {
     }
 
     #[test]
-    fn default_registry_lists_mock_claude_codex_and_grok_slots() {
+    fn default_registry_lists_all_harness_slots_in_order() {
         let registry = default_registry();
         let ids: Vec<HarnessId> = registry.descriptors().iter().map(|d| d.id).collect();
         assert_eq!(
@@ -510,9 +526,11 @@ mod tests {
                 HarnessId::Cursor,
                 HarnessId::Grok,
                 HarnessId::Hermes,
-                HarnessId::Pi
+                HarnessId::Pi,
+                HarnessId::OpenCode,
             ]
         );
+        assert!(!default_enabled().contains(&HarnessId::OpenCode));
         assert!(registry.resolve(HarnessId::Mock).is_ok());
         assert!(registry.resolve(HarnessId::ClaudeCode).is_ok());
         // A codex-configured chat resolves the right harness (construction is
@@ -559,6 +577,11 @@ mod tests {
                 ReasoningLevel::Max
             ]
         );
+        let opencode = registry.resolve(HarnessId::OpenCode).unwrap();
+        assert_eq!(opencode.id(), HarnessId::OpenCode);
+        assert_eq!(opencode.display_name(), "OpenCode");
+        assert_eq!(opencode.steering_mode(), SteeringMode::TurnBoundary);
+        assert!(opencode.reasoning_levels().is_empty());
     }
 
     /// Catalogs serialized by engines that predate the `installed`/`enabled`
@@ -669,6 +692,26 @@ mod tests {
             .descriptors()
             .into_iter()
             .find(|d| d.id == HarnessId::Codex)
+            .unwrap();
+        assert_eq!(before.name, after.name);
+        assert_eq!(before.supports_steering, after.supports_steering);
+        assert_eq!(before.steering_mode, after.steering_mode);
+        assert_eq!(before.reasoning_levels, after.reasoning_levels);
+    }
+
+    #[test]
+    fn opencode_lazy_descriptor_matches_resolved_harness() {
+        let registry = default_registry();
+        let before = registry
+            .descriptors()
+            .into_iter()
+            .find(|d| d.id == HarnessId::OpenCode)
+            .unwrap();
+        registry.resolve(HarnessId::OpenCode).unwrap();
+        let after = registry
+            .descriptors()
+            .into_iter()
+            .find(|d| d.id == HarnessId::OpenCode)
             .unwrap();
         assert_eq!(before.name, after.name);
         assert_eq!(before.supports_steering, after.supports_steering);

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -3,8 +3,8 @@
 //! implementation covers every ACP agent; [`AcpHarness::grok`] configures it
 //! for xAI's Grok Build (`grok agent stdio`), the first registered agent —
 //! [`AcpHarness::hermes`] (Nous Research, `hermes acp`), [`AcpHarness::pi`]
-//! (pi.dev via `pi-acp`) and [`AcpHarness::cursor`] (`cursor-agent acp`)
-//! followed.
+//! (pi.dev via `pi-acp`), [`AcpHarness::cursor`] (`cursor-agent acp`) and
+//! [`AcpHarness::opencode`] (`opencode acp`) followed.
 //!
 //! - `initialize` (protocolVersion 1, fs/terminal capabilities declined) →
 //!   `session/new`, or `session/load` with a fresh-session fallback when
@@ -90,6 +90,9 @@ struct AcpAgentSpec {
     /// Transform applied to the initial prompt and every steer — Claude's
     /// Ultrathink is a prompt-prefix convention, not an effort flag.
     prompt_transform: fn(Option<ReasoningLevel>, &str) -> String,
+    /// Whether selecting the model returns a refreshed config-option snapshot
+    /// that must be used for the remaining per-session settings.
+    refresh_config_after_model: bool,
     /// Preference-ordered `thought_level` value ids for the run's reasoning
     /// (per-agent clamping, e.g. Claude xhigh→max off the xhigh family). The
     /// first value the agent actually advertises wins.
@@ -187,6 +190,7 @@ fn claude_spec() -> AcpAgentSpec {
             ReasoningLevel::Max,
         ],
         prompt_transform: crate::claude::catalog::apply_ultrathink,
+        refresh_config_after_model: false,
         effort_values: |reasoning, model| {
             crate::claude::catalog::to_effort(reasoning, model)
                 .into_iter()
@@ -219,6 +223,7 @@ fn codex_spec() -> AcpAgentSpec {
         steering_mode: SteeringMode::StepBoundary,
         reasoning_levels: crate::codex::catalog::REASONING_LEVELS,
         prompt_transform: identity_transform,
+        refresh_config_after_model: false,
         effort_values: |reasoning, _model| {
             crate::codex::catalog::to_effort(reasoning)
                 .into_iter()
@@ -302,6 +307,7 @@ fn grok_spec() -> AcpAgentSpec {
             ReasoningLevel::High,
         ],
         prompt_transform: identity_transform,
+        refresh_config_after_model: false,
         effort_values: default_effort_values,
         ladder_extras: &[],
     }
@@ -360,6 +366,7 @@ fn cursor_spec() -> AcpAgentSpec {
         // that actually advertise effort variants (see `cursor::enrich_models`).
         reasoning_levels: &[],
         prompt_transform: identity_transform,
+        refresh_config_after_model: false,
         // Cursor has no thought_level config option — effort rides the model
         // id. When a collapsed family exposes a Reasoning ladder, these
         // tokens pick the matching sibling via `cursor::pick_model_id`.
@@ -425,6 +432,7 @@ fn hermes_spec() -> AcpAgentSpec {
         // model-internal); revisit when the adapter advertises a ladder.
         reasoning_levels: &[],
         prompt_transform: identity_transform,
+        refresh_config_after_model: false,
         effort_values: default_effort_values,
         ladder_extras: &[],
     }
@@ -478,6 +486,66 @@ fn pi_spec() -> AcpAgentSpec {
             ReasoningLevel::Max,
         ],
         prompt_transform: identity_transform,
+        refresh_config_after_model: false,
+        effort_values: default_effort_values,
+        ladder_extras: &[],
+    }
+}
+
+fn opencode_install_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let mut push = |path: PathBuf| {
+        if !paths.contains(&path) {
+            paths.push(path);
+        }
+    };
+    for variable in ["OPENCODE_INSTALL_DIR", "XDG_BIN_DIR"] {
+        if let Some(dir) = std::env::var_os(variable).filter(|dir| !dir.is_empty()) {
+            push(PathBuf::from(dir).join("opencode"));
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        push(home.join("bin").join("opencode"));
+        push(home.join(".opencode").join("bin").join("opencode"));
+        push(home.join(".local").join("bin").join("opencode"));
+    }
+    push(PathBuf::from("/opt/homebrew/bin/opencode"));
+    push(PathBuf::from("/usr/local/bin/opencode"));
+    paths
+}
+
+fn opencode_spec() -> AcpAgentSpec {
+    AcpAgentSpec {
+        id: HarnessId::OpenCode,
+        display_name: "OpenCode",
+        executable: "opencode",
+        env_override: "OPENCODE_EXECUTABLE",
+        args: &["acp"],
+        npm_package: None,
+        extra_paths: opencode_install_paths,
+        cli_executable: "opencode",
+        cli_extra_paths: opencode_install_paths,
+        install_hint: "opencode (searched PATH, the login shell's PATH, OPENCODE_INSTALL_DIR, \
+             XDG_BIN_DIR, $HOME/bin, $HOME/.opencode/bin, $HOME/.local/bin, \
+             /opt/homebrew/bin, and /usr/local/bin; install with \
+             `curl -fsSL https://opencode.ai/install | bash` or a supported package \
+             manager; set OPENCODE_EXECUTABLE to override)",
+        // ACP is the source of truth; this is only the conservative fallback
+        // used when a live session cannot advertise configured providers.
+        models: || {
+            vec![Model {
+                id: "default".into(),
+                label: "OpenCode default".into(),
+                description: Some("Uses the model configured in OpenCode".into()),
+                reasoning_levels: Vec::new(),
+                options: Vec::new(),
+            }]
+        },
+        // OpenCode does not advertise zeron's private steering extension yet.
+        steering_mode: SteeringMode::TurnBoundary,
+        reasoning_levels: &[],
+        prompt_transform: identity_transform,
+        refresh_config_after_model: true,
         effort_values: default_effort_values,
         ladder_extras: &[],
     }
@@ -598,6 +666,11 @@ impl AcpHarness {
     /// pi's RPC mode.
     pub fn pi() -> Self {
         Self::with_spec(pi_spec())
+    }
+
+    /// OpenCode's native ACP server (`opencode acp`).
+    pub fn opencode() -> Self {
+        Self::with_spec(opencode_spec())
     }
 
     /// Use a fixed agent binary instead of PATH/known-location resolution.
@@ -1201,6 +1274,7 @@ impl Harness for AcpHarness {
             agent_name: self.spec.display_name,
             prompt_transform: self.spec.prompt_transform,
             effort_values: self.spec.effort_values,
+            refresh_config_after_model: self.spec.refresh_config_after_model,
             interrupt_grace: self.interrupt_grace,
             kill_grace: self.kill_grace,
             handshake_timeout: self.handshake_timeout,
@@ -1229,6 +1303,7 @@ struct Session {
     agent_name: &'static str,
     prompt_transform: fn(Option<ReasoningLevel>, &str) -> String,
     effort_values: fn(Option<ReasoningLevel>, Option<&str>) -> Vec<&'static str>,
+    refresh_config_after_model: bool,
     interrupt_grace: Duration,
     kill_grace: Duration,
     handshake_timeout: Duration,
@@ -1381,6 +1456,7 @@ fn config_option_sets(
     model: Option<&str>,
     efforts: &[&'static str],
     model_options: &serde_json::Map<String, Value>,
+    cursor_model: bool,
 ) -> Vec<(String, Value)> {
     let Some(options) = session_response
         .get("configOptions")
@@ -1415,9 +1491,22 @@ fn config_option_sets(
                 // (`auto-smart[optimize_for=cost]`) still has to match. When
                 // the catalog is still exploded, effort siblings switch via
                 // `pick_model_id`.
-                let requested = model.map(cursor::strip_variant_suffix);
-                requested
-                    .and_then(|m| cursor::pick_model_id(m, efforts, &available))
+                // Other ACP agents, notably OpenCode, advertise their exact
+                // provider/model ids and must not go through Cursor's family
+                // or bracket-suffix transformations.
+                let requested = model.map(|m| {
+                    if cursor_model {
+                        cursor::strip_variant_suffix(m)
+                    } else {
+                        m
+                    }
+                });
+                let cursor_variant = if cursor_model {
+                    requested.and_then(|m| cursor::pick_model_id(m, efforts, &available))
+                } else {
+                    None
+                };
+                cursor_variant
                     .or_else(|| requested.and_then(|m| pick_model_value(m, &available, context_1m)))
                     .or_else(|| model.and_then(|m| pick_model_value(m, &available, context_1m)))
                     .map(Value::String)
@@ -1983,6 +2072,7 @@ async fn run_session(session: Session) {
         agent_name,
         prompt_transform,
         effort_values,
+        refresh_config_after_model,
         interrupt_grace,
         kill_grace,
         handshake_timeout,
@@ -2052,18 +2142,26 @@ async fn run_session(session: Session) {
         // field). Best-effort: a rejected set is logged, never fatal — the
         // agent's default runs.
         //
-        // Cursor parameterized mode only lists parameters for the *current*
-        // model. Set the model first, then apply optimize_for / effort / fast
-        // against the refreshed configOptions in the response.
+        // Cursor parameterized mode and OpenCode's model-dependent effort
+        // ladder only list the remaining parameters for the *current* model.
+        // Set the model first, then apply the remaining settings against the
+        // refreshed configOptions in the response.
         let efforts = effort_values(request.reasoning, request.model.as_deref());
-        let requested_model = request.model.as_deref().map(cursor::strip_variant_suffix);
+        let cursor_model = harness == HarnessId::Cursor;
+        let requested_model = if cursor_model {
+            request.model.as_deref().map(cursor::strip_variant_suffix)
+        } else {
+            request.model.as_deref()
+        };
         let mut options_snapshot = session_response;
-        if harness == HarnessId::Cursor {
+        let model_first = refresh_config_after_model || cursor_model;
+        if model_first {
             let model_sets = config_option_sets(
                 &options_snapshot,
                 requested_model,
                 &[],
                 &serde_json::Map::new(),
+                cursor_model,
             );
             if let Some((_, payload)) = model_sets.iter().find(|(id, _)| id == "model") {
                 let mut params = serde_json::Map::new();
@@ -2100,8 +2198,9 @@ async fn run_session(session: Session) {
             requested_model,
             &efforts,
             &request.model_options,
+            cursor_model,
         ) {
-            if harness == HarnessId::Cursor && config_id == "model" {
+            if model_first && config_id == "model" {
                 continue;
             }
             let mut params = serde_json::Map::new();
@@ -3104,7 +3203,13 @@ mod tests {
         // Model switch + effort preference list; fastMode untouched without a
         // model-option selection.
         assert_eq!(
-            config_option_sets(&response, Some("claude-opus-5"), &["medium"], &no_opts),
+            config_option_sets(
+                &response,
+                Some("claude-opus-5"),
+                &["medium"],
+                &no_opts,
+                false,
+            ),
             vec![
                 ("model".to_owned(), json!({ "value": "claude-opus-5" })),
                 ("effort".to_owned(), json!({ "value": "medium" })),
@@ -3112,7 +3217,7 @@ mod tests {
         );
         // Effort preference order: first ADVERTISED candidate wins.
         assert_eq!(
-            config_option_sets(&response, None, &["xhigh", "max"], &no_opts),
+            config_option_sets(&response, None, &["xhigh", "max"], &no_opts, false),
             vec![("effort".to_owned(), json!({ "value": "max" }))]
         );
         // contextWindow=1m composes the [1m] model id; fastMode=on matches the
@@ -3121,7 +3226,7 @@ mod tests {
         opts.insert("contextWindow".into(), json!("1m"));
         opts.insert("fastMode".into(), json!("on"));
         assert_eq!(
-            config_option_sets(&response, Some("claude-opus-5"), &["high"], &opts),
+            config_option_sets(&response, Some("claude-opus-5"), &["high"], &opts, false),
             vec![
                 ("model".to_owned(), json!({ "value": "claude-opus-5[1m]" })),
                 (
@@ -3132,16 +3237,28 @@ mod tests {
         );
         // Already-current values and unadvertised models set nothing.
         assert_eq!(
-            config_option_sets(&response, Some("claude-sonnet-5"), &["high"], &no_opts),
+            config_option_sets(
+                &response,
+                Some("claude-sonnet-5"),
+                &["high"],
+                &no_opts,
+                false,
+            ),
             Vec::new()
         );
         assert_eq!(
-            config_option_sets(&response, Some("gpt-5.6-sol"), &[], &no_opts),
+            config_option_sets(&response, Some("gpt-5.6-sol"), &[], &no_opts, false),
             Vec::new()
         );
         // No configOptions advertised → nothing to set.
         assert_eq!(
-            config_option_sets(&json!({"sessionId": "s"}), Some("x"), &["high"], &no_opts),
+            config_option_sets(
+                &json!({"sessionId": "s"}),
+                Some("x"),
+                &["high"],
+                &no_opts,
+                false,
+            ),
             Vec::new()
         );
     }
@@ -3538,6 +3655,74 @@ mod tests {
     }
 
     #[test]
+    fn opencode_spec_targets_the_native_acp_server() {
+        let spec = opencode_spec();
+        assert_eq!(spec.id, HarnessId::OpenCode);
+        assert_eq!(spec.display_name, "OpenCode");
+        assert_eq!(spec.executable, "opencode");
+        assert_eq!(spec.env_override, "OPENCODE_EXECUTABLE");
+        assert_eq!(spec.args, &["acp"]);
+        assert!(spec.npm_package.is_none());
+        assert_eq!(spec.cli_executable, "opencode");
+        assert_eq!(spec.steering_mode, SteeringMode::TurnBoundary);
+        assert!(spec.reasoning_levels.is_empty());
+        assert!(spec.refresh_config_after_model);
+        let models = (spec.models)();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "default");
+        assert_eq!(models[0].label, "OpenCode default");
+        assert!(models[0].reasoning_levels.is_empty());
+        assert!(models[0].options.is_empty());
+        assert_eq!(
+            (spec.effort_values)(Some(ReasoningLevel::XHigh), Some("anthropic/model-b")),
+            vec!["xhigh", "x-high", "high"]
+        );
+    }
+
+    #[test]
+    fn opencode_mode_values_keep_the_acp_default_when_unselected() {
+        let response = json!({
+            "configOptions": [
+                {
+                    "id": "model",
+                    "category": "model",
+                    "type": "select",
+                    "currentValue": "openai/model-a",
+                    "options": [
+                        { "value": "openai/model-a" },
+                        { "value": "anthropic/model-b" }
+                    ]
+                },
+                {
+                    "id": "effort",
+                    "category": "thought_level",
+                    "type": "select",
+                    "currentValue": "medium",
+                    "options": [{ "value": "low" }, { "value": "medium" }]
+                },
+                {
+                    "id": "mode",
+                    "category": "mode",
+                    "type": "select",
+                    "currentValue": "build",
+                    "options": [{ "value": "build" }, { "value": "plan" }]
+                }
+            ]
+        });
+        let sets = config_option_sets(
+            &response,
+            Some("anthropic/model-b"),
+            &["xhigh"],
+            &serde_json::Map::new(),
+            false,
+        );
+        assert_eq!(
+            sets,
+            vec![("model".to_owned(), json!({ "value": "anthropic/model-b" }))]
+        );
+    }
+
+    #[test]
     fn cursor_mode_trait_wins_over_no_prompt_fallback() {
         let cursor = json!({
             "sessionId": "s-1",
@@ -3566,7 +3751,7 @@ mod tests {
         let mut opts = serde_json::Map::new();
         opts.insert("mode".into(), json!("plan"));
         assert_eq!(
-            config_option_sets(&cursor, None, &[], &opts),
+            config_option_sets(&cursor, None, &[], &opts, true),
             vec![("mode".to_owned(), json!({ "value": "plan" }))]
         );
         // Reasoning Low switches the effort family to the -low sibling.
@@ -3575,7 +3760,8 @@ mod tests {
                 &cursor,
                 Some("example[reasoning_effort=high]"),
                 &["low"],
-                &serde_json::Map::new()
+                &serde_json::Map::new(),
+                true,
             ),
             vec![("model".to_owned(), json!({ "value": "example-low[]" }))]
         );
@@ -3623,6 +3809,7 @@ mod tests {
             Some("auto-smart[optimize_for=balanced]"),
             &[],
             &opts,
+            true,
         );
         assert!(
             sets.iter()
@@ -3678,7 +3865,7 @@ mod tests {
         });
         let no_opts = serde_json::Map::new();
         assert_eq!(
-            config_option_sets(&codex, None, &[], &no_opts),
+            config_option_sets(&codex, None, &[], &no_opts, false),
             vec![("mode".to_owned(), json!({ "value": "agent-full-access" }))]
         );
     }

--- a/crates/harness/src/acp/normalize.rs
+++ b/crates/harness/src/acp/normalize.rs
@@ -6,7 +6,7 @@
 //! and missing fields degrade to empty strings rather than errors. Wire shapes
 //! verified against `agent-client-protocol-schema` 1.3.0 (`SessionUpdate` is
 //! tagged `sessionUpdate`/snake_case; structs are camelCase; tool kinds and
-//! statuses are snake_case).
+//! statuses are snake_case), including OpenCode's native ACP stream.
 
 use serde_json::Value;
 use zeron_proto::{AgentEvent, SlashCommand, TodoItem, ToolCall, ToolDiff};

--- a/crates/harness/src/adapter_install.rs
+++ b/crates/harness/src/adapter_install.rs
@@ -343,6 +343,7 @@ mod tests {
         assert_eq!(pin.dir_name(), "pi-acp");
     }
 
+    #[cfg(unix)]
     #[test]
     fn npm_errno_exits_are_decoded() {
         use std::os::unix::process::ExitStatusExt;

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -28,6 +28,19 @@ fn fixture_path() -> PathBuf {
     path
 }
 
+fn opencode_fixture_path() -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake-opencode-acp.sh");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
+    }
+    path
+}
+
 fn harness() -> AcpHarness {
     AcpHarness::grok().with_executable(fixture_path())
 }
@@ -282,6 +295,10 @@ async fn claude_and_codex_specs_drive_the_same_wire() {
         (
             "cursor",
             AcpHarness::cursor().with_executable(fixture_path()),
+        ),
+        (
+            "opencode",
+            AcpHarness::opencode().with_executable(fixture_path()),
         ),
     ] {
         let (controls, _steer, _token) = controls();
@@ -944,6 +961,56 @@ async fn hung_handshake_errors_instead_of_spinning_forever() {
     );
 }
 
+#[tokio::test]
+async fn opencode_models_preserve_provider_model_ids_from_config_options() {
+    let harness = AcpHarness::opencode().with_executable(opencode_fixture_path());
+    let models = harness.models().await.expect("discovery");
+    assert_eq!(
+        models.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+        vec!["openai/model-a", "anthropic/model-b"],
+        "{models:?}"
+    );
+    assert!(models.iter().all(|m| {
+        m.reasoning_levels
+            == vec![
+                zeron_proto::ReasoningLevel::Low,
+                zeron_proto::ReasoningLevel::Medium,
+            ]
+    }));
+}
+
+#[tokio::test]
+async fn opencode_model_selection_refreshes_effort_and_preserves_default_mode() {
+    let (controls, _steer, _token) = controls();
+    let harness = AcpHarness::opencode().with_executable(opencode_fixture_path());
+    let mut req = request("scenario:opencode-config");
+    req.model = Some("anthropic/model-b".into());
+    req.reasoning = Some(zeron_proto::ReasoningLevel::XHigh);
+    let events = run_to_end(&harness, req, controls).await;
+    assert!(
+        events.contains(&AgentEvent::TextDelta {
+            text: "configured".into()
+        }),
+        "{events:?}"
+    );
+    assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)]);
+}
+
+#[tokio::test]
+async fn opencode_static_fallback_is_a_configured_default_passthrough() {
+    let harness = AcpHarness::opencode().with_executable("/nonexistent/never-an-opencode");
+    let models = harness.models().await.expect("static fallback");
+    assert_eq!(models.len(), 1, "{models:?}");
+    assert_eq!(models[0].id, "default");
+    assert_eq!(models[0].label, "OpenCode default");
+    assert_eq!(
+        models[0].description.as_deref(),
+        Some("Uses the model configured in OpenCode")
+    );
+    assert!(models[0].reasoning_levels.is_empty());
+    assert!(models[0].options.is_empty());
+}
+
 #[test]
 fn cursor_descriptor_surface_matches_registry_expectations() {
     let cursor = AcpHarness::cursor();
@@ -981,6 +1048,13 @@ fn hermes_and_pi_descriptor_surfaces_match_registry_expectations() {
             zeron_proto::ReasoningLevel::Max,
         ]
     );
+
+    let opencode = AcpHarness::opencode();
+    assert_eq!(opencode.id(), HarnessId::OpenCode);
+    assert_eq!(opencode.display_name(), "OpenCode");
+    assert!(opencode.supports_steering());
+    assert_eq!(opencode.steering_mode(), SteeringMode::TurnBoundary);
+    assert!(opencode.reasoning_levels().is_empty());
 }
 
 /// The 2026-08-12 stuck-Working wedge, end to end: a prompt whose turn was

--- a/crates/harness/tests/fixtures/fake-opencode-acp.sh
+++ b/crates/harness/tests/fixtures/fake-opencode-acp.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Fake OpenCode ACP agent for model-dependent config sequencing tests.
+#
+# The initial effort ladder belongs to openai/model-a. Selecting
+# anthropic/model-b returns a fresh configOptions snapshot with a different
+# effort ladder. The fixture rejects an old effort, an unnecessary mode write,
+# or a second model write.
+
+emit() { printf '%s\n' "$1"; }
+rid() { printf '%s' "$1" | sed 's/.*"id":\([0-9]*\).*/\1/'; }
+has() { case "$1" in *"$2"*) return 0 ;; *) return 1 ;; esac; }
+
+update() {
+  emit "{\"method\":\"session/update\",\"params\":{\"sessionId\":\"$SID\",\"update\":$1}}"
+}
+
+read -r line || exit 1
+has "$line" '"method":"initialize"' || exit 1
+has "$line" '"protocolVersion":1' || exit 1
+has "$line" '"name":"zeron"' || exit 1
+emit "{\"id\":$(rid "$line"),\"result\":{\"protocolVersion\":1}}"
+
+read -r line || exit 1
+has "$line" '"method":"session/new"' || exit 1
+has "$line" '"mcpServers":[]' || exit 1
+SID="opencode-session"
+emit "{\"id\":$(rid "$line"),\"result\":{\"sessionId\":\"$SID\",\"configOptions\":[{\"id\":\"model\",\"name\":\"Model\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":\"openai/model-a\",\"options\":[{\"value\":\"openai/model-a\",\"name\":\"OpenAI Model A\"},{\"value\":\"anthropic/model-b\",\"name\":\"Anthropic Model B\"}]},{\"id\":\"effort\",\"name\":\"Effort\",\"category\":\"thought_level\",\"type\":\"select\",\"currentValue\":\"medium\",\"options\":[{\"value\":\"low\",\"name\":\"Low\"},{\"value\":\"medium\",\"name\":\"Medium\"}]},{\"id\":\"mode\",\"name\":\"Session Mode\",\"category\":\"mode\",\"type\":\"select\",\"currentValue\":\"build\",\"options\":[{\"value\":\"build\",\"name\":\"Build\"},{\"value\":\"plan\",\"name\":\"Plan\"}]}]}}"
+
+read -r line || exit 0
+valid=1
+model_set=0
+effort_set=0
+mode_set=0
+state="initial"
+
+while has "$line" '"method":"session/set_config_option"'; do
+  id=$(rid "$line")
+  if [ "$state" = "initial" ]; then
+    if has "$line" '"configId":"model"' && has "$line" '"value":"anthropic/model-b"'; then
+      model_set=1
+      state="selected"
+      # OpenCode's model response is the refreshed snapshot used by the next
+      # config phase.
+      emit "{\"id\":$id,\"result\":{\"configOptions\":[{\"id\":\"model\",\"name\":\"Model\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":\"anthropic/model-b\",\"options\":[{\"value\":\"openai/model-a\",\"name\":\"OpenAI Model A\"},{\"value\":\"anthropic/model-b\",\"name\":\"Anthropic Model B\"}]},{\"id\":\"effort\",\"name\":\"Effort\",\"category\":\"thought_level\",\"type\":\"select\",\"currentValue\":\"high\",\"options\":[{\"value\":\"high\",\"name\":\"High\"},{\"value\":\"xhigh\",\"name\":\"XHigh\"}]},{\"id\":\"mode\",\"name\":\"Session Mode\",\"category\":\"mode\",\"type\":\"select\",\"currentValue\":\"build\",\"options\":[{\"value\":\"build\",\"name\":\"Build\"},{\"value\":\"plan\",\"name\":\"Plan\"}]}]}}"
+    else
+      valid=0
+      emit "{\"id\":$id,\"result\":{}}"
+    fi
+  else
+    if has "$line" '"configId":"effort"' && has "$line" '"value":"xhigh"'; then
+      effort_set=1
+    elif has "$line" '"configId":"mode"'; then
+      mode_set=1
+      valid=0
+    elif has "$line" '"configId":"model"'; then
+      valid=0
+    else
+      valid=0
+    fi
+    emit "{\"id\":$id,\"result\":{}}"
+  fi
+  read -r line || exit 1
+done
+
+has "$line" '"method":"session/prompt"' || exit 1
+pid=$(rid "$line")
+if [ "$valid" -eq 1 ] && [ "$model_set" -eq 1 ] && [ "$effort_set" -eq 1 ] && [ "$mode_set" -eq 0 ]; then
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"configured"}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+else
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"refusal\"}}"
+fi

--- a/crates/harness/tests/shell_env_resolution.rs
+++ b/crates/harness/tests/shell_env_resolution.rs
@@ -25,6 +25,7 @@ async fn cli_on_login_shell_path_only_is_resolved() {
     write_executable(&shell_bin.join("claude-agent-acp"), "#!/bin/sh\nexit 0\n");
     write_executable(&shell_bin.join("hermes"), "#!/bin/sh\nexit 0\n");
     write_executable(&shell_bin.join("pi-acp"), "#!/bin/sh\nexit 0\n");
+    write_executable(&shell_bin.join("opencode"), "#!/bin/sh\nexit 0\n");
 
     // A $SHELL whose init shapes PATH — the shape resolution must survive.
     let fake_shell = dir.path().join("fake-shell");
@@ -51,6 +52,7 @@ async fn cli_on_login_shell_path_only_is_resolved() {
         std::env::remove_var("CLAUDE_ACP_EXECUTABLE");
         std::env::remove_var("HERMES_EXECUTABLE");
         std::env::remove_var("PI_ACP_EXECUTABLE");
+        std::env::remove_var("OPENCODE_EXECUTABLE");
         std::env::remove_var("ZERON_NO_LOGIN_SHELL");
     }
 
@@ -80,4 +82,16 @@ async fn cli_on_login_shell_path_only_is_resolved() {
         .launch_program()
         .expect("pi-acp resolves via login-shell PATH");
     assert_eq!(pi, shell_bin.join("pi-acp"), "{pi:?}");
+    let opencode = AcpHarness::opencode()
+        .launch_program()
+        .expect("opencode resolves via login-shell PATH");
+    assert_eq!(opencode, shell_bin.join("opencode"), "{opencode:?}");
+
+    let override_path = dir.path().join("opencode-override");
+    write_executable(&override_path, "#!/bin/sh\nexit 0\n");
+    unsafe { std::env::set_var("OPENCODE_EXECUTABLE", &override_path) };
+    assert_eq!(
+        AcpHarness::opencode().launch_program().unwrap(),
+        override_path
+    );
 }

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -14,6 +14,9 @@ pub enum HarnessId {
     Hermes,
     /// The pi coding agent (pi.dev), driven over ACP via the `pi-acp` adapter.
     Pi,
+    /// OpenCode's native ACP server (`opencode acp`).
+    #[serde(rename = "opencode")]
+    OpenCode,
     /// Test harness; never shown in production pickers.
     Mock,
 }
@@ -362,6 +365,10 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&HarnessId::ClaudeCode).unwrap(),
             "\"claude-code\""
+        );
+        assert_eq!(
+            serde_json::to_string(&HarnessId::OpenCode).unwrap(),
+            "\"opencode\""
         );
     }
 }

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -3293,6 +3293,8 @@ pub(crate) fn harness_brand_icon(harness: HarnessId) -> (&'static str, Option<gp
         // Nous Research's mark (the Hermes product icon), monochrome.
         HarnessId::Hermes => (crate::icons::HERMES_MARK, None),
         HarnessId::Pi => (crate::icons::PI_MARK, None),
+        // OpenCode has no dedicated asset here; use the generic terminal mark.
+        HarnessId::OpenCode => (crate::icons::TERMINAL, None),
     }
 }
 

--- a/crates/ui/src/settings/harnesses.rs
+++ b/crates/ui/src/settings/harnesses.rs
@@ -39,6 +39,7 @@ pub fn blurb(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "xAI's Grok Build agent (grok CLI).",
         HarnessId::Hermes => "Nous Research's Hermes Agent (hermes CLI).",
         HarnessId::Pi => "The pi coding agent (pi CLI).",
+        HarnessId::OpenCode => "OpenCode's coding agent, driven through the opencode CLI.",
         HarnessId::Mock => "Scripted test harness.",
     }
 }
@@ -52,6 +53,7 @@ pub fn cli_name(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "grok",
         HarnessId::Hermes => "hermes",
         HarnessId::Pi => "pi",
+        HarnessId::OpenCode => "opencode",
         HarnessId::Mock => "mock",
     }
 }

--- a/docs/research/acp.md
+++ b/docs/research/acp.md
@@ -1,4 +1,4 @@
-# ACP integration: shared harness + Grok Build (2026-08)
+# ACP integration: shared harness + native ACP agents (2026-08)
 
 ## Decision
 - Add an **ACP harness** (`crates/harness/src/acp/`) speaking Agent Client Protocol
@@ -45,6 +45,15 @@
   ride pi's own provider config (catalog advertises a `default` pass-through
   entry); thinking ladder minimal→max maps onto zeron's levels via the
   generic `thought_level` preference ladder ("off" has no zeron tier).
+- **OpenCode registered** (2026-08): `AcpHarness::opencode()` runs the native
+  `opencode acp` server with no custom transport. Provider/model rows come from
+  ACP `configOptions`; selecting a model first refreshes that snapshot before
+  applying its model-dependent effort ladder. The initial integration leaves
+  OpenCode's configured/default session mode untouched and uses turn-boundary
+  steering unless a future handshake advertises zeron's private extension.
+  The discovery probe applies its initial session's effort ladder to the
+  discovered rows; the selected model's refreshed snapshot is authoritative at
+  run time, avoiding an expensive per-model probe in this integration.
 - **ACP is the source of truth for model lists** (2026-08-08; preference
   order inverted 2026-08-09): `models()` runs a short-lived probe
   (initialize → `session/new`, the `discover_commands` pattern) and reads


### PR DESCRIPTION
## Summary

* Implements #101 using OpenCode's native `opencode acp` server through Zeron's shared `AcpHarness`.
* OpenCode remains opt-in and preserves its configured/default session mode.

## OpenCode-specific ACP correctness

* OpenCode's `thought_level`/effort options depend on the selected model.
* Model selection is therefore performed first.
* The returned refreshed `configOptions` snapshot is consumed.
* Only then is the requested reasoning effort applied against the selected model's valid variants.
* The regression fixture proves that different models expose different effort ladders. It rejects a stale effort, a mode write, or a duplicate model write, preventing Zeron from silently running a different effort than the one selected in the UI.

## Integration

* Adds `HarnessId::OpenCode` with the `opencode` wire ID.
* Runs the native `opencode acp` command through the shared ACP transport.
* Explicitly uses no managed npm adapter package for OpenCode; it remains a native CLI.
* Remains compatible with the shared managed-adapter installation, bounded-handshake, and legible-error lifecycle used by adapter-backed ACP agents.
* Supports `OPENCODE_EXECUTABLE`.
* Discovers official/custom install paths and provides the official installer hint.
* Discovers provider/model entries dynamically through ACP while preserving exact IDs.
* Provides a conservative configured-model fallback when discovery is unavailable.
* Registers OpenCode lazily and keeps it out of the default-enabled set.
* Adds Settings, picker, and generic terminal-icon UI support.
* Supports `ZERON_HARNESS=opencode`.
* Adds the iOS catalog label and configured-model fallback handling.
* Updates README and ACP documentation.

## Mode

* OpenCode build, plan, and custom modes are not switched automatically.
* This first implementation intentionally preserves OpenCode's configured/default mode; generic ACP mode selection remains separate.

## Validation

* `cargo fmt --all -- --check` - passed.
* `git diff --check` - passed.
* `cargo check --workspace` - passed.
* `cargo test -p zeron-proto` - 18 passed, 0 failed; doc-tests passed.
* `cargo test -p zeron-engine --lib` - 53 passed, 0 failed.
* `cargo test -p zeron-harness --lib` - 43 passed, 0 failed.
* LF-normalized WSL `cargo test -p zeron-harness --test acp` - 32 passed, 0 failed, 7 ignored.
* LF-normalized WSL `cargo test -p zeron-harness --test shell_env_resolution` - 1 passed, 0 failed.
* `cargo test -p zeron-harness --test managed_install` - 0 passed, 0 failed, 1 ignored real-install test.
* `cargo test -p zeron-harness --test managed_install_failure` - 0 passed, 0 failed.

Windows cannot execute the Unix ACP fixtures directly, so the integration tests were run from a LF-normalized WSL checkout. The upstream errno-status fixture is Unix-only; it is cfg-gated so the Windows harness suite compiles without changing production install behavior. The full `cargo test -p zeron --bin zeron` GPUI app-test build previously timed out during compilation without reporting test failures; `cargo check --workspace` passes. No authenticated live OpenCode installation was available for the optional real smoke test.

PR #103 is an overlapping implementation. This branch was already in progress from #101 and additionally covers OpenCode's model-dependent config refresh semantics and the remaining CLI/mobile integration surfaces, with regression coverage for the model -> refreshed `configOptions` -> effort sequence. Happy for the maintainers to choose whichever approach fits the project best.