### PR TITLE
iOS: reveal cached transcripts on layout-quiet — kills the 2.1s skeleton on every open

### DIFF
--- a/apps/ios/Zeron/Transcript/TranscriptView.swift
+++ b/apps/ios/Zeron/Transcript/TranscriptView.swift
@@ -339,6 +339,7 @@ struct TranscriptView: View {
         // same ~2s, but a transcript that converges in a few frames reveals
         // in ~50ms instead of holding the skeleton for multiples of 50ms —
         // this cadence IS the "cached session shows a skeleton" time.
+        var quietTicks = 0
         for _ in 0..<120 {
             guard scroll.pinned, !scroll.userScrolling else { break }
             // Don't chase targets through a keyboard transition — the edge
@@ -355,8 +356,22 @@ struct TranscriptView: View {
                 // poll spent here is the user staring at the loader.
                 if abs(error) < 24 { break }
                 scrollPosition.scrollTo(y: scroll.contentOffsetY + error)
+                quietTicks = 0
             } else {
                 scrollPosition.scrollTo(edge: .bottom)
+                // No pad report while we hold the bottom anchor means layout
+                // is quiescent exactly where defaultScrollAnchor put it — the
+                // warm cached-open case. The pad's onGeometryChange only
+                // fires on CHANGE, and the zeroing above discarded its last
+                // report, so a stable layout never re-reports: this loop then
+                // burned its whole budget blind (measured 2.1s on device for
+                // a 6-entry cached transcript, the "skeleton on every open").
+                // A short quiet streak WITH content = converged; reveal.
+                quietTicks += 1
+                if quietTicks >= 6,
+                   !store.entries.isEmpty || !store.pendingSends.isEmpty {
+                    break
+                }
             }
             try? await Task.sleep(nanoseconds: 16_000_000)
         }


### PR DESCRIPTION
## Problem

On-device instrumentation (Release build, iPhone Air) showed every session open holding the transcript skeleton for the settle loop's ENTIRE ~2s budget, cached or not: 2134ms for a 29-entry transcript, 2106ms for a 6-entry one. Entries were warm in memory at view init in both cases — the local pipeline (disk cache, projection, markdown memo) is fast and blameless.

Root cause: `settleToBottom` zeroes `scroll.padGlobalMaxY` at start so a stale frame can't fake convergence, but the pad's `onGeometryChange` only fires when the observed geometry CHANGES. A warm cached open is already laid out and anchored at the bottom — nothing ever changes, no report arrives, and the loop scroll-to-bottoms blind until timeout. The better the cache, the longer the skeleton. (#122's 16ms poll cadence never mattered: the loop wasn't slow-converging, it was unmeasurable.)

## Change

In the unmeasured branch, count a quiet streak: ~100ms of no geometry report while holding the bottom anchor, with content present, counts as converged — reveal. Any report resets the streak, so genuinely-settling layouts (streaming growth, big lazy reflows) keep the measured `|error| < 24` path. Empty transcripts never early-reveal (the void is worse than the skeleton).

## Validation

Same device, same sessions, instrumented before/after: settle 2134ms/2106ms → **84ms** on every open (31-, 7-, and 2-entry cached transcripts). Simulator build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789504773&installation_model_id=425430&pr_number=124&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F124&signature=caf62c382afee429ccbc3b4614c81d4c584c4ce39dc3098aca8146064e027bc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->