### PR TITLE
fixed the auto model not available issue on the cursor agent model picker

### DIFF
--- a/crates/harness/src/acp/cursor.rs
+++ b/crates/harness/src/acp/cursor.rs
@@ -15,6 +15,39 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde_json::Value;
 use zeron_proto::{Model, ModelOption, ModelOptionChoice, ReasoningLevel};
 
+pub(crate) const AUTO_SMART_ID: &str = "auto-smart";
+
+/// Cursor advertises Auto on the wire as `default` (or `default[]` exploded),
+/// not `auto-smart`. That row is a real model — unlike Claude's duplicate
+/// "Default (recommended)" alias.
+pub(crate) fn is_cursor_auto_wire(id: &str, label: &str) -> bool {
+    strip_variant_suffix(id).eq_ignore_ascii_case("default")
+        && clean_label(label).0.eq_ignore_ascii_case("auto")
+}
+
+/// Map a wire model config value to the picker id (`default` → `auto-smart`).
+pub(crate) fn wire_model_picker_id(id: &str) -> String {
+    if strip_variant_suffix(id).eq_ignore_ascii_case("default") {
+        AUTO_SMART_ID.to_owned()
+    } else {
+        strip_variant_suffix(id).to_owned()
+    }
+}
+
+/// Map a saved picker id to the wire value Cursor's session advertises.
+pub(crate) fn wire_model_value(requested: &str, available: &[&str]) -> Option<String> {
+    if is_auto_smart(requested) {
+        return available
+            .iter()
+            .find(|id| strip_variant_suffix(id).eq_ignore_ascii_case("default"))
+            .map(|id| (*id).to_owned());
+    }
+    available
+        .iter()
+        .find(|id| **id == requested)
+        .map(|id| (*id).to_owned())
+}
+
 /// Strip Cursor's effort-badge HTML from a model name and return the plain
 /// label plus the badge text when present.
 ///
@@ -331,7 +364,7 @@ fn thought_ladder(option: &Value) -> Option<Vec<ReasoningLevel>> {
 }
 
 fn is_auto_smart(id: &str) -> bool {
-    strip_variant_suffix(id) == "auto-smart"
+    strip_variant_suffix(id) == AUTO_SMART_ID
 }
 
 /// Majority base ids (no `[key=value]` suffix) → parameterized picker.
@@ -373,7 +406,7 @@ fn enrich_parameterized(
         .find(|o| o.get("id").and_then(Value::as_str) == Some("optimize_for"))
         .and_then(model_option_from_config)
         .unwrap_or_else(|| optimize_for_option(option_current(options, "optimize_for")));
-    let current_id = option_current(options, "model").map(strip_variant_suffix);
+    let current_id = option_current(options, "model").map(wire_model_picker_id);
     let current_extras: Vec<ModelOption> = options
         .iter()
         .filter(|o| {
@@ -402,7 +435,11 @@ fn enrich_parameterized(
         .map(|mut model| {
             let (label, _) = clean_label(&model.label);
             model.label = label;
-            model.id = strip_variant_suffix(&model.id).to_owned();
+            model.id = if is_cursor_auto_wire(&model.id, &model.label) {
+                AUTO_SMART_ID.to_owned()
+            } else {
+                strip_variant_suffix(&model.id).to_owned()
+            };
             // Discovery clones the current model's wire traits onto every
             // row; those are wrong under parameterized mode.
             model.options.clear();
@@ -411,7 +448,7 @@ fn enrich_parameterized(
             if is_auto_smart(&model.id) {
                 model.options.push(optimize.clone());
             }
-            if current_id == Some(model.id.as_str()) {
+            if current_id.as_deref() == Some(model.id.as_str()) {
                 model.options.extend(current_extras.iter().cloned());
                 model
                     .options
@@ -499,6 +536,9 @@ fn enrich_exploded(models: Vec<Model>, mode_current: Option<&str>) -> Vec<Model>
         }
 
         for (_, mut model) in annotated {
+            if is_cursor_auto_wire(&model.id, &model.label) {
+                model.id = AUTO_SMART_ID.to_owned();
+            }
             // Locked single-variant params stay on the description; Mode is
             // the one trait every Cursor row can actually change.
             model.options.insert(0, mode.clone());
@@ -656,6 +696,28 @@ mod tests {
     }
 
     #[test]
+    fn wire_auto_row_maps_to_auto_smart() {
+        let models = enrich_models(
+            vec![Model {
+                id: "default".into(),
+                label: "Auto".into(),
+                description: None,
+                reasoning_levels: vec![],
+                options: vec![],
+            }],
+            &json!({
+                "configOptions": [
+                    { "id": "mode", "category": "mode", "currentValue": "agent" },
+                    { "id": "model", "category": "model", "currentValue": "default" },
+                ]
+            }),
+        );
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, AUTO_SMART_ID);
+        assert!(models[0].options.iter().any(|o| o.id == "optimize_for"));
+    }
+
+    #[test]
     fn parameterized_catalog_injects_optimize_for_on_auto_only() {
         let models = enrich_models(
             vec![
@@ -724,6 +786,19 @@ mod tests {
         let opus = models.iter().find(|m| m.id == "claude-opus-5").unwrap();
         assert!(opus.options.iter().all(|o| o.id == "mode"));
         assert!(opus.reasoning_levels.is_empty());
+    }
+
+    #[test]
+    fn wire_model_value_maps_auto_smart_to_default() {
+        let available = ["default", "composer-2.5"];
+        assert_eq!(
+            wire_model_value(AUTO_SMART_ID, &available).as_deref(),
+            Some("default")
+        );
+        assert_eq!(
+            wire_model_value("composer-2.5", &available).as_deref(),
+            Some("composer-2.5")
+        );
     }
 
     #[test]

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -839,17 +839,22 @@ fn models_from_session(session_response: &Value, catalog: &[Model]) -> Vec<Model
         // `default` is an ALIAS row (Claude Code's "Default (recommended)"),
         // duplicating whichever real model the CLI resolves it to — dropped
         // whenever a real row exists (it read as clutter in the picker, user
-        // request). Send-side, a chat that saved `default` still matches the
-        // advertised value exactly.
+        // request). Cursor's Auto is also wire id `default`, but labeled "Auto"
+        // — that row is kept and normalized to `auto-smart` in enrichment.
+        // Send-side, a chat that saved `default` still matches the advertised
+        // value exactly.
         let has_real = raw_ids.iter().any(|id| norm_id(id) != "default");
         return model_select
             .iter()
             .filter_map(|o| {
                 let id = o.get("value").and_then(Value::as_str)?;
-                if has_real && norm_id(id) == "default" {
+                let name = o.get("name").and_then(Value::as_str);
+                if has_real
+                    && norm_id(id) == "default"
+                    && !cursor::is_cursor_auto_wire(id, name.unwrap_or(""))
+                {
                     return None;
                 }
-                let name = o.get("name").and_then(Value::as_str);
                 let description = o.get("description").and_then(Value::as_str);
                 let mut options = wire_options.clone();
                 if let Some(base) = strip_context_hint(id) {
@@ -1272,12 +1277,13 @@ fn config_option_sets(
                 // Parameterized Cursor uses base ids; a saved exploded id
                 // (`auto-smart[optimize_for=cost]`) still has to match. When
                 // the catalog is still exploded, effort siblings switch via
-                // `pick_model_id`.
+                // `pick_model_id`. Cursor advertises Auto as wire id `default`.
                 let requested = model.map(cursor::strip_variant_suffix);
                 requested
                     .and_then(|m| cursor::pick_model_id(m, efforts, &available))
                     .or_else(|| requested.and_then(|m| pick_model_value(m, &available, context_1m)))
                     .or_else(|| model.and_then(|m| pick_model_value(m, &available, context_1m)))
+                    .or_else(|| requested.and_then(|m| cursor::wire_model_value(m, &available)))
                     .map(Value::String)
             }
             // Unattended parity with the retired custom adapters (claude
@@ -3421,7 +3427,110 @@ mod tests {
     }
 
     #[test]
+    fn cursor_discovery_keeps_auto_from_default_wire_row() {
+        let session = json!({
+            "sessionId": "s-1",
+            "configOptions": [
+                { "id": "mode", "category": "mode", "currentValue": "agent" },
+                {
+                    "id": "model",
+                    "category": "model",
+                    "currentValue": "composer-2.5",
+                    "options": [
+                        { "value": "default", "name": "Auto" },
+                        { "value": "composer-2.5", "name": "Composer 2.5" },
+                    ],
+                },
+            ],
+        });
+        let models = cursor::enrich_models(models_from_session(&session, &[]), &session);
+        let auto = models
+            .iter()
+            .find(|m| m.id == cursor::AUTO_SMART_ID)
+            .expect("Auto must survive discovery");
+        assert_eq!(auto.label, "Auto");
+        assert!(auto.options.iter().any(|o| o.id == "optimize_for"));
+    }
+
+    #[test]
+    fn models_from_session_keeps_cursor_auto_default_row() {
+        let response = json!({
+            "sessionId": "s-1",
+            "configOptions": [{
+                "id": "model",
+                "category": "model",
+                "type": "select",
+                "currentValue": "composer-2.5",
+                "options": [
+                    { "value": "default", "name": "Auto" },
+                    { "value": "composer-2.5", "name": "Composer 2.5" },
+                ],
+            }],
+        });
+        let models = models_from_session(&response, &[]);
+        assert!(
+            models.iter().any(|m| m.id == "default" && m.label == "Auto"),
+            "{models:?}"
+        );
+    }
+
+    #[test]
     fn cursor_optimize_for_sets_on_parameterized_auto() {
+        let cursor = json!({
+            "sessionId": "s-1",
+            "configOptions": [{
+                "id": "mode",
+                "category": "mode",
+                "type": "select",
+                "currentValue": "agent",
+                "options": [
+                    { "value": "agent" },
+                    { "value": "plan" },
+                    { "value": "ask" },
+                ],
+            }, {
+                "id": "model",
+                "category": "model",
+                "type": "select",
+                "currentValue": "composer-2.5",
+                "options": [
+                    { "value": "default", "name": "Auto" },
+                    { "value": "composer-2.5" },
+                ],
+            }, {
+                "id": "optimize_for",
+                "category": "model_config",
+                "type": "select",
+                "currentValue": "balanced",
+                "options": [
+                    { "value": "intelligence" },
+                    { "value": "balanced" },
+                    { "value": "cost" },
+                ],
+            }],
+        });
+        let mut opts = serde_json::Map::new();
+        opts.insert("optimize_for".into(), json!("cost"));
+        let sets = config_option_sets(
+            &cursor,
+            Some("auto-smart[optimize_for=balanced]"),
+            &[],
+            &opts,
+        );
+        assert!(
+            sets.iter()
+                .any(|(id, v)| id == "model" && v == &json!({ "value": "default" })),
+            "{sets:?}"
+        );
+        assert!(
+            sets.iter()
+                .any(|(id, v)| id == "optimize_for" && v == &json!({ "value": "cost" })),
+            "{sets:?}"
+        );
+    }
+
+    #[test]
+    fn cursor_optimize_for_sets_on_auto_smart_wire_id() {
         let cursor = json!({
             "sessionId": "s-1",
             "configOptions": [{

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -347,6 +347,25 @@ enum ModelRail {
     Harness,
 }
 
+/// Which rail to show when the model picker opens. Favorites-first matches
+/// t3, but fall back to the harness catalog when that view would hide the
+/// resolved pick (Cursor Auto is often unstarred).
+fn initial_model_rail(
+    harness_locked: bool,
+    has_favorites: bool,
+    selected_id: Option<&str>,
+    favorite_ids: &[String],
+) -> ModelRail {
+    if harness_locked || !has_favorites || favorite_ids.is_empty() {
+        return ModelRail::Harness;
+    }
+    if selected_id.is_some_and(|id| favorite_ids.iter().any(|f| f == id)) {
+        ModelRail::Favorites
+    } else {
+        ModelRail::Harness
+    }
+}
+
 /// One row of the model list: the model plus the harness it belongs to —
 /// search results and the favorites view mix harnesses, and every row's
 /// subline names its harness (t3code ModelListRow `showProvider`).
@@ -784,13 +803,33 @@ impl Pickers {
         // Prime the model picker's rail BEFORE anchoring the highlight (the
         // visible rows depend on it): the favorites view when stars exist —
         // t3 ModelPickerContent's initial selection — else the effective
-        // harness. Locked chats stay on their own harness.
+        // harness. Locked chats stay on their own harness. Fall back to the
+        // harness catalog when favorites wouldn't show the resolved pick (e.g.
+        // Cursor Auto before it's starred).
         if kind == PickerKind::HarnessModel {
-            self.model_rail = if !self.harness_locked(cx) && !self.defaults.favorites.is_empty() {
-                ModelRail::Favorites
-            } else {
-                ModelRail::Harness
-            };
+            let favorite_ids: Vec<String> = self
+                .rail_descriptors(cx)
+                .iter()
+                .flat_map(|descriptor| {
+                    self.models
+                        .get(&descriptor.id)
+                        .and_then(|slot| slot.ready())
+                        .into_iter()
+                        .flat_map(|models| {
+                            models.iter().filter_map(|model| {
+                                self.defaults
+                                    .is_favorite(descriptor.id, &model.id)
+                                    .then(|| model.id.clone())
+                            })
+                        })
+                })
+                .collect();
+            self.model_rail = initial_model_rail(
+                self.harness_locked(cx),
+                !self.defaults.favorites.is_empty(),
+                self.selected_model(cx).map(|m| m.id.as_str()),
+                &favorite_ids,
+            );
         }
         // The keyboard-nav highlight starts ON the selected row — row 0
         // otherwise reads as a second active row (user report).
@@ -3236,7 +3275,11 @@ pub(crate) fn normalize_model_rows(harness: HarnessId, models: Vec<Model>) -> Ve
         .into_iter()
         .filter_map(|mut model| {
             if has_real && model.id.eq_ignore_ascii_case("default") {
-                return None;
+                if harness == HarnessId::Cursor && model.label.eq_ignore_ascii_case("auto") {
+                    model.id = "auto-smart".into();
+                } else {
+                    return None;
+                }
             }
             if let Some(base) = strip_1m(&model.id.clone()) {
                 if ids.iter().any(|other| other == base) {
@@ -3667,6 +3710,37 @@ mod tests {
         // Idempotent over a clean list.
         let clean = vec![bare_model("titan-5", "Titan 5")];
         assert_eq!(normalize_model_rows(HarnessId::Codex, clean.clone()), clean);
+    }
+
+    #[test]
+    fn initial_model_rail_falls_back_when_pick_is_not_starred() {
+        assert_eq!(
+            initial_model_rail(false, true, Some("auto-smart"), &["composer-2.5".into()]),
+            ModelRail::Harness
+        );
+        assert_eq!(
+            initial_model_rail(false, true, Some("auto-smart"), &["auto-smart".into()]),
+            ModelRail::Favorites
+        );
+        assert_eq!(initial_model_rail(false, true, Some("auto-smart"), &[]), ModelRail::Harness);
+    }
+
+    #[test]
+    fn normalize_keeps_cursor_auto_and_maps_to_auto_smart() {
+        let models = normalize_model_rows(
+            HarnessId::Cursor,
+            vec![
+                bare_model("default", "Auto"),
+                bare_model("composer-2.5", "Composer 2.5"),
+                bare_model("claude-opus-5", "Opus 5"),
+                bare_model("grok-4.6", "Grok 4.6"),
+            ],
+        );
+        assert_eq!(models.len(), 4);
+        assert_eq!(models[0].id, "auto-smart");
+        assert_eq!(models[0].label, "Auto");
+        assert_eq!(models[1].id, "composer-2.5");
+        assert_eq!(models[2].id, "claude-opus-5");
     }
 
     #[test]


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789397359&installation_model_id=425430&pr_number=109&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F109&signature=b4d00c57a493c4246bc064f9693f2f6c92bcdff6c9a88eba43ce5b4ff549a75c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->