### PR TITLE
iOS: single-flight token refresh, staggered room dials, frame-rate settle

### DIFF
--- a/apps/ios/Zeron/App/AppConfig.swift
+++ b/apps/ios/Zeron/App/AppConfig.swift
@@ -20,6 +20,14 @@ final class AppConfig: @unchecked Sendable {
     private let lock = NSLock()
     private var tokens: AuthTokens?
     private var devBearer: String?
+    /// In-flight refresh shared by every caller (single-flight). WorkOS
+    /// refresh tokens are SINGLE-USE (rotated per use, desktop auth.rs
+    /// refresh_gate): without this, a cold launch's N room dials raced N
+    /// concurrent refreshes with the same token — one won and rotated it,
+    /// the rest failed, dialed with the dead access token, got rejected,
+    /// and every socket sat in backoff. That was the 5–10s "connecting"
+    /// stall on every app open past token expiry (~5 min).
+    private var refreshTask: Task<String?, Never>?
 
     init(edgeURL: URL, mode: Mode, userId: String, orgId: String,
          deviceId: String, deviceName: String,
@@ -53,17 +61,40 @@ final class AppConfig: @unchecked Sendable {
             if !Self.isExpired(jwt: current.accessToken) {
                 return current.accessToken
             }
-            let client = AuthClient(baseURL: edgeURL)
-            guard let refreshed = try? await client.refresh(refreshToken: current.refreshToken,
-                                                            organizationId: orgId) else {
-                roomLog.error("auth: token refresh failed; using expired access token (server will reject and rooms will redial)")
-                return current.accessToken  // let the server reject; backoff redials
-            }
-            updateTokens(refreshed)
-            Keychain.save(refreshed.accessToken, key: "accessToken")
-            Keychain.save(refreshed.refreshToken, key: "refreshToken")
-            return refreshed.accessToken
+            return await refreshedToken(current: current)
         }
+    }
+
+    /// Join (or start) the one in-flight refresh. The task clears itself
+    /// under the lock as its last act, so a caller either joins a live
+    /// refresh or starts a fresh one — never a second concurrent POST.
+    private func refreshedToken(current: AuthTokens) async -> String? {
+        lock.lock()
+        if let existing = refreshTask {
+            lock.unlock()
+            return await existing.value
+        }
+        let task = Task<String?, Never> { [edgeURL, orgId] in
+            let client = AuthClient(baseURL: edgeURL)
+            let refreshed = try? await client.refresh(refreshToken: current.refreshToken,
+                                                      organizationId: orgId)
+            if let refreshed {
+                self.updateTokens(refreshed)
+                Keychain.save(refreshed.accessToken, key: "accessToken")
+                Keychain.save(refreshed.refreshToken, key: "refreshToken")
+            } else {
+                roomLog.error("auth: token refresh failed; using expired access token (server will reject and rooms will redial)")
+            }
+            self.lock.lock()
+            self.refreshTask = nil
+            self.lock.unlock()
+            // Failure falls back to the expired token: let the server
+            // reject; the rooms' backoff redials retry through here.
+            return refreshed?.accessToken ?? current.accessToken
+        }
+        refreshTask = task
+        lock.unlock()
+        return await task.value
     }
 
     private var wsBase: URL {

--- a/apps/ios/Zeron/App/AppModel.swift
+++ b/apps/ios/Zeron/App/AppModel.swift
@@ -510,13 +510,35 @@ final class AppModel {
     private func kickAllRooms() {
         workspace?.kickRoom()
         // Deliver any roomGen flips that landed while the store had no open
-        // view, then kick every room.
+        // view, then kick every room — registry first and instantly, chat
+        // rooms trickled one per 200ms in attention order. Post-suspend and
+        // path-recovery kicks redial dead sockets; a simultaneous N-socket
+        // redial competed with the registry (the sidebar the user is
+        // actually looking at) on thin links.
         if let workspace {
             for chat in workspace.chats {
                 sessionStores[chat.id]?.updateRoomGen(chat.roomGen)
             }
         }
-        sessionStores.values.forEach { $0.kickRoom() }
+        var delay: UInt64 = 0
+        var kicked = Set<String>()
+        for chat in overviewChats {
+            guard let store = sessionStores[chat.id] else { continue }
+            kicked.insert(chat.id)
+            scheduleKick(store, afterNs: delay)
+            delay += 200_000_000
+        }
+        for (id, store) in sessionStores where !kicked.contains(id) {
+            scheduleKick(store, afterNs: delay)
+            delay += 200_000_000
+        }
+    }
+
+    private func scheduleKick(_ store: SessionStore, afterNs delay: UInt64) {
+        Task { @MainActor in
+            if delay > 0 { try? await Task.sleep(nanoseconds: delay) }
+            store.kickRoom()
+        }
     }
 
     /// Kick rooms the moment the network path recovers or hops interfaces
@@ -563,6 +585,8 @@ final class AppModel {
             // views re-derive `chat` from the registry on every change, so
             // this accessor is the flip's delivery path.
             existing.updateRoomGen(chat.roomGen)
+            // An open view wants live sync NOW — any preload dial-hold ends.
+            existing.releaseDial()
             return existing
         }
         let store = SessionStore(chatId: chat.id, config: config)
@@ -578,11 +602,27 @@ final class AppModel {
     }
 
     /// Warm every non-archived session: stores hydrate from disk instantly
-    /// and keep their rooms syncing, so opening a session never shows a
-    /// loading state.
+    /// so opening a session never shows a loading state. The room DIALS are
+    /// held and released one per 300ms in attention order — N simultaneous
+    /// TLS handshakes at launch competed with the registry dial for a thin
+    /// uplink (and, pre-single-flight, raced N token refreshes), which was
+    /// the cold-open "connecting…" stall. Opening a session releases its
+    /// hold immediately (sessionStore(for:) above).
     func preloadSessions() {
-        for chat in overviewChats {
-            _ = sessionStore(for: chat)
+        guard demo == nil, let config else { return }
+        var stagger: UInt64 = 0
+        for chat in overviewChats where sessionStores[chat.id] == nil {
+            let store = SessionStore(chatId: chat.id, config: config)
+            store.hostDeviceId = chat.deviceId
+            sessionStores[chat.id] = store
+            store.start(holdDial: true)
+            store.updateRoomGen(chat.roomGen)
+            let delay = stagger
+            Task { @MainActor in
+                if delay > 0 { try? await Task.sleep(nanoseconds: delay) }
+                store.releaseDial()
+            }
+            stagger += 300_000_000
         }
     }
 }

--- a/apps/ios/Zeron/Sync/SessionStore.swift
+++ b/apps/ios/Zeron/Sync/SessionStore.swift
@@ -55,6 +55,11 @@ final class SessionStore {
     /// the registry never walks a chat back to s2.
     @ObservationIgnored private var roomGen = 1
     @ObservationIgnored private var started = false
+    /// Preload holds the dial (AppModel staggers the release) so a cold
+    /// launch doesn't stampede N TLS handshakes against the registry dial
+    /// on a thin link. The disk snapshot still hydrates immediately —
+    /// only the socket waits its turn.
+    @ObservationIgnored private var holdDial = false
 
     /// Demo mode: no room, entries driven externally.
     private let offline: Bool
@@ -95,9 +100,10 @@ final class SessionStore {
 
     @ObservationIgnored private var saver: DocSaver?
 
-    func start() {
+    func start(holdDial: Bool = false) {
         guard !started, !offline else { return }
         started = true
+        self.holdDial = holdDial
         // Local-first: the last-synced chat2 snapshot renders instantly (even
         // when the host device is offline); the join backfills incrementally
         // from its cursor.
@@ -142,8 +148,16 @@ final class SessionStore {
         connectIfReady()
     }
 
+    /// End a preload dial-hold: an open view (or the stagger timer) wants
+    /// live sync now.
+    func releaseDial() {
+        guard holdDial else { return }
+        holdDial = false
+        connectIfReady()
+    }
+
     private func connectIfReady() {
-        guard started, !offline, chatRoom == nil, roomGen >= 2 else { return }
+        guard started, !offline, !holdDial, chatRoom == nil, roomGen >= 2 else { return }
         let delegate = ChatRoomClient.Delegate(
             cursor: { [weak self] in self?.cursor ?? 0 },
             containsFrontier: { [weak self] frontier in
@@ -252,6 +266,7 @@ final class SessionStore {
     /// ChatRoomClient.kick). Also the catch-all re-check for a roomGen flip
     /// that landed while this store had no open view.
     func kickRoom() {
+        holdDial = false  // a kick is a user/foreground signal: dial now
         connectIfReady()
         guard let chatRoom else { return }
         Task { await chatRoom.kick() }

--- a/apps/ios/Zeron/Transcript/TranscriptView.swift
+++ b/apps/ios/Zeron/Transcript/TranscriptView.swift
@@ -335,7 +335,11 @@ struct TranscriptView: View {
     /// scroll view. `settled` flips either way — never left invisible.
     private func settleToBottom() async {
         scroll.padGlobalMaxY = 0  // stale pad frames must not fake convergence
-        for _ in 0..<60 {
+        // Frame-rate polling (16ms, was 50ms): the loop's total budget is the
+        // same ~2s, but a transcript that converges in a few frames reveals
+        // in ~50ms instead of holding the skeleton for multiples of 50ms —
+        // this cadence IS the "cached session shows a skeleton" time.
+        for _ in 0..<120 {
             guard scroll.pinned, !scroll.userScrolling else { break }
             // Don't chase targets through a keyboard transition — the edge
             // math lies there and the budget burns on garbage jumps. The
@@ -348,13 +352,13 @@ struct TranscriptView: View {
                 let error = scroll.padGlobalMaxY - scroll.insetTopGlobalY
                 // Near-pinned is good enough to reveal — correctPin's trailing
                 // nudges close the last few points invisibly, while every
-                // 50ms spent here is the user staring at the loader.
+                // poll spent here is the user staring at the loader.
                 if abs(error) < 24 { break }
                 scrollPosition.scrollTo(y: scroll.contentOffsetY + error)
             } else {
                 scrollPosition.scrollTo(edge: .bottom)
             }
-            try? await Task.sleep(nanoseconds: 50_000_000)
+            try? await Task.sleep(nanoseconds: 16_000_000)
         }
         settled = true
         // Revealed-with-CONTENT only: a settle that ran against a still-empty


### PR DESCRIPTION
Follow-up to #107 — these fixes were mistakenly pushed to that PR's branch *after* it merged, so they never landed. Same commit, cherry-picked onto main.

## Problem

On-device testing after the #107 release showed a 5–10s connect spinner on every cold open and a transcript skeleton on every session open, cached or not. Three mobile-side causes:

1. **Token refresh had no single-flight** (`AppConfig.currentToken`). WorkOS refresh tokens are single-use (rotated per use — the desktop grew `auth.rs`'s `refresh_gate` for exactly this), and `HomeView`'s `preloadSessions()` dials every non-archived chat at launch: N+1 concurrent `currentToken` calls raced N+1 refresh POSTs with the same token. One won and rotated it; the rest failed, fell back to the expired access token, dialed sockets the edge rejected, and sat in backoff until the winner's tokens propagated. This stalls on any network, good wifi included.
2. **Dial stampede**: N simultaneous TLS handshakes at launch competed with the registry dial (the sidebar the user is looking at) for a thin uplink.
3. **The skeleton time was the settle loop's 50ms poll** in `TranscriptView` — a cached transcript that converges in a few frames still held the skeleton for multiples of 50ms, on every open.

## Changes

- `AppConfig`: refresh is one shared in-flight `Task` every caller awaits; it clears itself under the lock as its last act, so callers either join a live refresh or start a fresh one — never a second concurrent POST. Failure still falls back to the expired token (server rejects, rooms redial through the gate).
- `SessionStore`/`AppModel`: preload still hydrates every store from disk instantly, but room dials are held and released one per 300ms in attention order; opening a session releases its hold immediately. The foreground/path-recovery kick sweep gets the same stagger (registry instant, chats one per 200ms).
- `TranscriptView.settleToBottom`: poll at frame rate (16ms), same ~2s total budget — cached transcripts reveal in ~50ms.

## Validation

Swift doesn't compile on this box — @wing-anara validates on device. Expected: cached sessions render near-instantly; the spinner reflects one refresh + one dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789491545&installation_model_id=425430&pr_number=122&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F122&signature=1b948d3124135df406ead6d154824ec02c5bd793d765f5d4726d680720cef4cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->