### PR TITLE
450kbps cold open: dial caps, checkpoint overlap, early sends + pull-first HTTPS transport

### DIFF
--- a/apps/ios/Zeron/App/AppConfig.swift
+++ b/apps/ios/Zeron/App/AppConfig.swift
@@ -133,6 +133,58 @@ final class AppConfig: @unchecked Sendable {
         return request
     }
 
+    /// GET /chat2/{chatId}/rows?after= — pull over plain HTTPS: one request
+    /// collapses the socket's connect→hello→state→rowsReq→backfill, and it
+    /// works on networks that strip WS upgrades (airplane wifi).
+    func chat2RowsRequest(chatId: String, after: UInt64) async -> URLRequest? {
+        guard let token = await currentToken() else { return nil }
+        var url = edgeURL.appending(path: "chat2/\(chatId)/rows")
+        url.append(queryItems: [URLQueryItem(name: "after", value: String(after)),
+                                URLQueryItem(name: "device", value: deviceId)])
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
+    }
+
+    /// POST /chat2/{chatId}/rows?batchId= — push over plain HTTPS (batchId
+    /// dedupe makes replays no-ops); body is the raw update batch.
+    func chat2PushRequest(chatId: String, batchId: String) async -> URLRequest? {
+        guard let token = await currentToken() else { return nil }
+        var url = edgeURL.appending(path: "chat2/\(chatId)/rows")
+        url.append(queryItems: [URLQueryItem(name: "batchId", value: batchId),
+                                URLQueryItem(name: "device", value: deviceId)])
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
+    }
+
+    /// GET /registry/{orgId}/rows?since= — the WS hello's delta answer over
+    /// plain HTTPS. `beat=1` doubles as a presence beat.
+    func registryRowsRequest(since: UInt64?) async -> URLRequest? {
+        guard let token = await currentToken() else { return nil }
+        var url = edgeURL.appending(path: "registry/\(orgId)/rows")
+        var items = [URLQueryItem(name: "device", value: deviceId),
+                     URLQueryItem(name: "beat", value: "1"),
+                     URLQueryItem(name: "token", value: token)]
+        if let since { items.append(URLQueryItem(name: "since", value: String(since))) }
+        url.append(queryItems: items)
+        return URLRequest(url: url)
+    }
+
+    /// POST /registry/{orgId}/push — one op batch over plain HTTPS (LWW
+    /// clocks make replays apply zero ops).
+    func registryPushRequest() async -> URLRequest? {
+        guard let token = await currentToken() else { return nil }
+        var url = edgeURL.appending(path: "registry/\(orgId)/push")
+        url.append(queryItems: [URLQueryItem(name: "device", value: deviceId)])
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        return request
+    }
+
     /// Decode the JWT payload's `exp` (60s early-refresh margin). Unparseable
     /// tokens read as non-expired — the server is the arbiter.
     private static func isExpired(jwt: String) -> Bool {

--- a/apps/ios/Zeron/App/AppModel.swift
+++ b/apps/ios/Zeron/App/AppModel.swift
@@ -523,12 +523,15 @@ final class AppModel {
         var delay: UInt64 = 0
         var kicked = Set<String>()
         for chat in overviewChats {
-            guard let store = sessionStores[chat.id] else { continue }
+            // Dial-held stores stay held: a kick force-dials, and sweeping 46
+            // of them on every foreground/path flap is the stampede the warm
+            // cap exists to prevent. Held chats reconnect on open.
+            guard let store = sessionStores[chat.id], !store.isDialHeld else { continue }
             kicked.insert(chat.id)
             scheduleKick(store, afterNs: delay)
             delay += 200_000_000
         }
-        for (id, store) in sessionStores where !kicked.contains(id) {
+        for (id, store) in sessionStores where !kicked.contains(id) && !store.isDialHeld {
             scheduleKick(store, afterNs: delay)
             delay += 200_000_000
         }
@@ -608,15 +611,27 @@ final class AppModel {
     /// uplink (and, pre-single-flight, raced N token refreshes), which was
     /// the cold-open "connecting…" stall. Opening a session releases its
     /// hold immediately (sessionStore(for:) above).
+    /// Sessions that keep a live socket without an open view. Everything else
+    /// hydrates from disk but dials on demand: 46 background joins (TLS +
+    /// hello + state each) drowned a 450kbps link for tens of seconds at
+    /// every cold open and network kick, for transcripts nobody was reading —
+    /// sidebar status (Working, presence, titles) rides the registry room, so
+    /// an undialed chat's row stays live regardless, and opening it releases
+    /// its dial instantly.
+    static let warmDialCap = 8
+
     func preloadSessions() {
         guard demo == nil, let config else { return }
         var stagger: UInt64 = 0
+        var released = 0
         for chat in overviewChats where sessionStores[chat.id] == nil {
             let store = SessionStore(chatId: chat.id, config: config)
             store.hostDeviceId = chat.deviceId
             sessionStores[chat.id] = store
             store.start(holdDial: true)
             store.updateRoomGen(chat.roomGen)
+            guard released < Self.warmDialCap else { continue }
+            released += 1
             let delay = stagger
             Task { @MainActor in
                 if delay > 0 { try? await Task.sleep(nanoseconds: delay) }

--- a/apps/ios/Zeron/App/AppModel.swift
+++ b/apps/ios/Zeron/App/AppModel.swift
@@ -261,7 +261,10 @@ final class AppModel {
 
     var spaces: [Space] { demo?.spaces ?? workspace?.spaces ?? [] }
 
-    var connected: Bool { demo != nil || workspace?.connected == true }
+    // "Connected" for the header spinner means "server state has reached this
+    // session" — over the socket OR the HTTPS pull (which lands in ~1 RTT and
+    // is the only transport airplane wifi permits).
+    var connected: Bool { demo != nil || workspace?.connected == true || workspace?.synced == true }
 
     var overviewChats: [Chat] {
         if let demo {

--- a/apps/ios/Zeron/App/AppModel.swift
+++ b/apps/ios/Zeron/App/AppModel.swift
@@ -634,6 +634,16 @@ final class AppModel {
             released += 1
             let delay = stagger
             Task { @MainActor in
+                // The registry (the sidebar the user is looking at) gets the
+                // pipe to itself first: on a 240kbps link, warm chat dials
+                // racing the registry's own handshake+state pushed the
+                // connect spinner from ~1.5s to ~7s (NLC Edge, 2026-08-17).
+                // An open view still dials instantly via releaseDial.
+                let start = DispatchTime.now()
+                while !(self.workspace?.connected ?? false),
+                      DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds < 10_000_000_000 {
+                    try? await Task.sleep(nanoseconds: 200_000_000)
+                }
                 if delay > 0 { try? await Task.sleep(nanoseconds: delay) }
                 store.releaseDial()
             }

--- a/apps/ios/Zeron/Sync/ChatRoomClient.swift
+++ b/apps/ios/Zeron/Sync/ChatRoomClient.swift
@@ -175,13 +175,19 @@ actor ChatRoomClient {
                let seq = (ack["seq"] as? NSNumber)?.uint64Value {
                 pending.removeAll { $0.batchId == push.batchId }
                 await delegate.advanceCursor(seq)
-            } else if http.statusCode == 400 || http.statusCode == 413 {
-                // Permanent server verdict: retire, same as the error frame
-                // path — the ops stay in the local doc.
-                roomLog.error("chat2 \(self.chatId, privacy: .public): http push rejected (\(http.statusCode)); retiring batch")
+            } else if let err = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let code = err["error"] as? String,
+                      ["bad_push", "too_large", "empty"].contains(code) {
+                // Permanent verdict — and provably OUR edge's (a parsed error
+                // code, not a middlebox's arbitrary 4xx: captive portals
+                // answer POSTs with junk statuses, and retiring a real
+                // message batch on one would silently drop the send on
+                // exactly the networks this path exists for). Retire, same
+                // as the WS error-frame path; the ops stay in the local doc.
+                roomLog.error("chat2 \(self.chatId, privacy: .public): http push rejected (\(code, privacy: .public)); retiring batch")
                 pending.removeAll { $0.batchId == push.batchId }
             } else {
-                break  // quota/transient: retry next cycle
+                break  // quota/transient/middlebox: retry next cycle
             }
         }
         let after = await delegate.cursor()

--- a/apps/ios/Zeron/Sync/ChatRoomClient.swift
+++ b/apps/ios/Zeron/Sync/ChatRoomClient.swift
@@ -82,6 +82,12 @@ actor ChatRoomClient {
     private var livenessTask: Task<Void, Never>?
     private var quotaTask: Task<Void, Never>?
     private var pending: [PendingPush] = []
+    /// State frame received on the CURRENT socket — pushes are legal from
+    /// here (the server accepts them any time post-hello; batchId dedupe).
+    private var stateReceived = false
+    /// Non-nil while a checkpoint downloads in parallel with the row
+    /// backfill: row/rowsDone frames land here and replay after the import.
+    private var checkpointBuffer: [ChatWireFrame]?
     private var joined = false
     private var closed = false
     private var generation = 0
@@ -143,7 +149,7 @@ actor ChatRoomClient {
             return
         }
         pending.append(PendingPush(batchId: UUID().uuidString.lowercased(), bytes: update))
-        if joined {
+        if stateReceived {
             Task { await self.pushPending() }
         }
     }
@@ -187,6 +193,8 @@ actor ChatRoomClient {
         generation += 1
         let gen = generation
         joined = false
+        stateReceived = false
+        checkpointBuffer = nil
         helloSentAt = nil
         backfillStartedAt = nil
         probeSentAt = nil
@@ -350,25 +358,16 @@ actor ChatRoomClient {
         case ChatFrameType.state:
             await handleState(frame, gen: gen)
 
-        case ChatFrameType.row:
-            guard let seq = (frame.header["seq"] as? NSNumber)?.uint64Value else { return }
-            // Own-device rows can still arrive (first-backfill redownload, a
-            // racing second socket) — Loro re-import is a no-op; the cursor
-            // advance is what matters.
-            await delegate.applyRow(frame.payload, seq)
-
-        case ChatFrameType.rowsDone:
-            guard backfillStartedAt != nil else { return }
-            backfillStartedAt = nil
-            let wasResumed = resumed
-            resumed = true
-            joined = true
-            backoffMs = ChatRoomClient.backoffBaseMs
-            roomLog.info("chat2 \(self.chatId, privacy: .public): joined (converged, resumed=\(wasResumed))")
-            await delegate.event(.connected)
-            // Anything pending (offline writes, reconnect re-pushes) goes
-            // now — the server's batchId dedupe makes replays exact no-ops.
-            await pushPending()
+        case ChatFrameType.row, ChatFrameType.rowsDone:
+            // Rows landing while a checkpoint downloads in parallel wait for
+            // the import (their seqs are all past the checkpoint; applying
+            // them first would advance the cursor past state the doc doesn't
+            // hold if the fetch then dies).
+            if checkpointBuffer != nil {
+                checkpointBuffer?.append(frame)
+                return
+            }
+            await applyRowFrame(frame)
 
         case ChatFrameType.ack:
             guard let batchId = frame.header["batchId"] as? String,
@@ -419,28 +418,83 @@ actor ChatRoomClient {
             contained = await delegate.containsFrontier(frame.payload)
         }
         let plan = chatPlanCatchUp(cursor: cursor, state: state, frontierContained: contained)
+        stateReceived = true
         let after: UInt64
         switch plan {
         case .rowsOnly(let a):
             after = a
         case .checkpointThenRows(let a):
-            roomLog.info("chat2 \(self.chatId, privacy: .public): fetching checkpoint (seq=\(state.checkpointSeq), \(state.checkpointSize)B)")
-            guard let bytes = await fetchCheckpoint(), gen == generation, !closed else {
-                if gen == generation, !closed {
-                    roomLog.warning("chat2 \(self.chatId, privacy: .public): checkpoint fetch failed; redialing")
-                    await onSocketError(gen: gen)
-                }
-                return
-            }
-            guard await delegate.applyCheckpoint(bytes, state.checkpointSeq) else {
-                roomLog.error("chat2 \(self.chatId, privacy: .public): checkpoint import failed; redialing")
-                await onSocketError(gen: gen)
-                return
-            }
+            // Fetch in PARALLEL with the row backfill: the rows request goes
+            // out below immediately, rows landing mid-download buffer (see
+            // handleInbound), and the import + replay happen when the bytes
+            // arrive. On a thin link the checkpoint download IS the join
+            // time; serializing download → rows pushed "joined" back by the
+            // whole blob.
+            roomLog.info("chat2 \(self.chatId, privacy: .public): fetching checkpoint (seq=\(state.checkpointSeq), \(state.checkpointSize)B, rows in parallel)")
+            checkpointBuffer = []
+            let seq = state.checkpointSeq
+            Task { await self.completeCheckpointFetch(gen: gen, seq: seq) }
             after = a
         }
         await send(ChatWire.encode(ChatFrameType.rowsReq,
                                    header: ["after": after, "excludeOwn": resumed]))
+        // Pending pushes go before catch-up completes: batchId dedupe makes
+        // replays no-ops and rows are CRDT-commutative, so a message written
+        // offline flushes ~2 RTTs after the socket lands instead of waiting
+        // out the whole checkpoint + backfill.
+        await pushPending()
+    }
+
+    /// Second half of the parallel checkpoint fetch: import the blob, then
+    /// replay the rows that buffered while it downloaded.
+    private func completeCheckpointFetch(gen: Int, seq: UInt64) async {
+        let bytes = await fetchCheckpoint()
+        guard gen == generation, !closed else { return }
+        guard let bytes else {
+            roomLog.warning("chat2 \(self.chatId, privacy: .public): checkpoint fetch failed; redialing")
+            checkpointBuffer = nil
+            await onSocketError(gen: gen)
+            return
+        }
+        guard await delegate.applyCheckpoint(bytes, seq), gen == generation, !closed else {
+            if gen == generation, !closed {
+                roomLog.error("chat2 \(self.chatId, privacy: .public): checkpoint import failed; redialing")
+                checkpointBuffer = nil
+                await onSocketError(gen: gen)
+            }
+            return
+        }
+        while let frame = checkpointBuffer?.first {
+            checkpointBuffer?.removeFirst()
+            await applyRowFrame(frame)
+            guard gen == generation, !closed else { return }
+        }
+        checkpointBuffer = nil
+    }
+
+    /// One backfill/broadcast frame: a row, or the ROWS_DONE terminator.
+    /// Factored out so frames buffered during a parallel checkpoint fetch
+    /// replay through exactly the live path.
+    private func applyRowFrame(_ frame: ChatWireFrame) async {
+        if frame.kind == ChatFrameType.row {
+            guard let seq = (frame.header["seq"] as? NSNumber)?.uint64Value else { return }
+            // Own-device rows can still arrive (first-backfill redownload, a
+            // racing second socket) — Loro re-import is a no-op; the cursor
+            // advance is what matters.
+            await delegate.applyRow(frame.payload, seq)
+            return
+        }
+        guard backfillStartedAt != nil else { return }
+        backfillStartedAt = nil
+        let wasResumed = resumed
+        resumed = true
+        joined = true
+        backoffMs = ChatRoomClient.backoffBaseMs
+        roomLog.info("chat2 \(self.chatId, privacy: .public): joined (converged, resumed=\(wasResumed))")
+        await delegate.event(.connected)
+        // Anything not yet in flight goes now — the server's batchId dedupe
+        // makes replays exact no-ops.
+        await pushPending()
     }
 
     private func handleErrorFrame(_ header: [String: Any], gen: Int) async {
@@ -481,7 +535,7 @@ actor ChatRoomClient {
     // MARK: Outbound
 
     private func pushPending() async {
-        guard joined else { return }
+        guard stateReceived else { return }
         for ix in pending.indices where !pending[ix].inFlight {
             pending[ix].inFlight = true
             let push = pending[ix]

--- a/apps/ios/Zeron/Sync/ChatRoomClient.swift
+++ b/apps/ios/Zeron/Sync/ChatRoomClient.swift
@@ -74,9 +74,14 @@ actor ChatRoomClient {
     private let device: String
     private let urlProvider: @Sendable () async -> URL?
     private let checkpointRequest: @Sendable () async -> URLRequest?
+    /// GET /chat2/{id}/rows?after= — the HTTPS pull twin of the backfill.
+    private let rowsRequest: @Sendable (UInt64) async -> URLRequest?
+    /// POST /chat2/{id}/rows?batchId= — the HTTPS push twin.
+    private let pushRequest: @Sendable (String) async -> URLRequest?
     private let delegate: Delegate
 
     private var socket: URLSessionWebSocketTask?
+    private var pullTask: Task<Void, Never>?
     private var receiveTask: Task<Void, Never>?
     private var pingTask: Task<Void, Never>?
     private var livenessTask: Task<Void, Never>?
@@ -121,11 +126,15 @@ actor ChatRoomClient {
          device: String,
          urlProvider: @escaping @Sendable () async -> URL?,
          checkpointRequest: @escaping @Sendable () async -> URLRequest?,
+         rowsRequest: @escaping @Sendable (UInt64) async -> URLRequest?,
+         pushRequest: @escaping @Sendable (String) async -> URLRequest?,
          delegate: Delegate) {
         self.chatId = chatId
         self.device = device
         self.urlProvider = urlProvider
         self.checkpointRequest = checkpointRequest
+        self.rowsRequest = rowsRequest
+        self.pushRequest = pushRequest
         self.delegate = delegate
     }
 
@@ -134,12 +143,101 @@ actor ChatRoomClient {
     func start() {
         closed = false
         connect()
+        // Pull-first bootstrap + poll-while-unjoined: one HTTPS GET catches
+        // the doc up in ~1 RTT while the socket spends 4+ on TLS + upgrade +
+        // hello — and on networks that strip WS upgrades (airplane wifi) the
+        // 20s poll is the transport, delivering reads AND queued sends.
+        pullTask?.cancel()
+        pullTask = Task { [weak self] in
+            await self?.pullSync()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 20_000_000_000)
+                guard let self, !Task.isCancelled else { return }
+                if await self.shouldPoll() { await self.pullSync() }
+            }
+        }
+    }
+
+    /// One HTTPS sync cycle: flush pending batches (POST — batchId dedupe
+    /// makes replays no-ops), then pull rows (GET) and apply them through the
+    /// exact frame path the socket uses. The airplane-wifi transport.
+    func pullSync() async {
+        guard !closed else { return }
+        // Push first, so a message typed on dead wifi leaves the device on
+        // this cycle rather than the next.
+        for push in pending {
+            guard var request = await pushRequest(push.batchId) else { break }
+            request.httpBody = push.bytes
+            guard let (data, response) = try? await URLSession.shared.data(for: request),
+                  let http = response as? HTTPURLResponse else { break }
+            if http.statusCode == 200,
+               let ack = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let seq = (ack["seq"] as? NSNumber)?.uint64Value {
+                pending.removeAll { $0.batchId == push.batchId }
+                await delegate.advanceCursor(seq)
+            } else if http.statusCode == 400 || http.statusCode == 413 {
+                // Permanent server verdict: retire, same as the error frame
+                // path — the ops stay in the local doc.
+                roomLog.error("chat2 \(self.chatId, privacy: .public): http push rejected (\(http.statusCode)); retiring batch")
+                pending.removeAll { $0.batchId == push.batchId }
+            } else {
+                break  // quota/transient: retry next cycle
+            }
+        }
+        let after = await delegate.cursor()
+        guard let request = await rowsRequest(after) else { return }
+        guard let (body, response) = try? await URLSession.shared.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200 else { return }
+        // u32-LE length-prefixed frames: state first, then rows, rowsDone.
+        var frames: [ChatWireFrame] = []
+        var off = 0
+        while off + 4 <= body.count {
+            let len = body.subdata(in: off..<(off + 4)).withUnsafeBytes {
+                Int($0.loadUnaligned(as: UInt32.self).littleEndian)
+            }
+            off += 4
+            guard off + len <= body.count else { break }
+            if let frame = ChatWire.decode(body.subdata(in: off..<(off + len))) {
+                frames.append(frame)
+            }
+            off += len
+        }
+        guard let stateFrame = frames.first, stateFrame.kind == ChatFrameType.state,
+              let state = ChatStateHeader(stateFrame.header) else { return }
+        var contained = state.checkpointSize == 0
+        if !contained {
+            contained = await delegate.containsFrontier(stateFrame.payload)
+        }
+        if case .checkpointThenRows = chatPlanCatchUp(cursor: after, state: state,
+                                                      frontierContained: contained) {
+            // The local doc lacks the checkpoint's frontier — fetch it over
+            // HTTPS first (Range-resumed, shared with the socket path via
+            // fetchInFlight) so the rows below land on their base.
+            guard !fetchInFlight else { return }
+            fetchInFlight = true
+            let bytes = await fetchCheckpoint()
+            fetchInFlight = false
+            checkpointProgressAt = nil
+            guard let bytes, !closed,
+                  await delegate.applyCheckpoint(bytes, state.checkpointSeq) else { return }
+        }
+        guard !closed else { return }
+        for frame in frames.dropFirst()
+        where frame.kind == ChatFrameType.row || frame.kind == ChatFrameType.rowsDone {
+            await applyRowFrame(frame)
+        }
+    }
+
+    private func shouldPoll() -> Bool {
+        !closed && !joined
     }
 
     func stop() {
         closed = true
         generation += 1
         cancelTasks()
+        pullTask?.cancel()
+        pullTask = nil
         socket?.cancel(with: .goingAway, reason: nil)
         socket = nil
         joined = false

--- a/apps/ios/Zeron/Sync/ChatRoomClient.swift
+++ b/apps/ios/Zeron/Sync/ChatRoomClient.swift
@@ -88,6 +88,17 @@ actor ChatRoomClient {
     /// Non-nil while a checkpoint downloads in parallel with the row
     /// backfill: row/rowsDone frames land here and replay after the import.
     private var checkpointBuffer: [ChatWireFrame]?
+    /// One checkpoint download at a time, and it OUTLIVES socket redials: on
+    /// a saturated link the WS silence lease can trip mid-download (pongs
+    /// queue behind the blob), and discarding the bytes on every redial
+    /// looped a fresh-chat open forever (NLC Edge, 2026-08-17).
+    private var fetchInFlight = false
+    /// Partial download preserved across fetch attempts (Range-resumed).
+    private var partialCheckpoint = Data()
+    private var partialCheckpointSeq: String?
+    /// Bytes moved on the checkpoint stream recently — download progress IS
+    /// liveness while it runs; the silence lease defers to it.
+    private var checkpointProgressAt: DispatchTime?
     private var joined = false
     private var closed = false
     private var generation = 0
@@ -292,7 +303,14 @@ actor ChatRoomClient {
     private func pingTick(gen: Int) async {
         guard gen == generation, let socket else { return }
         let silence = DispatchTime.now().uptimeNanoseconds - lastInbound.uptimeNanoseconds
-        if silence > ChatRoomClient.silenceLeaseNs {
+        // A checkpoint download that is still moving bytes owns the pipe —
+        // pongs queueing behind it are not a dead socket. The 120s backfill
+        // deadline stays as the true backstop.
+        let fetchMoving = checkpointProgressAt.map {
+            DispatchTime.now().uptimeNanoseconds - $0.uptimeNanoseconds
+                < ChatRoomClient.silenceLeaseNs
+        } ?? false
+        if silence > ChatRoomClient.silenceLeaseNs, !fetchMoving {
             roomLog.warning("chat2 \(self.chatId, privacy: .public): socket silent past lease; treating as dead")
             await onSocketError(gen: gen)
             return
@@ -432,8 +450,14 @@ actor ChatRoomClient {
             // whole blob.
             roomLog.info("chat2 \(self.chatId, privacy: .public): fetching checkpoint (seq=\(state.checkpointSeq), \(state.checkpointSize)B, rows in parallel)")
             checkpointBuffer = []
-            let seq = state.checkpointSeq
-            Task { await self.completeCheckpointFetch(gen: gen, seq: seq) }
+            // One download per chat, and it survives redials: a new session
+            // that still needs the checkpoint just re-arms the buffer and
+            // waits for the in-flight fetch to land.
+            if !fetchInFlight {
+                fetchInFlight = true
+                let seq = state.checkpointSeq
+                Task { await self.completeCheckpointFetch(seq: seq) }
+            }
             after = a
         }
         await send(ChatWire.encode(ChatFrameType.rowsReq,
@@ -446,28 +470,40 @@ actor ChatRoomClient {
     }
 
     /// Second half of the parallel checkpoint fetch: import the blob, then
-    /// replay the rows that buffered while it downloaded.
-    private func completeCheckpointFetch(gen: Int, seq: UInt64) async {
+    /// replay the rows that buffered while it downloaded. Deliberately NOT
+    /// generation-guarded on the apply: the blob's content is socket-
+    /// independent (CRDT import, cursor advances via max), so a download
+    /// that outlived its socket still becomes progress — the next session's
+    /// frontier check finds it contained and joins RowsOnly instead of
+    /// starting the download over.
+    private func completeCheckpointFetch(seq: UInt64) async {
         let bytes = await fetchCheckpoint()
-        guard gen == generation, !closed else { return }
+        fetchInFlight = false
+        checkpointProgressAt = nil
+        guard !closed else { return }
         guard let bytes else {
-            roomLog.warning("chat2 \(self.chatId, privacy: .public): checkpoint fetch failed; redialing")
-            checkpointBuffer = nil
-            await onSocketError(gen: gen)
+            // Redial only if a session is actually waiting on this blob
+            // (buffer armed) — a stale failure must not kill a healthy
+            // RowsOnly session that no longer needs it.
+            if checkpointBuffer != nil {
+                roomLog.warning("chat2 \(self.chatId, privacy: .public): checkpoint fetch failed (partial kept); redialing")
+                checkpointBuffer = nil
+                await onSocketError(gen: generation)
+            }
             return
         }
-        guard await delegate.applyCheckpoint(bytes, seq), gen == generation, !closed else {
-            if gen == generation, !closed {
+        guard await delegate.applyCheckpoint(bytes, seq), !closed else {
+            if !closed {
                 roomLog.error("chat2 \(self.chatId, privacy: .public): checkpoint import failed; redialing")
                 checkpointBuffer = nil
-                await onSocketError(gen: gen)
+                await onSocketError(gen: generation)
             }
             return
         }
         while let frame = checkpointBuffer?.first {
             checkpointBuffer?.removeFirst()
             await applyRowFrame(frame)
-            guard gen == generation, !closed else { return }
+            guard !closed else { return }
         }
         checkpointBuffer = nil
     }
@@ -566,10 +602,20 @@ actor ChatRoomClient {
     /// response with the checkpoint's seq, and a mid-download replacement
     /// restarts from 0 (a Range against a new blob would splice two blobs).
     private func fetchCheckpoint() async -> Data? {
-        var got = Data()
-        var seenSeq: String?
+        // Resume from any partial a previous attempt (even a previous
+        // SOCKET generation) left behind — starting a slow blob over from
+        // zero on every hiccup is how a thin link never converges.
+        var got = partialCheckpoint
+        var seenSeq: String? = partialCheckpointSeq
+        func keepPartial() {
+            partialCheckpoint = got
+            partialCheckpointSeq = seenSeq
+        }
         for _ in 0..<4 {
-            guard var request = await checkpointRequest() else { return nil }
+            guard var request = await checkpointRequest() else {
+                keepPartial()
+                return nil
+            }
             if !got.isEmpty {
                 request.setValue("bytes=\(got.count)-", forHTTPHeaderField: "Range")
             }
@@ -590,18 +636,27 @@ actor ChatRoomClient {
             case 206: break
             default:
                 roomLog.warning("chat2 \(self.chatId, privacy: .public): checkpoint HTTP \(http.statusCode)")
+                keepPartial()
                 return nil
             }
             do {
                 for try await byte in stream {
                     got.append(byte)
+                    // Download progress is liveness (see pingTick) — stamp
+                    // it every 8KB, not every byte.
+                    if got.count & 0x1FFF == 0 {
+                        checkpointProgressAt = .now()
+                    }
                 }
+                partialCheckpoint = Data()
+                partialCheckpointSeq = nil
                 return got
             } catch {
                 // Mid-body drop: keep the bytes, resume via Range.
                 roomLog.warning("chat2 \(self.chatId, privacy: .public): checkpoint stream dropped at \(got.count)B; resuming")
             }
         }
+        keepPartial()
         return nil
     }
 }

--- a/apps/ios/Zeron/Sync/RegistryClient.swift
+++ b/apps/ios/Zeron/Sync/RegistryClient.swift
@@ -112,8 +112,20 @@ actor RegistryClient {
     func kick() async {
         guard !closed else { return }
         backoffMs = RegistryClient.backoffBaseMs
-        if socket == nil || !joined {
+        if socket == nil {
             connect()
+            return
+        }
+        if !joined {
+            // A dial/handshake is already in flight on this socket — its own
+            // hello deadline polices it. Redialing here killed the launch
+            // dial mid-TLS every cold open (foregrounded() fires on scene
+            // activation), rerunning the handshake on the busiest link and
+            // doubling the spinner (NLC Edge, 2026-08-17). Only a zombie
+            // socket with NO handshake pending is redialed.
+            if helloSentAt == nil {
+                connect()
+            }
             return
         }
         guard probeSentAt == nil, helloSentAt == nil else { return }  // already policed

--- a/apps/ios/Zeron/Sync/SessionStore.swift
+++ b/apps/ios/Zeron/Sync/SessionStore.swift
@@ -148,6 +148,10 @@ final class SessionStore {
         connectIfReady()
     }
 
+    /// Still holding the preload dial (never connected) — the kick sweep
+    /// skips these so a foreground/path flap can't stampede held sockets.
+    var isDialHeld: Bool { holdDial }
+
     /// End a preload dial-hold: an open view (or the stagger timer) wants
     /// live sync now.
     func releaseDial() {

--- a/apps/ios/Zeron/Sync/SessionStore.swift
+++ b/apps/ios/Zeron/Sync/SessionStore.swift
@@ -207,6 +207,12 @@ final class SessionStore {
             checkpointRequest: { [config, chatId] in
                 await config.chat2CheckpointRequest(chatId: chatId)
             },
+            rowsRequest: { [config, chatId] after in
+                await config.chat2RowsRequest(chatId: chatId, after: after)
+            },
+            pushRequest: { [config, chatId] batchId in
+                await config.chat2PushRequest(chatId: chatId, batchId: batchId)
+            },
             delegate: delegate)
         chatRoom = client
         // First contact with the room (cursor 0): everything committed

--- a/apps/ios/Zeron/Sync/WorkspaceStore.swift
+++ b/apps/ios/Zeron/Sync/WorkspaceStore.swift
@@ -23,6 +23,12 @@ final class WorkspaceStore {
     private(set) var sessions: [String: SessionRow] = [:]
     private(set) var presence: [String: Int64] = [:]  // deviceId → last beat ms
     private(set) var connected = false
+    /// True once ANY transport delivered server state this session (socket
+    /// state frame or HTTPS pull). Drives the "connecting" spinner: with the
+    /// pull-first bootstrap this flips in ~1 round trip, while the socket
+    /// spends 4+ on TLS + upgrade + hello — and on networks that strip WS
+    /// upgrades it's the only flag that ever would.
+    private(set) var synced = false
 
     /// Presence entries older than this are expired (mirrors the Rust
     /// client's 30s TTL, measured from RECEIPT — beats carry the sender's
@@ -66,6 +72,78 @@ final class WorkspaceStore {
                                     delegate: delegate)
         self.client = client
         Task { await client.start() }
+        // Pull-first bootstrap + poll-while-down: one HTTPS GET syncs the
+        // sidebar in ~1 RTT while the socket dials, and while the socket is
+        // down (airplane wifi strips WS upgrades) a 20s poll keeps rows,
+        // presence, and pending writes flowing. The GET doubles as our
+        // presence beat, so this device stays visible to peers.
+        pollTask?.cancel()
+        pollTask = Task { [weak self] in
+            await self?.pullDelta()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 20_000_000_000)
+                guard let self, !Task.isCancelled else { return }
+                if !self.connected {
+                    await self.pushPendingOverHTTP()
+                    await self.pullDelta()
+                }
+            }
+        }
+    }
+
+    @ObservationIgnored private var pollTask: Task<Void, Never>?
+
+    /// The WS hello's delta answer over plain HTTPS, applied through the
+    /// exact state path the socket uses.
+    private func pullDelta() async {
+        guard let request = await config.registryRowsRequest(since: doc.helloCursor) else { return }
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200 else { return }
+        struct PullBody: Decodable {
+            var seq: UInt64
+            var full: Bool
+            var gcFloor: UInt64?
+            var rows: [RegistryRow]
+            var presence: [String: Int64]?
+        }
+        guard let body = try? JSONDecoder().decode(PullBody.self, from: data) else {
+            roomLog.warning("registry: http pull body unparseable")
+            return
+        }
+        handle(.state(seq: body.seq, full: body.full, gcFloor: body.gcFloor ?? 0,
+                      rows: body.rows, presence: body.presence ?? [:]))
+    }
+
+    /// Flush pending op batches over HTTPS while the socket is down (LWW
+    /// clocks make replays apply zero ops).
+    private func pushPendingOverHTTP() async {
+        struct PushBody: Encodable {
+            var batch: String
+            var ops: [RegistryOp]
+        }
+        struct AckBody: Decodable {
+            var batch: String
+            var seq: UInt64
+            var applied: UInt64?
+        }
+        let batches = doc.takePushable()
+        guard !batches.isEmpty else { return }
+        for pending in batches {
+            guard var request = await config.registryPushRequest(),
+                  let body = try? JSONEncoder().encode(PushBody(batch: pending.batch,
+                                                                ops: pending.ops)) else { break }
+            request.httpBody = body
+            guard let (data, response) = try? await URLSession.shared.data(for: request),
+                  (response as? HTTPURLResponse)?.statusCode == 200,
+                  let ack = try? JSONDecoder().decode(AckBody.self, from: data) else {
+                // takePushable marked these in flight; nothing clears that
+                // until the next socket disconnect — un-mark so the next
+                // cycle (HTTP or WS) retries them.
+                doc.markDisconnected()
+                break
+            }
+            handle(.ack(batch: ack.batch, seq: ack.seq, applied: ack.applied ?? 0))
+        }
     }
 
     /// Backgrounding hook: persist immediately.
@@ -81,6 +159,8 @@ final class WorkspaceStore {
     }
 
     func stop() {
+        pollTask?.cancel()
+        pollTask = nil
         saver?.flush()
         if let client {
             Task { await client.stop() }
@@ -109,6 +189,7 @@ final class WorkspaceStore {
             }
             project()
             saver?.poke()
+            synced = true
         case .connected:
             connected = true
         case .rows(let seq, let rows):
@@ -138,6 +219,11 @@ final class WorkspaceStore {
         saver?.poke()
         if let client {
             Task { await client.nudge() }
+        }
+        // Socket down: the write still leaves the device promptly over
+        // HTTPS instead of waiting out the reconnect backoff.
+        if !connected {
+            Task { await self.pushPendingOverHTTP() }
         }
     }
 

--- a/crates/engine/src/chat2_host.rs
+++ b/crates/engine/src/chat2_host.rs
@@ -218,3 +218,98 @@ impl CheckpointFetcher for EdgeCheckpointFetcher {
         })
     }
 }
+
+
+/// Plain-HTTPS chat pull/push (the airplane-wifi transport): GET/POST
+/// `/chat2/{id}/rows` with the same bearer auth the checkpoint fetcher uses.
+pub struct EdgeChatTransport {
+    http: reqwest::Client,
+    edge: EdgeConfig,
+    chat_id: String,
+    device_id: String,
+}
+
+impl EdgeChatTransport {
+    pub fn new(
+        http: reqwest::Client,
+        edge: EdgeConfig,
+        chat_id: impl Into<String>,
+        device_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            http,
+            edge,
+            chat_id: chat_id.into(),
+            device_id: device_id.into(),
+        }
+    }
+
+    fn rows_url(&self) -> String {
+        format!(
+            "{}/chat2/{}/rows",
+            self.edge.url.trim_end_matches('/'),
+            self.chat_id
+        )
+    }
+}
+
+impl zeron_sync::chat_client::ChatTransport for EdgeChatTransport {
+    fn fetch_rows(&self, after: u64) -> BoxFuture<'static, Result<Vec<u8>, SyncError>> {
+        let http = self.http.clone();
+        let edge = self.edge.clone();
+        let url = self.rows_url();
+        let device = self.device_id.clone();
+        Box::pin(async move {
+            let bearer = edge
+                .bearer()
+                .await
+                .ok_or_else(|| SyncError::Auth("signed out".into()))?;
+            let res = http
+                .get(&url)
+                .query(&[("after", after.to_string()), ("device", device)])
+                .bearer_auth(&bearer)
+                .send()
+                .await
+                .map_err(|e| SyncError::WebSocket(e.to_string()))?;
+            if !res.status().is_success() {
+                return Err(SyncError::Protocol(format!("chat pull http {}", res.status())));
+            }
+            let bytes = res
+                .bytes()
+                .await
+                .map_err(|e| SyncError::WebSocket(e.to_string()))?;
+            Ok(bytes.to_vec())
+        })
+    }
+
+    fn push(
+        &self,
+        batch_id: String,
+        bytes: Vec<u8>,
+    ) -> BoxFuture<'static, Result<String, SyncError>> {
+        let http = self.http.clone();
+        let edge = self.edge.clone();
+        let url = self.rows_url();
+        let device = self.device_id.clone();
+        Box::pin(async move {
+            let bearer = edge
+                .bearer()
+                .await
+                .ok_or_else(|| SyncError::Auth("signed out".into()))?;
+            let res = http
+                .post(&url)
+                .query(&[("batchId", batch_id), ("device", device)])
+                .bearer_auth(&bearer)
+                .body(bytes)
+                .send()
+                .await
+                .map_err(|e| SyncError::WebSocket(e.to_string()))?;
+            if !res.status().is_success() {
+                return Err(SyncError::Protocol(format!("chat push http {}", res.status())));
+            }
+            res.text()
+                .await
+                .map_err(|e| SyncError::WebSocket(e.to_string()))
+        })
+    }
+}

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -962,14 +962,26 @@ impl DocHost {
                 if weak.upgrade().is_none() {
                     return; // evicted or purged while dialing
                 }
+                // Dual transport: WS dial + a plain-HTTPS pull/push seam
+                // (rows GET / POST on the same bearer auth as the checkpoint
+                // fetch) — bootstraps in ~1 RTT and keeps syncing at backoff
+                // cadence on networks that never pass the WS upgrade. With
+                // the transport, connect resolves immediately (local-first).
+                let transport = Arc::new(crate::chat2_host::EdgeChatTransport::new(
+                    host.inner.http.clone(),
+                    edge.clone(),
+                    chat.clone(),
+                    device.clone(),
+                ));
                 let dial = tokio::time::timeout(
                     std::time::Duration::from_secs(60),
-                    zeron_sync::ChatClient::connect_via(
+                    zeron_sync::ChatClient::connect_via_transport(
                         url.clone(),
                         sink.clone(),
                         fetcher.clone(),
                         &device,
                         cursor,
+                        transport,
                     ),
                 )
                 .await;

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -1024,11 +1024,26 @@ impl DocHost {
                             let host = host.clone();
                             let weak = weak.clone();
                             host.clone().spawn_worker(async move {
-                                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                                // With the pull-first transport the client
+                                // constructs before any state answer — wait
+                                // until the server's view is KNOWN (bounded)
+                                // or the all-zero placeholder stats would
+                                // misread as "no checkpoint" and upload a
+                                // spurious full-doc heal on a thin link.
+                                for _ in 0..40u32 {
+                                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                                    let Some(handle) = weak.upgrade() else { return };
+                                    let known = lock(&handle.chat2)
+                                        .as_ref()
+                                        .is_some_and(|c| c.stats().server_known);
+                                    if known {
+                                        break;
+                                    }
+                                }
                                 let Some(handle) = weak.upgrade() else { return };
                                 let no_checkpoint = lock(&handle.chat2)
                                     .as_ref()
-                                    .is_some_and(|c| c.stats().checkpoint_size == 0);
+                                    .is_some_and(|c| c.stats().server_known && c.stats().checkpoint_size == 0);
                                 let has_content = handle
                                     .doc
                                     .read_entries()

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -333,14 +333,25 @@ impl WorkspaceHost {
                 let tuning = RegistryTuning {
                     probe_quiet: REGISTRY_PROBE_QUIET,
                 };
-                match RegistryClient::connect_via_tuned(
-                    url.clone(),
-                    reg.clone(),
-                    &device_id,
-                    tuning,
-                )
-                .await
-                {
+                // Production path (token present): dual transport — the WS
+                // dials as before, and a plain-HTTPS pull/push seam derived
+                // from the same URL provider bootstraps the doc in ~1 RTT
+                // and keeps syncing at backoff cadence when the socket can't
+                // connect (airplane-wifi networks strip WS upgrades).
+                let result = if token.is_some() {
+                    RegistryClient::connect_via_transport(
+                        url.clone(),
+                        reg.clone(),
+                        &device_id,
+                        tuning,
+                        Arc::new(WsDerivedRegistryTransport::new(url.clone())),
+                    )
+                    .await
+                } else {
+                    RegistryClient::connect_via_tuned(url.clone(), reg.clone(), &device_id, tuning)
+                        .await
+                };
+                match result {
                     Ok(client) => {
                         let client = Arc::new(client);
                         client.set_presence(now_ms());
@@ -1267,6 +1278,102 @@ fn device_name_on_boot(existing_name: Option<&str>, detected_name: &str) -> Stri
         })
         .unwrap_or(detected_name)
         .to_string()
+}
+
+
+/// Plain-HTTPS registry pull/push derived from the SAME WebSocket URL
+/// provider the dial uses (`wss://…/registry/{org}/ws?token=…&device=…`):
+/// swap the scheme, swap the `/ws` leaf for `/rows` or `/push`, keep the
+/// fresh token+device the provider already mints per attempt. No second
+/// auth path to maintain, and the `?beat=1` keeps presence alive for a
+/// device that can only reach the edge over HTTPS.
+struct WsDerivedRegistryTransport {
+    url: Arc<dyn zeron_sync::UrlProvider>,
+    client: reqwest::Client,
+}
+
+impl WsDerivedRegistryTransport {
+    fn new(url: Arc<dyn zeron_sync::UrlProvider>) -> Self {
+        Self {
+            url,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    async fn leaf_url(
+        provider: &Arc<dyn zeron_sync::UrlProvider>,
+        leaf: &str,
+    ) -> Result<reqwest::Url, zeron_sync::SyncError> {
+        let ws = provider.url().await?;
+        let mut u = reqwest::Url::parse(&ws)
+            .map_err(|e| zeron_sync::SyncError::Protocol(format!("bad ws url: {e}")))?;
+        let scheme = if u.scheme() == "wss" { "https" } else { "http" };
+        let _ = u.set_scheme(scheme);
+        let path = u.path().to_string();
+        let Some(base) = path.strip_suffix("/ws") else {
+            return Err(zeron_sync::SyncError::Protocol("ws url without /ws leaf".into()));
+        };
+        let new_path = format!("{base}/{leaf}");
+        u.set_path(&new_path);
+        Ok(u)
+    }
+}
+
+impl zeron_sync::RegistryTransport for WsDerivedRegistryTransport {
+    fn fetch(
+        &self,
+        since: u64,
+    ) -> futures::future::BoxFuture<'static, Result<String, zeron_sync::SyncError>> {
+        let provider = self.url.clone();
+        let client = self.client.clone();
+        Box::pin(async move {
+            let mut u = Self::leaf_url(&provider, "rows").await?;
+            u.query_pairs_mut()
+                .append_pair("since", &since.to_string())
+                .append_pair("beat", "1");
+            let resp = client
+                .get(u)
+                .send()
+                .await
+                .map_err(|e| zeron_sync::SyncError::WebSocket(e.to_string()))?;
+            if !resp.status().is_success() {
+                return Err(zeron_sync::SyncError::Protocol(format!(
+                    "registry pull http {}",
+                    resp.status()
+                )));
+            }
+            resp.text()
+                .await
+                .map_err(|e| zeron_sync::SyncError::WebSocket(e.to_string()))
+        })
+    }
+
+    fn push(
+        &self,
+        body: String,
+    ) -> futures::future::BoxFuture<'static, Result<String, zeron_sync::SyncError>> {
+        let provider = self.url.clone();
+        let client = self.client.clone();
+        Box::pin(async move {
+            let u = Self::leaf_url(&provider, "push").await?;
+            let resp = client
+                .post(u)
+                .header("content-type", "application/json")
+                .body(body)
+                .send()
+                .await
+                .map_err(|e| zeron_sync::SyncError::WebSocket(e.to_string()))?;
+            if !resp.status().is_success() {
+                return Err(zeron_sync::SyncError::Protocol(format!(
+                    "registry push http {}",
+                    resp.status()
+                )));
+            }
+            resp.text()
+                .await
+                .map_err(|e| zeron_sync::SyncError::WebSocket(e.to_string()))
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -285,6 +285,10 @@ struct Shared {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ChatStatsSnapshot {
     pub connected: bool,
+    /// A state answer (socket hello or HTTPS pull) has been received —
+    /// until then every server-side field below is a placeholder zero, and
+    /// consumers like the host's bootstrap heal must not act on them.
+    pub server_known: bool,
     pub cursor: u64,
     pub head_seq: u64,
     pub seq_floor: u64,
@@ -555,6 +559,7 @@ impl ChatClient {
         });
         ChatStatsSnapshot {
             connected: self.flags.connected.load(Relaxed),
+            server_known: shared.server.is_some(),
             cursor: shared.cursor,
             // The server's honest view — deliberately NOT clamped to the
             // cursor: cursor > headSeq is the reset signal and must stay

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -753,48 +753,22 @@ impl Actor {
         let plan = plan_catch_up(cursor, &state, contained);
         let after = match plan {
             CatchUpPlan::RowsOnly { after } => after,
-            CatchUpPlan::CheckpointThenRows { after } => {
-                tracing::info!(
-                    checkpoint_seq = state.checkpoint_seq,
-                    checkpoint_size = state.checkpoint_size,
-                    "chat2: fetching checkpoint"
-                );
-                // Deadline + shutdown-interruptible: a hung fetch (half-open
-                // TCP, stalled link) must neither pin the actor forever nor
-                // block `shutdown()`. The fetch is Range-resumable, so the
-                // redial retries from wherever the bytes stopped.
-                let fetch = self.fetcher.fetch();
-                let fetched = tokio::select! {
-                    fetched = tokio::time::timeout(CHECKPOINT_FETCH_DEADLINE, fetch) => fetched,
-                    _ = self.shutdown.changed() => return SessionEnd::Stop,
-                };
-                let bytes = match fetched {
-                    Ok(Ok(bytes)) => bytes,
-                    Ok(Err(err)) => {
-                        tracing::warn!(error = %err, "chat2: checkpoint fetch failed");
-                        return SessionEnd::Reconnect;
-                    }
-                    Err(_) => {
-                        tracing::warn!("chat2: checkpoint fetch timed out; redialing");
-                        return SessionEnd::Reconnect;
-                    }
-                };
-                if let Err(err) = self.sink.apply_checkpoint(&bytes, state.checkpoint_seq) {
-                    tracing::warn!(error = %err, "chat2: checkpoint import failed");
-                    return SessionEnd::Reconnect;
-                }
-                let mut shared = lock(&self.shared);
-                shared.cursor = shared.cursor.max(state.checkpoint_seq);
-                drop(shared);
-                let _ = self.events.send(ChatEvent::Applied);
-                after
-            }
+            CatchUpPlan::CheckpointThenRows { after } => after,
         };
         // Clamp the persisted cursor into the room's honest range (server
         // reset detection happened in plan_catch_up via after==0).
         if after < cursor {
             lock(&self.shared).cursor = after;
         }
+        // Rows request goes out BEFORE any checkpoint fetch: the row backfill
+        // streams over the socket while the checkpoint downloads over HTTP in
+        // parallel, instead of serializing download → request → backfill. On
+        // a thin link the checkpoint download IS the join time, and every
+        // byte of it used to push the row stream (and "ready") back by that
+        // much. Rows received mid-fetch are buffered and applied after the
+        // checkpoint imports — row seqs are all > checkpointSeq, so ordering
+        // is preserved, and the persisted cursor can't advance past state it
+        // doesn't contain because nothing applies until the import lands.
         let rows_req = wire::encode(
             frame_type::ROWS_REQ,
             &wire::RowsReqHeader {
@@ -808,42 +782,118 @@ impl Actor {
         if pipe.tx.send(rows_req).await.is_err() {
             return SessionEnd::Reconnect;
         }
-        let backfill = tokio::time::timeout(BACKFILL_DEADLINE, async {
-            loop {
-                let bytes = pipe.rx.recv().await?;
-                let Some(frame) = wire::decode(&bytes) else {
-                    return None;
-                };
-                match frame.kind {
-                    frame_type::ROWS_DONE => {
-                        let done: wire::RowsDoneHeader =
-                            serde_json::from_value(frame.header).ok()?;
-                        return Some(done.head_seq);
-                    }
-                    _ => {
-                        if !self.handle_frame(frame) {
-                            return None;
+        // Pending pushes ALSO go before catch-up completes: the server's
+        // batchId dedupe makes replays no-ops and rows are CRDT-commutative,
+        // so a message written on a dead network flushes ~2 RTTs after the
+        // socket lands instead of waiting out a whole checkpoint download +
+        // backfill ("typing works even when load doesn't").
+        if !self.push_pending(&mut pipe).await {
+            return SessionEnd::Reconnect;
+        }
+        let mut buffered: Vec<wire::WireFrame> = Vec::new();
+        if let CatchUpPlan::CheckpointThenRows { .. } = plan {
+            tracing::info!(
+                checkpoint_seq = state.checkpoint_seq,
+                checkpoint_size = state.checkpoint_size,
+                "chat2: fetching checkpoint (rows streaming in parallel)"
+            );
+            // Deadline + shutdown-interruptible: a hung fetch (half-open
+            // TCP, stalled link) must neither pin the actor forever nor
+            // block `shutdown()`. The fetch is Range-resumable, so the
+            // redial retries from wherever the bytes stopped. The socket is
+            // drained (into the buffer) for the whole fetch so backpressure
+            // can't stall the server's row stream.
+            let fetch = self.fetcher.fetch();
+            tokio::pin!(fetch);
+            let deadline = tokio::time::sleep(CHECKPOINT_FETCH_DEADLINE);
+            tokio::pin!(deadline);
+            let bytes = loop {
+                tokio::select! {
+                    fetched = &mut fetch => match fetched {
+                        Ok(bytes) => break bytes,
+                        Err(err) => {
+                            tracing::warn!(error = %err, "chat2: checkpoint fetch failed");
+                            return SessionEnd::Reconnect;
                         }
+                    },
+                    _ = &mut deadline => {
+                        tracing::warn!("chat2: checkpoint fetch timed out; redialing");
+                        return SessionEnd::Reconnect;
+                    }
+                    _ = self.shutdown.changed() => return SessionEnd::Stop,
+                    inbound = pipe.rx.recv() => match inbound {
+                        Some(raw) => match wire::decode(&raw) {
+                            Some(frame) => buffered.push(frame),
+                            None => {
+                                tracing::warn!("chat2: unparseable frame during checkpoint fetch");
+                                return SessionEnd::Reconnect;
+                            }
+                        },
+                        None => return SessionEnd::Reconnect,
                     }
                 }
+            };
+            if let Err(err) = self.sink.apply_checkpoint(&bytes, state.checkpoint_seq) {
+                tracing::warn!(error = %err, "chat2: checkpoint import failed");
+                return SessionEnd::Reconnect;
             }
-        })
-        .await;
-        let Ok(Some(head_seq)) = backfill else {
-            tracing::warn!("chat2: backfill did not complete");
-            return SessionEnd::Reconnect;
+            let mut shared = lock(&self.shared);
+            shared.cursor = shared.cursor.max(state.checkpoint_seq);
+            drop(shared);
+            let _ = self.events.send(ChatEvent::Applied);
+        }
+        // Frames buffered during the fetch replay first, then the live socket
+        // finishes the backfill — one pass, same ROWS_DONE terminator either
+        // way.
+        let mut head_seq: Option<u64> = None;
+        for frame in buffered.drain(..) {
+            if head_seq.is_none() && frame.kind == frame_type::ROWS_DONE {
+                let Ok(done) = serde_json::from_value::<wire::RowsDoneHeader>(frame.header) else {
+                    return SessionEnd::Reconnect;
+                };
+                head_seq = Some(done.head_seq);
+                continue; // frames after ROWS_DONE are steady-state; keep them
+            }
+            if !self.handle_frame(frame) {
+                return SessionEnd::Reconnect;
+            }
+        }
+        let head_seq = match head_seq {
+            Some(seq) => seq,
+            None => {
+                let backfill = tokio::time::timeout(BACKFILL_DEADLINE, async {
+                    loop {
+                        let bytes = pipe.rx.recv().await?;
+                        let Some(frame) = wire::decode(&bytes) else {
+                            return None;
+                        };
+                        match frame.kind {
+                            frame_type::ROWS_DONE => {
+                                let done: wire::RowsDoneHeader =
+                                    serde_json::from_value(frame.header).ok()?;
+                                return Some(done.head_seq);
+                            }
+                            _ => {
+                                if !self.handle_frame(frame) {
+                                    return None;
+                                }
+                            }
+                        }
+                    }
+                })
+                .await;
+                let Ok(Some(seq)) = backfill else {
+                    tracing::warn!("chat2: backfill did not complete");
+                    return SessionEnd::Reconnect;
+                };
+                seq
+            }
         };
         self.resumed = true;
         if let Some(ready) = ready.take() {
             let _ = ready.send(Ok(()));
         }
         let _ = self.events.send(ChatEvent::CaughtUp { head_seq });
-
-        // Anything pending (offline writes, reconnect re-pushes) goes now —
-        // the server's batchId dedupe makes replays exact no-ops.
-        if !self.push_pending(&mut pipe).await {
-            return SessionEnd::Reconnect;
-        }
 
         // ── steady state ────────────────────────────────────────────────────
         let mut last_frame = tokio::time::Instant::now();

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -119,6 +119,17 @@ pub trait CheckpointFetcher: Send + Sync + 'static {
     fn fetch(&self) -> BoxFuture<'static, Result<Vec<u8>, SyncError>>;
 }
 
+/// Plain-HTTPS pull/push seam — the airplane-wifi transport. `fetch_rows`
+/// GETs `/chat2/{id}/rows?after=` and returns the body: u32-LE
+/// length-prefixed frames (state, rows, rowsDone — the WS encoding). `push`
+/// POSTs one batch to `/chat2/{id}/rows?batchId=` and returns the JSON ack.
+/// Both are safe at-least-once: batchId dedupe and Loro re-import no-ops.
+pub trait ChatTransport: Send + Sync + 'static {
+    fn fetch_rows(&self, after: u64) -> BoxFuture<'static, Result<Vec<u8>, SyncError>>;
+    fn push(&self, batch_id: String, bytes: Vec<u8>)
+    -> BoxFuture<'static, Result<String, SyncError>>;
+}
+
 // ── catch-up planning (pure — the client-side precision rule) ───────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -363,6 +374,33 @@ impl ChatClient {
         .await
     }
 
+    /// Connect with a plain-HTTPS pull/push seam alongside the socket: the
+    /// construction resolves immediately (local-first — the doc is usable
+    /// now and converging it is the actor's ongoing job), an HTTP pull
+    /// bootstraps in ~1 RTT while the WS spends its round trips, and every
+    /// backoff cycle syncs over HTTPS so a network that never passes the
+    /// upgrade still converges and still delivers sends.
+    pub async fn connect_via_transport(
+        provider: Arc<dyn UrlProvider>,
+        sink: Arc<dyn ChatDocSink>,
+        fetcher: Arc<dyn CheckpointFetcher>,
+        device_id: &str,
+        initial_cursor: u64,
+        transport: Arc<dyn ChatTransport>,
+    ) -> Result<Self, SyncError> {
+        let connector = Arc::new(WsBinConnector { url: provider });
+        Self::connect_with_transport(
+            connector,
+            sink,
+            fetcher,
+            device_id,
+            initial_cursor,
+            ChatTuning::default(),
+            Some(transport),
+        )
+        .await
+    }
+
     pub(crate) async fn connect_with_tuned(
         connector: Arc<dyn BinConnector>,
         sink: Arc<dyn ChatDocSink>,
@@ -370,6 +408,19 @@ impl ChatClient {
         device_id: &str,
         initial_cursor: u64,
         tuning: ChatTuning,
+    ) -> Result<Self, SyncError> {
+        Self::connect_with_transport(connector, sink, fetcher, device_id, initial_cursor, tuning, None)
+            .await
+    }
+
+    pub(crate) async fn connect_with_transport(
+        connector: Arc<dyn BinConnector>,
+        sink: Arc<dyn ChatDocSink>,
+        fetcher: Arc<dyn CheckpointFetcher>,
+        device_id: &str,
+        initial_cursor: u64,
+        tuning: ChatTuning,
+        transport: Option<Arc<dyn ChatTransport>>,
     ) -> Result<Self, SyncError> {
         let (events, _) = broadcast::channel(256);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -399,6 +450,8 @@ impl ChatClient {
             presence_rx,
             flags: flags.clone(),
             resumed: false,
+            transport,
+            sync_busy: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         let task = tokio::spawn(actor.run(ready_tx));
 
@@ -553,6 +606,10 @@ struct Actor {
     redial_rx: mpsc::Receiver<()>,
     presence_rx: mpsc::Receiver<(i64, Vec<u8>)>,
     flags: Arc<Flags>,
+    /// Plain-HTTPS pull/push (None = socket-only: tests, dev bearers).
+    transport: Option<Arc<dyn ChatTransport>>,
+    /// One offline sync in flight at a time.
+    sync_busy: Arc<std::sync::atomic::AtomicBool>,
     /// False until the first backfill of THIS client instance completes.
     /// (Continuity is instance-scoped: a host that restores an older doc
     /// snapshot must construct a fresh `ChatClient` — C3 wiring contract.)
@@ -584,6 +641,15 @@ impl Actor {
     async fn run(mut self, ready: oneshot::Sender<Result<(), SyncError>>) {
         let mut ready = Some(ready);
         let mut backoff = BACKOFF_BASE;
+        // Pull-first bootstrap (see registry.rs run): with an HTTPS
+        // transport, construction resolves immediately and an HTTP pull
+        // converges the doc in ~1 RTT while the socket spends its 4+.
+        if self.transport.is_some() {
+            if let Some(ready) = ready.take() {
+                let _ = ready.send(Ok(()));
+            }
+            self.spawn_offline_sync();
+        }
         // Suspend/resume and sibling-dial successes are EVENTS that end a
         // backoff wait immediately (see room.rs) — without them a recovered
         // network still waited out the full accumulated delay.
@@ -602,6 +668,7 @@ impl Actor {
                         return; // first join failed: caller owns the retry
                     }
                     tracing::warn!(error = %err, "chat2 dial failed; backing off");
+                    self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
                         Waited::Woke => backoff = BACKOFF_BASE,
@@ -615,6 +682,7 @@ impl Actor {
                         return;
                     }
                     tracing::warn!("chat2 dial timed out; backing off");
+                    self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
                         Waited::Woke => backoff = BACKOFF_BASE,
@@ -644,6 +712,7 @@ impl Actor {
                     if joined {
                         backoff = BACKOFF_BASE;
                     }
+                    self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
                         Waited::Woke => backoff = BACKOFF_BASE,
@@ -1007,6 +1076,141 @@ impl Actor {
             Some(frame) => pipe.tx.send(frame).await.is_ok(),
             None => true,
         }
+    }
+
+    /// One HTTPS sync cycle off the critical path: flush pending batches
+    /// (POST — batchId dedupe), then pull rows (GET) and apply them exactly
+    /// as the WS backfill would, fetching the checkpoint first when the
+    /// state says the local doc lacks its frontier. Single-flight; failures
+    /// retry on the next backoff cycle.
+    fn spawn_offline_sync(&self) {
+        use std::sync::atomic::Ordering::Relaxed;
+        let Some(transport) = self.transport.clone() else {
+            return;
+        };
+        if self.sync_busy.swap(true, Relaxed) {
+            return;
+        }
+        let shared = self.shared.clone();
+        let sink = self.sink.clone();
+        let fetcher = self.fetcher.clone();
+        let events = self.events.clone();
+        let busy = self.sync_busy.clone();
+        tokio::spawn(async move {
+            let batches: Vec<(String, Vec<u8>)> = lock(&shared)
+                .pending
+                .iter()
+                .map(|p| (p.batch_id.clone(), p.bytes.clone()))
+                .collect();
+            for (batch_id, bytes) in batches {
+                match transport.push(batch_id, bytes).await {
+                    Ok(ack) => {
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&ack) {
+                            if let (Some(b), Some(seq)) = (v["batchId"].as_str(), v["seq"].as_u64())
+                            {
+                                let mut sh = lock(&shared);
+                                sh.pending.retain(|p| p.batch_id != b);
+                                sh.cursor = sh.cursor.max(seq);
+                                let cursor = sh.cursor;
+                                drop(sh);
+                                sink.advance_cursor(cursor);
+                                let _ = events.send(ChatEvent::Applied);
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        tracing::debug!(error = %err, "chat2: http push failed; will retry");
+                        break;
+                    }
+                }
+            }
+            let cursor = lock(&shared).cursor;
+            let body = match transport.fetch_rows(cursor).await {
+                Ok(body) => body,
+                Err(err) => {
+                    tracing::debug!(error = %err, "chat2: http pull failed; will retry");
+                    busy.store(false, Relaxed);
+                    return;
+                }
+            };
+            // u32-LE length-prefixed frames: state first, rows, rowsDone.
+            let mut frames: Vec<wire::WireFrame> = Vec::new();
+            let mut off = 0usize;
+            while off + 4 <= body.len() {
+                let len =
+                    u32::from_le_bytes([body[off], body[off + 1], body[off + 2], body[off + 3]])
+                        as usize;
+                off += 4;
+                if off + len > body.len() {
+                    break;
+                }
+                if let Some(frame) = wire::decode(&body[off..off + len]) {
+                    frames.push(frame);
+                }
+                off += len;
+            }
+            let mut iter = frames.into_iter();
+            let Some(state_frame) = iter.next() else {
+                busy.store(false, Relaxed);
+                return;
+            };
+            if state_frame.kind == frame_type::STATE {
+                if let Ok(state) =
+                    serde_json::from_value::<wire::StateHeader>(state_frame.header.clone())
+                {
+                    lock(&shared).server = Some(state);
+                    let contained = state.checkpoint_size == 0
+                        || sink.contains_frontier(&state_frame.payload);
+                    if let CatchUpPlan::CheckpointThenRows { after } =
+                        plan_catch_up(cursor, &state, contained)
+                    {
+                        let fetched = tokio::time::timeout(
+                            CHECKPOINT_FETCH_DEADLINE,
+                            fetcher.fetch(),
+                        )
+                        .await;
+                        match fetched {
+                            Ok(Ok(bytes)) => {
+                                if sink.apply_checkpoint(&bytes, state.checkpoint_seq).is_err() {
+                                    busy.store(false, Relaxed);
+                                    return;
+                                }
+                                let mut sh = lock(&shared);
+                                sh.cursor = sh.cursor.max(after);
+                                drop(sh);
+                                let _ = events.send(ChatEvent::Applied);
+                            }
+                            _ => {
+                                busy.store(false, Relaxed);
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            let mut applied = false;
+            for frame in iter {
+                match frame.kind {
+                    frame_type::ROW => {
+                        let Ok(row) = serde_json::from_value::<wire::RowHeader>(frame.header)
+                        else {
+                            continue;
+                        };
+                        sink.apply_row(&frame.payload, row.seq);
+                        let mut sh = lock(&shared);
+                        sh.cursor = sh.cursor.max(row.seq);
+                        drop(sh);
+                        applied = true;
+                    }
+                    frame_type::ROWS_DONE => {}
+                    _ => {}
+                }
+            }
+            if applied {
+                let _ = events.send(ChatEvent::Applied);
+            }
+            busy.store(false, Relaxed);
+        });
     }
 
     async fn push_pending(&self, pipe: &mut BinPipe) -> bool {

--- a/crates/sync/src/chat_client/tests.rs
+++ b/crates/sync/src/chat_client/tests.rs
@@ -50,14 +50,19 @@ struct RecordingSink {
     checkpoints: Mutex<Vec<(Vec<u8>, u64)>>,
     cursor_advances: Mutex<Vec<u64>>,
     frontier_contained: std::sync::atomic::AtomicBool,
+    /// Global apply order across rows and checkpoints — the overlap test
+    /// pins "checkpoint imports before any row that buffered during it".
+    ops: Mutex<Vec<String>>,
 }
 
 impl ChatDocSink for RecordingSink {
     fn apply_row(&self, bytes: &[u8], cursor: u64) {
         lock(&self.rows).push((bytes.to_vec(), cursor));
+        lock(&self.ops).push(format!("row@{cursor}"));
     }
     fn apply_checkpoint(&self, bytes: &[u8], cursor: u64) -> Result<(), String> {
         lock(&self.checkpoints).push((bytes.to_vec(), cursor));
+        lock(&self.ops).push(format!("ckpt@{cursor}"));
         Ok(())
     }
     fn contains_frontier(&self, _frontier: &[u8]) -> bool {
@@ -718,5 +723,154 @@ async fn seeded_at_zero_room_fetches_the_checkpoint() {
         *lock(&sink.checkpoints),
         vec![(b"seed-checkpoint-bytes".to_vec(), 0)]
     );
+    client.shutdown().await;
+}
+
+// ── 450kbps cold-open: overlap + early push ─────────────────────────────────
+
+/// Fetch that resolves only when the test releases its gate — stands in for
+/// a checkpoint blob crawling down a thin link.
+struct GatedFetcher {
+    gate: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+    bytes: Vec<u8>,
+}
+
+impl CheckpointFetcher for GatedFetcher {
+    fn fetch(&self) -> BoxFuture<'static, Result<Vec<u8>, SyncError>> {
+        let gate = lock(&self.gate).take().expect("single fetch");
+        let bytes = self.bytes.clone();
+        Box::pin(async move {
+            let _ = gate.await;
+            Ok(bytes)
+        })
+    }
+}
+
+/// The rows request leaves BEFORE the checkpoint download finishes (the
+/// server observes it while the fetch is still gated), rows landing
+/// mid-download buffer, and the import still applies before any of them —
+/// the join must not serialize download → request → backfill.
+#[tokio::test]
+async fn checkpoint_fetch_overlaps_row_backfill() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default()); // frontier NOT contained
+    let (gate_tx, gate_rx) = tokio::sync::oneshot::channel();
+    let fetch = Arc::new(GatedFetcher {
+        gate: Mutex::new(Some(gate_rx)),
+        bytes: b"parallel-checkpoint".to_vec(),
+    });
+
+    let server = tokio::spawn(async move {
+        let _hello = expect_kind(&mut end, frame_type::HELLO).await;
+        send(
+            &end,
+            frame_type::STATE,
+            serde_json::json!({"headSeq": 7, "seqFloor": 0,
+                "checkpointSeq": 5, "checkpointSize": 1000,
+                "rowCount": 2, "rowBytes": 64}),
+            b"frontier",
+        )
+        .await;
+        // The ordering pin: this arrives while the fetch is still GATED.
+        let req = expect_kind(&mut end, frame_type::ROWS_REQ).await;
+        assert_eq!(req.header["after"], 5, "rows resume past the checkpoint");
+        send(
+            &end,
+            frame_type::ROW,
+            serde_json::json!({"seq": 6, "device": "dev-b", "batchId": "b6"}),
+            b"r6",
+        )
+        .await;
+        send(
+            &end,
+            frame_type::ROW,
+            serde_json::json!({"seq": 7, "device": "dev-b", "batchId": "b7"}),
+            b"r7",
+        )
+        .await;
+        send(&end, frame_type::ROWS_DONE, serde_json::json!({"headSeq": 7}), &[]).await;
+        // Only now does the "download" complete.
+        let _ = gate_tx.send(());
+        end
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds with rows served before the checkpoint bytes");
+
+    let _end = server.await.unwrap();
+    assert_eq!(
+        *lock(&sink.ops),
+        vec!["ckpt@5", "row@6", "row@7"],
+        "checkpoint imports before any row that buffered during the download"
+    );
+    assert_eq!(client.stats().cursor, 7);
+    client.shutdown().await;
+}
+
+/// A batch queued while offline flushes right after the reconnect's state
+/// answer — NOT after backfill converges. The server script only serves the
+/// backfill AFTER seeing (and acking) the push; the old order deadlocks here.
+#[tokio::test(start_paused = true)]
+async fn pending_push_flushes_before_backfill_completes() {
+    let (pipe_a, mut end_a) = pipe_pair();
+    let (pipe_b, mut end_b) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    sink.frontier_contained
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    let (fetch, _) = fetcher(b"");
+    let empty_state = serde_json::json!({"headSeq": 0, "seqFloor": 0,
+        "checkpointSeq": 0, "checkpointSize": 0, "rowCount": 0, "rowBytes": 0});
+
+    let state_b = empty_state.clone();
+    let server = tokio::spawn(async move {
+        serve_join(&mut end_a, empty_state, &[], vec![], false).await;
+        // The push arrives on session A but goes UNACKED; the socket dies.
+        let _push = expect_kind(&mut end_a, frame_type::PUSH).await;
+        drop(end_a);
+
+        // Session B: the replay must arrive before ANY backfill is served.
+        let _hello = expect_kind(&mut end_b, frame_type::HELLO).await;
+        send(&end_b, frame_type::STATE, state_b, &[]).await;
+        let _req = expect_kind(&mut end_b, frame_type::ROWS_REQ).await;
+        let replay = expect_kind(&mut end_b, frame_type::PUSH).await;
+        let batch_id = replay.header["batchId"].as_str().unwrap().to_string();
+        send(
+            &end_b,
+            frame_type::ACK,
+            serde_json::json!({"batchId": batch_id, "seq": 1, "dup": false}),
+            &[],
+        )
+        .await;
+        send(&end_b, frame_type::ROWS_DONE, serde_json::json!({"headSeq": 1}), &[]).await;
+        end_b
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe_a, pipe_b]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("first join succeeds");
+
+    client.enqueue_update(vec![0xaa]);
+    let mut events = client.events();
+    // Ride events until the reconnect's early replay is acked.
+    while client.stats().pending_pushes > 0 {
+        let _ = events.recv().await;
+    }
+    let _end = server.await.unwrap();
+    assert_eq!(client.stats().cursor, 1, "early replay acked before ROWS_DONE");
     client.shutdown().await;
 }

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -21,6 +21,6 @@ pub mod wake;
 pub use chat_client::{
     ChatClient, ChatDocSink, ChatEvent, ChatStatsSnapshot, ChatTuning, CheckpointFetcher,
 };
-pub use registry::{RegistryClient, RegistryEvent, RegistryTuning};
+pub use registry::{RegistryClient, RegistryEvent, RegistryTransport, RegistryTuning};
 pub use store::{DocsStore, StoreError};
 pub use types::{RoomStatsSnapshot, StaticUrl, SyncError, UrlProvider};

--- a/crates/sync/src/registry.rs
+++ b/crates/sync/src/registry.rs
@@ -146,6 +146,15 @@ pub(crate) trait TextConnector: Send + Sync + 'static {
     fn connect(&self) -> BoxFuture<'static, Result<TextPipe, SyncError>>;
 }
 
+/// Plain-HTTPS pull/push seam — the airplane-wifi transport. `fetch` GETs
+/// `/registry/{org}/rows?since=` (the WS hello's exact delta answer as JSON);
+/// `push` POSTs one op batch to `/registry/{org}/push` and returns the ack
+/// body. Both are safe at-least-once: LWW clocks make replays apply zero ops.
+pub trait RegistryTransport: Send + Sync + 'static {
+    fn fetch(&self, since: u64) -> BoxFuture<'static, Result<String, SyncError>>;
+    fn push(&self, body: String) -> BoxFuture<'static, Result<String, SyncError>>;
+}
+
 struct WsTextConnector {
     url: Arc<dyn UrlProvider>,
 }
@@ -310,7 +319,22 @@ impl RegistryClient {
         tuning: RegistryTuning,
     ) -> Result<Self, SyncError> {
         let connector = Arc::new(WsTextConnector { url: provider });
-        Self::connect_with_tuned(connector, doc, device_id, tuning).await
+        Self::connect_with_transport(connector, doc, device_id, tuning, None).await
+    }
+
+    /// Connect with a plain-HTTPS pull/push seam alongside the socket (the
+    /// airplane-wifi transport): an immediate delta GET bootstraps the doc
+    /// in ~1 RTT while the WS dials, and every backoff cycle syncs over
+    /// HTTPS so a network that never passes the upgrade still converges.
+    pub async fn connect_via_transport(
+        provider: Arc<dyn UrlProvider>,
+        doc: Arc<Mutex<RegistryDoc>>,
+        device_id: &str,
+        tuning: RegistryTuning,
+        transport: Arc<dyn RegistryTransport>,
+    ) -> Result<Self, SyncError> {
+        let connector = Arc::new(WsTextConnector { url: provider });
+        Self::connect_with_transport(connector, doc, device_id, tuning, Some(transport)).await
     }
 
     pub(crate) async fn connect_with_tuned(
@@ -318,6 +342,16 @@ impl RegistryClient {
         doc: Arc<Mutex<RegistryDoc>>,
         device_id: &str,
         tuning: RegistryTuning,
+    ) -> Result<Self, SyncError> {
+        Self::connect_with_transport(connector, doc, device_id, tuning, None).await
+    }
+
+    pub(crate) async fn connect_with_transport(
+        connector: Arc<dyn TextConnector>,
+        doc: Arc<Mutex<RegistryDoc>>,
+        device_id: &str,
+        tuning: RegistryTuning,
+        transport: Option<Arc<dyn RegistryTransport>>,
     ) -> Result<Self, SyncError> {
         let (events, _) = broadcast::channel(256);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -342,6 +376,8 @@ impl RegistryClient {
             presence_rx,
             presence: presence.clone(),
             stats: stats.clone(),
+            transport,
+            sync_busy: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         let task = tokio::spawn(actor.run(ready_tx));
 
@@ -444,6 +480,10 @@ struct Actor {
     presence_rx: mpsc::Receiver<i64>,
     presence: Arc<Mutex<HashMap<String, (i64, tokio::time::Instant)>>>,
     stats: Arc<Stats>,
+    /// Plain-HTTPS pull/push (None = socket-only: tests, dev bearers).
+    transport: Option<Arc<dyn RegistryTransport>>,
+    /// One offline sync in flight at a time.
+    sync_busy: Arc<std::sync::atomic::AtomicBool>,
 }
 
 enum SessionEnd {
@@ -465,6 +505,18 @@ impl Actor {
     async fn run(mut self, ready: oneshot::Sender<Result<(), SyncError>>) {
         let mut ready = Some(ready);
         let mut backoff = BACKOFF_BASE;
+        // Pull-first bootstrap: with an HTTPS transport, the doc syncs in
+        // ~1 round trip while the socket spends its 4+ on TLS + upgrade +
+        // hello — and construction resolves immediately (local-first: the
+        // doc is usable now; keeping it converged is this actor's job, over
+        // whichever transport the network permits). Socket-only clients
+        // keep the original contract: ready resolves on the first join.
+        if self.transport.is_some() {
+            if let Some(ready) = ready.take() {
+                let _ = ready.send(Ok(()));
+            }
+            self.spawn_offline_sync();
+        }
         // Suspend/resume and sibling-dial successes are EVENTS that end a
         // backoff wait immediately (see room.rs) — without them a recovered
         // network still waited out the full accumulated delay.
@@ -483,6 +535,7 @@ impl Actor {
                         return; // first join failed: caller owns the retry
                     }
                     tracing::warn!(error = %err, "registry dial failed; backing off");
+                    self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
                         Waited::Woke => backoff = BACKOFF_BASE,
@@ -496,6 +549,7 @@ impl Actor {
                         return;
                     }
                     tracing::warn!("registry dial timed out; backing off");
+                    self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
                         Waited::Woke => backoff = BACKOFF_BASE,
@@ -531,6 +585,11 @@ impl Actor {
                     if joined {
                         backoff = BACKOFF_BASE;
                     }
+                    // Socket down: sync over HTTPS while we wait — pending
+                    // pushes flush and the doc stays fresh at backoff cadence
+                    // (≤30s), so a WS-hostile network degrades to polling
+                    // instead of silence.
+                    self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
                         Waited::Woke => backoff = BACKOFF_BASE,
@@ -728,6 +787,91 @@ impl Actor {
             *probe_deadline = Some(tokio::time::Instant::now() + PROBE_DEADLINE);
         }
         true
+    }
+
+    /// One HTTPS sync cycle off the actor's critical path: flush pending op
+    /// batches (POST — LWW replays are no-ops), then pull the delta (GET) and
+    /// apply it exactly as a state frame. Single-flight; failures are logged
+    /// and retried on the next backoff cycle.
+    fn spawn_offline_sync(&self) {
+        use std::sync::atomic::Ordering::Relaxed;
+        let Some(transport) = self.transport.clone() else {
+            return;
+        };
+        if self.sync_busy.swap(true, Relaxed) {
+            return;
+        }
+        let doc = self.doc.clone();
+        let events = self.events.clone();
+        let presence = self.presence.clone();
+        let stats = self.stats.clone();
+        let busy = self.sync_busy.clone();
+        tokio::spawn(async move {
+            let batches: Vec<PendingBatch> = lock(&doc).take_pushable();
+            let mut push_failed = false;
+            for batch in &batches {
+                let body = serde_json::json!({ "batch": batch.batch, "ops": batch.ops }).to_string();
+                match transport.push(body).await {
+                    Ok(ack) => {
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&ack) {
+                            if let (Some(b), Some(seq)) = (v["batch"].as_str(), v["seq"].as_u64()) {
+                                lock(&doc).ack_batch(b, seq);
+                                stats.last_ack_ms.store(epoch_ms(), Relaxed);
+                                let _ = events.send(RegistryEvent::Applied);
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        tracing::debug!(error = %err, "registry: http push failed; will retry");
+                        push_failed = true;
+                        break;
+                    }
+                }
+            }
+            if push_failed {
+                // take_pushable marked them in flight; nothing will clear
+                // that until the next socket disconnect — un-mark so the
+                // next cycle (HTTP or WS) retries them.
+                lock(&doc).mark_disconnected();
+            }
+            let since = lock(&doc).cursor();
+            match transport.fetch(since).await {
+                Ok(body) => {
+                    #[derive(serde::Deserialize)]
+                    #[serde(rename_all = "camelCase")]
+                    struct PullBody {
+                        seq: u64,
+                        full: bool,
+                        gc_floor: u64,
+                        rows: Vec<RegistryRow>,
+                        #[serde(default)]
+                        presence: HashMap<String, i64>,
+                    }
+                    match serde_json::from_str::<PullBody>(&body) {
+                        Ok(pull) => {
+                            let mut d = lock(&doc);
+                            d.apply_state(pull.seq, pull.full, pull.gc_floor, pull.rows);
+                            drop(d);
+                            let now = tokio::time::Instant::now();
+                            let mut map = lock(&presence);
+                            for (device, at) in pull.presence {
+                                map.insert(device, (at, now));
+                            }
+                            drop(map);
+                            stats.last_pushed_ms.store(epoch_ms(), Relaxed);
+                            let _ = events.send(RegistryEvent::Applied);
+                        }
+                        Err(err) => {
+                            tracing::warn!(error = %err, "registry: http pull body unparseable");
+                        }
+                    }
+                }
+                Err(err) => {
+                    tracing::debug!(error = %err, "registry: http pull failed; will retry");
+                }
+            }
+            busy.store(false, Relaxed);
+        });
     }
 
     async fn push_pending(&self, pipe: &mut TextPipe) -> bool {

--- a/edge/scripts/pullpush-check.mjs
+++ b/edge/scripts/pullpush-check.mjs
@@ -1,0 +1,152 @@
+// Checks the plain-HTTPS pull/push endpoints (450kbps cold-open PR) against
+// a running `wrangler dev --var AUTH_MODE:dev` on :8787.
+import { randomUUID } from "node:crypto";
+
+const base = process.env.EDGE_URL ?? "http://127.0.0.1:8787";
+const org = "pporg";
+const user = "ppuser";
+const token = `${user}@${org}`;
+const chatId = randomUUID();
+const device = "pp-dev-a";
+let failures = 0;
+const ok = (m) => console.log(`ok: ${m}`);
+const fail = (m) => {
+  console.error(`FAIL: ${m}`);
+  failures += 1;
+};
+
+const auth = { authorization: `Bearer ${token}` };
+
+// ── registry: push over HTTP, then pull the delta ─────────────────────────
+{
+  const now = Date.now();
+  const hlc = `${String(now).padStart(13, "0")}-000001-${device}`;
+  const op = {
+    kind: "chats",
+    id: "pp-chat-1",
+    op: "upsert",
+    hlc,
+    set: { id: "pp-chat-1", deviceId: device, title: "pull push check", createdAt: now }
+  };
+  const res = await fetch(`${base}/registry/${org}/push?device=${device}`, {
+    method: "POST",
+    headers: { ...auth, "content-type": "application/json" },
+    body: JSON.stringify({ batch: "pp-batch-1", ops: [op] })
+  });
+  const ack = await res.json();
+  if (res.status !== 200 || ack.batch !== "pp-batch-1" || !(ack.seq >= 1)) {
+    fail(`registry push: ${res.status} ${JSON.stringify(ack)}`);
+  } else ok(`registry push acked seq=${ack.seq} applied=${ack.applied}`);
+
+  // replay: LWW no-op, still acked
+  const replay = await fetch(`${base}/registry/${org}/push?device=${device}`, {
+    method: "POST",
+    headers: { ...auth, "content-type": "application/json" },
+    body: JSON.stringify({ batch: "pp-batch-1", ops: [op] })
+  });
+  const rack = await replay.json();
+  if (replay.status !== 200 || rack.applied !== 0) {
+    fail(`registry push replay should apply 0 ops: ${JSON.stringify(rack)}`);
+  } else ok("registry push replay is a no-op");
+
+  const full = await (
+    await fetch(`${base}/registry/${org}/rows?device=${device}&beat=1`, { headers: auth })
+  ).json();
+  if (!full.full || !Array.isArray(full.rows) || full.rows.length < 1) {
+    fail(`registry pull full: ${JSON.stringify(full).slice(0, 200)}`);
+  } else ok(`registry pull (no cursor) full=${full.full} rows=${full.rows.length}`);
+  if (!(full.presence && full.presence[device])) fail("beat=1 did not record presence");
+  else ok("pull beat recorded presence");
+
+  const delta = await (
+    await fetch(`${base}/registry/${org}/rows?since=${full.seq}`, { headers: auth })
+  ).json();
+  if (delta.full !== false || delta.rows.length !== 0) {
+    fail(`registry pull at head should be an empty delta: ${JSON.stringify(delta).slice(0, 200)}`);
+  } else ok("registry pull at cursor is an empty delta");
+}
+
+// ── chat2: push rows over HTTP, pull framed backfill ──────────────────────
+const FRAME = { state: 0x02, row: 0x04, rowsDone: 0x05 };
+const decodeFrames = (buf) => {
+  const bytes = new Uint8Array(buf);
+  const frames = [];
+  let off = 0;
+  while (off + 4 <= bytes.length) {
+    const len = new DataView(bytes.buffer, bytes.byteOffset + off).getUint32(0, true);
+    off += 4;
+    const frame = bytes.subarray(off, off + len);
+    const type = frame[0];
+    const headerLen = new DataView(frame.buffer, frame.byteOffset + 1).getUint32(0, true);
+    const header = JSON.parse(new TextDecoder().decode(frame.subarray(5, 5 + headerLen)));
+    const payload = frame.subarray(5 + headerLen);
+    frames.push({ type, header, payload });
+    off += len;
+  }
+  return frames;
+};
+
+{
+  // claim the room via a checkpoint POST (owner gate), then push rows
+  const seed = await fetch(`${base}/chat2/${chatId}/checkpoint?seqCovered=0`, {
+    method: "POST",
+    headers: { ...auth, "x-chat2-frontier": "" },
+    body: new Uint8Array([1, 2, 3])
+  });
+  if (seed.status !== 200) fail(`chat2 seed checkpoint: ${seed.status}`);
+  else ok("chat2 room claimed via checkpoint POST");
+
+  const payload = new Uint8Array([9, 9, 9, 9]);
+  const push = await fetch(
+    `${base}/chat2/${chatId}/rows?batchId=pp-row-1&device=${device}`,
+    { method: "POST", headers: auth, body: payload }
+  );
+  const ack = await push.json();
+  if (push.status !== 200 || ack.seq !== 1 || ack.dup !== false) {
+    fail(`chat2 push: ${push.status} ${JSON.stringify(ack)}`);
+  } else ok(`chat2 push acked seq=${ack.seq}`);
+
+  const dup = await (
+    await fetch(`${base}/chat2/${chatId}/rows?batchId=pp-row-1&device=${device}`, {
+      method: "POST",
+      headers: auth,
+      body: payload
+    })
+  ).json();
+  if (dup.dup !== true || dup.seq !== 1) fail(`chat2 push dedupe: ${JSON.stringify(dup)}`);
+  else ok("chat2 push replay deduped");
+
+  const pull = await fetch(`${base}/chat2/${chatId}/rows?after=0&device=pp-dev-b`, {
+    headers: auth
+  });
+  if (pull.status !== 200) fail(`chat2 pull: ${pull.status}`);
+  const frames = decodeFrames(await pull.arrayBuffer());
+  const kinds = frames.map((f) => f.type);
+  if (kinds[0] !== FRAME.state || kinds[kinds.length - 1] !== FRAME.rowsDone) {
+    fail(`chat2 pull framing: kinds=${JSON.stringify(kinds)}`);
+  } else ok(`chat2 pull framing state→rows→rowsDone (${frames.length} frames)`);
+  const state = frames[0].header;
+  if (state.headSeq !== 1 || state.checkpointSize !== 3) {
+    fail(`chat2 pull state header: ${JSON.stringify(state)}`);
+  } else ok(`chat2 pull state headSeq=${state.headSeq} checkpointSize=${state.checkpointSize}`);
+  const row = frames.find((f) => f.type === FRAME.row);
+  if (!row || row.header.seq !== 1 || row.header.batchId !== "pp-row-1" ||
+      row.payload.length !== 4 || row.payload[0] !== 9) {
+    fail(`chat2 pull row: ${row && JSON.stringify(row.header)}`);
+  } else ok("chat2 pull row bytes intact");
+
+  // exclude own rows
+  const own = await fetch(
+    `${base}/chat2/${chatId}/rows?after=0&device=${device}&excludeOwn=1`,
+    { headers: auth }
+  );
+  const ownFrames = decodeFrames(await own.arrayBuffer());
+  if (ownFrames.some((f) => f.type === FRAME.row)) fail("excludeOwn=1 still returned own rows");
+  else ok("chat2 pull excludeOwn honored");
+}
+
+if (failures > 0) {
+  console.error(`${failures} failure(s)`);
+  process.exit(1);
+}
+console.log("ALL PULL/PUSH CHECKS PASSED");

--- a/edge/src/chat-room.ts
+++ b/edge/src/chat-room.ts
@@ -160,6 +160,92 @@ export class ChatRoom implements DurableObject {
       return new Response(body, { status: range !== null ? 206 : 200, headers });
     }
 
+    if (url.pathname === "/rows" && request.method === "GET") {
+      // Pull over plain HTTPS: one GET collapses connect → hello → state →
+      // rowsReq → backfill (4+ serial round trips on a WS, and impossible on
+      // networks that strip the upgrade) into a single request. The body is
+      // u32-LE length-prefixed frames — state (frontier payload), rows after
+      // `?after=`, rowsDone — byte-identical frame encoding to the WS path,
+      // so clients reuse their existing decoder.
+      const afterRaw = Number(url.searchParams.get("after") ?? "0");
+      const after = Number.isInteger(afterRaw) && afterRaw >= 0 ? afterRaw : 0;
+      const device = url.searchParams.get("device") ?? "";
+      const exclude =
+        url.searchParams.get("excludeOwn") === "1" && device !== "" ? device : undefined;
+      const stats = logStats(sql);
+      const frontier = this.blobs.get(FRONTIER_BLOB) ?? new Uint8Array(0);
+      const frames: Uint8Array[] = [
+        encodeFrame(
+          FRAME.state,
+          {
+            headSeq: stats.headSeq,
+            seqFloor: stats.seqFloor,
+            checkpointSeq: stats.checkpointSeq,
+            checkpointSize: stats.checkpointSize,
+            rowCount: stats.rowCount,
+            rowBytes: stats.rowBytes
+          },
+          frontier
+        )
+      ];
+      for (const row of rowsAfter(sql, after, exclude)) {
+        frames.push(
+          encodeFrame(
+            FRAME.row,
+            { seq: row.seq, device: row.device, batchId: row.batchId },
+            row.bytes
+          )
+        );
+      }
+      frames.push(encodeFrame(FRAME.rowsDone, { headSeq: headSeq(sql) }));
+      const total = frames.reduce((n, f) => n + 4 + f.length, 0);
+      const body = new Uint8Array(total);
+      const view = new DataView(body.buffer);
+      let off = 0;
+      for (const f of frames) {
+        view.setUint32(off, f.length, true);
+        body.set(f, off + 4);
+        off += 4 + f.length;
+      }
+      return new Response(body, {
+        headers: { "content-type": "application/octet-stream" }
+      });
+    }
+
+    if (url.pathname === "/rows" && request.method === "POST") {
+      // Push over plain HTTPS — the WS push's fallback twin for networks
+      // where the upgrade never completes. batchId dedupe (UNIQUE column)
+      // makes at-least-once delivery exact-once in effect.
+      const device = url.searchParams.get("device") ?? "";
+      const batchId = url.searchParams.get("batchId") ?? "";
+      if (batchId === "" || batchId.length > 128) {
+        this.recordPush(device, false);
+        return json({ error: "bad_push" }, 400);
+      }
+      const payload = new Uint8Array(await request.arrayBuffer());
+      if (!this.admitQuota(device, payload.byteLength)) {
+        this.recordPush(device, false);
+        return json({ error: "quota" }, 429);
+      }
+      const outcome = appendRow(sql, device, batchId, payload, Date.now());
+      if (!outcome.ok) {
+        this.recordPush(device, false);
+        return json({ error: outcome.error }, outcome.error === "too_large" ? 413 : 400);
+      }
+      this.recordPush(device, true);
+      if (!outcome.dup) {
+        this.markBackupDirty();
+        // Live relay to every ready socket — a same-device socket would
+        // re-import its own bytes as a Loro no-op, so no exclusion needed.
+        for (const socket of this.ctx.getWebSockets()) {
+          const socketState = socket.deserializeAttachment() as SocketState | null;
+          if (!socketState?.ready) continue;
+          send(socket, FRAME.row, { seq: outcome.seq, device, batchId }, payload);
+        }
+      }
+      return json({ batchId, seq: outcome.seq, dup: outcome.dup });
+    }
+
     if ((url.pathname === "/tail" || url.pathname === "/diff") && request.method === "PUT") {
       const name = url.pathname === "/tail" ? "sidecar-tail" : "sidecar-diff";
       const body = new Uint8Array(await request.arrayBuffer());

--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -216,6 +216,10 @@ export default {
       }
       const routes: Record<string, string[]> = {
         checkpoint: ["GET", "POST"],
+        // Pull/push over plain HTTPS (the airplane-wifi transport): GET
+        // /rows?after= collapses connect→hello→state→rowsReq→backfill into
+        // one round trip; POST /rows is the batchId-deduped push twin.
+        rows: ["GET", "POST"],
         tail: ["GET", "PUT"],
         diff: ["GET", "PUT"],
         stats: ["GET"],
@@ -315,9 +319,17 @@ export default {
       if (parts[2] === "stats" && request.method === "GET") {
         return forward(env.REGISTRY_ROOMS, room, request, auth.userId, "/stats", "");
       }
-      // Repair/inspection read: the full current row table.
+      // Pull over plain HTTPS: `?since=` returns the same delta the WS
+      // hello would (full table without it — the original repair read).
+      // One round trip on any network that passes HTTPS at all, where the
+      // WS upgrade needs 4 and a cooperative middlebox.
       if (parts[2] === "rows" && request.method === "GET") {
-        return forward(env.REGISTRY_ROOMS, room, request, auth.userId, "/rows", "");
+        return forward(env.REGISTRY_ROOMS, room, request, auth.userId, "/rows", url.search);
+      }
+      // Push over plain HTTPS — the WS push's fallback twin (LWW clocks
+      // make replays no-ops, so at-least-once delivery is safe).
+      if (parts[2] === "push" && request.method === "POST") {
+        return forward(env.REGISTRY_ROOMS, room, request, auth.userId, "/push", url.search);
       }
       // Operator wipe. Unlike the CRDT rooms this needs no recipe: clients
       // detect the seq regression on their next hello and re-seed the table

--- a/edge/src/registry-room.ts
+++ b/edge/src/registry-room.ts
@@ -185,8 +185,51 @@ export class RegistryRoom implements DurableObject {
     }
 
     if (url.pathname === "/rows" && request.method === "GET") {
-      // Repair/inspection read: the full current table.
-      return json({ seq: this.seq(), gcFloor: this.gcFloor(), rows: this.rowsSince(0) });
+      // Pull over plain HTTPS: with `?since=` this is the WS hello's exact
+      // delta answer (same full/gcFloor rules); without it, the original
+      // full-table repair read. `?device=&beat=1` doubles as a presence
+      // beat so an HTTP-only client stays visible to socket peers.
+      const sinceRaw = url.searchParams.get("since");
+      const sinceNum = sinceRaw === null ? NaN : Number(sinceRaw);
+      const cursor = Number.isInteger(sinceNum) && sinceNum >= 0 ? sinceNum : null;
+      const device = url.searchParams.get("device") ?? "";
+      if (device !== "" && url.searchParams.get("beat") === "1") {
+        const at = Date.now();
+        this.presence.set(device, at);
+        for (const socket of this.ctx.getWebSockets()) {
+          const socketState = socket.deserializeAttachment() as SocketState | null;
+          if (!socketState?.ready) continue;
+          send(socket, { t: "presence", device, at });
+        }
+      }
+      const seq = this.seq();
+      const gcFloor = this.gcFloor();
+      const full = cursor === null || cursor < gcFloor || cursor > seq;
+      return json({
+        seq,
+        full,
+        gcFloor,
+        rows: full ? this.rowsSince(0) : this.rowsSince(cursor),
+        presence: Object.fromEntries(this.presence)
+      });
+    }
+
+    if (url.pathname === "/push" && request.method === "POST") {
+      // Push over plain HTTPS — the WS push's fallback twin for networks
+      // where the upgrade never completes. Same validation, same atomic
+      // apply, same rows broadcast to live sockets; the ack is the response
+      // body. LWW clocks make replayed batches apply zero ops, so
+      // at-least-once delivery (including 0-RTT/early-data replays) is safe.
+      const device = url.searchParams.get("device") ?? "";
+      let frame: Record<string, unknown>;
+      try {
+        frame = (await request.json()) as Record<string, unknown>;
+      } catch {
+        return json({ error: "bad_push", message: "malformed body" }, 400);
+      }
+      const outcome = this.applyPushBatch(device, frame);
+      if (!outcome.ok) return json({ error: outcome.code, message: outcome.message }, 400);
+      return json({ batch: outcome.batch, seq: outcome.seq, applied: outcome.applied });
     }
 
     if (url.pathname === "/reset" && request.method === "POST") {
@@ -280,17 +323,37 @@ export class RegistryRoom implements DurableObject {
   }
 
   private handlePush(ws: WebSocket, state: SocketState, frame: Record<string, unknown>): void {
-    const batch = typeof frame.batch === "string" ? frame.batch : "";
-    if (!state.ready || batch === "" || !Array.isArray(frame.ops)) {
+    if (!state.ready) {
       this.recordPush(state.device, false);
       send(ws, { t: "error", code: "bad_push", message: "hello first / malformed push" });
       return;
     }
+    const outcome = this.applyPushBatch(state.device, frame);
+    if (!outcome.ok) {
+      send(ws, { t: "error", code: outcome.code, message: outcome.message });
+      return;
+    }
+    send(ws, { t: "ack", batch: outcome.batch, seq: outcome.seq, applied: outcome.applied });
+  }
+
+  /** Validate + atomically apply one op batch and broadcast merged rows to
+   * every ready socket -- shared by the WS push and the HTTP `POST /push`
+   * fallback. The caller delivers the ack/error on its own transport. */
+  private applyPushBatch(
+    device: string,
+    frame: Record<string, unknown>
+  ):
+    | { ok: false; code: string; message: string }
+    | { ok: true; batch: string; seq: number; applied: number } {
+    const batch = typeof frame.batch === "string" ? frame.batch : "";
+    if (batch === "" || !Array.isArray(frame.ops)) {
+      this.recordPush(device, false);
+      return { ok: false, code: "bad_push", message: "malformed push" };
+    }
     const ops = frame.ops as WireOp[];
     if (ops.length === 0 || ops.length > MAX_BATCH_OPS) {
-      this.recordPush(state.device, false);
-      send(ws, { t: "error", code: "bad_push", message: `batch of ${ops.length} ops` });
-      return;
+      this.recordPush(device, false);
+      return { ok: false, code: "bad_push", message: `batch of ${ops.length} ops` };
     }
     for (const op of ops) {
       const invalid = validateOp(op);
@@ -298,9 +361,8 @@ export class RegistryRoom implements DurableObject {
         // Reject the WHOLE batch: batches are transactional (cascade deletes)
         // and a client that builds one bad op is a client bug to surface, not
         // to partially apply. Rejections are attributed per device on /stats.
-        this.recordPush(state.device, false);
-        send(ws, { t: "error", code: "invalid_op", message: `${op.kind}/${op.id}: ${invalid}` });
-        return;
+        this.recordPush(device, false);
+        return { ok: false, code: "invalid_op", message: `${op.kind}/${op.id}: ${invalid}` };
       }
     }
 
@@ -310,7 +372,7 @@ export class RegistryRoom implements DurableObject {
     const touched = new Map<string, Row>();
     let applied = 0;
     for (const op of ops) {
-      const key = `${op.kind} ${op.id}`;
+      const key = `${op.kind} ${op.id}`;
       const before = touched.get(key) ?? this.loadRow(op.kind, op.id);
       const { row, changed } = applyOp(before, op);
       if (!changed || row === undefined) continue;
@@ -323,13 +385,13 @@ export class RegistryRoom implements DurableObject {
       this.setMeta("seq", String(nextSeq));
       this.markBackupDirty();
     }
-    this.recordPush(state.device, true);
+    this.recordPush(device, true);
     const seq = applied > 0 ? nextSeq : this.seq();
     if (applied > 0) {
-      // Merged full rows to EVERY ready socket (sender included — its op may
+      // Merged full rows to EVERY ready socket (sender included -- its op may
       // have lost LWW, and the merged row is the truth it must display).
       // Rows go out BEFORE the ack so the sender's authoritative state is
-      // current by the time the ack retires its optimistic pending batch —
+      // current by the time the ack retires its optimistic pending batch --
       // no between-frames flicker window.
       const rows = [...touched.values()];
       for (const socket of this.ctx.getWebSockets()) {
@@ -338,7 +400,7 @@ export class RegistryRoom implements DurableObject {
         send(socket, { t: "rows", seq, rows });
       }
     }
-    send(ws, { t: "ack", batch, seq, applied });
+    return { ok: true, batch, seq, applied };
   }
 
   private handlePresence(ws: WebSocket, state: SocketState, frame: Record<string, unknown>): void {


### PR DESCRIPTION
Driven by on-device NLC (Network Link Conditioner, Edge profile) measurement and the user report that WS connects sometimes never complete on airplane wifi. Three commits:

## 1. `cc6713a` — wire cuts (measured on device)
- iOS warm-dial cap (8) — cold open went from 46 background TLS+WS joins to 8; sidebar liveness rides the registry; undialed chats connect on open.
- Checkpoint download ∥ row backfill (both clients) — the rows request no longer serializes behind the checkpoint HTTP download; rows buffer mid-download and replay after import (ordered-ops regression test).
- Sends flush at state (both clients) — a message typed offline lands ~2 RTTs after a socket, not after full convergence (deadlock-shaped regression test).

## 2. `f8c0767` — NLC-measured fixes
- Checkpoint downloads survive socket redials + Range-resume across attempts + download progress defers the silence lease. (Measured: a 78KB fresh-chat open looped forever — silence lease tripped mid-download because pongs queued behind the blob, and each redial restarted from zero. Now: one download, joined 18ms after it lands.)
- Registry single-dial: `foregrounded()` fires on scene activation at launch and killed the in-flight dial mid-TLS every cold open (measured double handshake; spinner 6.9→4.5s on Edge after the fix).
- Warm chat dials gated behind registry connect — the sidebar's own handshake gets the thin pipe to itself.

## 3. `d768576` — pull-first HTTPS transport (push/pull/poke)
The WS costs 4+ serial RTTs before byte one and hostile middleboxes strip the upgrade entirely. A plain HTTPS GET is ~1 RTT on a warm connection and proxy-proof:
- **Edge**: `GET /registry/{org}/rows?since=` (the hello's exact delta answer; `beat=1` = presence), `POST /registry/{org}/push`; `GET /chat2/{id}/rows?after=` (one request = connect→hello→state→rowsReq→backfill, length-prefixed WS-identical frames), `POST /chat2/{id}/rows?batchId=`. All shared-core with the WS handlers; replays are no-ops (LWW / batchId dedupe).
- **Desktop + iOS**: pull bootstraps each room in ~1 RTT while the socket dials; while the socket is down both clients push pending + pull on a poll (≤30s desktop, 20s iOS); the iOS header spinner now flips on delta-applied (~1 RTT), not socket-connected (4+ RTTs). The WS remains the preferred live transport when it connects — it's just no longer load-bearing.
- Clients tolerate 404s from a pre-deploy edge (rollout-order safe).

## Validation
- Edge: new `scripts/pullpush-check.mjs` green vs wrangler dev (ack/replay-no-op, delta-at-cursor, presence beat, framed pull, excludeOwn, batchId dedupe); existing smoke + chat2-check (65) + reset suites green.
- Rust: zeron-sync 34 (2 new regression tests), engine+rpc 180. iOS: sim + device builds clean.
- On-device NLC scorecard (Edge profile, 240kbps/400ms — harsher than the 450kbps target): cached open 2.1s→85ms; fresh 78KB chat ∞→~10s (bandwidth floor); spinner 7–12s→4.5s socket-measured, ~1 RTT once the pull path is deployed; sends ~2 RTTs after any transport lands.

## Post-merge
- CI deploys the edge; then re-measure on device under NLC (pull path only goes live then).
- Enable zone toggles: HTTP/3 + 0-RTT Connection Resumption (0-RTT applies to bare GETs; a follow-up can move cursors into the path to qualify).
- Follow-ups: strip capped tool outputs from session docs (checkpoint size is now the fresh-open floor), worker-side multi-room fan-out (one GET = whole workspace), edge upgrade-path latency audit (~1s serial on good wifi: JWKS fetch + DO wake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)