### PR TITLE
fix: Open local workspace links in Changes

### DIFF
--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -268,6 +268,13 @@ struct ReadAttachmentChunkParams {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct ReadWorkspaceFileParams {
+    chat_id: String,
+    path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct FetchToolBlobParams {
     /// Doc-resident sidecar ref (`{chatId}/{partId}` or `…​.diff`).
     blob_ref: String,
@@ -790,6 +797,7 @@ fn forwardable(method: &str) -> bool {
             | methods::WATCH_CHECKOUT_DIFFS
             | methods::GET_CHECKOUT_DIFF
             | methods::GET_CHECKOUT_FILE_DIFF_TEXT
+            | methods::READ_WORKSPACE_FILE
             // Terminals live on the chat's host device.
             | methods::OPEN_TERMINAL
             | methods::SUBSCRIBE_TERMINAL
@@ -1704,6 +1712,44 @@ impl RpcService for EngineRpc {
                     .read_chunk(&p.path, p.offset, &roots)
                     .map_err(|e| RpcError::Failed(e.to_string()))?;
                 RpcReply::value(&chunk)
+            }
+            methods::READ_WORKSPACE_FILE => {
+                let p: ReadWorkspaceFileParams = parse_params(params)?;
+                let chat = self
+                    .workspace
+                    .chat(&p.chat_id)
+                    .map_err(|e| RpcError::Failed(e.to_string()))?
+                    .ok_or_else(|| RpcError::Failed("chat not found".into()))?;
+                let cwd = chat
+                    .cwd
+                    .ok_or_else(|| RpcError::Failed("chat has no workspace".into()))?;
+                let relative = std::path::Path::new(&p.path);
+                if relative.is_absolute()
+                    || relative.components().any(|part| {
+                        matches!(
+                            part,
+                            std::path::Component::ParentDir
+                                | std::path::Component::RootDir
+                                | std::path::Component::Prefix(_)
+                        )
+                    })
+                {
+                    return Err(RpcError::Failed("invalid workspace path".into()));
+                }
+                let root =
+                    std::fs::canonicalize(&cwd).map_err(|e| RpcError::Failed(e.to_string()))?;
+                let file = root.join(relative);
+                let metadata = std::fs::symlink_metadata(&file)
+                    .map_err(|e| RpcError::Failed(e.to_string()))?;
+                if metadata.file_type().is_symlink()
+                    || !metadata.is_file()
+                    || metadata.len() > 1024 * 1024
+                {
+                    return Err(RpcError::Failed("workspace file is not previewable".into()));
+                }
+                let text = std::fs::read_to_string(&file)
+                    .map_err(|_| RpcError::Failed("workspace file is not UTF-8".into()))?;
+                RpcReply::value(&serde_json::json!({ "text": text }))
             }
             methods::FETCH_TOOL_BLOB => {
                 let p: FetchToolBlobParams = parse_params(params)?;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -111,6 +111,7 @@ pub mod methods {
     pub const WATCH_CHECKOUT_DIFFS: &str = "WatchCheckoutDiffs";
     pub const GET_CHECKOUT_DIFF: &str = "GetCheckoutDiff";
     pub const GET_CHECKOUT_FILE_DIFF_TEXT: &str = "GetCheckoutFileDiffText";
+    pub const READ_WORKSPACE_FILE: &str = "ReadWorkspaceFile";
     // Agent accounts (ControlRpc, relay-forwardable — CLI logins are per-device).
     pub const LIST_AGENT_ACCOUNTS: &str = "ListAgentAccounts";
     pub const ACTIVATE_AGENT_ACCOUNT: &str = "ActivateAgentAccount";

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -28,8 +28,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use gpui::{
-    AnyElement, App, Context, Entity, FocusHandle, Focusable as _, ListAlignment, ListState,
-    SharedString, Subscription, Task, Window, div, font, list, prelude::*, px,
+    AnyElement, App, Context, Entity, FocusHandle, Focusable as _, ListAlignment, ListOffset,
+    ListState, SharedString, Subscription, Task, Window, div, font, list, prelude::*, px,
 };
 
 use zeron_proto::{Chat, CheckoutDiff, GitHistoryCommit};
@@ -1120,6 +1120,11 @@ pub struct Changes {
     /// Pinned commit for a [`DiffScope::Commit`] pane (sha + subject drive
     /// the fetch and the surface-tab title).
     commit: Option<GitHistoryCommit>,
+    /// A project link can arrive before the async diff parser. Keep it until
+    /// rows exist, then expand and scroll to the requested file.
+    reveal_path: Option<String>,
+    preview: Option<(SharedString, SharedString)>,
+    preview_task: Option<Task<()>>,
     _observe: Subscription,
 }
 
@@ -1171,6 +1176,9 @@ impl Changes {
             history_fetch_button: None,
             history_events: None,
             commit: None,
+            reveal_path: None,
+            preview: None,
+            preview_task: None,
             _observe: observe,
         }
     }
@@ -1199,6 +1207,92 @@ impl Changes {
             return commit.sha.chars().take(7).collect::<String>().into();
         }
         gpui::SharedString::from(self.scope.label())
+    }
+
+    pub fn is_working_tree(&self) -> bool {
+        self.scope == DiffScope::WorkingTree
+    }
+
+    pub fn reveal_file(&mut self, path: String, cx: &mut Context<Self>) {
+        self.reveal_path = Some(path);
+        self.preview = None;
+        self.error = None;
+        self.ensure_content(cx);
+        self.apply_reveal(cx);
+    }
+
+    fn apply_reveal(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.reveal_path.clone() else {
+            return;
+        };
+        let Some(parsed) = &self.parsed else {
+            return;
+        };
+        let Some(file_ix) = parsed.files.iter().position(|file| file.path == path) else {
+            self.reveal_path = None;
+            self.load_preview(path, cx);
+            cx.notify();
+            return;
+        };
+        if self.folds.get(&path).is_some_and(|fold| fold.collapsed) {
+            self.toggle_fold(file_ix, cx);
+        }
+        if let Some(range) = self.row_ranges.get(file_ix) {
+            self.list.scroll_to(ListOffset {
+                item_ix: range.start,
+                offset_in_item: px(0.0),
+            });
+        }
+        self.reveal_path = None;
+        cx.notify();
+    }
+
+    fn load_preview(&mut self, path: String, cx: &mut Context<Self>) {
+        let Some(engine) = self.state.read(cx).engine().cloned() else {
+            self.error = Some("File preview is unavailable".into());
+            return;
+        };
+        let chat_id = self
+            .state
+            .read(cx)
+            .selected_chat_row()
+            .map(|chat| chat.id.clone());
+        let Some(chat_id) = chat_id else {
+            self.error = Some("File preview has no workspace".into());
+            return;
+        };
+        let target = self.desired_target(cx);
+        self.preview_task = Some(cx.spawn(async move |this, cx| {
+            let mut params = serde_json::json!({ "chatId": chat_id, "path": path });
+            if let Some(target) = target
+                && let Some(object) = params.as_object_mut()
+            {
+                object.insert("targetDeviceId".into(), target.into());
+            }
+            let text = engine
+                .client()
+                .call(methods::READ_WORKSPACE_FILE, params)
+                .await
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("text")
+                        .and_then(|text| text.as_str())
+                        .map(str::to_string)
+                });
+            this.update(cx, |changes, cx| {
+                changes.preview_task = None;
+                match text {
+                    Some(text) => changes.preview = Some((path.into(), text.into())),
+                    None => {
+                        changes.error =
+                            Some("File is unavailable, binary, or larger than 1 MiB".into())
+                    }
+                }
+                cx.notify();
+            })
+            .ok();
+        }));
     }
 
     /// The selected chat's host device when it differs from the connected
@@ -1684,6 +1778,7 @@ impl Changes {
                     file_count,
                     files: Arc::new(files),
                 });
+                changes.apply_reveal(cx);
                 cx.notify();
             })
             .ok();
@@ -2954,7 +3049,6 @@ impl Changes {
                 .flex_col()
                 .gap(px(2.0))
                 .max_h(px(240.0))
-                .overflow_y_scroll()
                 .track_scroll(&list_scroll)
                 .children(rows.into_iter().enumerate().map(|(row_ix, branch_ix)| {
                     let name = branches[branch_ix].clone();
@@ -3636,6 +3730,25 @@ impl Render for Changes {
                     theme.text_faint
                 })
                 .child(message)
+                .into_any_element()
+        } else if let Some((path, text)) = self.preview.clone() {
+            div()
+                .id(format!("changes-preview-{path}"))
+                .flex_1()
+                .min_h_0()
+                .overflow_y_scroll()
+                .px(px(Theme::SPACE_MD))
+                .py(px(Theme::SPACE_MD))
+                .font_family(theme.font_mono.clone())
+                .text_size(px(12.0))
+                .text_color(theme.text)
+                .child(
+                    div()
+                        .mb(px(Theme::SPACE_SM))
+                        .text_color(theme.text_muted)
+                        .child(path),
+                )
+                .child(text)
                 .into_any_element()
         } else {
             match phase {

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -79,6 +79,9 @@ pub struct RenderOptions {
     /// Code-block copy-button plumbing (round 9): `None` renders no button
     /// (previews outside the transcript).
     pub copy: Option<CopyUi>,
+    /// Link activation is owned by the transcript host. This lets project
+    /// paths navigate to the in-app diff while web links still open externally.
+    pub link: Option<LinkUi>,
 }
 
 /// Copy-button wiring for one row's code blocks: the handler writes the code
@@ -90,6 +93,11 @@ pub struct CopyUi {
     pub copied_ix: Option<usize>,
 }
 
+#[derive(Clone)]
+pub struct LinkUi {
+    pub handler: Rc<dyn Fn(SharedString, &mut Window, &mut gpui::App)>,
+}
+
 impl RenderOptions {
     /// Options for a completed (non-streaming) row — no veil, no cache.
     pub fn settled(row_key: SharedString) -> Self {
@@ -99,6 +107,7 @@ impl RenderOptions {
             cache: None,
             now: Instant::now(),
             copy: None,
+            link: None,
         }
     }
 }
@@ -662,11 +671,16 @@ fn flat_text_element(
         styled.into_any_element()
     } else {
         let (ranges, urls): (Vec<_>, Vec<_>) = flat.links.iter().cloned().unzip();
+        let link = opts.link.clone();
         let id: SharedString = format!("{}-t{ix}", opts.row_key).into();
         InteractiveText::new(id, styled)
-            .on_click(ranges, move |clicked_ix, _window, cx| {
+            .on_click(ranges, move |clicked_ix, window, cx| {
                 if let Some(url) = urls.get(clicked_ix) {
-                    cx.open_url(url);
+                    if let Some(link) = &link {
+                        (link.handler)(url.clone().into(), window, cx);
+                    } else {
+                        cx.open_url(url);
+                    }
                 }
             })
             .into_any_element()

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -11,7 +11,7 @@
 //! ghost view + `on_drag_move::<Marker>` on the root), the same idiom as Zed's
 //! dock. Double-clicking a handle resets that pane to its default width.
 
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
 use chrono::Utc;
@@ -72,6 +72,22 @@ actions!(
 /// fullscreen hides them and the cluster reclaims the inset.
 pub fn titlebar_cluster_start(fullscreen: bool) -> f32 {
     if fullscreen { 12.0 } else { 88.0 }
+}
+
+fn checkout_relative_path(cwd: &str, target: &str) -> Option<String> {
+    let relative = Path::new(target).strip_prefix(cwd).ok()?;
+    if relative.as_os_str().is_empty()
+        || relative.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return None;
+    }
+    let path = relative.to_str()?.replace('\\', "/");
+    (!path.is_empty()).then_some(path)
 }
 
 /// Width of the spacer ahead of the control cluster for a strip that already
@@ -1471,6 +1487,56 @@ impl Shell {
         cx.notify();
     }
 
+    fn open_transcript_link(&mut self, url: &str, cx: &mut Context<Self>) {
+        if url.starts_with("https://") || url.starts_with("http://") {
+            cx.open_url(url);
+            return;
+        }
+        let cwd = self
+            .state
+            .read(cx)
+            .selected_chat_row()
+            .and_then(|chat| chat.cwd.clone());
+        let Some(cwd) = cwd else {
+            return;
+        };
+        let Some(path) = checkout_relative_path(&cwd, url) else {
+            return;
+        };
+        self.reveal_change_file(path, cx);
+    }
+
+    fn reveal_change_file(&mut self, path: String, cx: &mut Context<Self>) {
+        let key = self.panel_key(cx);
+        let existing = self.right_tabs.get(&key).and_then(|tabs| {
+            tabs.iter().find_map(|surface| match surface {
+                RightSurface::Diff(id)
+                    if self
+                        .diffs
+                        .get(id)
+                        .is_some_and(|changes| changes.read(cx).is_working_tree()) =>
+                {
+                    Some(*id)
+                }
+                _ => None,
+            })
+        });
+        let id = match existing {
+            Some(id) => id,
+            None => {
+                self.add_diff_surface(cx);
+                self.diff_seq
+            }
+        };
+        self.set_right_active(RightSurface::Diff(id), cx);
+        if !self.right_pane_open(cx) {
+            self.toggle_right_pane(cx);
+        }
+        if let Some(changes) = self.diffs.get(&id).cloned() {
+            changes.update(cx, |changes, cx| changes.reveal_file(path, cx));
+        }
+    }
+
     fn right_terminal_panel(&mut self, cx: &mut Context<Self>) -> Entity<TerminalPanel> {
         if let Some(terminal) = &self.right_terminal {
             return terminal.clone();
@@ -1658,13 +1724,20 @@ impl Shell {
         cx: &mut Context<Self>,
     ) {
         match event {
+            TranscriptEvent::OpenLink(url) => self.open_transcript_link(url, cx),
             TranscriptEvent::OpenSubagent {
                 chat_id,
                 doc_id,
                 title,
                 frozen,
             } => {
-                self.add_subagent_surface(chat_id.clone(), doc_id.clone(), title.clone(), *frozen, cx);
+                self.add_subagent_surface(
+                    chat_id.clone(),
+                    doc_id.clone(),
+                    title.clone(),
+                    *frozen,
+                    cx,
+                );
             }
         }
     }
@@ -4999,12 +5072,7 @@ impl Shell {
                 .right(px(10.0))
                 .flex()
                 .justify_center()
-                .child(self.jump_pill(
-                    "jump-to-bottom",
-                    "jump-pill",
-                    self.transcript.clone(),
-                    cx,
-                ))
+                .child(self.jump_pill("jump-to-bottom", "jump-pill", self.transcript.clone(), cx))
                 .into_any_element(),
         )
     }
@@ -7409,6 +7477,22 @@ mod tests {
         // The right pane round-trips back closed.
         assert!(!panels.toggle_changes("a"));
         assert!(!panels.get("a").changes_open);
+    }
+
+    #[test]
+    fn checkout_relative_path_rejects_escape_and_keeps_project_paths() {
+        assert_eq!(
+            checkout_relative_path("/workspace/comet", "/workspace/comet/docs/plan.md"),
+            Some("docs/plan.md".into())
+        );
+        assert_eq!(
+            checkout_relative_path("/workspace/comet", "/workspace/other/a.md"),
+            None
+        );
+        assert_eq!(
+            checkout_relative_path("/workspace/comet", "/workspace/comet/../secret.md"),
+            None
+        );
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -1531,6 +1531,7 @@ enum BlobFetch {
 /// Shell-facing events (the transcript itself hosts no surfaces).
 #[derive(Debug, Clone)]
 pub enum TranscriptEvent {
+    OpenLink(SharedString),
     /// A spawn chip's "Open subagent" affordance: open the subagent's
     /// transcript as a right-pane tab. `chat_id` is the doc the chip lives
     /// in (the frozen blob is keyed `{chat_id}/{doc_id}`); `frozen` means
@@ -2991,6 +2992,7 @@ impl Transcript {
                     cache: (!render_cache_disabled()).then(|| self.render_cache.clone()),
                     now: Instant::now(),
                     copy: Some(self.copy_ui_for(&row.id, cx)),
+                    link: Some(self.link_ui(cx)),
                 };
                 let highlight = self.code_highlight_for(&row.id, tree, Some(*block_ix), cx);
                 let Some(top) = tree.blocks.get(*block_ix) else {
@@ -3033,6 +3035,7 @@ impl Transcript {
                     cache: (!render_cache_disabled()).then(|| self.render_cache.clone()),
                     now: Instant::now(),
                     copy: Some(self.copy_ui_for(&row.id, cx)),
+                    link: Some(self.link_ui(cx)),
                 };
                 let highlight = self.code_highlight_for(&row.id, tree, Some(*block_ix), cx);
                 let Some(top) = tree.blocks.get(*block_ix) else {
@@ -3201,6 +3204,20 @@ impl Transcript {
                     .ok();
             });
         render::CopyUi { handler, copied_ix }
+    }
+
+    fn link_ui(&self, cx: &mut Context<Self>) -> render::LinkUi {
+        let entity = cx.weak_entity();
+        render::LinkUi {
+            handler: Rc::new(move |url, _, cx| {
+                entity
+                    .update(cx, |_this, cx| {
+                        cx.emit(TranscriptEvent::OpenLink(url));
+                        cx.notify();
+                    })
+                    .ok();
+            }),
+        }
     }
 
     /// Request highlights for the code blocks of a tree. `only` limits to one
@@ -4101,15 +4118,17 @@ fn chip_header_row(
             // The sidebar working-row spinner, in the chip's trailing slot —
             // paint-local (fixed footprint), so it never moves the layout.
             row.child(
-                div().flex_none().child(crate::loaders::mini_gradient_spinner(
-                    format!(
-                        "subagent-chip-{}",
-                        tool.subagent_ref.as_deref().unwrap_or_default()
-                    ),
-                    2.0,
-                    view,
-                    cx,
-                )),
+                div()
+                    .flex_none()
+                    .child(crate::loaders::mini_gradient_spinner(
+                        format!(
+                            "subagent-chip-{}",
+                            tool.subagent_ref.as_deref().unwrap_or_default()
+                        ),
+                        2.0,
+                        view,
+                        cx,
+                    )),
             )
         })
         .when_some(chevron, |row, open| {


### PR DESCRIPTION
## Summary

Closes #199.


- Open absolute workspace links in the Changes panel instead of sending them to the operating system.
- Reveal changed files in their diff and show a read-only preview for clean UTF-8 files up to 1 MiB.
- Reject paths outside the current checkout, symlinks, and non-text files.

## Verification

- `cargo check -p zeron --locked`
- `cargo test -p zeron-ui`
- `cargo test -p zeron-engine`
- Manual: clicked a clean workspace file and confirmed the read-only preview renders.

## Notes

Documentation artifacts remain intentionally uncommitted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789578235&installation_model_id=425430&pr_number=139&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F139&signature=cd119a37608d9af703ffb1aca12389845bb0afe10082092aa16ece98d25864e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
