### PR TITLE
Transcript: drill into a subagent's activity from its Task chip

### DIFF
--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -402,8 +402,10 @@ pub fn sidecar_payload(event: &AgentEvent) -> Option<SidecarPayload> {
 
 /// Render-only privacy policy — strip heavy/sensitive tool inputs before a call enters the doc.
 ///
-/// Keeps: command / path / pattern / url / query / todo items / server+tool names.
-/// Drops: WriteFile content, EditFile old/new strings, WebFetch prompt, Mcp/Unknown input.
+/// Keeps: command / path / pattern / url / query / todo items / server+tool names /
+/// task description+agent type.
+/// Drops: WriteFile content, EditFile old/new strings, WebFetch prompt, Task prompt,
+/// Mcp/Unknown input.
 /// Full inputs remain only in the host's local run journal. Idempotent.
 pub fn sanitize_tool_call(call: &ToolCall) -> ToolCall {
     match call {
@@ -424,6 +426,15 @@ pub fn sanitize_tool_call(call: &ToolCall) -> ToolCall {
             server: server.clone(),
             tool: tool.clone(),
             input: None,
+        },
+        ToolCall::Task {
+            description,
+            agent_type,
+            ..
+        } => ToolCall::Task {
+            description: description.clone(),
+            agent_type: agent_type.clone(),
+            prompt: None,
         },
         ToolCall::Unknown { name, .. } => ToolCall::Unknown {
             name: name.clone(),

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -29,6 +29,7 @@ pub mod rpc;
 pub mod run_journal;
 pub mod sessions;
 pub mod spaces;
+pub mod subagents;
 pub mod terminals;
 pub mod titles;
 pub mod uploads;

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -166,6 +166,7 @@ fn tool_file_path(call: &ToolCall) -> Option<&str> {
         | ToolCall::WebSearch { .. }
         | ToolCall::Todo { .. }
         | ToolCall::Mcp { .. }
+        | ToolCall::Task { .. }
         | ToolCall::Unknown { .. } => None,
     }
 }
@@ -271,6 +272,15 @@ struct ReadAttachmentChunkParams {
 struct FetchToolBlobParams {
     /// Doc-resident sidecar ref (`{chatId}/{partId}` or `…​.diff`).
     blob_ref: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SubagentTranscriptParams {
+    chat_id: String,
+    /// The Task tool part's id — the harness-native tool_use id, which keys
+    /// the sidecar's meta.json on the host device's disk.
+    tool_call_id: String,
 }
 
 /// The Mutate surface (feature-inventory §2 DataRpc), tagged by `op`.
@@ -810,6 +820,9 @@ fn forwardable(method: &str) -> bool {
             | methods::UPLOAD_CHUNK
             | methods::UPLOAD_COMMIT
             | methods::READ_ATTACHMENT_CHUNK
+            // Subagent transcripts live in the harness's session store on the
+            // chat's host device.
+            | methods::SUBAGENT_TRANSCRIPT
             // Updates report/apply on the device whose binary they concern.
             | methods::UPDATE_STATUS
             | methods::APPLY_UPDATE
@@ -1713,6 +1726,40 @@ impl RpcService for EngineRpc {
                     .await
                     .map_err(|e| RpcError::Failed(e.to_string()))?;
                 RpcReply::value(&serde_json::json!({ "text": text }))
+            }
+            methods::SUBAGENT_TRANSCRIPT => {
+                let p: SubagentTranscriptParams = parse_params(params)?;
+                let chat = self
+                    .workspace
+                    .chat(&p.chat_id)
+                    .map_err(|e| RpcError::Failed(e.to_string()))?
+                    .ok_or_else(|| RpcError::Failed("chat not found".into()))?;
+                if chat.device_id != self.doc_host.device_id() {
+                    return Err(RpcError::Failed("chat belongs to another device".into()));
+                }
+                if self.doc_host.harness_for(&p.chat_id) != HarnessId::ClaudeCode {
+                    return Err(RpcError::Failed(
+                        "subagent transcripts are recorded by Claude Code only".into(),
+                    ));
+                }
+                // The sidecar store is keyed by the cwd the harness session ran
+                // in; the stamped session cwd wins over the chat row's.
+                let cwd = self
+                    .workspace
+                    .chat_harness_session(&p.chat_id)
+                    .and_then(|(_, cwd)| cwd)
+                    .or(chat.cwd)
+                    .ok_or_else(|| RpcError::Failed("chat has no workspace folder".into()))?;
+                let transcript = crate::subagents::claude_subagent_transcript(
+                    &crate::subagents::claude_config_dir(),
+                    &cwd,
+                    &p.tool_call_id,
+                )
+                .map_err(|e| RpcError::Failed(e.to_string()))?
+                .ok_or_else(|| {
+                    RpcError::Failed("no subagent transcript on disk for this tool call".into())
+                })?;
+                RpcReply::value(&transcript)
             }
             other => Err(RpcError::UnknownMethod(other.to_string())),
         }

--- a/crates/engine/src/subagents.rs
+++ b/crates/engine/src/subagents.rs
@@ -1,0 +1,478 @@
+//! Subagent transcript sidecars — reading a Task tool call's inner activity
+//! back from the harness's own on-disk session store.
+//!
+//! Claude Code persists every subagent's full transcript next to the parent
+//! session file: `{config_dir}/projects/{slug(cwd)}/{sessionId}/subagents/`
+//! holds an `agent-{id}.jsonl` transcript plus an `agent-{id}.meta.json`
+//! carrying the parent Task call's `toolUseId` — the same id comet stores on
+//! the doc's tool part. Comet never writes here; this is a read-only view
+//! served over the `SubagentTranscript` RPC from the chat's host device.
+
+use std::path::{Path, PathBuf};
+
+use zeron_proto::{SubagentEntry, SubagentTranscript, TodoItem, ToolCall};
+use serde_json::Value;
+
+/// Claude's config dir: `$CLAUDE_CONFIG_DIR` or `~/.claude` (same resolution
+/// as [`crate::agent_accounts::AgentAccountsConfig::detect`]).
+pub fn claude_config_dir() -> PathBuf {
+    std::env::var_os("CLAUDE_CONFIG_DIR")
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| crate::repos::home_dir().join(".claude"))
+}
+
+/// Entry cap per transcript — bounds the RPC payload; the tail is counted.
+const MAX_ENTRIES: usize = 500;
+/// Per-text-entry char cap. Sized off the real store: the largest final
+/// reports observed run ~44k chars, and the report is the whole payoff of
+/// expanding a subagent — a 16k cap visibly cut them mid-sentence.
+const MAX_TEXT_CHARS: usize = 64 * 1024;
+
+/// Claude Code's project-dir slug: every non-alphanumeric byte of the session
+/// cwd becomes `-` (`/Users/x/.dir` → `-Users-x--dir`).
+fn project_slug(cwd: &str) -> String {
+    cwd.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
+/// Locate the sidecar transcript for `tool_call_id` under one project's
+/// session dirs. Scans every session's `subagents/*.meta.json` rather than
+/// trusting a remembered session id: resumes re-mint the session UUID, but
+/// the sidecar stays filed under the id that was live when the Task ran.
+fn find_sidecar(projects_dir: &Path, cwd: &str, tool_call_id: &str) -> Option<(PathBuf, Value)> {
+    let project = projects_dir.join(project_slug(cwd));
+    let sessions = std::fs::read_dir(&project).ok()?;
+    for session in sessions.flatten() {
+        // The project dir holds the session dirs AND the sibling
+        // `{sessionId}.jsonl` transcripts; only the former can carry sidecars.
+        if !session.file_type().is_ok_and(|t| t.is_dir()) {
+            continue;
+        }
+        let subagents = session.path().join("subagents");
+        let Ok(metas) = std::fs::read_dir(&subagents) else {
+            continue;
+        };
+        for meta_entry in metas.flatten() {
+            let meta_path = meta_entry.path();
+            if meta_path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(meta) = std::fs::read_to_string(&meta_path)
+                .ok()
+                .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+            else {
+                continue;
+            };
+            if meta.get("toolUseId").and_then(Value::as_str) != Some(tool_call_id) {
+                continue;
+            }
+            // agent-{id}.meta.json → agent-{id}.jsonl. A matching id on a file
+            // that isn't `*.meta.json` keeps the scan going — it must not end
+            // the search for every remaining session.
+            let Some(stem) = meta_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .and_then(|n| n.strip_suffix(".meta.json"))
+            else {
+                continue;
+            };
+            return Some((subagents.join(format!("{stem}.jsonl")), meta));
+        }
+    }
+    None
+}
+
+/// Read the subagent transcript behind a Task tool call, or `None` when no
+/// sidecar exists (non-Claude harness, cleaned store, or foreign device).
+pub fn claude_subagent_transcript(
+    config_dir: &Path,
+    cwd: &str,
+    tool_call_id: &str,
+) -> std::io::Result<Option<SubagentTranscript>> {
+    let Some((jsonl, meta)) = find_sidecar(&config_dir.join("projects"), cwd, tool_call_id) else {
+        return Ok(None);
+    };
+    let raw = std::fs::read_to_string(&jsonl)?;
+    let mut entries = Vec::new();
+    let mut truncated_entries = 0usize;
+    let mut push = |entry: SubagentEntry| {
+        if entries.len() < MAX_ENTRIES {
+            entries.push(entry);
+        } else {
+            truncated_entries += 1;
+        }
+    };
+    for line in raw.lines() {
+        let Ok(row) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if row.get("type").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+        let Some(content) = row
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        // One Text entry per assistant message; tool_use blocks stay ordered.
+        let mut text = String::new();
+        for block in content {
+            match block.get("type").and_then(Value::as_str) {
+                Some("text") => {
+                    if let Some(t) = block.get("text").and_then(Value::as_str) {
+                        let t = t.trim();
+                        if !t.is_empty() {
+                            if !text.is_empty() {
+                                text.push_str("\n\n");
+                            }
+                            text.push_str(t);
+                        }
+                    }
+                }
+                Some("tool_use") => {
+                    if !text.is_empty() {
+                        push(SubagentEntry::Text {
+                            text: cap_text(std::mem::take(&mut text)),
+                        });
+                    }
+                    let name = block.get("name").and_then(Value::as_str).unwrap_or("");
+                    let input = block.get("input").unwrap_or(&Value::Null);
+                    push(SubagentEntry::Tool {
+                        call: native_tool_call(name, input),
+                    });
+                }
+                _ => {}
+            }
+        }
+        if !text.is_empty() {
+            push(SubagentEntry::Text {
+                text: cap_text(text),
+            });
+        }
+    }
+    Ok(Some(SubagentTranscript {
+        agent_type: meta
+            .get("agentType")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        description: meta
+            .get("description")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        entries,
+        truncated_entries,
+    }))
+}
+
+fn cap_text(text: String) -> String {
+    if text.chars().count() <= MAX_TEXT_CHARS {
+        return text;
+    }
+    let mut capped: String = text.chars().take(MAX_TEXT_CHARS).collect();
+    capped.push('…');
+    capped
+}
+
+/// Map a Claude-native tool_use (SDK names + input shapes, not ACP) to the
+/// typed [`ToolCall`] the transcript renders. Inputs are reduced to the same
+/// fields the render-parts policy would keep — no prompts, no file contents.
+fn native_tool_call(name: &str, input: &Value) -> ToolCall {
+    let s = |key: &str| -> Option<String> {
+        input
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|v| !v.is_empty())
+            .map(str::to_owned)
+    };
+    match name {
+        "Bash" => ToolCall::Exec {
+            command: s("command").unwrap_or_default(),
+        },
+        "Read" | "NotebookRead" => ToolCall::ReadFile {
+            path: s("file_path")
+                .or_else(|| s("notebook_path"))
+                .unwrap_or_default(),
+        },
+        "Write" => ToolCall::WriteFile {
+            path: s("file_path").unwrap_or_default(),
+            content: None,
+        },
+        "Edit" | "MultiEdit" | "NotebookEdit" => ToolCall::EditFile {
+            path: s("file_path")
+                .or_else(|| s("notebook_path"))
+                .unwrap_or_default(),
+            old_string: None,
+            new_string: None,
+        },
+        "Grep" => ToolCall::Search {
+            pattern: s("pattern").unwrap_or_default(),
+            path: s("path"),
+        },
+        "Glob" => ToolCall::Glob {
+            pattern: s("pattern").unwrap_or_default(),
+        },
+        "WebFetch" => ToolCall::WebFetch {
+            url: s("url").unwrap_or_default(),
+            prompt: None,
+        },
+        "WebSearch" => ToolCall::WebSearch {
+            query: s("query").unwrap_or_default(),
+        },
+        "TodoWrite" => ToolCall::Todo {
+            items: input
+                .get("todos")
+                .and_then(Value::as_array)
+                .map(|todos| {
+                    todos
+                        .iter()
+                        .filter_map(|t| {
+                            Some(TodoItem {
+                                text: t.get("content")?.as_str()?.to_owned(),
+                                done: t.get("status").and_then(Value::as_str) == Some("completed"),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+        },
+        "Task" | "Agent" => ToolCall::Task {
+            description: s("description").unwrap_or_default(),
+            agent_type: s("subagent_type"),
+            prompt: None,
+        },
+        _ => match name.strip_prefix("mcp__").map(|rest| rest.splitn(2, "__")) {
+            Some(mut parts) => {
+                let server = parts.next().unwrap_or_default().to_owned();
+                let tool = parts.next().unwrap_or(name).to_owned();
+                ToolCall::Mcp {
+                    server,
+                    tool,
+                    input: None,
+                }
+            }
+            None => ToolCall::Unknown {
+                name: name.to_owned(),
+                input: None,
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_matches_claude_code() {
+        assert_eq!(
+            project_slug("/Users/sina/fun/comet"),
+            "-Users-sina-fun-comet"
+        );
+        assert_eq!(
+            project_slug("/Users/sina/.zeron/worktrees/zeron-quiet-comet"),
+            "-Users-sina--zeron-worktrees-zeron-quiet-comet"
+        );
+    }
+
+    #[test]
+    fn native_calls_reduce_to_typed_variants() {
+        assert_eq!(
+            native_tool_call(
+                "Bash",
+                &serde_json::json!({"command": "ls", "description": "x"})
+            ),
+            ToolCall::Exec {
+                command: "ls".into()
+            }
+        );
+        assert_eq!(
+            native_tool_call(
+                "Grep",
+                &serde_json::json!({"pattern": "foo", "path": "src"})
+            ),
+            ToolCall::Search {
+                pattern: "foo".into(),
+                path: Some("src".into())
+            }
+        );
+        assert_eq!(
+            native_tool_call("mcp__linear__create_issue", &Value::Null),
+            ToolCall::Mcp {
+                server: "linear".into(),
+                tool: "create_issue".into(),
+                input: None
+            }
+        );
+        assert_eq!(
+            native_tool_call("Skill", &serde_json::json!({"skill": "run"})),
+            ToolCall::Unknown {
+                name: "Skill".into(),
+                input: None
+            }
+        );
+    }
+
+    fn write_fixture(root: &Path, cwd: &str, session: &str, agent: &str, tool_use_id: &str) {
+        let dir = root
+            .join("projects")
+            .join(project_slug(cwd))
+            .join(session)
+            .join("subagents");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(format!("agent-{agent}.meta.json")),
+            serde_json::json!({
+                "agentType": "Explore",
+                "description": "Map the repo",
+                "toolUseId": tool_use_id,
+                "spawnDepth": 1,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        // Real shape: ONE content block per row (a single reply is split
+        // across rows sharing `message.id`), `thinking` blocks interleaved,
+        // and `attachment` rows between them.
+        let lines = [
+            serde_json::json!({"type": "user", "message": {"role": "user", "content": "prompt"}}),
+            serde_json::json!({"type": "assistant", "message": {"role": "assistant", "id": "m1", "content": [
+                {"type": "thinking", "thinking": "", "signature": "sig"},
+            ]}}),
+            serde_json::json!({"type": "assistant", "message": {"role": "assistant", "id": "m1", "content": [
+                {"type": "text", "text": "Scanning the crates."},
+            ]}}),
+            serde_json::json!({"type": "assistant", "message": {"role": "assistant", "id": "m1", "content": [
+                {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls crates"}},
+            ]}}),
+            serde_json::json!({"type": "attachment", "subtype": "skill_listing"}),
+            serde_json::json!({"type": "assistant", "message": {"role": "assistant", "id": "m1", "content": [
+                {"type": "tool_use", "id": "t2", "name": "Read", "input": {"file_path": "/a/b.rs"}},
+            ]}}),
+            serde_json::json!({"type": "assistant", "message": {"role": "assistant", "id": "m2", "content": [
+                {"type": "text", "text": "Done."},
+            ]}}),
+            serde_json::json!({"type": "assistant", "message": {"role": "assistant", "id": "m2", "content": [
+                {"type": "text", "text": "Report body."},
+            ]}}),
+        ];
+        let body: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+        std::fs::write(dir.join(format!("agent-{agent}.jsonl")), body.join("\n")).unwrap();
+    }
+
+    #[test]
+    fn reads_transcript_by_tool_use_id_across_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = "/tmp/proj";
+        write_fixture(tmp.path(), cwd, "session-a", "aaa", "toolu_other");
+        write_fixture(tmp.path(), cwd, "session-b", "bbb", "toolu_match");
+
+        let got = claude_subagent_transcript(tmp.path(), cwd, "toolu_match")
+            .unwrap()
+            .expect("sidecar found");
+        assert_eq!(got.agent_type.as_deref(), Some("Explore"));
+        assert_eq!(got.description.as_deref(), Some("Map the repo"));
+        assert_eq!(got.truncated_entries, 0);
+        assert_eq!(
+            got.entries,
+            vec![
+                SubagentEntry::Text {
+                    text: "Scanning the crates.".into()
+                },
+                SubagentEntry::Tool {
+                    call: ToolCall::Exec {
+                        command: "ls crates".into()
+                    }
+                },
+                SubagentEntry::Tool {
+                    call: ToolCall::ReadFile {
+                        path: "/a/b.rs".into()
+                    }
+                },
+                // One-block-per-row means a split reply stays two entries;
+                // the renderer joins them with a single blank line.
+                SubagentEntry::Text {
+                    text: "Done.".into()
+                },
+                SubagentEntry::Text {
+                    text: "Report body.".into()
+                },
+            ]
+        );
+
+        assert!(
+            claude_subagent_transcript(tmp.path(), cwd, "toolu_missing")
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            claude_subagent_transcript(tmp.path(), "/elsewhere", "toolu_match")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// Nested subagents (spawnDepth 2–3) are filed FLAT beside their ancestors
+    /// under the root session's dir, with an extra `parentAgentId`. Keying the
+    /// scan on the globally-unique `toolUseId` resolves them with no special
+    /// case — a nested Agent chip drills in exactly like a top-level one.
+    #[test]
+    fn resolves_a_nested_subagent_filed_beside_its_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = "/tmp/proj";
+        write_fixture(tmp.path(), cwd, "root-session", "parent", "toolu_parent");
+        let dir = tmp
+            .path()
+            .join("projects")
+            .join(project_slug(cwd))
+            .join("root-session")
+            .join("subagents");
+        std::fs::write(
+            dir.join("agent-child.meta.json"),
+            serde_json::json!({
+                "agentType": "general-purpose",
+                "description": "Nested probe",
+                "toolUseId": "toolu_child",
+                "parentAgentId": "parent",
+                "spawnDepth": 2,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("agent-child.jsonl"),
+            serde_json::json!({"type": "assistant", "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "n1", "name": "Agent",
+                 "input": {"description": "deeper", "subagent_type": "Explore", "prompt": "secret"}},
+            ]}})
+            .to_string(),
+        )
+        .unwrap();
+
+        let got = claude_subagent_transcript(tmp.path(), cwd, "toolu_child")
+            .unwrap()
+            .expect("nested sidecar found");
+        assert_eq!(got.description.as_deref(), Some("Nested probe"));
+        assert_eq!(
+            got.entries,
+            // The nested spawn keeps its own Task chip — and the prompt never
+            // leaves the host (same policy as the doc's render parts).
+            vec![SubagentEntry::Tool {
+                call: ToolCall::Task {
+                    description: "deeper".into(),
+                    agent_type: Some("Explore".into()),
+                    prompt: None,
+                }
+            }]
+        );
+        // The parent still resolves from the same directory.
+        assert!(
+            claude_subagent_transcript(tmp.path(), cwd, "toolu_parent")
+                .unwrap()
+                .is_some()
+        );
+    }
+}

--- a/crates/harness/src/acp/normalize.rs
+++ b/crates/harness/src/acp/normalize.rs
@@ -261,19 +261,13 @@ fn typed_call(update: &Value) -> ToolCall {
                 }
             }
         }
-        _ if raw_str("_toolName").as_deref() == Some("task") => ToolCall::Unknown {
-            name: raw_str("description")
+        _ if raw_str("_toolName").as_deref() == Some("task") => ToolCall::Task {
+            description: raw_str("description")
                 .filter(|d| d != "Subagent task")
-                .map(|d| format!("Task: {d}"))
                 .or_else(|| arg_from_title(&title))
-                .unwrap_or_else(|| {
-                    if title.is_empty() {
-                        "Task".into()
-                    } else {
-                        title
-                    }
-                }),
-            input: raw.cloned(),
+                .unwrap_or_default(),
+            agent_type: raw_str("subagent_type").or_else(|| raw_str("subagentType")),
+            prompt: raw_str("prompt"),
         },
         _ => ToolCall::Unknown {
             name: if title.is_empty() { kind.into() } else { title },
@@ -827,19 +821,17 @@ mod tests {
                 "_toolName": "task",
                 "description": "Look up multitask docs",
                 "prompt": "find the reminder",
+                "subagent_type": "Explore",
             },
         });
         assert_eq!(
             map_update(&update),
             vec![AgentEvent::ToolCall {
                 id: "t1".into(),
-                call: ToolCall::Unknown {
-                    name: "Task: Look up multitask docs".into(),
-                    input: Some(json!({
-                        "_toolName": "task",
-                        "description": "Look up multitask docs",
-                        "prompt": "find the reminder",
-                    })),
+                call: ToolCall::Task {
+                    description: "Look up multitask docs".into(),
+                    agent_type: Some("Explore".into()),
+                    prompt: Some("find the reminder".into()),
                 },
             }]
         );

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -174,11 +174,46 @@ pub enum ToolCall {
         #[serde(skip_serializing_if = "Option::is_none")]
         input: Option<serde_json::Value>,
     },
+    /// A subagent run (Claude Code's Agent/Task tool). The id of the part
+    /// carrying this call doubles as the key into the harness's on-disk
+    /// subagent transcript (`SubagentTranscript` RPC).
+    Task {
+        description: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        agent_type: Option<String>,
+        /// Full subagent prompt; STRIPPED by the render-parts policy before
+        /// entering the doc (journal-only, like WriteFile content).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        prompt: Option<String>,
+    },
     Unknown {
         name: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         input: Option<serde_json::Value>,
     },
+}
+
+/// A subagent's transcript, read back from the harness's on-disk sidecar by
+/// the `SubagentTranscript` RPC (host-device local, like tool blobs).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubagentTranscript {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub entries: Vec<SubagentEntry>,
+    /// Entries dropped past the cap; 0 when complete.
+    #[serde(default)]
+    pub truncated_entries: usize,
+}
+
+/// One step of a subagent transcript: prose or a tool invocation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum SubagentEntry {
+    Text { text: String },
+    Tool { call: ToolCall },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/proto/src/view.rs
+++ b/crates/proto/src/view.rs
@@ -424,6 +424,17 @@ fn tool_chip_content_raw(call: &crate::ToolCall) -> (&'static str, String) {
             ("Todo", format!("{done}/{} done", items.len()))
         }
         ToolCall::Mcp { server, tool, .. } => ("MCP", format!("{server} · {tool}")),
+        ToolCall::Task {
+            description,
+            agent_type,
+            ..
+        } => (
+            "Agent",
+            match agent_type {
+                Some(agent) if !agent.is_empty() => format!("{agent} · {description}"),
+                _ => description.clone(),
+            },
+        ),
         ToolCall::Unknown { name, .. } => ("Tool", name.clone()),
     }
 }
@@ -465,7 +476,7 @@ pub fn tool_group_summary(tools: &[(crate::ToolCall, bool)]) -> String {
             }
             ToolCall::WebFetch { .. } => fetches += 1,
             ToolCall::Todo { .. } => todos += 1,
-            ToolCall::Mcp { .. } | ToolCall::Unknown { .. } => other += 1,
+            ToolCall::Mcp { .. } | ToolCall::Task { .. } | ToolCall::Unknown { .. } => other += 1,
         }
     }
     let mut segments: Vec<String> = Vec::new();

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -126,6 +126,10 @@ pub mod methods {
     /// Lazy full-tool-output fetch from the R2 sidecar by doc-resident ref
     /// (chat2-sync A3). Edge-direct from any device — never relay-forwarded.
     pub const FETCH_TOOL_BLOB: &str = "FetchToolBlob";
+    /// Read a subagent's transcript (a Task tool call's inner activity) from
+    /// the harness's on-disk sidecar. Relay-forwardable — the files live on
+    /// the chat's host device (claude-code only today).
+    pub const SUBAGENT_TRANSCRIPT: &str = "SubagentTranscript";
     // Updates (ControlRpc, relay-forwardable — a device reports/applies its own
     // binary's update). Stream: current UpdateStatus, then every change.
     pub const UPDATE_STATUS: &str = "UpdateStatus";

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -239,6 +239,10 @@ pub struct ToolItem {
     pub output_bytes: Option<u64>,
     /// Sidecar key of the full diff (doc carries only per-file stats).
     pub diff_ref: Option<SharedString>,
+    /// The part id of a Task (subagent) call — the harness-native tool_use id
+    /// that keys the subagent's on-disk transcript. Expanding offers a lazy
+    /// "Show subagent activity" fetch (`SubagentTranscript` RPC).
+    pub subagent_id: Option<SharedString>,
 }
 
 /// A chip's expandable detail payload.
@@ -391,6 +395,21 @@ pub fn call_block(call: &ToolCall) -> Option<ToolDetail> {
             ),
             None => format!("{server} · {tool}"),
         },
+        ToolCall::Task {
+            description,
+            agent_type,
+            prompt,
+        } => {
+            let mut text = match agent_type {
+                Some(agent) if !agent.is_empty() => format!("{agent} · {description}"),
+                _ => description.clone(),
+            };
+            if let Some(prompt) = prompt {
+                text.push('\n');
+                text.push_str(prompt);
+            }
+            text
+        }
         ToolCall::Unknown { name, input } => match input {
             Some(input) => format!(
                 "{name}\n{}",
@@ -714,6 +733,7 @@ pub fn rows_for_entry(
     for (part_ix, part) in entry.parts.iter().enumerate() {
         match part {
             MessagePart::Tool {
+                id: part_id,
                 call,
                 is_error,
                 resolved,
@@ -735,6 +755,8 @@ pub fn rows_for_entry(
                     output_ref: output_ref.clone().map(SharedString::from),
                     output_bytes: *output_bytes,
                     diff_ref: diff_ref.clone().map(SharedString::from),
+                    subagent_id: matches!(call, ToolCall::Task { .. })
+                        .then(|| SharedString::from(part_id.clone())),
                 });
                 group_last_part_ix = part_ix;
             }
@@ -1080,6 +1102,56 @@ fn blob_detail(text: &str, is_diff: bool) -> Option<ToolDetail> {
         .collect();
     while lines.last().is_some_and(|l| l.trim().is_empty()) {
         lines.pop();
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    let truncated_by = lines.len().saturating_sub(FULL_OUTPUT_MAX_LINES);
+    lines.truncate(FULL_OUTPUT_MAX_LINES);
+    Some(ToolDetail::Output {
+        lines,
+        truncated_by,
+    })
+}
+
+/// Build a fetched subagent transcript's detail block: one line per tool step
+/// (the chip vocabulary — "Run · cargo test"), prose blocks soft-wrapped like
+/// invocation lines. Reuses the output payload so rendering and the analytic
+/// height stay one implementation.
+fn subagent_detail(transcript: &zeron_proto::SubagentTranscript) -> Option<ToolDetail> {
+    let mut lines: Vec<SharedString> = Vec::new();
+    for entry in &transcript.entries {
+        match entry {
+            zeron_proto::SubagentEntry::Tool { call } => {
+                let (label, detail) = tool_chip_content(call);
+                lines.push(SharedString::from(if detail.is_empty() {
+                    label.to_owned()
+                } else {
+                    format!("{label} · {detail}")
+                }));
+            }
+            zeron_proto::SubagentEntry::Text { text } => {
+                // Claude Code writes ONE content block per row, so a single
+                // reply arrives as consecutive Text entries — separate them by
+                // exactly one blank line, never two.
+                if lines.last().is_some_and(|l| !l.is_empty()) {
+                    lines.push(SharedString::default());
+                }
+                for raw in text.lines() {
+                    lines.extend(wrap_cols(raw, CALL_WRAP_COLS));
+                }
+                lines.push(SharedString::default());
+            }
+        }
+    }
+    while lines.last().is_some_and(|l| l.trim().is_empty()) {
+        lines.pop();
+    }
+    if transcript.truncated_entries > 0 {
+        lines.push(SharedString::from(format!(
+            "… {} more steps",
+            transcript.truncated_entries
+        )));
     }
     if lines.is_empty() {
         return None;
@@ -1446,9 +1518,15 @@ pub struct Transcript {
     /// Deliberately NOT cleared on chat switch: refs are chat-qualified and a
     /// fetched blob stays valid.
     blob_details: HashMap<SharedString, BlobFetch>,
-    /// Monotonic fetch order per blob ref: when a tool has BOTH a diff and
-    /// an output blob fetched, the chip shows the one requested most
-    /// recently (click "Show full output" after a diff → see the output).
+    /// Subagent transcripts keyed by the Task call's tool id — the same
+    /// lifecycle and upgrade rules as `blob_details`, fetched from the chat's
+    /// host device instead of the edge. Kept across chat switches for the same
+    /// reason: a tool id names one call forever.
+    subagent_details: HashMap<SharedString, BlobFetch>,
+    /// Monotonic fetch order per target (see [`FetchTarget::order_key`]): when
+    /// a tool has BOTH a diff and an output blob fetched, the chip shows the
+    /// one requested most recently (click "Show full output" after a diff →
+    /// see the output).
     blob_fetch_order: HashMap<SharedString, u64>,
     blob_fetch_counter: u64,
     _observe: Subscription,
@@ -1460,6 +1538,48 @@ enum BlobFetch {
     /// Failed with the affordance re-armed as a retry.
     Failed,
     Ready(Arc<ToolDetail>),
+}
+
+/// What an expanded chip's fetch affordance pulls: a sidecar blob (full output
+/// or diff, edge-direct) or a subagent transcript (host-device disk). Both
+/// upgrade the chip's detail in place, so they share the recency ordering.
+#[derive(Debug, Clone, PartialEq)]
+enum FetchTarget {
+    Blob(SharedString),
+    Subagent(SharedString),
+}
+
+impl FetchTarget {
+    /// Key into the shared recency map. Namespaced because the two id spaces
+    /// are unrelated (`chatId/partId` vs a harness tool id).
+    fn order_key(&self) -> SharedString {
+        match self {
+            FetchTarget::Blob(r) => r.clone(),
+            FetchTarget::Subagent(id) => SharedString::from(format!("sub:{id}")),
+        }
+    }
+}
+
+/// Every lazily-fetchable upgrade a chip offers — `(target, noun, size)` — in
+/// the order the affordance row prefers them. A subagent transcript comes
+/// first: for a Task chip it is the whole story, and the doc-resident detail
+/// is just the description line.
+fn fetch_targets(tool: &ToolItem) -> Vec<(FetchTarget, &'static str, Option<u64>)> {
+    let mut out = Vec::new();
+    if let Some(id) = &tool.subagent_id {
+        out.push((FetchTarget::Subagent(id.clone()), "subagent activity", None));
+    }
+    if let Some(r) = &tool.diff_ref {
+        out.push((FetchTarget::Blob(r.clone()), "full diff", None));
+    }
+    if let Some(r) = &tool.output_ref {
+        out.push((
+            FetchTarget::Blob(r.clone()),
+            "full output",
+            tool.output_bytes,
+        ));
+    }
+    out
 }
 
 impl Transcript {
@@ -1514,6 +1634,7 @@ impl Transcript {
             attachment_loads: HashMap::new(),
             attachment_retries: HashMap::new(),
             blob_details: HashMap::new(),
+            subagent_details: HashMap::new(),
             blob_fetch_order: HashMap::new(),
             blob_fetch_counter: 0,
             _observe: observe,
@@ -2406,6 +2527,101 @@ impl Transcript {
         self.blob_details.insert(blob_ref, BlobFetch::Loading(task));
     }
 
+    /// Lifecycle of a fetch target, whichever store backs it.
+    fn fetch_state(&self, target: &FetchTarget) -> Option<&BlobFetch> {
+        match target {
+            FetchTarget::Blob(r) => self.blob_details.get(r),
+            FetchTarget::Subagent(id) => self.subagent_details.get(id),
+        }
+    }
+
+    fn fetch_order(&self, target: &FetchTarget) -> u64 {
+        self.blob_fetch_order
+            .get(&target.order_key())
+            .copied()
+            .unwrap_or(0)
+    }
+
+    fn spawn_fetch(&mut self, target: FetchTarget, cx: &mut Context<Self>) {
+        match target {
+            FetchTarget::Blob(r) => self.spawn_blob_fetch(r, cx),
+            FetchTarget::Subagent(id) => self.spawn_subagent_fetch(id, cx),
+        }
+    }
+
+    /// Fetch a Task call's subagent transcript — the steps the subagent ran,
+    /// which never cross the ACP wire — from the chat's host device, and build
+    /// its detail once, off the render path. Same re-entry rules as
+    /// [`Self::spawn_blob_fetch`]: Ready re-ranks, Loading no-ops, Failed
+    /// re-arms as a retry.
+    fn spawn_subagent_fetch(&mut self, tool_call_id: SharedString, cx: &mut Context<Self>) {
+        self.blob_fetch_counter += 1;
+        self.blob_fetch_order.insert(
+            FetchTarget::Subagent(tool_call_id.clone()).order_key(),
+            self.blob_fetch_counter,
+        );
+        match self.subagent_details.get(&tool_call_id) {
+            Some(BlobFetch::Ready(_)) => {
+                cx.notify();
+                return;
+            }
+            Some(BlobFetch::Loading(_)) => return,
+            Some(BlobFetch::Failed) | None => {}
+        }
+        let Some(chat_id) = self.chat_id.clone() else {
+            return;
+        };
+        // The sidecar files live on the chat's HOST device; target the relay
+        // when that isn't us (the engine rejects a foreign chat outright).
+        let (engine, target_device) = {
+            let state = self.state.read(cx);
+            let Some(engine) = state.engine().cloned() else {
+                return;
+            };
+            let target = state
+                .chats
+                .iter()
+                .find(|c| c.id == chat_id)
+                .map(|c| c.device_id.clone())
+                .filter(|d| state.local_device_id.as_deref() != Some(d.as_str()));
+            (engine, target)
+        };
+        let key = tool_call_id.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let mut params = serde_json::json!({
+                "chatId": chat_id,
+                "toolCallId": key.as_ref(),
+            });
+            if let (Some(target), Some(map)) = (target_device, params.as_object_mut()) {
+                map.insert("targetDeviceId".into(), target.into());
+            }
+            let reply = crate::attachments::call_with_timeout(
+                &engine,
+                cx.background_executor(),
+                zeron_rpc::methods::SUBAGENT_TRANSCRIPT,
+                params,
+                Duration::from_secs(20),
+            )
+            .await;
+            let fetched = match reply {
+                Ok(value) => serde_json::from_value::<zeron_proto::SubagentTranscript>(value)
+                    .ok()
+                    .as_ref()
+                    .and_then(subagent_detail)
+                    .map(|d| BlobFetch::Ready(Arc::new(d)))
+                    .unwrap_or(BlobFetch::Failed),
+                Err(_) => BlobFetch::Failed,
+            };
+            this.update(cx, |this, cx| {
+                this.subagent_details.insert(key, fetched);
+                cx.notify();
+            })
+            .ok();
+        });
+        self.subagent_details
+            .insert(tool_call_id, BlobFetch::Loading(task));
+    }
+
     fn toggle_fold(&mut self, row_id: SharedString, open_height: f32, auto_open: bool) {
         let entry = self.folds.entry(row_id).or_default();
         let currently_open = entry.open.unwrap_or(auto_open);
@@ -3088,9 +3304,9 @@ impl Transcript {
                 // a tool can carry both a diff and an output ref, and the
                 // user's last click decides which upgrade is showing.
                 let mut best: Option<(u64, Arc<ToolDetail>)> = None;
-                for blob_ref in [&tool.diff_ref, &tool.output_ref].into_iter().flatten() {
-                    if let Some(BlobFetch::Ready(detail)) = self.blob_details.get(blob_ref) {
-                        let order = self.blob_fetch_order.get(blob_ref).copied().unwrap_or(0);
+                for (target, _, _) in fetch_targets(tool) {
+                    if let Some(BlobFetch::Ready(detail)) = self.fetch_state(&target) {
+                        let order = self.fetch_order(&target);
                         if best.as_ref().is_none_or(|(o, _)| order > *o) {
                             best = Some((order, detail.clone()));
                         }
@@ -3108,47 +3324,43 @@ impl Transcript {
         // upgrade), then the output — a fetched ref hands the affordance to
         // the NEXT unfetched one instead of retiring it (both must stay
         // reachable when a tool has both).
-        let affordances: Vec<Option<(SharedString, SharedString)>> = tools
+        let affordances: Vec<Option<(FetchTarget, SharedString)>> = tools
             .iter()
             .map(|tool| {
-                // The currently-displayed ref (same recency rule as
+                let targets = fetch_targets(tool);
+                // The currently-displayed target (same recency rule as
                 // `details` above): its affordance is spent; any OTHER
-                // Ready ref stays offered as a no-fetch toggle.
-                let shown: Option<&SharedString> = {
-                    let mut best: Option<(u64, &SharedString)> = None;
-                    for blob_ref in [&tool.diff_ref, &tool.output_ref].into_iter().flatten() {
-                        if matches!(self.blob_details.get(blob_ref), Some(BlobFetch::Ready(_))) {
-                            let order = self.blob_fetch_order.get(blob_ref).copied().unwrap_or(0);
+                // Ready target stays offered as a no-fetch toggle.
+                let shown: Option<FetchTarget> = {
+                    let mut best: Option<(u64, &FetchTarget)> = None;
+                    for (target, _, _) in &targets {
+                        if matches!(self.fetch_state(target), Some(BlobFetch::Ready(_))) {
+                            let order = self.fetch_order(target);
                             if best.is_none_or(|(o, _)| order > o) {
-                                best = Some((order, blob_ref));
+                                best = Some((order, target));
                             }
                         }
                     }
-                    best.map(|(_, r)| r)
+                    best.map(|(_, t)| t.clone())
                 };
-                let candidates = [
-                    (tool.diff_ref.as_ref(), "diff", None),
-                    (tool.output_ref.as_ref(), "output", tool.output_bytes),
-                ];
-                for (blob_ref, what, bytes) in candidates {
-                    let Some(blob_ref) = blob_ref else { continue };
-                    let label = match self.blob_details.get(blob_ref) {
+                for (target, what, bytes) in targets {
+                    let label = match self.fetch_state(&target) {
                         Some(BlobFetch::Ready(_)) => {
-                            if shown == Some(blob_ref) {
+                            if shown.as_ref() == Some(&target) {
                                 continue;
                             }
-                            format!("Show full {what}")
+                            format!("Show {what}")
                         }
-                        Some(BlobFetch::Loading(_)) => format!("Loading full {what}…"),
+                        Some(BlobFetch::Loading(_)) => format!("Loading {what}…"),
                         Some(BlobFetch::Failed) => {
-                            format!("Couldn't load full {what} — tap to retry")
+                            format!("Couldn't load {what} — tap to retry")
                         }
                         None => match bytes {
-                            Some(b) => format!("Show full {what} ({})", format_kb(b)),
-                            None => format!("Show full {what}"),
+                            Some(b) => format!("Show {what} ({})", format_kb(b)),
+                            None => format!("Show {what}"),
                         },
                     };
-                    return Some((blob_ref.clone(), SharedString::from(label)));
+                    return Some((target, SharedString::from(label)));
                 }
                 None
             })
@@ -3363,11 +3575,9 @@ impl Transcript {
                             )
                             .child(detail_body(detail, detail_highlights[ix].clone(), theme));
                     }
-                    if let Some((blob_ref, label)) = affordance {
-                        let loading = matches!(
-                            self.blob_details.get(&blob_ref),
-                            Some(BlobFetch::Loading(_))
-                        );
+                    if let Some((target, label)) = affordance {
+                        let loading =
+                            matches!(self.fetch_state(&target), Some(BlobFetch::Loading(_)));
                         let mut row = div()
                             .id(SharedString::from(format!("{key}-blob")))
                             .h(px(BLOB_AFFORDANCE_HEIGHT))
@@ -3383,7 +3593,7 @@ impl Transcript {
                                 .cursor_pointer()
                                 .hover(|s| s.text_color(theme.text_muted))
                                 .on_click(cx.listener(move |this, _, _, cx| {
-                                    this.spawn_blob_fetch(blob_ref.clone(), cx);
+                                    this.spawn_fetch(target.clone(), cx);
                                     cx.notify();
                                 }));
                         }
@@ -3682,6 +3892,7 @@ fn tool_icon_path(call: &ToolCall) -> &'static str {
         ToolCall::Glob { .. } => crate::icons::FOLDER_WITH_FILES,
         ToolCall::WebFetch { .. } | ToolCall::WebSearch { .. } => crate::icons::GLOBAL,
         ToolCall::Todo { .. } => crate::icons::CHECKLIST,
+        ToolCall::Task { .. } => crate::icons::CHAT_ROUND_LINE,
         ToolCall::Mcp { .. } | ToolCall::Unknown { .. } => crate::icons::WIDGET,
     }
 }
@@ -4588,6 +4799,118 @@ mod tests {
     }
 
     #[test]
+    fn subagent_detail_lists_steps_in_chip_language() {
+        use zeron_proto::{SubagentEntry, SubagentTranscript};
+        let transcript = SubagentTranscript {
+            agent_type: Some("Explore".into()),
+            description: Some("Map the repo".into()),
+            entries: vec![
+                SubagentEntry::Text {
+                    text: "Scanning.".into(),
+                },
+                SubagentEntry::Tool {
+                    call: ToolCall::Exec {
+                        command: "ls crates".into(),
+                    },
+                },
+                SubagentEntry::Tool {
+                    call: ToolCall::ReadFile {
+                        path: "a/b.rs".into(),
+                    },
+                },
+            ],
+            truncated_entries: 3,
+        };
+        let Some(ToolDetail::Output {
+            lines,
+            truncated_by,
+        }) = subagent_detail(&transcript)
+        else {
+            panic!("expected an output block");
+        };
+        assert_eq!(truncated_by, 0);
+        assert_eq!(
+            lines.iter().map(|l| l.as_ref()).collect::<Vec<_>>(),
+            vec![
+                "Scanning.",
+                "",
+                "Run · ls crates",
+                "Read · a/b.rs",
+                "… 3 more steps",
+            ]
+        );
+        // An empty transcript has nothing to show (no empty card).
+        assert!(
+            subagent_detail(&SubagentTranscript {
+                agent_type: None,
+                description: None,
+                entries: Vec::new(),
+                truncated_entries: 0,
+            })
+            .is_none()
+        );
+        // Claude Code splits one reply across rows, so consecutive Text
+        // entries are the norm — they get ONE blank line between them.
+        let split = SubagentTranscript {
+            agent_type: None,
+            description: None,
+            entries: vec![
+                SubagentEntry::Text {
+                    text: "Done.".into(),
+                },
+                SubagentEntry::Text {
+                    text: "Report body.".into(),
+                },
+            ],
+            truncated_entries: 0,
+        };
+        let Some(ToolDetail::Output { lines, .. }) = subagent_detail(&split) else {
+            panic!("expected an output block");
+        };
+        assert_eq!(
+            lines.iter().map(|l| l.as_ref()).collect::<Vec<_>>(),
+            vec!["Done.", "", "Report body."]
+        );
+    }
+
+    #[test]
+    fn task_chip_offers_the_subagent_affordance() {
+        let task = ToolItem {
+            call: ToolCall::Task {
+                description: "Map the repo".into(),
+                agent_type: Some("Explore".into()),
+                prompt: None,
+            },
+            is_error: false,
+            resolved: true,
+            detail: None,
+            invocation: None,
+            output_ref: None,
+            output_bytes: None,
+            diff_ref: None,
+            subagent_id: Some("toolu_abc".into()),
+        };
+        let targets = fetch_targets(&task);
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].0, FetchTarget::Subagent("toolu_abc".into()));
+        assert_eq!(targets[0].1, "subagent activity");
+        // The chip reads as an agent run, not a generic tool.
+        assert_eq!(
+            tool_chip_content(&task.call),
+            ("Agent", "Explore · Map the repo".to_string())
+        );
+        // A plain tool offers nothing to fetch when the doc carries it all.
+        let exec = ToolItem {
+            call: ToolCall::Exec {
+                command: "ls".into(),
+            },
+            subagent_id: None,
+            ..task
+        };
+        assert!(fetch_targets(&exec).is_empty());
+    }
+
+    #[test]
     fn tool_group_summaries() {
         let exec = |c: &str| ToolItem {
             call: ToolCall::Exec { command: c.into() },
@@ -4598,6 +4921,7 @@ mod tests {
             output_ref: None,
             output_bytes: None,
             diff_ref: None,
+            subagent_id: None,
         };
         let edit = |p: &str| ToolItem {
             call: ToolCall::EditFile {
@@ -4612,6 +4936,7 @@ mod tests {
             output_ref: None,
             output_bytes: None,
             diff_ref: None,
+            subagent_id: None,
         };
         let tools = vec![
             exec("ls"),
@@ -4642,6 +4967,7 @@ mod tests {
                 output_ref: None,
                 output_bytes: None,
                 diff_ref: None,
+                subagent_id: None,
             },
             ToolItem {
                 call: ToolCall::Glob {
@@ -4654,6 +4980,7 @@ mod tests {
                 output_ref: None,
                 output_bytes: None,
                 diff_ref: None,
+                subagent_id: None,
             },
             ToolItem {
                 call: ToolCall::WebSearch { query: "q".into() },
@@ -4664,6 +4991,7 @@ mod tests {
                 output_ref: None,
                 output_bytes: None,
                 diff_ref: None,
+                subagent_id: None,
             },
         ];
         assert_eq!(tool_group_summary(&tools), "Read 1 file · searched 2 times");


### PR DESCRIPTION
## The problem

A subagent shows up in the transcript as a single opaque chip. The ACP stream carries the Task call and the subagent's final report, but never the steps it ran — so "what did it actually look at?" had no answer in the UI.

## Where the data comes from

Those steps do exist on disk. Claude Code writes every subagent's transcript beside the parent session:

```
~/.claude/projects/{slug(cwd)}/{sessionId}/subagents/
├── agent-{id}.jsonl        # the transcript
└── agent-{id}.meta.json    # {"agentType", "description", "toolUseId", "spawnDepth"}
```

`toolUseId` is the same id comet already stores on the doc's tool part — it survives verbatim from the ACP adapter through `AgentEvent` and the run journal into the part — so a chip on screen maps to exactly one sidecar file with no new bookkeeping.

## What changed

- **proto** — `ToolCall::Task { description, agent_type, prompt }`, so a subagent is a first-class chip (`Agent · Explore · Map the repo`) instead of `Unknown`. The ACP `_toolName == "task"` arm mints it.
- **doc** — `sanitize_tool_call` keeps description and agent type, strips the prompt (journal-only, the same policy as `WriteFile` content).
- **engine** — `subagents.rs` resolves the cwd slug, scans sessions for the matching `toolUseId`, and reduces Claude-native `tool_use` blocks to typed `ToolCall`s, dropping prompts and file contents exactly like the doc policy does.
- **rpc** — `SubagentTranscript`, relay-forwardable (the files live on the chat's host device), gated on chat ownership.
- **ui** — the expanded chip offers **"Show subagent activity"**, reusing the existing sidecar-blob fetch lifecycle (loading/failed/retry labels, recency ordering, analytic heights, RESIZE tween) through a shared `FetchTarget`.

## Claude Code only

**This works for the Claude Code harness and nothing else.** No other agent writes these sidecar files, so there is nothing to read for Codex, Cursor, Grok, Hermes, or Pi. The RPC checks the chat's harness and returns an explicit error for anything else.

One consequence worth flagging for review: `_toolName == "task"` is generic ACP, so a Cursor subagent also becomes a `ToolCall::Task` chip and is therefore *offered* the affordance — clicking it fails with "Couldn't load subagent activity". Gating the affordance on the chat's harness in the UI is a small follow-up; I left it out to keep this diff to one concern.

Also: the reader is read-only and never writes into the harness's store, and a missing or cleaned-up sidecar degrades to a normal failed-fetch label rather than an error state.

## Sizes taken from the real store, not guessed

Measured against 26 agent transcripts / 3,388 rows on disk:

- Text blocks cap at **64k chars** — observed final reports reach ~44k, and an earlier 16k cap visibly cut them mid-sentence.
- Claude Code writes **one content block per row** (2019 of 2019 assistant rows), so a single reply arrives as consecutive `Text` entries; the renderer joins them with exactly one blank line.
- **Nested subagents** (`spawnDepth` up to 3) are filed *flat* beside their ancestors with an extra `parentAgentId`. Because the scan keys on the globally-unique `toolUseId`, they resolve with no special case — a nested chip drills in like a top-level one. Covered by a test.
- `thinking` blocks are skipped (all 561 on disk are empty, carrying only a signature).

## Testing

- 6 new tests: sidecar resolution across sessions, nested-subagent resolution, native tool-name mapping, the cwd slug, and the two UI renderer cases.
- `zeron-ui` 425, `zeron-engine` 59, `zeron-doc` 71, `zeron-proto` 18 — all green on this base.
- Verified end to end against the real store: a live subagent's transcript was read back through the full path (31 entries, 22 tool steps, nothing truncated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789422731&installation_model_id=425430&pr_number=114&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F114&signature=9545e4b628c1c1836c2615011e9eacd2e94abd518678365c5f41589c84fdfc8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->