### PR TITLE
ios: move "+" and the space filter into the bottom bar

### DIFF
--- a/apps/ios/Zeron/Theme/Theme.swift
+++ b/apps/ios/Zeron/Theme/Theme.swift
@@ -33,6 +33,8 @@ enum Theme {
     // ---- paint: accents ----
     static let accent = oklch(0.673, 0.182, 276.935)        // indigo-400
     static let accentStrong = oklch(0.585, 0.233, 277.117)  // indigo-500
+    /// violet-400 — the create/compose hue (the "+" glass, inline code's wash).
+    static let violet = oklch(0.702, 0.183, 293.541)
     static let danger = oklch(0.704, 0.191, 22.216)         // red-400
     static let dangerSoft = oklch(0.808, 0.114, 19.571)     // red-300
     static let warning = oklch(0.828, 0.189, 84.429)        // amber-400
@@ -45,7 +47,7 @@ enum Theme {
 
     // ---- paint: markdown inline code (violet family) ----
     static let inlineCodeText = oklch(0.811, 0.111, 293.571)  // violet-300
-    static let inlineCodeWash = oklch(0.702, 0.183, 293.541).opacity(0.12) // violet-400 @ 0.12
+    static let inlineCodeWash = violet.opacity(0.12)          // violet-400 @ 0.12
 
     // ---- paint: syntax tokens (soft, paint-only) ----
     static let tokenKeyword = oklch(0.709, 0.129, 20.0)   // soft rose

--- a/apps/ios/Zeron/Theme/Theme.swift
+++ b/apps/ios/Zeron/Theme/Theme.swift
@@ -33,8 +33,12 @@ enum Theme {
     // ---- paint: accents ----
     static let accent = oklch(0.673, 0.182, 276.935)        // indigo-400
     static let accentStrong = oklch(0.585, 0.233, 277.117)  // indigo-500
-    /// violet-400 — the create/compose hue (the "+" glass, inline code's wash).
+    /// violet-400 — the create/compose hue, as paint: inline code's wash.
     static let violet = oklch(0.702, 0.183, 293.541)
+    /// violet-500 — the same hue as a FILL under a white glyph. violet-400 only
+    /// reaches 2.5:1 there, under the 3:1 floor for a control; this clears it at
+    /// 4.4:1. Same 400/500 split as accent/accentStrong above.
+    static let violetStrong = oklch(0.606, 0.250, 292.717)
     static let danger = oklch(0.704, 0.191, 22.216)         // red-400
     static let dangerSoft = oklch(0.808, 0.114, 19.571)     // red-300
     static let warning = oklch(0.828, 0.189, 84.429)        // amber-400

--- a/apps/ios/Zeron/Views/HomeView.swift
+++ b/apps/ios/Zeron/Views/HomeView.swift
@@ -1,7 +1,8 @@
 // Home — the mobile shell. The desktop sidebar collapses into one screen: a
-// space dropdown in the nav bar (default "All") scopes the attention-sorted
-// session list below it. Tabs-as-sessions don't fit a phone; close=archive
-// becomes swipe-to-archive.
+// space dropdown on the bottom bar (default "All") scopes the attention-sorted
+// session list above it, with "+" at the other end of the same bar. Both sit in
+// thumb reach. Tabs-as-sessions don't fit a phone; close=archive becomes
+// swipe-to-archive.
 
 import SwiftUI
 
@@ -49,56 +50,48 @@ struct HomeView: View {
                 }
             }
             .toolbar {
-                // One leading item: a second topBarLeading entry gets folded
-                // into a "…" overflow next to the dropdown. The item's SHARED
-                // glass is hidden and the selector wears its own capsule, so
-                // the connect spinner sits bare on the bar beside it instead
-                // of inside the button's glass.
+                // Connecting reads at the top-leading corner, the nav bar's
+                // status slot. The space filter moved to the bottom bar, so
+                // this item carries the connection state on its own; the
+                // item's shared glass is hidden, so it sits bare on the bar.
+                //
+                // In the bar, not the list: as a list row it appeared and
+                // vanished with the connection and shoved the content down.
+                // Degraded states are GRACED (4s of continuous raw
+                // degradation before anything shows; recovery hides
+                // instantly) and quiet — a bare grayscale spinner or dot
+                // with a faint caption, no surface, no border (shell.rs
+                // render_connection_pill).
                 ToolbarItem(placement: .topBarLeading) {
-                    HStack(spacing: 10) {
-                        spaceDropdown
-                            // The hidden shared glass still reserves its
-                            // content inset, landing the capsule's edge at
-                            // ~30pt while the list rows' rail starts at 20 —
-                            // pull it back onto the content's left line.
-                            .padding(.leading, -10)
-                        // In the bar, not the list: as a list row it appeared
-                        // and vanished with the connection and shoved the
-                        // content down. Degraded states are GRACED (4s of
-                        // continuous raw degradation before anything shows;
-                        // recovery hides instantly) and quiet — a bare
-                        // grayscale spinner or dot with a faint caption, no
-                        // surface, no border (shell.rs render_connection_pill).
-                        switch model.connectivity.state {
-                        case .offline:
-                            HStack(spacing: 5) {
-                                Circle()
-                                    .fill(Theme.warning)
-                                    .frame(width: 5, height: 5)
-                                Text("Offline — sends are saved")
-                                    .font(Theme.sans(11))
-                                    .foregroundStyle(Theme.textFaint)
-                            }
-                            .transition(.opacity)
-                        case .reconnecting:
-                            HStack(spacing: 5) {
-                                ProgressView()
-                                    .controlSize(.mini)
-                                    .tint(Theme.textMuted)
-                                Text("Reconnecting…")
-                                    .font(Theme.sans(11))
-                                    .foregroundStyle(Theme.textFaint)
-                            }
-                            .transition(.opacity)
-                        case .connected:
-                            // Initial catch-up (within the grace): the old
-                            // quiet "connecting" spinner, gone on first sync.
-                            if !model.connected {
-                                ProgressView()
-                                    .controlSize(.mini)
-                                    .tint(Theme.textMuted)
-                                    .accessibilityLabel("Connecting")
-                            }
+                    switch model.connectivity.state {
+                    case .offline:
+                        HStack(spacing: 5) {
+                            Circle()
+                                .fill(Theme.warning)
+                                .frame(width: 5, height: 5)
+                            Text("Offline — sends are saved")
+                                .font(Theme.sans(11))
+                                .foregroundStyle(Theme.textFaint)
+                        }
+                        .transition(.opacity)
+                    case .reconnecting:
+                        HStack(spacing: 5) {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .tint(Theme.textMuted)
+                            Text("Reconnecting…")
+                                .font(Theme.sans(11))
+                                .foregroundStyle(Theme.textFaint)
+                        }
+                        .transition(.opacity)
+                    case .connected:
+                        // Initial catch-up (within the grace): the old
+                        // quiet "connecting" spinner, gone on first sync.
+                        if !model.connected {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .tint(Theme.textMuted)
+                                .accessibilityLabel("Connecting")
                         }
                     }
                 }
@@ -113,12 +106,36 @@ struct HomeView: View {
                         Image(systemName: "person.circle")
                     }
                 }
-                // "+" lives on the bottom bar, in thumb reach. Bottom-bar
-                // items lay out from the leading edge, so a flexible spacer
-                // ahead of it does the trailing alignment.
+                // The bottom bar carries both ends of the screen's reach: the
+                // space filter on the leading side, "+" on the trailing.
+                // Bottom-bar items lay out leading-first, so the flexible
+                // spacer between them does the trailing alignment.
+                //
+                // The selector wears its own glass capsule, so the item's
+                // shared glass is hidden — two of them would stack.
+                ToolbarItem(placement: .bottomBar) {
+                    spaceDropdown
+                }
+                .sharedBackgroundVisibility(.hidden)
                 ToolbarSpacer(.flexible, placement: .bottomBar)
                 ToolbarItem(placement: .bottomBar) {
+                    // Violet marks "create" — the one tinted control on the
+                    // screen (the hue markdown already gives inline code).
+                    // borderedProminent fills the disc with the tint; the
+                    // glass styles reach the glyph only. menuStyle is what
+                    // makes the Menu branch adopt the button style at all.
+                    //
+                    // KNOWN: the Menu branch (the All filter) draws a 52x48
+                    // pill where the Button branches draw a 48pt circle —
+                    // SwiftUI lays a menu-as-button out 4pt wider. A toolbar
+                    // item bridges to UIKit and drops the shape modifiers on
+                    // the way, so buttonBorderShape(.circle), clipShape,
+                    // menuIndicator(.hidden) and Label-vs-Image all no-op
+                    // here. Only dropping the Menu makes it a circle.
                     newButton
+                        .tint(Theme.violet)
+                        .buttonStyle(.borderedProminent)
+                        .menuStyle(.button)
                 }
             }
             .sheet(isPresented: $showNewSpace) {
@@ -151,7 +168,7 @@ struct HomeView: View {
 
     // MARK: Space dropdown
 
-    /// The nav-bar dropdown that scopes the session list — a NATIVE glass
+    /// The bottom-bar dropdown that scopes the session list — a NATIVE glass
     /// menu. Rows are Buttons, not a Picker: Picker menu rows drop two-Text
     /// subtitles, while Button rows map to UIAction subtitles, so each space
     /// shows its owning device ("@ mac") on the small second line without the
@@ -222,16 +239,14 @@ struct HomeView: View {
             Button {
                 path.append(.newSession(spaceId: space.id))
             } label: {
-                Image(systemName: "plus")
+                Label("New session", systemImage: "plus")
             }
-            .accessibilityLabel("New session")
         } else if model.spaces.isEmpty {
             Button {
                 showNewSpace = true
             } label: {
-                Image(systemName: "plus")
+                Label("New space", systemImage: "plus")
             }
-            .accessibilityLabel("New space")
         } else {
             Menu {
                 Section("New session in…") {
@@ -247,9 +262,8 @@ struct HomeView: View {
                     }
                 }
             } label: {
-                Image(systemName: "plus")
+                Label("New session", systemImage: "plus")
             }
-            .accessibilityLabel("New session")
         }
     }
 

--- a/apps/ios/Zeron/Views/HomeView.swift
+++ b/apps/ios/Zeron/Views/HomeView.swift
@@ -35,6 +35,8 @@ struct HomeView: View {
             .contentMargins(.top, 2, for: .scrollContent)
             .scrollContentBackground(.hidden)
             .scrollEdgeEffectStyle(.soft, for: .top)
+            // The list now scrolls under the bottom bar's glass.
+            .scrollEdgeEffectStyle(.soft, for: .bottom)
             .background(Theme.surface.ignoresSafeArea())
             .navigationTitle("Zeron")  // feeds the back menu; not displayed
             .navigationBarTitleDisplayMode(.inline)
@@ -102,9 +104,6 @@ struct HomeView: View {
                 }
                 .sharedBackgroundVisibility(.hidden)
                 ToolbarItem(placement: .topBarTrailing) {
-                    newButton
-                }
-                ToolbarItem(placement: .topBarTrailing) {
                     Menu {
                         if model.demo != nil {
                             Text("Demo mode")
@@ -113,6 +112,13 @@ struct HomeView: View {
                     } label: {
                         Image(systemName: "person.circle")
                     }
+                }
+                // "+" lives on the bottom bar, in thumb reach. Bottom-bar
+                // items lay out from the leading edge, so a flexible spacer
+                // ahead of it does the trailing alignment.
+                ToolbarSpacer(.flexible, placement: .bottomBar)
+                ToolbarItem(placement: .bottomBar) {
+                    newButton
                 }
             }
             .sheet(isPresented: $showNewSpace) {

--- a/apps/ios/Zeron/Views/HomeView.swift
+++ b/apps/ios/Zeron/Views/HomeView.swift
@@ -133,7 +133,7 @@ struct HomeView: View {
                     // menuIndicator(.hidden) and Label-vs-Image all no-op
                     // here. Only dropping the Menu makes it a circle.
                     newButton
-                        .tint(Theme.violet)
+                        .tint(Theme.violetStrong)
                         .buttonStyle(.borderedProminent)
                         .menuStyle(.button)
                 }

--- a/apps/ios/Zeron/Views/SpaceView.swift
+++ b/apps/ios/Zeron/Views/SpaceView.swift
@@ -43,6 +43,8 @@ struct SpaceView: View {
         .environment(\.defaultMinListRowHeight, 10)
         .scrollContentBackground(.hidden)
         .scrollEdgeEffectStyle(.soft, for: .top)
+        // The list now scrolls under the bottom bar's glass.
+        .scrollEdgeEffectStyle(.soft, for: .bottom)
         .background(Theme.surface.ignoresSafeArea())
         .navigationTitle(space?.displayName ?? "Space")  // feeds the back menu
         .navigationBarTitleDisplayMode(.inline)
@@ -66,7 +68,10 @@ struct SpaceView: View {
                     }
                 }
             }
-            ToolbarItem(placement: .topBarTrailing) {
+            // Same placement as Home's "+": bottom bar, trailing side, behind
+            // a flexible spacer (bottom-bar items lay out leading-first).
+            ToolbarSpacer(.flexible, placement: .bottomBar)
+            ToolbarItem(placement: .bottomBar) {
                 Button {
                     path.append(.newSession(spaceId: spaceId))
                 } label: {

--- a/apps/ios/Zeron/Views/SpaceView.swift
+++ b/apps/ios/Zeron/Views/SpaceView.swift
@@ -75,9 +75,11 @@ struct SpaceView: View {
                 Button {
                     path.append(.newSession(spaceId: spaceId))
                 } label: {
-                    Image(systemName: "plus")
+                    Label("New session", systemImage: "plus")
                 }
-                .accessibilityLabel("New session")
+                // Same violet "create" disc as Home's "+".
+                .tint(Theme.violet)
+                .buttonStyle(.borderedProminent)
             }
         }
         .onAppear {

--- a/apps/ios/Zeron/Views/SpaceView.swift
+++ b/apps/ios/Zeron/Views/SpaceView.swift
@@ -78,7 +78,7 @@ struct SpaceView: View {
                     Label("New session", systemImage: "plus")
                 }
                 // Same violet "create" disc as Home's "+".
-                .tint(Theme.violet)
+                .tint(Theme.violetStrong)
                 .buttonStyle(.borderedProminent)
             }
         }


### PR DESCRIPTION
Home and the space detail both put "new session" at the top-trailing corner,
the far end of a one-handed reach. Both move to the bottom bar's trailing
side, behind a flexible spacer (bottom-bar items lay out leading-first). On
Home the space dropdown follows it, so both ends of the screen's reach sit in
the same bar: filter on the leading side, "+" on the trailing. The account
menu keeps the top-trailing slot.

Both lists now scroll under the bar's glass, so the bottom edge gets the same
soft scroll-edge effect the top already had.

The connect spinner does not follow the dropdown down. It rode beside it only
to keep out of the list, and on the bottom bar it read as part of the filter,
so it takes the nav bar's top-leading status slot instead: bare, since the
item's shared glass is hidden, and level with the account button.

"+" is violet now, the one tinted control on the screen, the hue markdown
already gives inline code. Only `.buttonStyle(.borderedProminent)` gets the
tint onto the fill - `.glassEffect(.regular.tint())` and
`.buttonStyle(.glassProminent)` colour the glyph and leave the capsule
neutral, and a plain `Button` inside a `ToolbarItem` ignores the glass styles
outright.

`borderedProminent` paints a white glyph and does not darken the tint to suit
it, so the fill is violet-500, not the violet-400 the inline-code wash uses.
Measured off the simulator, violet-400 gave the glyph 2.5:1 - under the 3:1 a
control needs - and violet-500 gives 4.4:1. `Theme.violet` stays the paint
hue and `violetStrong` is the fill, matching the `accent`/`accentStrong`
split the file already keeps.

Labels are `Label`, not `Image` plus `.accessibilityLabel`: the toolbar
idiom, and it carries a title if the item ever folds into an overflow menu.

### Known rough edge

Under the All filter "+" is a `Menu`, and SwiftUI lays a menu-as-button out
4pt wider than the same `Button`, so that one state draws a 52x48 pill where
the others draw a 48pt circle. A toolbar item bridges to UIKit and drops
shape modifiers on the way, so `buttonBorderShape(.circle)`, `clipShape`,
`menuIndicator(.hidden)` and Label-vs-Image all no-op there. Only dropping
the `Menu` squares it up, and the system menu is worth more than the 4pt.

### Testing

Built and run on the iPhone 17 Pro simulator (iOS 26) in demo mode. Both
screens checked: the bottom bar lays out as described, the space filter and
"+" both work, and the "+" fill/glyph contrast was sampled from the rendered
pixels. No new build warnings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789550151&installation_model_id=425430&pr_number=133&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F133&signature=064453c6401c465cdce4ecea6eedc6aa44eccf3f7797e592e79a5028a7531706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->