### PR TITLE
Transcript: end-of-turn edit summary card with click-through to a turn-diff tab

### DIFF
--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -102,6 +102,98 @@ pub fn diff_stat(diff: &ToolDiff) -> ToolDiffStat {
     }
 }
 
+/// One file's aggregate in the end-of-turn edit summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnFileEdit {
+    pub path: String,
+    /// Summed `(additions, deletions)` across the turn's edits of this file;
+    /// `None` when no diff reached the doc for it (the harness attached no
+    /// diff content — the file still counts as edited).
+    pub counts: Option<(u64, u64)>,
+}
+
+/// The end-of-turn "Edited N files · +X −Y" recap a settled assistant entry
+/// shows under its reply (Codex/Cursor-style change summary).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnEdits {
+    /// One entry per file, in first-touched order.
+    pub files: Vec<TurnFileEdit>,
+    /// Totals over the files that carry counts.
+    pub additions: u64,
+    pub deletions: u64,
+}
+
+/// Aggregate a settled entry's tool parts into its edit summary, or `None`
+/// when the turn edited nothing.
+///
+/// Sources, best first: `diff_stats` (post-strip docs), the inline `diff`
+/// (pre-strip docs), else the edit-shaped call's own path with unknown
+/// counts. Failed and unresolved calls changed nothing — an aborted edit may
+/// never have run — so neither contributes. Shell-side edits (an `Exec` that
+/// writes files) are invisible to the doc; the checkout diff pane's
+/// latest-turn scope is the git-accurate view.
+pub fn turn_edits(parts: &[MessagePart]) -> Option<TurnEdits> {
+    let mut files: Vec<TurnFileEdit> = Vec::new();
+    let mut touch = |path: &str, counts: Option<(u64, u64)>| {
+        if let Some(existing) = files.iter_mut().find(|f| f.path == path) {
+            if let Some((a, d)) = counts {
+                let (ea, ed) = existing.counts.unwrap_or((0, 0));
+                existing.counts = Some((ea + a, ed + d));
+            }
+        } else {
+            files.push(TurnFileEdit {
+                path: path.to_owned(),
+                counts,
+            });
+        }
+    };
+    for part in parts {
+        let MessagePart::Tool {
+            call,
+            is_error,
+            resolved,
+            diff,
+            diff_stats,
+            ..
+        } = part
+        else {
+            continue;
+        };
+        if *is_error || !*resolved {
+            continue;
+        }
+        if let Some(stats) = diff_stats.as_ref().filter(|s| !s.is_empty()) {
+            for stat in stats {
+                touch(&stat.path, Some((stat.additions, stat.deletions)));
+            }
+        } else if let Some(diff) = diff {
+            let stat = diff_stat(diff);
+            touch(&stat.path, Some((stat.additions, stat.deletions)));
+        } else {
+            match call {
+                ToolCall::WriteFile { path, .. } | ToolCall::EditFile { path, .. } => {
+                    touch(path, None)
+                }
+                // A patch without a path names no file to attribute.
+                ToolCall::ApplyPatch { path: Some(path) } => touch(path, None),
+                _ => {}
+            }
+        }
+    }
+    if files.is_empty() {
+        return None;
+    }
+    let (additions, deletions) = files
+        .iter()
+        .filter_map(|f| f.counts)
+        .fold((0, 0), |(a, d), (fa, fd)| (a + fa, d + fd));
+    Some(TurnEdits {
+        files,
+        additions,
+        deletions,
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum MessageStatus {
@@ -419,7 +511,6 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
         | AgentEvent::UserMessage { .. } => {}
     }
 }
-
 
 /// Stamp sidecar keys onto resolved tool parts that have sidecar content.
 ///
@@ -988,5 +1079,128 @@ mod tests {
         .unwrap();
         assert_eq!(payload.part_id, "t");
         assert_eq!(payload.output.as_deref(), Some("full output"));
+    }
+
+    fn edit_tool(id: &str, path: &str, stats: Option<Vec<ToolDiffStat>>) -> MessagePart {
+        MessagePart::Tool {
+            id: id.into(),
+            call: ToolCall::EditFile {
+                path: path.into(),
+                old_string: None,
+                new_string: None,
+            },
+            is_error: false,
+            resolved: true,
+            output: None,
+            diff: None,
+            output_ref: None,
+            output_bytes: None,
+            diff_ref: None,
+            diff_stats: stats,
+            subagent_ref: None,
+            subagent_status: None,
+            subagent_tail: None,
+        }
+    }
+
+    fn stat(path: &str, additions: u64, deletions: u64) -> ToolDiffStat {
+        ToolDiffStat {
+            path: path.into(),
+            additions,
+            deletions,
+        }
+    }
+
+    #[test]
+    fn turn_edits_merges_per_file_and_totals() {
+        let parts = vec![
+            MessagePart::Text {
+                id: "t0".into(),
+                text: "reply".into(),
+            },
+            edit_tool("a", "src/a.rs", Some(vec![stat("src/a.rs", 10, 2)])),
+            edit_tool("b", "src/b.rs", Some(vec![stat("src/b.rs", 3, 0)])),
+            // Second edit of a.rs: counts sum onto the existing row.
+            edit_tool("c", "src/a.rs", Some(vec![stat("src/a.rs", 1, 4)])),
+        ];
+        let edits = turn_edits(&parts).unwrap();
+        assert_eq!(
+            edits.files.len(),
+            2,
+            "one row per file, first-touched order"
+        );
+        assert_eq!(edits.files[0].path, "src/a.rs");
+        assert_eq!(edits.files[0].counts, Some((11, 6)));
+        assert_eq!(edits.files[1].path, "src/b.rs");
+        assert_eq!(edits.files[1].counts, Some((3, 0)));
+        assert_eq!((edits.additions, edits.deletions), (14, 6));
+    }
+
+    #[test]
+    fn turn_edits_skips_failed_unresolved_and_non_edits() {
+        let mut failed = edit_tool("a", "boom.rs", Some(vec![stat("boom.rs", 5, 5)]));
+        if let MessagePart::Tool { is_error, .. } = &mut failed {
+            *is_error = true;
+        }
+        let mut unresolved = edit_tool("b", "maybe.rs", None);
+        if let MessagePart::Tool { resolved, .. } = &mut unresolved {
+            *resolved = false;
+        }
+        let exec = MessagePart::Tool {
+            id: "c".into(),
+            call: ToolCall::Exec {
+                command: "cargo test".into(),
+            },
+            is_error: false,
+            resolved: true,
+            output: None,
+            diff: None,
+            output_ref: None,
+            output_bytes: None,
+            diff_ref: None,
+            diff_stats: None,
+            subagent_ref: None,
+            subagent_status: None,
+            subagent_tail: None,
+        };
+        assert!(turn_edits(&[failed, unresolved, exec]).is_none());
+        assert!(turn_edits(&[]).is_none());
+    }
+
+    #[test]
+    fn turn_edits_falls_back_to_call_paths_without_counts() {
+        // No diff reached the doc: the call's path still marks the file
+        // edited; the totals then only cover counted files.
+        let parts = vec![
+            edit_tool("a", "src/blind.rs", None),
+            edit_tool("b", "src/seen.rs", Some(vec![stat("src/seen.rs", 7, 1)])),
+        ];
+        let edits = turn_edits(&parts).unwrap();
+        assert_eq!(edits.files[0].counts, None);
+        assert_eq!(edits.files[1].counts, Some((7, 1)));
+        assert_eq!((edits.additions, edits.deletions), (7, 1));
+        // A later counted edit of the blind file upgrades its row in place.
+        let parts = vec![
+            edit_tool("a", "src/blind.rs", None),
+            edit_tool("b", "src/blind.rs", Some(vec![stat("src/blind.rs", 2, 2)])),
+        ];
+        let edits = turn_edits(&parts).unwrap();
+        assert_eq!(edits.files.len(), 1);
+        assert_eq!(edits.files[0].counts, Some((2, 2)));
+    }
+
+    #[test]
+    fn turn_edits_reads_pre_strip_inline_diffs() {
+        // Old docs carry the inline diff instead of stats — counts still come out.
+        let mut part = edit_tool("a", "src/old.rs", None);
+        if let MessagePart::Tool { diff, .. } = &mut part {
+            *diff = Some(ToolDiff {
+                path: "src/old.rs".into(),
+                old_text: Some("one\ntwo\n".into()),
+                new_text: "one\nthree\nfour\n".into(),
+            });
+        }
+        let edits = turn_edits(&[part]).unwrap();
+        assert_eq!(edits.files[0].counts, Some((2, 1)));
     }
 }

--- a/crates/harness/src/claude/normalize.rs
+++ b/crates/harness/src/claude/normalize.rs
@@ -2,7 +2,7 @@
 //! decoding, error-code mapping).
 
 use serde_json::Value;
-use zeron_proto::{AgentEvent, DoneStatus, HarnessId, TodoItem, ToolCall};
+use zeron_proto::{AgentEvent, DoneStatus, HarnessId, TodoItem, ToolCall, ToolDiff};
 
 use super::wire::{ContentBlock, Frame};
 
@@ -153,6 +153,35 @@ fn tag(parent: &str, event: AgentEvent) -> AgentEvent {
     }
 }
 
+/// The synthesized diff for an edit-shaped call. The wire's `tool_result`
+/// carries no change payload, but the `tool_use` INPUT does: Edit's old/new
+/// strings diff as the changed region; Write's content counts as all-new
+/// lines (the previous file text is never echoed, so an overwrite reads as
+/// additions — approximate, like Cursor's own recap). Feeds the doc fold's
+/// `diff_stats`, which power edit chips and the end-of-turn summary card.
+fn edit_diff(call: &ToolCall) -> Option<ToolDiff> {
+    match call {
+        ToolCall::EditFile {
+            path,
+            old_string,
+            new_string,
+        } if old_string.is_some() || new_string.is_some() => Some(ToolDiff {
+            path: path.clone(),
+            old_text: old_string.clone(),
+            new_text: new_string.clone().unwrap_or_default(),
+        }),
+        ToolCall::WriteFile {
+            path,
+            content: Some(content),
+        } => Some(ToolDiff {
+            path: path.clone(),
+            old_text: None,
+            new_text: content.clone(),
+        }),
+        _ => None,
+    }
+}
+
 /// Per-run normalization state.
 ///
 /// `saw_init` dedupes `system:init` — the CLI re-emits it every time the model
@@ -170,6 +199,10 @@ pub(crate) struct Normalizer {
     /// re-keys them onto the spawn chip's feed (the wire never echoes the
     /// steer on the child feed — live-verified 2.1.228).
     agent_tasks: std::collections::HashMap<String, String>,
+    /// Edit/Write diffs synthesized at `tool_use` time ([`edit_diff`]),
+    /// keyed by tool id and attached to the matching `tool_result` — the
+    /// result frame itself carries no change payload.
+    edit_diffs: std::collections::HashMap<String, ToolDiff>,
     /// Rotates at each assistant-frame close and at each steer; SessionStarted
     /// carries the first value so folds can attribute deltas from the start.
     assistant_message_id: String,
@@ -182,6 +215,7 @@ impl Normalizer {
         Self {
             saw_init: false,
             agent_tasks: std::collections::HashMap::new(),
+            edit_diffs: std::collections::HashMap::new(),
             assistant_message_id: new_message_id(),
             session_id: None,
         }
@@ -325,13 +359,19 @@ impl Normalizer {
                                     text: format!("{}\n\n", b.text.trim_end()),
                                 },
                             )),
-                            "tool_use" => Some(tag(
-                                parent,
-                                AgentEvent::ToolCall {
-                                    id: b.id.clone(),
-                                    call: decode_tool_use(&b.name, &b.input),
-                                },
-                            )),
+                            "tool_use" => {
+                                let call = decode_tool_use(&b.name, &b.input);
+                                if let Some(diff) = edit_diff(&call) {
+                                    self.edit_diffs.insert(b.id.clone(), diff);
+                                }
+                                Some(tag(
+                                    parent,
+                                    AgentEvent::ToolCall {
+                                        id: b.id.clone(),
+                                        call,
+                                    },
+                                ))
+                            }
                             _ => None,
                         })
                         .collect();
@@ -350,9 +390,13 @@ impl Normalizer {
                     .blocks()
                     .filter(|b: &ContentBlock| b.kind == "tool_use")
                     .flat_map(|b| {
+                        let decoded = decode_tool_use(&b.name, &b.input);
+                        if let Some(diff) = edit_diff(&decoded) {
+                            self.edit_diffs.insert(b.id.clone(), diff);
+                        }
                         let call = AgentEvent::ToolCall {
                             id: b.id.clone(),
-                            call: decode_tool_use(&b.name, &b.input),
+                            call: decoded,
                         };
                         // A spawn's `prompt` is the subagent's opening user
                         // message — the wire never echoes it on the child
@@ -428,7 +472,7 @@ impl Normalizer {
                                     id: b.tool_use_id.clone(),
                                     is_error: b.is_error.unwrap_or(false),
                                     output: None,
-                                    diff: None,
+                                    diff: self.edit_diffs.remove(&b.tool_use_id),
                                 },
                             )
                         })
@@ -456,7 +500,7 @@ impl Normalizer {
                         id: b.tool_use_id.clone(),
                         is_error: b.is_error.unwrap_or(false),
                         output: None,
-                        diff: None,
+                        diff: self.edit_diffs.remove(&b.tool_use_id),
                     })
                     .collect()
             }
@@ -715,6 +759,59 @@ mod tests {
                     diff: None,
                 }),
             }]
+        );
+    }
+
+    #[test]
+    fn edit_results_carry_a_synthesized_diff() {
+        // The wire's tool_result has no change payload — the Edit input
+        // does; the normalizer stashes it at call time and attaches it to
+        // the matching result (feeds diff_stats → the turn summary card).
+        let mut norm = Normalizer::new();
+        let call = crate::claude::wire::parse_frame(
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"src/a.rs","old_string":"one\ntwo","new_string":"one\nthree\nfour"}}]}}"#,
+        )
+        .expect("parses");
+        norm.normalize(call, false);
+        let result_raw = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","is_error":false}]}}"#;
+        let result = crate::claude::wire::parse_frame(result_raw).expect("parses");
+        let ev = norm.normalize(result, false);
+        let diff = ev
+            .iter()
+            .find_map(|e| match e {
+                AgentEvent::ToolResult { diff, .. } => diff.clone(),
+                _ => None,
+            })
+            .expect("result carries the synthesized diff");
+        assert_eq!(diff.path, "src/a.rs");
+        assert_eq!(diff.old_text.as_deref(), Some("one\ntwo"));
+        assert_eq!(diff.new_text, "one\nthree\nfour");
+        // The stash is spent on attach — a duplicate result stays diff-less.
+        let result = crate::claude::wire::parse_frame(result_raw).expect("parses");
+        let ev = norm.normalize(result, false);
+        assert!(
+            ev.iter()
+                .all(|e| matches!(e, AgentEvent::ToolResult { diff: None, .. }))
+        );
+        // Non-edit tools never stash: their results stay diff-less.
+        let mut norm = Normalizer::new();
+        norm.normalize(
+            crate::claude::wire::parse_frame(
+                r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"ls"}}]}}"#,
+            )
+            .expect("parses"),
+            false,
+        );
+        let ev = norm.normalize(
+            crate::claude::wire::parse_frame(
+                r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t2","is_error":false}]}}"#,
+            )
+            .expect("parses"),
+            false,
+        );
+        assert!(
+            ev.iter()
+                .any(|e| matches!(e, AgentEvent::ToolResult { diff: None, .. }))
         );
     }
 

--- a/crates/harness/src/mock.rs
+++ b/crates/harness/src/mock.rs
@@ -450,11 +450,66 @@ impl Harness for MockHarness {
             })
             .into_iter()
             .flatten();
+        // Dev/testing knob: `ZERON_MOCK_EDITS=1` appends scripted file edits —
+        // EditFile calls whose results carry diffs, twice for one file (the
+        // per-file sum), plus one diff-less edit (the counts-unknown row) —
+        // the data-side way to put the end-of-turn "Edited N files" summary
+        // card on screen.
+        let mock_edits = std::env::var("ZERON_MOCK_EDITS")
+            .ok()
+            .is_some_and(|v| !v.is_empty() && v != "0");
+        let edit_tool_events = mock_edits
+            .then(|| {
+                let mut events = Vec::new();
+                let mut edit = |id: &str, path: &str, old: Option<&str>, new: Option<&str>| {
+                    events.push(AgentEvent::ToolCall {
+                        id: id.into(),
+                        call: zeron_proto::ToolCall::EditFile {
+                            path: path.into(),
+                            old_string: None,
+                            new_string: None,
+                        },
+                    });
+                    events.push(AgentEvent::ToolResult {
+                        id: id.into(),
+                        is_error: false,
+                        output: None,
+                        diff: new.map(|new_text| zeron_proto::ToolDiff {
+                            path: path.into(),
+                            old_text: old.map(str::to_owned),
+                            new_text: new_text.into(),
+                        }),
+                    });
+                };
+                edit(
+                    "mock-edit-1",
+                    "crates/ui/src/transcript.rs",
+                    Some("let fold = default();\nlet open = auto;\n"),
+                    Some("let fold = folds.get(id);\nlet open = fold.open;\nlet target = h;\n"),
+                );
+                edit(
+                    "mock-edit-2",
+                    "crates/doc/src/parts.rs",
+                    Some("pub fn diff_stat() {}\n"),
+                    Some("pub fn diff_stat() {}\npub fn turn_edits() {}\n"),
+                );
+                edit(
+                    "mock-edit-3",
+                    "crates/ui/src/transcript.rs",
+                    Some("let target = h;\n"),
+                    Some("let target = if open { h } else { 0.0 };\n"),
+                );
+                edit("mock-edit-4", "docs/notes.md", None, None);
+                events
+            })
+            .into_iter()
+            .flatten();
         let events: Vec<Result<AgentEvent, HarnessError>> = body
             .iter()
             .cycle()
             .take(body.len() * repeat)
             .cloned()
+            .chain(edit_tool_events)
             .chain(code_tool_events)
             .chain(subagent_events)
             .chain(code_event)

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -1188,6 +1188,21 @@ impl Changes {
         changes
     }
 
+    /// A pane born onto a non-default scope (the transcript's turn-summary
+    /// card opens a "Latest turn" tab this way). Unlike a commit pin the
+    /// scope menu stays available — it is an ordinary pane with a head start.
+    pub fn for_scope(state: Entity<AppState>, scope: DiffScope, cx: &mut Context<Self>) -> Self {
+        let mut changes = Self::new(state, cx);
+        changes.scope = scope;
+        changes
+    }
+
+    /// The pane's current scope — lets the shell find an existing
+    /// latest-turn tab instead of stacking duplicates.
+    pub fn scope(&self) -> DiffScope {
+        self.scope
+    }
+
     /// The surface-tab title (contextual, user request): the pinned commit's
     /// subject (short sha for subject-less commits), else the scope's label.
     pub fn tab_title(&self) -> gpui::SharedString {

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -28,8 +28,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use gpui::{
-    AnyElement, App, Context, Entity, FocusHandle, Focusable as _, ListAlignment, ListState,
-    SharedString, Subscription, Task, Window, div, font, list, prelude::*, px,
+    AnyElement, App, Context, Entity, FocusHandle, Focusable as _, ListAlignment, ListOffset,
+    ListState, SharedString, Subscription, Task, Window, div, font, list, prelude::*, px,
 };
 
 use zeron_proto::{Chat, CheckoutDiff, GitHistoryCommit};
@@ -952,6 +952,22 @@ pub fn body_rows(
     rows
 }
 
+/// The file index a transcript summary-card path refers to. Card paths are
+/// the tool calls' — often absolute — while diff paths are repo-relative,
+/// so fall back to suffix matching (the longest relative path wins when
+/// nested names collide).
+fn reveal_target_ix(files: &[FileDiff], path: &str) -> Option<usize> {
+    if let Some(ix) = files.iter().position(|f| f.path == path) {
+        return Some(ix);
+    }
+    files
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| path.ends_with(&format!("/{}", f.path)))
+        .max_by_key(|(_, f)| f.path.len())
+        .map(|(ix, _)| ix)
+}
+
 /// Flatten all files into rows + each file's row span (header at
 /// `range.start`, body rows after it). `collapsed(ix)` folds a file to just
 /// its header. `comments` is the whole staged set; each file takes its own
@@ -1090,6 +1106,10 @@ pub struct Changes {
     /// Sweeps [`DiffRow::FoldingBody`] stand-ins back to steady-state rows
     /// once their tween window elapses.
     fold_settle: Option<Task<()>>,
+    /// A file path to scroll into view ([`Self::reveal_file`] — the
+    /// transcript summary card's per-file jump). Applied when rows exist,
+    /// else parked until the next parse lands; consumed either way.
+    pending_reveal: Option<String>,
     list: ListState,
     /// What the pane diffs against (toolbar dropdown).
     scope: DiffScope,
@@ -1148,6 +1168,7 @@ impl Changes {
             rows: Vec::new(),
             row_ranges: Vec::new(),
             fold_settle: None,
+            pending_reveal: None,
             // Rows are single lines now — a deep overdraw is cheap and keeps
             // fast wheel flicks from outrunning measurement.
             list: ListState::new(0, ListAlignment::Top, px(1024.0)),
@@ -1201,6 +1222,35 @@ impl Changes {
     /// latest-turn tab instead of stacking duplicates.
     pub fn scope(&self) -> DiffScope {
         self.scope
+    }
+
+    /// Scroll `path`'s file section into view — the transcript summary
+    /// card's per-file jump. Applies immediately when the diff is already
+    /// parsed, else parks until the next parse lands (a freshly-minted tab
+    /// captures its diff async). Consumed on the first parse either way: a
+    /// turn diff WITHOUT the file (a gitignored edit, say) must not scroll
+    /// some unrelated later diff.
+    pub fn reveal_file(&mut self, path: String, cx: &mut Context<Self>) {
+        self.pending_reveal = Some(path);
+        if self.parsed.is_some() {
+            self.apply_pending_reveal();
+        }
+        cx.notify();
+    }
+
+    fn apply_pending_reveal(&mut self) {
+        let Some(path) = self.pending_reveal.take() else {
+            return;
+        };
+        let Some(parsed) = &self.parsed else { return };
+        if let Some(ix) = reveal_target_ix(&parsed.files, &path)
+            && let Some(range) = self.row_ranges.get(ix)
+        {
+            self.list.scroll_to(ListOffset {
+                item_ix: range.start,
+                offset_in_item: px(0.0),
+            });
+        }
     }
 
     /// The surface-tab title (contextual, user request): the pinned commit's
@@ -1699,6 +1749,7 @@ impl Changes {
                     file_count,
                     files: Arc::new(files),
                 });
+                changes.apply_pending_reveal();
                 cx.notify();
             })
             .ok();
@@ -4375,5 +4426,22 @@ rename to new_name.rs
         };
         assert!(!sources_match_patch(&file, &response));
         assert!(full_highlights(&file, Lang::Rust, &response).is_none());
+    }
+
+    #[test]
+    fn reveal_target_matches_relative_and_absolute_paths() {
+        let files = parse_patch(PATCH);
+        // Exact relative path — what an ACP harness puts on the tool call.
+        assert_eq!(reveal_target_ix(&files, "src/main.rs"), Some(0));
+        // Absolute tool-call path suffixed by the repo-relative diff path.
+        assert_eq!(
+            reveal_target_ix(&files, "/Users/dev/repo/src/main.rs"),
+            Some(0)
+        );
+        assert_eq!(reveal_target_ix(&files, "/repo/added.txt"), Some(1));
+        // A path the diff doesn't cover (gitignored edit): no target.
+        assert_eq!(reveal_target_ix(&files, "/tmp/elsewhere/other.rs"), None);
+        // Never a bare-suffix false positive ("main.rs" is not "src/main.rs").
+        assert_eq!(reveal_target_ix(&files, "notsrc/main.rs"), None);
     }
 }

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -968,6 +968,17 @@ fn reveal_target_ix(files: &[FileDiff], path: &str) -> Option<usize> {
         .map(|(ix, _)| ix)
 }
 
+/// Whether a parked file jump can be consumed against the rows on screen.
+/// A matching parsed/active key is necessary but not sufficient while a
+/// scoped refresh is replacing that active capture.
+fn reveal_ready(
+    parsed_key: Option<&str>,
+    active_key: Option<&str>,
+    refresh_inflight: bool,
+) -> bool {
+    !refresh_inflight && parsed_key.zip(active_key).is_some_and(|(a, b)| a == b)
+}
+
 /// Flatten all files into rows + each file's row span (header at
 /// `range.start`, body rows after it). `collapsed(ix)` folds a file to just
 /// its header. `comments` is the whole staged set; each file takes its own
@@ -1107,8 +1118,9 @@ pub struct Changes {
     /// once their tween window elapses.
     fold_settle: Option<Task<()>>,
     /// A file path to scroll into view ([`Self::reveal_file`] — the
-    /// transcript summary card's per-file jump). Applied when rows exist,
-    /// else parked until the next parse lands; consumed either way.
+    /// transcript summary card's per-file jump). Applied only when the parsed
+    /// rows match the active capture and no scoped refresh is in flight;
+    /// otherwise parked until that refreshed capture parses.
     pending_reveal: Option<String>,
     list: ListState,
     /// What the pane diffs against (toolbar dropdown).
@@ -1225,24 +1237,30 @@ impl Changes {
     }
 
     /// Scroll `path`'s file section into view — the transcript summary
-    /// card's per-file jump. Applies immediately when the diff is already
-    /// parsed, else parks until the next parse lands (a freshly-minted tab
-    /// captures its diff async). Consumed on the first parse either way: a
-    /// turn diff WITHOUT the file (a gitignored edit, say) must not scroll
-    /// some unrelated later diff.
+    /// card's per-file jump. Applies immediately when the diff is parsed for
+    /// the CURRENT capture, else parks until the next parse lands (a fresh tab
+    /// captures async; a reused tab may still show the previous turn during
+    /// its refresh). Consumed on the first matching parse either way: a turn
+    /// diff WITHOUT the file (a gitignored edit, say) must not scroll some
+    /// unrelated later diff.
     pub fn reveal_file(&mut self, path: String, cx: &mut Context<Self>) {
         self.pending_reveal = Some(path);
-        if self.parsed.is_some() {
+        let active_key = self.active_diff(cx).map(|diff| self.parse_key(&diff));
+        if reveal_ready(
+            self.parsed.as_ref().map(|parsed| parsed.key.as_str()),
+            active_key.as_deref(),
+            self.scoped_inflight.is_some(),
+        ) {
             self.apply_pending_reveal();
         }
         cx.notify();
     }
 
     fn apply_pending_reveal(&mut self) {
+        let Some(parsed) = &self.parsed else { return };
         let Some(path) = self.pending_reveal.take() else {
             return;
         };
-        let Some(parsed) = &self.parsed else { return };
         if let Some(ix) = reveal_target_ix(&parsed.files, &path)
             && let Some(range) = self.row_ranges.get(ix)
         {
@@ -1696,6 +1714,12 @@ impl Changes {
         let key = self.parse_key(&diff);
         if self.parsed.as_ref().is_some_and(|p| p.key == key) {
             self.sync_comment_rows(cx);
+            // A refreshed capture can legitimately have the same checksum as
+            // the previous one. Its fetch still had to finish before a queued
+            // summary-row reveal was safe to consume.
+            if self.scoped_inflight.is_none() {
+                self.apply_pending_reveal();
+            }
             return;
         }
         // Parse off the render path — patches run to megabytes.
@@ -1749,7 +1773,9 @@ impl Changes {
                     file_count,
                     files: Arc::new(files),
                 });
-                changes.apply_pending_reveal();
+                if changes.scoped_inflight.is_none() {
+                    changes.apply_pending_reveal();
+                }
                 cx.notify();
             })
             .ok();
@@ -4443,5 +4469,13 @@ rename to new_name.rs
         assert_eq!(reveal_target_ix(&files, "/tmp/elsewhere/other.rs"), None);
         // Never a bare-suffix false positive ("main.rs" is not "src/main.rs").
         assert_eq!(reveal_target_ix(&files, "notsrc/main.rs"), None);
+    }
+
+    #[test]
+    fn reveal_waits_for_the_active_refreshed_capture() {
+        assert!(reveal_ready(Some("turn:new"), Some("turn:new"), false));
+        assert!(!reveal_ready(Some("turn:old"), Some("turn:new"), false));
+        assert!(!reveal_ready(Some("turn:old"), Some("turn:old"), true));
+        assert!(!reveal_ready(None, Some("turn:new"), false));
     }
 }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -1707,8 +1707,9 @@ impl Shell {
     /// right-hand pane. Closed → the pane opens onto a turn-scoped diff tab;
     /// open → the chat's existing "Latest turn" tab activates, else a fresh
     /// one opens (per-commit History tabs set the precedent for minting tabs
-    /// from content clicks).
-    fn show_turn_diff(&mut self, cx: &mut Context<Self>) {
+    /// from content clicks). A clicked file row passes its path through, and
+    /// the pane scrolls that file's section into view once its diff lands.
+    fn show_turn_diff(&mut self, file: Option<String>, cx: &mut Context<Self>) {
         if !self.right_pane_open(cx) {
             self.toggle_right_pane(cx);
         }
@@ -1729,13 +1730,23 @@ impl Shell {
                 _ => false,
             })
             .copied();
-        match existing {
-            Some(surface) => self.set_right_active(surface, cx),
+        let changes = match existing {
+            Some(surface) => {
+                self.set_right_active(surface, cx);
+                match surface {
+                    RightSurface::Diff(id) => self.diffs.get(&id).cloned(),
+                    _ => None,
+                }
+            }
             None => {
                 let changes =
                     cx.new(|cx| Changes::for_scope(self.state.clone(), DiffScope::LatestTurn, cx));
-                self.register_diff_surface(changes, cx);
+                self.register_diff_surface(changes.clone(), cx);
+                Some(changes)
             }
+        };
+        if let (Some(path), Some(changes)) = (file, changes) {
+            changes.update(cx, |changes, cx| changes.reveal_file(path, cx));
         }
     }
 
@@ -1780,7 +1791,7 @@ impl Shell {
                     cx,
                 );
             }
-            TranscriptEvent::OpenTurnDiff => self.show_turn_diff(cx),
+            TranscriptEvent::OpenTurnDiff { file } => self.show_turn_diff(file.clone(), cx),
         }
     }
 

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -26,7 +26,7 @@ use zeron_engine::InstanceLock;
 use zeron_proto::{AuthState, WorkspaceScope};
 use zeron_rpc::methods;
 
-use crate::changes::{Changes, ChangesEvent};
+use crate::changes::{Changes, ChangesEvent, DiffScope};
 use crate::composer::{Composer, ComposerEvent, ComposerInput, ComposerInputEvent};
 use crate::icons::{self, icon};
 use crate::loaders;
@@ -966,7 +966,7 @@ pub struct Shell {
     _ticker: Task<()>,
     _state_observation: Subscription,
     _composer_events: Subscription,
-    /// The primary transcript's spawn-chip events (subagent tabs).
+    /// The primary transcript's events (subagent tabs, turn-summary clicks).
     _transcript_events: Subscription,
 }
 
@@ -993,7 +993,8 @@ impl Shell {
                 }
             }
         });
-        // Spawn chips open their subagent's transcript as a right-pane tab.
+        // Spawn chips open their subagent's transcript as a right-pane tab;
+        // turn-summary cards reveal the turn diff the same way.
         let transcript_events = cx.subscribe(&transcript, Self::on_transcript_event);
         // Working-indicator heartbeat: notify once a second while a session is
         // live so elapsed time and the flavour word stay fresh.
@@ -1702,6 +1703,42 @@ impl Shell {
         self.set_right_active(RightSurface::Diff(id), cx);
     }
 
+    /// A transcript turn-summary card click: reveal the turn's diff in the
+    /// right-hand pane. Closed → the pane opens onto a turn-scoped diff tab;
+    /// open → the chat's existing "Latest turn" tab activates, else a fresh
+    /// one opens (per-commit History tabs set the precedent for minting tabs
+    /// from content clicks).
+    fn show_turn_diff(&mut self, cx: &mut Context<Self>) {
+        if !self.right_pane_open(cx) {
+            self.toggle_right_pane(cx);
+        }
+        // Reuse the chat's existing latest-turn tab — one click per turn must
+        // not pile up identical tabs. Commit-pinned panes can't match: their
+        // scope is `Commit`, never `LatestTurn`.
+        let key = self.panel_key(cx);
+        let existing = self
+            .right_tabs
+            .get(&key)
+            .into_iter()
+            .flatten()
+            .find(|surface| match surface {
+                RightSurface::Diff(id) => self
+                    .diffs
+                    .get(id)
+                    .is_some_and(|c| c.read(cx).scope() == DiffScope::LatestTurn),
+                _ => false,
+            })
+            .copied();
+        match existing {
+            Some(surface) => self.set_right_active(surface, cx),
+            None => {
+                let changes =
+                    cx.new(|cx| Changes::for_scope(self.state.clone(), DiffScope::LatestTurn, cx));
+                self.register_diff_surface(changes, cx);
+            }
+        }
+    }
+
     /// The picker's Terminal card / the `+` menu's Terminal row: every click
     /// opens a fresh embedded terminal tab.
     fn add_terminal_surface(&mut self, cx: &mut Context<Self>) {
@@ -1743,6 +1780,7 @@ impl Shell {
                     cx,
                 );
             }
+            TranscriptEvent::OpenTurnDiff => self.show_turn_diff(cx),
         }
     }
 

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -530,6 +530,12 @@ pub enum RowKind {
         tools: Arc<Vec<ToolItem>>,
         auto_open: bool,
     },
+    /// End-of-turn edit recap (Codex/Cursor-style): "Edited N files · +X −Y"
+    /// over a foldable per-file stat list — the last row of a settled
+    /// assistant entry that edited files.
+    TurnSummary {
+        edits: Arc<zeron_doc::TurnEdits>,
+    },
     InputChip {
         /// First question's header (chat-view.tsx `InputChip`: the resolved
         /// chip shows it; unresolved shows "Awaiting your answer…" — which
@@ -656,6 +662,20 @@ fn tool_fingerprint(tools: &[ToolItem], auto_open: bool) -> u64 {
         }
     }
     acc.push(auto_open as u8);
+    fnv1a(&acc)
+}
+
+/// Diff key for the end-of-turn summary row — a content hash over the file
+/// set and counts, so late-arriving stats (a slow ToolResult) re-splice.
+fn edits_fingerprint(edits: &zeron_doc::TurnEdits) -> u64 {
+    let mut acc = Vec::with_capacity(edits.files.len() * 24);
+    for f in &edits.files {
+        acc.extend_from_slice(f.path.as_bytes());
+        // Sentinel for "no counts": distinct from a real (0, 0).
+        let (a, d) = f.counts.unwrap_or((u64::MAX, u64::MAX));
+        acc.extend_from_slice(&a.to_le_bytes());
+        acc.extend_from_slice(&d.to_le_bytes());
+    }
     fnv1a(&acc)
 }
 
@@ -878,6 +898,24 @@ pub fn rows_for_entry(
         group_last_part_ix,
     );
 
+    // End-of-turn edit recap (Codex/Cursor-style), once the turn settles —
+    // mid-stream the live tool chips already tell the story, and the
+    // aggregate would churn on every edit. Aborted turns keep theirs: the
+    // edits that landed before the stop are exactly what the user needs to
+    // see.
+    if !streaming && let Some(edits) = zeron_doc::turn_edits(&entry.parts) {
+        rows.push(Row {
+            id: format!("{}#edits", entry.id).into(),
+            version: edits_fingerprint(&edits),
+            turn_start: false,
+            kind: RowKind::TurnSummary {
+                edits: Arc::new(edits),
+            },
+            entry_id: entry_id.clone(),
+            timestamp: None,
+        });
+    }
+
     if let Some(first) = rows.first_mut() {
         first.turn_start = true;
     }
@@ -1092,6 +1130,17 @@ pub fn detail_height(detail: &ToolDetail) -> f32 {
         ToolDetail::Stats { stats } => stats.len() as f32 * OUTPUT_LINE_HEIGHT + OUTPUT_BODY_PAD,
     };
     DETAIL_SEPARATOR + body
+}
+
+/// Max file rows the end-of-turn summary card lists before the counted tail
+/// ("… N more files") — the card is a recap, the changes pane is the full view.
+pub const SUMMARY_MAX_FILES: usize = 12;
+
+/// Analytic height of the summary card's foldable file list (separator +
+/// capped rows + the counted tail) — the fold tween's open target.
+pub fn summary_body_height(file_count: usize) -> f32 {
+    let rows = file_count.min(SUMMARY_MAX_FILES) + usize::from(file_count > SUMMARY_MAX_FILES);
+    DETAIL_SEPARATOR + rows as f32 * OUTPUT_LINE_HEIGHT + OUTPUT_BODY_PAD
 }
 
 /// Height of the "Show full output/diff" affordance row appended below an
@@ -1537,6 +1586,9 @@ pub enum TranscriptEvent {
         title: String,
         frozen: bool,
     },
+    /// A turn-summary card was clicked: reveal the turn diff in the
+    /// right-hand pane.
+    OpenTurnDiff,
 }
 
 impl gpui::EventEmitter<TranscriptEvent> for Transcript {}
@@ -3181,6 +3233,7 @@ impl Transcript {
             RowKind::ToolGroup { tools, auto_open } => {
                 self.render_tool_group(&row.id, tools, *auto_open, &theme, cx)
             }
+            RowKind::TurnSummary { edits } => self.render_turn_summary(&row.id, edits, &theme, cx),
             RowKind::InputChip { header, resolved } => {
                 input_chip(header.clone(), *resolved, &theme)
             }
@@ -3807,6 +3860,240 @@ impl Transcript {
             .flex_col()
             .child(header)
             .child(body)
+            .into_any_element()
+    }
+
+    /// The end-of-turn edit recap card: a 36px header — pen tile, "Edited N
+    /// files", the turn's `+X −Y` totals — over a foldable per-file stat list
+    /// (the Codex/Cursor change summary, adapted to the chip language). Open
+    /// by default; the chevron folds it with the same RESIZE tween as tool
+    /// groups, and heights stay analytic like every transcript row.
+    fn render_turn_summary(
+        &mut self,
+        row_id: &SharedString,
+        edits: &Arc<zeron_doc::TurnEdits>,
+        theme: &Theme,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let fold = self.folds.get(row_id).copied().unwrap_or_default();
+        let open = fold.open.unwrap_or(true);
+        let body_height = summary_body_height(edits.files.len());
+        let target = if open { body_height } else { 0.0 };
+        let animating = fold.epoch > 0
+            && fold
+                .toggled_at
+                .is_some_and(|at| at.elapsed() < FOLD_TWEEN_WINDOW);
+
+        let label: SharedString = if edits.files.len() == 1 {
+            "Edited 1 file".into()
+        } else {
+            format!("Edited {} files", edits.files.len()).into()
+        };
+        let toggle_id = row_id.clone();
+        // The card group: hover anywhere on it fades in the "View changes"
+        // hint (opacity only — the hint's slot is reserved, reveal never
+        // shifts layout).
+        let group: SharedString = format!("{row_id}-grp").into();
+        let header = div()
+            .h(px(36.0))
+            .flex_none()
+            .w_full()
+            .flex()
+            .items_center()
+            .gap(px(8.0))
+            .pl(px(8.0))
+            .pr(px(6.0))
+            .text_size(px(12.0))
+            .child(
+                div()
+                    .flex_none()
+                    .size(px(20.0))
+                    .rounded(px(6.0))
+                    .bg(crate::theme::ink(0.09))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(
+                        crate::icons::icon(crate::icons::PEN)
+                            .size(px(12.0))
+                            .text_color(theme.text_muted),
+                    ),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_color(theme.text_muted)
+                    .child(label),
+            )
+            // Totals cover only counted files; an all-blind turn (no diffs
+            // reached the doc) shows the file list alone rather than a
+            // misleading "+0 −0".
+            .when(edits.additions > 0 || edits.deletions > 0, |el| {
+                el.child(
+                    div()
+                        .flex_none()
+                        .font_family(theme.font_mono.clone())
+                        .text_size(px(11.5))
+                        .text_color(theme.success)
+                        .child(SharedString::from(format!("+{}", edits.additions))),
+                )
+                .child(
+                    div()
+                        .flex_none()
+                        .font_family(theme.font_mono.clone())
+                        .text_size(px(11.5))
+                        .text_color(theme.danger)
+                        .child(SharedString::from(format!("−{}", edits.deletions))),
+                )
+            })
+            .child(div().flex_1())
+            .child(
+                div()
+                    .flex_none()
+                    .text_size(px(11.0))
+                    .text_color(theme.text_faint)
+                    .opacity(0.0)
+                    .group_hover(group.clone(), |s| s.opacity(1.0))
+                    .child(SharedString::from("View changes")),
+            )
+            // The fold toggle is ITS OWN button — the rest of the card is one
+            // big open-the-diff target, and a fold click must not also fling
+            // the pane open.
+            .child(
+                div()
+                    .id(SharedString::from(format!("{row_id}-fold-btn")))
+                    .flex_none()
+                    .size(px(22.0))
+                    .rounded(px(6.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .text_size(px(10.0))
+                    .text_color(theme.text_muted.opacity(0.7))
+                    .hover(|s| s.bg(crate::theme::ink(0.08)).text_color(theme.text_muted))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        // auto_open=true: the summary's unpinned default is open.
+                        this.toggle_fold(toggle_id.clone(), body_height, true);
+                        cx.notify();
+                    }))
+                    .child(SharedString::from(if open { "▾" } else { "▸" })),
+            );
+
+        let overflow = edits.files.len().saturating_sub(SUMMARY_MAX_FILES);
+        let files = div()
+            .py(px(6.0))
+            .font_family(theme.font_mono.clone())
+            .text_size(px(11.5))
+            .children(edits.files.iter().take(SUMMARY_MAX_FILES).map(|file| {
+                div()
+                    .h(px(OUTPUT_LINE_HEIGHT))
+                    .w_full()
+                    .min_w_0()
+                    .px(px(12.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .child(
+                        div()
+                            .min_w_0()
+                            .flex_1()
+                            .truncate()
+                            .text_color(theme.text.opacity(0.85))
+                            .child(SharedString::from(file.path.clone())),
+                    )
+                    .when_some(file.counts, |el, (additions, deletions)| {
+                        el.child(
+                            div()
+                                .flex_none()
+                                .text_color(theme.success)
+                                .child(SharedString::from(format!("+{additions}"))),
+                        )
+                        .child(
+                            div()
+                                .flex_none()
+                                .text_color(theme.danger)
+                                .child(SharedString::from(format!("−{deletions}"))),
+                        )
+                    })
+            }))
+            .when(overflow > 0, |el| {
+                el.child(
+                    div()
+                        .h(px(OUTPUT_LINE_HEIGHT))
+                        .px(px(12.0))
+                        .flex()
+                        .items_center()
+                        .text_size(px(10.5))
+                        .text_color(theme.text_faint)
+                        .child(SharedString::from(format!("… {overflow} more files"))),
+                )
+            });
+        let list = div()
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .h(px(DETAIL_SEPARATOR))
+                    .flex_none()
+                    .bg(crate::theme::hairline(0.06)),
+            )
+            .child(files);
+        // Fold body: same rules as the tool group's — tween only within the
+        // click window (an armed-forever tween replays on every virtualized
+        // remount), static height otherwise.
+        let body: AnyElement = if animating {
+            let from = fold.from;
+            div()
+                .overflow_hidden()
+                .child(list)
+                .with_animation(
+                    SharedString::from(format!("{row_id}-fold{}", fold.epoch)),
+                    RESIZE.animation(),
+                    move |el, t| el.h(px(motion::lerp(from, target, t))),
+                )
+                .into_any_element()
+        } else {
+            div()
+                .overflow_hidden()
+                .h(px(target))
+                .child(list)
+                .into_any_element()
+        };
+
+        // The whole card is the click target — header or file row, one press
+        // reveals the diff in the right-hand pane (the shell decides between
+        // opening the pane and re-scoping it). Hover lifts the wash and
+        // brightens the hairline; press deepens it — the same quiet feedback
+        // language as the window controls.
+        div()
+            .py(px(4.0))
+            .w_full()
+            .child(
+                div()
+                    .id(SharedString::from(format!("{row_id}-card")))
+                    .group(group)
+                    .w_full()
+                    .flex()
+                    .flex_col()
+                    .overflow_hidden()
+                    .rounded(px(12.0))
+                    .border_1()
+                    .border_color(crate::theme::hairline(0.08))
+                    .bg(crate::theme::ink(0.03))
+                    .cursor_pointer()
+                    .hover(|s| {
+                        s.bg(crate::theme::ink(0.055))
+                            .border_color(crate::theme::hairline(0.16))
+                    })
+                    .active(|s| s.bg(crate::theme::ink(0.075)))
+                    .on_click(cx.listener(|_, _, _, cx| {
+                        cx.emit(TranscriptEvent::OpenTurnDiff);
+                    }))
+                    .child(header)
+                    .child(body),
+            )
             .into_any_element()
     }
 }
@@ -5547,5 +5834,99 @@ mod tests {
             vec![text_part("t0", ""), text_part("t1", "   ")],
         );
         assert!(rows_for_entry(&entry, false, &mut parse).is_empty());
+    }
+
+    fn edit_part(id: &str, path: &str, additions: u64, deletions: u64) -> MessagePart {
+        MessagePart::Tool {
+            id: id.into(),
+            call: ToolCall::EditFile {
+                path: path.into(),
+                old_string: None,
+                new_string: None,
+            },
+            is_error: false,
+            resolved: true,
+            output: None,
+            diff: None,
+            output_ref: None,
+            output_bytes: None,
+            diff_ref: None,
+            diff_stats: Some(vec![zeron_doc::ToolDiffStat {
+                path: path.into(),
+                additions,
+                deletions,
+            }]),
+            subagent_ref: None,
+            subagent_status: None,
+            subagent_tail: None,
+        }
+    }
+
+    #[test]
+    fn edit_turns_end_with_a_summary_row() {
+        let parts = vec![
+            text_part("t0", "changing things"),
+            edit_part("a", "src/a.rs", 10, 2),
+            edit_part("b", "src/b.rs", 3, 0),
+        ];
+        // Mid-stream: no recap — the live chips tell the story.
+        let live = assistant("m1", MessageStatus::Streaming, parts.clone());
+        assert!(
+            rows_for_entry(&live, false, &mut parse)
+                .iter()
+                .all(|r| !matches!(r.kind, RowKind::TurnSummary { .. }))
+        );
+        // Settled: the recap is the LAST row (so it carries the timestamp
+        // strip) and aggregates per file.
+        let done = assistant("m1", MessageStatus::Complete, parts);
+        let rows = rows_for_entry(&done, false, &mut parse);
+        let last = rows.last().unwrap();
+        assert_eq!(last.id.as_ref(), "m1#edits");
+        assert_eq!(last.timestamp, Some(done.created_at));
+        let RowKind::TurnSummary { edits } = &last.kind else {
+            panic!("summary expected")
+        };
+        assert_eq!(edits.files.len(), 2);
+        assert_eq!((edits.additions, edits.deletions), (13, 2));
+        // Late-arriving stats change the diff key, so the row re-splices.
+        let mut richer = assistant(
+            "m1",
+            MessageStatus::Complete,
+            vec![edit_part("a", "src/a.rs", 10, 2)],
+        );
+        let rows_a = rows_for_entry(&richer, false, &mut parse);
+        if let MessagePart::Tool { diff_stats, .. } = &mut richer.parts[0] {
+            diff_stats.as_mut().unwrap()[0].additions = 11;
+        }
+        let rows_b = rows_for_entry(&richer, false, &mut parse);
+        assert_ne!(
+            rows_a.last().unwrap().version,
+            rows_b.last().unwrap().version
+        );
+        // Turns that edited nothing stay recap-free.
+        let plain = assistant(
+            "m2",
+            MessageStatus::Complete,
+            vec![text_part("t0", "hi"), tool_part("x", "ls")],
+        );
+        assert!(
+            rows_for_entry(&plain, false, &mut parse)
+                .iter()
+                .all(|r| !matches!(r.kind, RowKind::TurnSummary { .. }))
+        );
+    }
+
+    #[test]
+    fn summary_body_height_is_analytic_and_capped() {
+        assert_eq!(
+            summary_body_height(2),
+            DETAIL_SEPARATOR + 2.0 * OUTPUT_LINE_HEIGHT + OUTPUT_BODY_PAD
+        );
+        // Past the cap: capped rows + one counted-tail line, independent of n.
+        let capped = DETAIL_SEPARATOR
+            + (SUMMARY_MAX_FILES as f32 + 1.0) * OUTPUT_LINE_HEIGHT
+            + OUTPUT_BODY_PAD;
+        assert_eq!(summary_body_height(SUMMARY_MAX_FILES + 1), capped);
+        assert_eq!(summary_body_height(500), capped);
     }
 }

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -1587,8 +1587,9 @@ pub enum TranscriptEvent {
         frozen: bool,
     },
     /// A turn-summary card was clicked: reveal the turn diff in the
-    /// right-hand pane.
-    OpenTurnDiff,
+    /// right-hand pane. `file` carries a clicked file row's path — the pane
+    /// scrolls that file's section into view once its diff lands.
+    OpenTurnDiff { file: Option<String> },
 }
 
 impl gpui::EventEmitter<TranscriptEvent> for Transcript {}
@@ -3982,12 +3983,18 @@ impl Transcript {
             );
 
         let overflow = edits.files.len().saturating_sub(SUMMARY_MAX_FILES);
-        let files = div()
-            .py(px(6.0))
-            .font_family(theme.font_mono.clone())
-            .text_size(px(11.5))
-            .children(edits.files.iter().take(SUMMARY_MAX_FILES).map(|file| {
+        // Each row is its own jump target: click opens the pane scrolled to
+        // THIS file's section (the plain card click — anywhere else — opens
+        // it untargeted).
+        let file_rows: Vec<_> = edits
+            .files
+            .iter()
+            .take(SUMMARY_MAX_FILES)
+            .enumerate()
+            .map(|(ix, file)| {
+                let path = file.path.clone();
                 div()
+                    .id(SharedString::from(format!("{row_id}-f{ix}")))
                     .h(px(OUTPUT_LINE_HEIGHT))
                     .w_full()
                     .min_w_0()
@@ -3995,6 +4002,14 @@ impl Transcript {
                     .flex()
                     .items_center()
                     .gap(px(8.0))
+                    .cursor_pointer()
+                    .hover(|s| s.bg(crate::theme::ink(0.06)))
+                    .on_click(cx.listener(move |_, _, _, cx| {
+                        cx.stop_propagation();
+                        cx.emit(TranscriptEvent::OpenTurnDiff {
+                            file: Some(path.clone()),
+                        });
+                    }))
                     .child(
                         div()
                             .min_w_0()
@@ -4017,7 +4032,13 @@ impl Transcript {
                                 .child(SharedString::from(format!("−{deletions}"))),
                         )
                     })
-            }))
+            })
+            .collect();
+        let files = div()
+            .py(px(6.0))
+            .font_family(theme.font_mono.clone())
+            .text_size(px(11.5))
+            .children(file_rows)
             .when(overflow > 0, |el| {
                 el.child(
                     div()
@@ -4089,7 +4110,7 @@ impl Transcript {
                     })
                     .active(|s| s.bg(crate::theme::ink(0.075)))
                     .on_click(cx.listener(|_, _, _, cx| {
-                        cx.emit(TranscriptEvent::OpenTurnDiff);
+                        cx.emit(TranscriptEvent::OpenTurnDiff { file: None });
                     }))
                     .child(header)
                     .child(body),

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -1143,6 +1143,18 @@ pub fn summary_body_height(file_count: usize) -> f32 {
     DETAIL_SEPARATOR + rows as f32 * OUTPUT_LINE_HEIGHT + OUTPUT_BODY_PAD
 }
 
+/// The engine retains one LatestTurn snapshot per chat. A summary can open it
+/// only while it is the primary transcript's final row; any later row proves
+/// that the retained snapshot may belong to a newer turn.
+fn summary_can_open_diff(row_ix: usize, row_count: usize, subagent_doc: bool) -> bool {
+    !subagent_doc && row_ix + 1 == row_count
+}
+
+/// Headline totals are exact only when every edited file contributed stats.
+fn summary_totals_are_exact(edits: &zeron_doc::TurnEdits) -> bool {
+    edits.files.iter().all(|file| file.counts.is_some())
+}
+
 /// Height of the "Show full output/diff" affordance row appended below an
 /// open detail whose full payload lives in the sidecar (chat2-sync A3).
 pub const BLOB_AFFORDANCE_HEIGHT: f32 = 24.0;
@@ -3042,6 +3054,13 @@ impl Transcript {
         let Some(row) = self.rows.get(ix).cloned() else {
             return gpui::Empty.into_any_element();
         };
+        // `LatestTurn` is backed by the engine's one snapshot per chat. Only
+        // the final transcript row can still own that snapshot; once another
+        // turn adds any row, older summary cards stay readable/foldable but
+        // must not open the newer turn's diff. Subagent transcripts address a
+        // different doc and never own the selected chat's snapshot.
+        let current_turn_summary =
+            summary_can_open_diff(ix, self.rows.len(), self.doc_override.is_some());
         let theme = Theme::of(cx).clone();
         // The viewport spans the full window (under the titlebar): the first
         // row's gap adds the titlebar's height so a top-scrolled transcript
@@ -3234,7 +3253,9 @@ impl Transcript {
             RowKind::ToolGroup { tools, auto_open } => {
                 self.render_tool_group(&row.id, tools, *auto_open, &theme, cx)
             }
-            RowKind::TurnSummary { edits } => self.render_turn_summary(&row.id, edits, &theme, cx),
+            RowKind::TurnSummary { edits } => {
+                self.render_turn_summary(&row.id, edits, current_turn_summary, &theme, cx)
+            }
             RowKind::InputChip { header, resolved } => {
                 input_chip(header.clone(), *resolved, &theme)
             }
@@ -3873,6 +3894,7 @@ impl Transcript {
         &mut self,
         row_id: &SharedString,
         edits: &Arc<zeron_doc::TurnEdits>,
+        interactive: bool,
         theme: &Theme,
         cx: &mut Context<Self>,
     ) -> AnyElement {
@@ -3895,6 +3917,7 @@ impl Transcript {
         // hint (opacity only — the hint's slot is reserved, reveal never
         // shifts layout).
         let group: SharedString = format!("{row_id}-grp").into();
+        let exact_totals = summary_totals_are_exact(edits);
         let header = div()
             .h(px(36.0))
             .flex_none()
@@ -3927,37 +3950,42 @@ impl Transcript {
                     .text_color(theme.text_muted)
                     .child(label),
             )
-            // Totals cover only counted files; an all-blind turn (no diffs
-            // reached the doc) shows the file list alone rather than a
-            // misleading "+0 −0".
-            .when(edits.additions > 0 || edits.deletions > 0, |el| {
+            // A headline total is exact only when EVERY file has counts. If
+            // even one diff failed to reach the doc, the honest file rows
+            // remain but the partial sum must not masquerade as a turn total.
+            .when(
+                exact_totals && (edits.additions > 0 || edits.deletions > 0),
+                |el| {
+                    el.child(
+                        div()
+                            .flex_none()
+                            .font_family(theme.font_mono.clone())
+                            .text_size(px(11.5))
+                            .text_color(theme.success)
+                            .child(SharedString::from(format!("+{}", edits.additions))),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .font_family(theme.font_mono.clone())
+                            .text_size(px(11.5))
+                            .text_color(theme.danger)
+                            .child(SharedString::from(format!("−{}", edits.deletions))),
+                    )
+                },
+            )
+            .child(div().flex_1())
+            .when(interactive, |el| {
                 el.child(
                     div()
                         .flex_none()
-                        .font_family(theme.font_mono.clone())
-                        .text_size(px(11.5))
-                        .text_color(theme.success)
-                        .child(SharedString::from(format!("+{}", edits.additions))),
-                )
-                .child(
-                    div()
-                        .flex_none()
-                        .font_family(theme.font_mono.clone())
-                        .text_size(px(11.5))
-                        .text_color(theme.danger)
-                        .child(SharedString::from(format!("−{}", edits.deletions))),
+                        .text_size(px(11.0))
+                        .text_color(theme.text_faint)
+                        .opacity(0.0)
+                        .group_hover(group.clone(), |s| s.opacity(1.0))
+                        .child(SharedString::from("View changes")),
                 )
             })
-            .child(div().flex_1())
-            .child(
-                div()
-                    .flex_none()
-                    .text_size(px(11.0))
-                    .text_color(theme.text_faint)
-                    .opacity(0.0)
-                    .group_hover(group.clone(), |s| s.opacity(1.0))
-                    .child(SharedString::from("View changes")),
-            )
             // The fold toggle is ITS OWN button — the rest of the card is one
             // big open-the-diff target, and a fold click must not also fling
             // the pane open.
@@ -4002,14 +4030,16 @@ impl Transcript {
                     .flex()
                     .items_center()
                     .gap(px(8.0))
-                    .cursor_pointer()
-                    .hover(|s| s.bg(crate::theme::ink(0.06)))
-                    .on_click(cx.listener(move |_, _, _, cx| {
-                        cx.stop_propagation();
-                        cx.emit(TranscriptEvent::OpenTurnDiff {
-                            file: Some(path.clone()),
-                        });
-                    }))
+                    .when(interactive, |el| {
+                        el.cursor_pointer()
+                            .hover(|s| s.bg(crate::theme::ink(0.06)))
+                            .on_click(cx.listener(move |_, _, _, cx| {
+                                cx.stop_propagation();
+                                cx.emit(TranscriptEvent::OpenTurnDiff {
+                                    file: Some(path.clone()),
+                                });
+                            }))
+                    })
                     .child(
                         div()
                             .min_w_0()
@@ -4083,11 +4113,9 @@ impl Transcript {
                 .into_any_element()
         };
 
-        // The whole card is the click target — header or file row, one press
-        // reveals the diff in the right-hand pane (the shell decides between
-        // opening the pane and re-scoping it). Hover lifts the wash and
-        // brightens the hairline; press deepens it — the same quiet feedback
-        // language as the window controls.
+        // Only the CURRENT turn's card is a diff target: the engine stores one
+        // LatestTurn snapshot per chat, so an older card cannot truthfully
+        // address its own diff. Historical cards remain readable/foldable.
         div()
             .py(px(4.0))
             .w_full()
@@ -4103,15 +4131,17 @@ impl Transcript {
                     .border_1()
                     .border_color(crate::theme::hairline(0.08))
                     .bg(crate::theme::ink(0.03))
-                    .cursor_pointer()
-                    .hover(|s| {
-                        s.bg(crate::theme::ink(0.055))
-                            .border_color(crate::theme::hairline(0.16))
+                    .when(interactive, |el| {
+                        el.cursor_pointer()
+                            .hover(|s| {
+                                s.bg(crate::theme::ink(0.055))
+                                    .border_color(crate::theme::hairline(0.16))
+                            })
+                            .active(|s| s.bg(crate::theme::ink(0.075)))
+                            .on_click(cx.listener(|_, _, _, cx| {
+                                cx.emit(TranscriptEvent::OpenTurnDiff { file: None });
+                            }))
                     })
-                    .active(|s| s.bg(crate::theme::ink(0.075)))
-                    .on_click(cx.listener(|_, _, _, cx| {
-                        cx.emit(TranscriptEvent::OpenTurnDiff { file: None });
-                    }))
                     .child(header)
                     .child(body),
             )
@@ -5949,5 +5979,34 @@ mod tests {
             + OUTPUT_BODY_PAD;
         assert_eq!(summary_body_height(SUMMARY_MAX_FILES + 1), capped);
         assert_eq!(summary_body_height(500), capped);
+    }
+
+    #[test]
+    fn only_the_primary_transcripts_final_summary_can_open_latest_turn() {
+        assert!(summary_can_open_diff(4, 5, false));
+        assert!(!summary_can_open_diff(2, 5, false));
+        assert!(!summary_can_open_diff(4, 5, true));
+    }
+
+    #[test]
+    fn summary_totals_require_counts_for_every_file() {
+        let exact = zeron_doc::TurnEdits {
+            files: vec![
+                zeron_doc::TurnFileEdit {
+                    path: "a.rs".into(),
+                    counts: Some((3, 1)),
+                },
+                zeron_doc::TurnFileEdit {
+                    path: "b.rs".into(),
+                    counts: Some((2, 0)),
+                },
+            ],
+            additions: 5,
+            deletions: 1,
+        };
+        assert!(summary_totals_are_exact(&exact));
+        let mut partial = exact;
+        partial.files[1].counts = None;
+        assert!(!summary_totals_are_exact(&partial));
     }
 }


### PR DESCRIPTION
## What

After each agent execution settles, the assistant's reply now ends with a change-summary card — **"Edited N files · +X −Y"** with a per-file `+/−` stat list — the recap Codex/Cursor show at the end of a turn. Clicking the card reveals the turn's diff in the right-hand pane: closed → the pane opens onto a turn-scoped diff tab; open → the chat's existing "Latest turn" tab activates, or a fresh one is minted.

Screenshots (mock run, dark + light):

| | |
|---|---|
| card | header `pen · Edited 3 files · +5 −3`, per-file rows, chevron fold |
| interactions | whole card = click target with hover/press feedback and a group-hover "View changes" hint; chevron folds the list (stop-propagation) |

## How

- **`zeron-doc`** — `turn_edits()` aggregates a settled entry's tool parts into per-file counts: `diff_stats` first, pre-strip inline `diff`s next, else the edit-shaped call's own path with counts omitted (no fake `+0 −0`). Same-file edits sum in first-touched order; failed/unresolved calls don't count. Doc-only sourcing means historical turns, remote viewports, and offline all work; shell-side edits (an `Exec` that writes files) remain the changes pane's job.
- **`zeron-ui` transcript** — new `RowKind::TurnSummary` emitted as the last row of a settled entry that edited files (so it carries the timestamp strip). House rules kept: content-hash `version` (late stats re-splice), analytic heights (`summary_body_height`, 12-file cap + counted tail), the tool-group fold tween with its remount guard.
- **`zeron-ui` shell** — a new `TranscriptEvent::OpenTurnDiff` on the existing transcript→shell channel (shared with the subagent spawn-chip events). `show_turn_diff` opens the pane if needed, then reuses the chat's latest-turn tab or mints one via the new `Changes::for_scope` (the `for_commit` pattern); commit-pinned tabs can't false-match (their scope is `Commit`).
- **`zeron-harness` mock** — `ZERON_MOCK_EDITS=1` scripts diffed edits (plus one diff-less edit for the counts-unknown row) so dev-demo puts the card on screen.

## Testing

- 6 new unit tests (`turn_edits` aggregation ×4, row emission/splice, analytic heights); full suites green: 425 `zeron-ui` + 75 `zeron-doc`. fmt/clippy clean.
- Verified live via a seeded mock engine + headed app in both appearances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789423348&installation_model_id=425430&pr_number=115&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F115&signature=6b01f4fe352e9e95c91369d7d803ab2bf1e80c08cdd4800637d30952c4733d07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
