### PR TITLE
diff-sync: stop reconcile churn spawning git diff back-to-back forever

### DIFF
--- a/crates/engine/src/diff_sync.rs
+++ b/crates/engine/src/diff_sync.rs
@@ -19,6 +19,14 @@
 //! slow 2-minute repair tick because native watchers may coalesce or drop events.
 //! Snapshots carry a sha256 checksum; an unchanged checksum publishes nothing.
 //!
+//! Reconcile is deliberately damped, because it runs on *every* workspace chat
+//! row change — including the `branch`/`checkoutId` writes `sync_entry` itself
+//! makes. Checkout identities are memoized per cwd (chat-watch reconciles spawn
+//! no git; the repair tick revalidates), and an entry whose chats vanish is torn
+//! down only after [`REPAIR_INTERVAL`] of continuous absence rather than on the
+//! first pass that misses it. See [`resolve_identity`] for the incident this
+//! guards against.
+//!
 //! Beyond the working-tree watch, the service also answers one-shot
 //! `GetCheckoutDiff` captures for the Changes pane's scopes: *branch changes*
 //! (vs `merge-base(baseRef, HEAD)`, same capture path with the base overridden)
@@ -108,10 +116,20 @@ struct CheckoutEntry {
     chats: Mutex<Vec<Chat>>,
     /// Last published checksum — unchanged snapshots publish nothing.
     checksum: Mutex<Option<String>>,
+    /// Set when a reconcile pass finds no chats for this checkout; cleared the
+    /// moment chats reappear. The entry (watchers, checksum state, published
+    /// diff) is only torn down after `orphan_grace` of *continuous* absence:
+    /// tearing down and re-adding restarts a full capture, which costs seconds
+    /// of CPU on a big checkout, so a single flapping chat-watch emission or
+    /// transient identity failure must never destroy a live entry.
+    orphaned_since: Mutex<Option<std::time::Instant>>,
     /// Kick channel into the entry's debounce/sync task.
     kick_tx: mpsc::UnboundedSender<()>,
-    /// Keeps the recursive fs watchers alive; dropped on entry close.
-    _watchers: Vec<notify::RecommendedWatcher>,
+    /// Keeps the recursive fs watchers alive; dropped on entry close. Filled
+    /// asynchronously — watcher setup (budget walk + FSEvents registration) can
+    /// block for seconds, so [`add_entry`] does it off the runtime and attaches
+    /// the result here once ready.
+    watchers: Mutex<Vec<notify::RecommendedWatcher>>,
 }
 
 /// Working-tree snapshot recorded when a chat's turn dispatches — the diff
@@ -133,6 +151,15 @@ struct DiffSyncInner {
     edge: Option<EdgeConfig>,
     http: reqwest::Client,
     entries: Mutex<HashMap<String, Arc<CheckoutEntry>>>,
+    /// Serializes [`reconcile`] passes. Concurrent passes (chat-watch task vs.
+    /// `reconcile_now`) can both observe a checkout as missing and both
+    /// `add_entry` it — the second insert silently replaces the first entry,
+    /// discarding its checksum state and kicking a redundant full capture.
+    reconcile_gate: tokio::sync::Mutex<()>,
+    /// cwd → resolved checkout identity. See [`resolve_identity`].
+    identities: Mutex<HashMap<String, CheckoutIdentity>>,
+    /// How long an entry may sit chat-less before reconcile removes it.
+    orphan_grace: Duration,
     diffs_tx: watch::Sender<Vec<CheckoutDiff>>,
     /// chat_id → turn-start tree (see [`TurnSnapshot`]).
     turn_trees: Mutex<HashMap<String, TurnSnapshot>>,
@@ -160,6 +187,21 @@ impl CheckoutDiffSync {
         device_id: &str,
         edge: Option<EdgeConfig>,
     ) -> Self {
+        // Grace = one repair interval: an entry must survive at least one full
+        // fresh revalidation pass before reconcile may tear it down.
+        Self::start_with_orphan_grace(repos, workspace, device_id, edge, REPAIR_INTERVAL)
+    }
+
+    /// [`CheckoutDiffSync::start`] with an explicit orphan grace — test hook so
+    /// removal-after-grace is exercisable without waiting out [`REPAIR_INTERVAL`].
+    #[doc(hidden)]
+    pub fn start_with_orphan_grace(
+        repos: Repos,
+        workspace: WorkspaceHost,
+        device_id: &str,
+        edge: Option<EdgeConfig>,
+        orphan_grace: Duration,
+    ) -> Self {
         let (diffs_tx, _) = watch::channel(Vec::new());
         let sync = Self {
             inner: Arc::new(DiffSyncInner {
@@ -169,6 +211,9 @@ impl CheckoutDiffSync {
                 edge,
                 http: reqwest::Client::new(),
                 entries: Mutex::new(HashMap::new()),
+                reconcile_gate: tokio::sync::Mutex::new(()),
+                identities: Mutex::new(HashMap::new()),
+                orphan_grace,
                 diffs_tx,
                 turn_trees: Mutex::new(HashMap::new()),
                 cancel: CancellationToken::new(),
@@ -205,7 +250,16 @@ impl CheckoutDiffSync {
     /// Public for tests (the background task calls it on every chat change).
     pub async fn reconcile_now(&self) {
         let chats = self.inner.workspace.watch_chats().borrow().clone();
-        reconcile(&self.inner, chats).await;
+        reconcile(&self.inner, chats, false).await;
+    }
+
+    /// Repair-tick path for tests: fresh identity revalidation, then kick every
+    /// tracked checkout.
+    #[doc(hidden)]
+    pub async fn repair_now(&self) {
+        let chats = self.inner.workspace.watch_chats().borrow().clone();
+        reconcile(&self.inner, chats, true).await;
+        self.sync_all();
     }
 
     /// Kick an immediate sync of every tracked checkout (repair-tick path).
@@ -258,9 +312,60 @@ impl CheckoutDiffSync {
 // Reconcile: chats ⇄ checkout entries
 // ---------------------------------------------------------------------------
 
-async fn reconcile(inner: &Arc<DiffSyncInner>, chats: Vec<Chat>) {
+/// Resolve `cwd` to its canonical checkout identity, preferring the memo.
+///
+/// [`Repos::checkout_identity`] spawns `git rev-parse` twice, and reconcile
+/// runs on *every* workspace chat row change — including the `branch` and
+/// `checkoutId` writes [`sync_entry`] itself makes. Resolving fresh on every
+/// pass had two failure modes that combined into a runaway loop on a checkout
+/// whose captures cost seconds of CPU:
+///
+/// 1. every publish fanned out into a storm of `git` spawns (fd pressure);
+/// 2. one transient spawn failure (e.g. EMFILE) made the chat ungroupable, so
+///    reconcile tore its entry down and re-added it on the next pass — and
+///    every re-add kicks a full capture, whose row writes trigger the next
+///    reconcile. Back-to-back `git diff` forever, on an idle tree.
+///
+/// So: chat-watch reconciles reuse the memo (no git at all), the repair tick
+/// revalidates (`fresh`), and a failed fresh resolve keeps the memo unless the
+/// directory is actually gone.
+async fn resolve_identity(
+    inner: &Arc<DiffSyncInner>,
+    cwd: &str,
+    fresh: bool,
+) -> Option<CheckoutIdentity> {
+    if !fresh && let Some(identity) = lock(&inner.identities).get(cwd).cloned() {
+        return Some(identity);
+    }
+    match inner.repos.checkout_identity(Path::new(cwd)).await {
+        Ok(identity) => {
+            lock(&inner.identities).insert(cwd.to_string(), identity.clone());
+            Some(identity)
+        }
+        Err(err) => {
+            if !Path::new(cwd).exists() {
+                lock(&inner.identities).remove(cwd);
+                tracing::debug!(cwd = %cwd, error = %err, "diff-sync: checkout gone");
+                return None;
+            }
+            let cached = lock(&inner.identities).get(cwd).cloned();
+            match &cached {
+                Some(_) => tracing::debug!(cwd = %cwd, error = %err,
+                    "diff-sync: identity resolve failed; keeping memoized identity"),
+                None => tracing::debug!(cwd = %cwd, error = %err, "diff-sync: not a checkout"),
+            }
+            cached
+        }
+    }
+}
+
+async fn reconcile(inner: &Arc<DiffSyncInner>, chats: Vec<Chat>, fresh: bool) {
+    // One pass at a time — see `reconcile_gate`.
+    let _gate = inner.reconcile_gate.lock().await;
     // Group this device's cwd-bearing chats by canonical checkout identity.
     let mut groups: HashMap<String, (CheckoutIdentity, Vec<Chat>)> = HashMap::new();
+    // Dedupe resolution within this pass — many chats share one checkout.
+    let mut resolved: HashMap<String, Option<CheckoutIdentity>> = HashMap::new();
     for chat in chats {
         if chat.device_id != inner.device_id {
             continue;
@@ -268,12 +373,16 @@ async fn reconcile(inner: &Arc<DiffSyncInner>, chats: Vec<Chat>) {
         let Some(cwd) = chat.cwd.clone() else {
             continue;
         };
-        let identity = match inner.repos.checkout_identity(Path::new(&cwd)).await {
-            Ok(identity) => identity,
-            Err(err) => {
-                tracing::debug!(cwd = %cwd, error = %err, "diff-sync: not a checkout");
-                continue;
+        let identity = match resolved.get(&cwd) {
+            Some(identity) => identity.clone(),
+            None => {
+                let identity = resolve_identity(inner, &cwd, fresh).await;
+                resolved.insert(cwd.clone(), identity.clone());
+                identity
             }
+        };
+        let Some(identity) = identity else {
+            continue;
         };
         // Stamp the row's checkoutId so every device groups this chat correctly.
         if chat.checkout_id.as_deref() != Some(identity.id.as_str())
@@ -288,14 +397,28 @@ async fn reconcile(inner: &Arc<DiffSyncInner>, chats: Vec<Chat>) {
             .push(chat);
     }
 
-    // Close entries whose checkout no longer has chats; drop their published diff.
+    // Close entries whose checkout has had no chats for a full grace period;
+    // drop their published diff. A single pass that misses a checkout only
+    // *marks* it — teardown is expensive to undo (re-add kicks a capture), so
+    // absence must be sustained before we act on it.
     let removed: Vec<String> = {
+        let now = std::time::Instant::now();
         let mut entries = lock(&inner.entries);
-        let removed: Vec<String> = entries
-            .keys()
-            .filter(|id| !groups.contains_key(*id))
-            .cloned()
-            .collect();
+        let mut removed = Vec::new();
+        for (id, entry) in entries.iter() {
+            if groups.contains_key(id) {
+                *lock(&entry.orphaned_since) = None;
+                continue;
+            }
+            let mut orphaned = lock(&entry.orphaned_since);
+            match *orphaned {
+                None => *orphaned = Some(now),
+                Some(since) if now.duration_since(since) >= inner.orphan_grace => {
+                    removed.push(id.clone());
+                }
+                Some(_) => {}
+            }
+        }
         for id in &removed {
             entries.remove(id); // dropping the entry drops watchers + ends its task
         }
@@ -392,12 +515,51 @@ fn watch_targets(identity: &CheckoutIdentity) -> Vec<PathBuf> {
 
 fn add_entry(inner: &Arc<DiffSyncInner>, identity: CheckoutIdentity, chats: Vec<Chat>) {
     let (kick_tx, kick_rx) = mpsc::unbounded_channel();
+    let entry = Arc::new(CheckoutEntry {
+        identity,
+        chats: Mutex::new(chats),
+        checksum: Mutex::new(None),
+        orphaned_since: Mutex::new(None),
+        kick_tx: kick_tx.clone(),
+        watchers: Mutex::new(Vec::new()),
+    });
+    lock(&inner.entries).insert(entry.identity.id.clone(), entry.clone());
+    tokio::spawn(entry_task(
+        Arc::downgrade(inner),
+        Arc::downgrade(&entry),
+        kick_rx,
+        inner.cancel.clone(),
+    ));
+    let _ = kick_tx.send(()); // initial snapshot — must not wait for watchers
 
-    // Recursive watchers on the worktree root (budget permitting) and the git
-    // dir — HEAD/index churn and file edits both land here. Failures are fine:
-    // the initial + repair sync still keep the snapshot correct.
+    // Watcher setup is genuinely blocking: the budget walk reads up to
+    // MAX_WATCH_DIRS directory entries and FSEvents stream registration stalls
+    // for seconds when fseventsd is contended. Doing it inline starved the whole
+    // runtime (workspace watches, presence) whenever entries were (re)built, so
+    // it runs on the blocking pool and attaches to the entry when ready. Events
+    // occurring before attachment are covered by the initial sync; one extra
+    // kick after attachment closes the capture→attach gap.
+    let weak = Arc::downgrade(&entry);
+    tokio::task::spawn_blocking(move || {
+        let Some(entry) = weak.upgrade() else {
+            return; // entry removed before watchers were ready
+        };
+        let watchers = build_watchers(&entry.identity, &kick_tx);
+        *lock(&entry.watchers) = watchers;
+        let _ = kick_tx.send(());
+    });
+}
+
+/// Recursive watchers on the worktree root (budget permitting) and the git
+/// dir — HEAD/index churn and file edits both land here. Failures are fine:
+/// the initial + repair sync still keep the snapshot correct. Blocking — call
+/// from the blocking pool.
+fn build_watchers(
+    identity: &CheckoutIdentity,
+    kick_tx: &mpsc::UnboundedSender<()>,
+) -> Vec<notify::RecommendedWatcher> {
     let mut watchers = Vec::new();
-    for target in watch_targets(&identity) {
+    for target in watch_targets(identity) {
         let tx = kick_tx.clone();
         let watcher =
             notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
@@ -418,22 +580,7 @@ fn add_entry(inner: &Arc<DiffSyncInner>, identity: CheckoutIdentity, chats: Vec<
             Err(err) => tracing::debug!(error = %err, "diff-sync: watcher create failed"),
         }
     }
-
-    let entry = Arc::new(CheckoutEntry {
-        identity,
-        chats: Mutex::new(chats),
-        checksum: Mutex::new(None),
-        kick_tx: kick_tx.clone(),
-        _watchers: watchers,
-    });
-    lock(&inner.entries).insert(entry.identity.id.clone(), entry.clone());
-    tokio::spawn(entry_task(
-        Arc::downgrade(inner),
-        Arc::downgrade(&entry),
-        kick_rx,
-        inner.cancel.clone(),
-    ));
-    let _ = kick_tx.send(()); // initial snapshot
+    watchers
 }
 
 /// Per-checkout task: trailing-debounce fs kicks, then compute + publish. Runs
@@ -600,12 +747,15 @@ async fn diff_sync_task(
                 }
                 let Some(inner) = inner.upgrade() else { break };
                 let chats = chats_rx.borrow_and_update().clone();
-                reconcile(&inner, chats).await;
+                // Memoized identities only: chat rows change constantly (the
+                // sync itself writes them) and must never fan out into git.
+                reconcile(&inner, chats, false).await;
             }
             _ = repair.tick() => {
                 let Some(inner) = inner.upgrade() else { break };
                 let chats = chats_rx.borrow().clone();
-                reconcile(&inner, chats).await;
+                // Fresh: revalidate every memoized identity against git.
+                reconcile(&inner, chats, true).await;
                 for entry in lock(&inner.entries).values() {
                     let _ = entry.kick_tx.send(());
                 }

--- a/crates/engine/src/spaces.rs
+++ b/crates/engine/src/spaces.rs
@@ -40,8 +40,10 @@ const REPAIR_INTERVAL: Duration = Duration::from_secs(120);
 struct SpaceEntry {
     path: PathBuf,
     kick_tx: mpsc::UnboundedSender<()>,
-    /// Keeps the folder watcher alive; dropped on entry close.
-    _watcher: Option<notify::RecommendedWatcher>,
+    /// Keeps the folder watcher alive; dropped on entry close. Filled
+    /// asynchronously — FSEvents registration blocks, so [`reconcile`] builds
+    /// it off the runtime and attaches it here once ready.
+    folder_watch: Mutex<Option<notify::RecommendedWatcher>>,
 }
 
 struct SpacesSyncInner {
@@ -122,11 +124,31 @@ fn reconcile(inner: &Arc<SpacesSyncInner>, spaces: &[Space]) {
             continue; // deviceId/path are immutable — nothing to refresh
         }
         let (kick_tx, kick_rx) = mpsc::unbounded_channel();
+        let entry = Arc::new(SpaceEntry {
+            path: PathBuf::from(&space.path),
+            kick_tx: kick_tx.clone(),
+            folder_watch: Mutex::new(None),
+        });
+        entries.insert(id.to_string(), entry.clone());
+        tokio::spawn(entry_task(
+            Arc::downgrade(inner),
+            id.to_string(),
+            Arc::downgrade(&entry),
+            kick_rx,
+        ));
+        let _ = kick_tx.send(()); // initial check (boot / first observed)
+
         // Non-recursive watcher on the space folder: `.git` appearing/vanishing
         // among the direct children is exactly the signal we need. Watch
-        // failures are fine — the repair tick still converges.
-        let watcher = {
-            let tx = kick_tx.clone();
+        // failures are fine — the repair tick still converges. Built off the
+        // runtime: FSEvents registration blocks, and reconcile runs on the
+        // spaces-watch task.
+        let weak = Arc::downgrade(&entry);
+        tokio::task::spawn_blocking(move || {
+            let Some(entry) = weak.upgrade() else {
+                return; // entry removed before the watcher was ready
+            };
+            let tx = entry.kick_tx.clone();
             let result =
                 notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
                     let Ok(event) = event else { return };
@@ -141,34 +163,23 @@ fn reconcile(inner: &Arc<SpacesSyncInner>, spaces: &[Space]) {
             match result {
                 Ok(mut watcher) => {
                     use notify::Watcher as _;
-                    match watcher.watch(Path::new(&space.path), notify::RecursiveMode::NonRecursive)
-                    {
-                        Ok(()) => Some(watcher),
+                    match watcher.watch(&entry.path, notify::RecursiveMode::NonRecursive) {
+                        Ok(()) => {
+                            *lock(&entry.folder_watch) = Some(watcher);
+                            // Close the check→attach gap: a `.git` change while
+                            // unwatched gets caught by this recheck.
+                            let _ = entry.kick_tx.send(());
+                        }
                         Err(err) => {
-                            tracing::debug!(path = %space.path, error = %err, "spaces: watch failed");
-                            None
+                            tracing::debug!(path = %entry.path.display(), error = %err, "spaces: watch failed");
                         }
                     }
                 }
                 Err(err) => {
                     tracing::debug!(error = %err, "spaces: watcher create failed");
-                    None
                 }
             }
-        };
-        let entry = Arc::new(SpaceEntry {
-            path: PathBuf::from(&space.path),
-            kick_tx: kick_tx.clone(),
-            _watcher: watcher,
         });
-        entries.insert(id.to_string(), entry.clone());
-        tokio::spawn(entry_task(
-            Arc::downgrade(inner),
-            id.to_string(),
-            Arc::downgrade(&entry),
-            kick_rx,
-        ));
-        let _ = kick_tx.send(()); // initial check (boot / first observed)
     }
 }
 

--- a/crates/engine/tests/diff_sync_churn.rs
+++ b/crates/engine/tests/diff_sync_churn.rs
@@ -1,0 +1,287 @@
+//! Regression coverage for the diff-sync reconcile runaway (idle checkout,
+//! back-to-back `git diff` forever).
+//!
+//! Reconcile runs on every workspace chat row change — including the writes
+//! `sync_entry` itself makes — and used to resolve every chat's checkout
+//! identity with fresh `git rev-parse` spawns. One transient spawn failure made
+//! the chat ungroupable, so its entry (watchers, checksum state, published
+//! diff) was torn down and re-added on the next pass, and every re-add kicked a
+//! full capture whose row writes triggered the next reconcile. These tests pin
+//! the two dampers: memoized identity resolution and the orphan grace period.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use zeron_engine::{CheckoutDiffSync, EngineCore, HarnessRegistry};
+use zeron_proto::CheckoutDiff;
+
+async fn git(cwd: &Path, args: &[&str]) {
+    let output = tokio::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@test")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@test")
+        .output()
+        .await
+        .expect("git spawns");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Init a repo at `dir` with one committed file and one dirty edit.
+async fn init_dirty_repo(dir: &Path) {
+    std::fs::create_dir_all(dir).expect("repo dir");
+    git(dir, &["init", "-b", "main"]).await;
+    std::fs::write(dir.join("a.txt"), "one\ntwo\n").expect("write a.txt");
+    git(dir, &["add", "."]).await;
+    git(dir, &["commit", "-m", "initial"]).await;
+    std::fs::write(dir.join("a.txt"), "one\ntwo\nedited\n").expect("dirty tree");
+}
+
+fn assemble(dir: &Path) -> EngineCore {
+    std::fs::create_dir_all(dir).expect("data dir");
+    EngineCore::assemble(
+        dir,
+        Arc::new(HarnessRegistry::new()),
+        zeron_proto::HarnessId::Mock,
+        None,
+    )
+    .expect("engine assembles")
+}
+
+/// Poll `sync`'s watch until a diff for some checkout appears (or panic).
+/// Generous deadline: these tests share the machine with real builds.
+async fn wait_for_diff(sync: &CheckoutDiffSync) -> CheckoutDiff {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        if let Some(diff) = sync.watch_diffs().borrow().first().cloned() {
+            return diff;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "diff published before timeout"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+fn current_diffs(sync: &CheckoutDiffSync) -> Vec<CheckoutDiff> {
+    sync.watch_diffs().borrow().clone()
+}
+
+/// Block until the workspace chat watch reflects `chat_id`'s presence/absence —
+/// row mutations land in the watch asynchronously, and the churn tests need
+/// reconcile passes to run against a settled chat list to be deterministic.
+async fn wait_chat_state(core: &EngineCore, chat_id: &str, present: bool) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        let found = core
+            .workspace
+            .watch_chats()
+            .borrow()
+            .iter()
+            .any(|c| c.id == chat_id);
+        if found == present {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "chat watch settled before timeout"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// A transient identity failure (fd exhaustion, EACCES, any failed git spawn)
+/// must not tear down a live entry: the memo keeps the chat groupable during
+/// chat-watch reconciles, and a failed fresh resolve keeps the memo while the
+/// directory still exists. Pre-fix, the first reconcile during the outage
+/// removed the entry and the next one re-added it, kicking a fresh capture —
+/// the runaway loop.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn entry_survives_transient_identity_failure() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo_dir = tmp.path().join("repo");
+    init_dirty_repo(&repo_dir).await;
+
+    let core = assemble(&tmp.path().join("data"));
+    core.workspace
+        .create_space(
+            "space-1",
+            &core.device_id,
+            &repo_dir.to_string_lossy(),
+            None,
+            true,
+        )
+        .expect("space row");
+    core.workspace
+        .create_chat("chat-1", Some("space-1"), None, None, None)
+        .expect("chat row");
+    wait_chat_state(&core, "chat-1", true).await;
+    core.diff_sync.reconcile_now().await;
+    let before = wait_for_diff(&core.diff_sync).await;
+
+    // Simulate the outage: every git spawn against the checkout now fails
+    // (chdir EACCES), exactly like fd exhaustion did in the incident logs.
+    let live = std::fs::metadata(&repo_dir).expect("meta").permissions();
+    let mut dead = live.clone();
+    dead.set_mode(0o000);
+    std::fs::set_permissions(&repo_dir, dead).expect("chmod 000");
+
+    // Chat-watch reconciles during the outage: memo hit, no git needed.
+    core.diff_sync.reconcile_now().await;
+    core.diff_sync.reconcile_now().await;
+    // Repair-tick reconcile during the outage: fresh resolve fails, but the
+    // directory still exists, so the memo (and the entry) must survive.
+    core.diff_sync.repair_now().await;
+
+    std::fs::set_permissions(&repo_dir, live).expect("chmod back");
+    core.diff_sync.reconcile_now().await;
+
+    // Give any (wrongly) kicked capture time to land, then assert nothing
+    // changed: same diff, never dropped, never re-published.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let after = current_diffs(&core.diff_sync);
+    assert_eq!(after.len(), 1, "diff must survive the outage");
+    assert_eq!(after[0].checkout_id, before.checkout_id);
+    assert_eq!(after[0].checksum, before.checksum);
+    assert_eq!(
+        after[0].updated_at, before.updated_at,
+        "entry must not be torn down and re-captured"
+    );
+    core.shutdown().await;
+}
+
+/// A chat-watch emission that briefly misses a chat (row flap) must not tear
+/// down the checkout's entry, and the chat coming back must not re-kick a
+/// capture. Sustained absence past the grace period must still remove it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chat_flap_keeps_entry_and_sustained_absence_removes_it() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo_dir = tmp.path().join("repo");
+    init_dirty_repo(&repo_dir).await;
+
+    let core = assemble(&tmp.path().join("data"));
+    // Standalone sync with a tiny grace so removal is testable; the core's own
+    // diff_sync (default grace) also runs but assertions target this instance.
+    let sync = CheckoutDiffSync::start_with_orphan_grace(
+        core.repos.clone(),
+        core.workspace.clone(),
+        &core.device_id,
+        None,
+        Duration::from_millis(300),
+    );
+    core.workspace
+        .create_space(
+            "space-1",
+            &core.device_id,
+            &repo_dir.to_string_lossy(),
+            None,
+            true,
+        )
+        .expect("space row");
+    core.workspace
+        .create_chat("chat-1", Some("space-1"), None, None, None)
+        .expect("chat row");
+    wait_chat_state(&core, "chat-1", true).await;
+    sync.reconcile_now().await;
+    let before = wait_for_diff(&sync).await;
+
+    // Flap: the chat vanishes for one reconcile pass...
+    core.workspace.delete_chat("chat-1").expect("delete chat");
+    wait_chat_state(&core, "chat-1", false).await;
+    sync.reconcile_now().await;
+    let during = current_diffs(&sync);
+    assert_eq!(
+        during.len(),
+        1,
+        "one pass without the chat must only mark the entry, not remove it"
+    );
+
+    // ...and comes right back. The surviving entry already knows this chat id,
+    // so no capture is kicked and nothing is re-published.
+    core.workspace
+        .create_chat("chat-1", Some("space-1"), None, None, None)
+        .expect("chat row again");
+    wait_chat_state(&core, "chat-1", true).await;
+    sync.reconcile_now().await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let after = current_diffs(&sync);
+    assert_eq!(after.len(), 1);
+    assert_eq!(
+        after[0].updated_at, before.updated_at,
+        "flap-back must not re-capture or re-publish"
+    );
+
+    // Genuine removal still works: absent past the grace on consecutive passes.
+    core.workspace.delete_chat("chat-1").expect("delete chat");
+    wait_chat_state(&core, "chat-1", false).await;
+    sync.reconcile_now().await; // marks orphaned
+    tokio::time::sleep(Duration::from_millis(400)).await; // > grace
+    sync.reconcile_now().await; // removes
+    assert!(
+        current_diffs(&sync).is_empty(),
+        "sustained absence must remove the entry and its diff"
+    );
+    core.shutdown().await;
+}
+
+/// A checkout whose directory is actually gone must still be evicted: the
+/// fresh (repair) resolve drops the memo when the cwd no longer exists, and
+/// the grace period then runs out. Guards against the dampers making removal
+/// impossible.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deleted_checkout_is_evicted_after_grace() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo_dir = tmp.path().join("repo");
+    init_dirty_repo(&repo_dir).await;
+
+    let core = assemble(&tmp.path().join("data"));
+    let sync = CheckoutDiffSync::start_with_orphan_grace(
+        core.repos.clone(),
+        core.workspace.clone(),
+        &core.device_id,
+        None,
+        Duration::from_millis(300),
+    );
+    core.workspace
+        .create_space(
+            "space-1",
+            &core.device_id,
+            &repo_dir.to_string_lossy(),
+            None,
+            true,
+        )
+        .expect("space row");
+    core.workspace
+        .create_chat("chat-1", Some("space-1"), None, None, None)
+        .expect("chat row");
+    wait_chat_state(&core, "chat-1", true).await;
+    sync.reconcile_now().await;
+    wait_for_diff(&sync).await;
+
+    // The checkout vanishes while its chat row remains.
+    std::fs::remove_dir_all(&repo_dir).expect("remove repo");
+
+    // Chat-watch reconciles keep using the memo (they must not spawn git), so
+    // eviction is the repair tick's job: fresh resolve fails + cwd is gone ⇒
+    // memo dropped ⇒ chat ungroupable ⇒ orphaned ⇒ removed after grace.
+    sync.repair_now().await; // marks orphaned
+    tokio::time::sleep(Duration::from_millis(400)).await; // > grace
+    sync.repair_now().await; // removes
+    assert!(
+        current_diffs(&sync).is_empty(),
+        "vanished checkout must be evicted once absence outlasts the grace"
+    );
+    core.shutdown().await;
+}

--- a/crates/engine/tests/m5_repos_diffs_terminals.rs
+++ b/crates/engine/tests/m5_repos_diffs_terminals.rs
@@ -819,9 +819,12 @@ async fn diff_sync_publishes_and_updates_chat_branch() {
     assert_eq!(chat.checkout_id.as_deref(), Some(diff.checkout_id.as_str()));
 
     // File watcher path: another edit re-publishes without a manual kick.
+    // Normally the watcher carries this in a debounce; FSEvents is allowed to
+    // drop events, and a dropped one converges only on the repair tick, so the
+    // deadline clears REPAIR_INTERVAL rather than reading loss as failure.
     let before = diff.checksum.clone();
     std::fs::write(repo_dir.join("watched.txt"), "fresh untracked\n").expect("new file");
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(150);
     loop {
         {
             let diffs = diffs_rx.borrow().clone();


### PR DESCRIPTION
## What happened

On an idle checkout, the engine spawned `git diff` back-to-back forever — each pass burning ~100% of a core for 1–3s, a new one starting the moment the last exited. Enough to starve the machine (WindowServer at 99%, UI hover lag). Nobody was editing files in the checkout.

## Root cause

Two mechanisms combined into a self-sustaining loop:

1. `reconcile` runs on **every** workspace chat row change — including the `branch` and `checkoutId` writes `sync_entry` itself makes — and resolved each chat's checkout identity by spawning `git rev-parse` twice. Every publish fanned out into a storm of `git` spawns.
2. Under that fd pressure, one transient spawn failure (EMFILE) made the chat ungroupable, so reconcile tore its entry down and re-added it on the next pass. Every re-add kicks a full capture, whose row writes trigger the next reconcile.

Teardown discards the entry's checksum state, so the re-capture always republishes, which always triggers the next reconcile. On a large checkout each pass costs seconds of CPU, so the loop never runs out of work.

Separately, watcher setup ran inline on the runtime: the budget walk reads up to `MAX_WATCH_DIRS` directory entries and FSEvents registration stalls for seconds under contention, starving workspace watches and presence for every checkout whenever entries were rebuilt.

## The fix

Damp reconcile rather than treat the symptom — the `apply_numstat` comment records a previous fix for the same runaway symptom, so treating symptoms here is a known failure mode.

- **Memoize identities per cwd.** Chat-watch reconciles spawn no `git` at all; the repair tick revalidates. A failed fresh resolve keeps the memo unless the directory is actually gone.
- **Orphan grace period.** An entry whose chats vanish is only *marked*; teardown happens after a full `REPAIR_INTERVAL` of continuous absence. A single flapping chat-watch emission can no longer destroy a live entry.
- **Serialize reconcile passes.** Concurrent passes could both observe a checkout as missing and both `add_entry` it, the second insert silently discarding the first's checksum state.
- **Watcher setup moves to the blocking pool** in both diff-sync and spaces, attaching to the entry when ready with a kick to close the capture→attach gap.

Repair tick, watch budget bail-out and checksum-suppressed publishing are unchanged. Nothing is special-cased by path or file count — a pathological checkout made this visible, but any checkout can trigger it.

## Testing

`crates/engine/tests/diff_sync_churn.rs` covers all three dampers. Verified they actually pin the fix by mutating each damper away: with pre-fix behaviour restored, `entry_survives_transient_identity_failure` fails with exactly the incident signature (`updated_at` moves — the entry was torn down and re-captured), and `chat_flap_keeps_entry_and_sustained_absence_removes_it` fails on the entry being removed after a single missed pass. `deleted_checkout_is_evicted_after_grace` passes both ways by design: it guards that the dampers don't make legitimate eviction impossible.

Full `cargo test -p zeron-engine` is green (all suites, including 20/20 in `m5_repos_diffs_terminals`). `cargo fmt --check` clean; clippy adds no new warnings in the touched files.

One test deadline moved: `diff_sync_publishes_and_updates_chat_branch`'s watcher-path wait went 20s → 150s. FSEvents is permitted to drop events, and a dropped one converges only on the 120s repair tick, so the old deadline read normal event loss as failure.

## What this doesn't cover

- A checkout whose capture legitimately costs seconds still costs that on every real change; this removes the *spurious* passes, not the cost of a genuine one.
- Identity memoization means a checkout's identity changing underneath us (a worktree repointed at a different repo) is picked up on the repair tick rather than instantly.
- The blocking-pool move bounds runtime starvation but the budget walk itself is unchanged.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789508311&installation_model_id=425430&pr_number=127&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F127&signature=69b3bf85f94def0f35a0172e2db0d7fc0c6a4e431e9514322674b8765d3ac2df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->