### PR TITLE
Pull/push transport hardening: bearer headers, body caps, bounded responses

### DIFF
--- a/apps/ios/Zeron/App/AppConfig.swift
+++ b/apps/ios/Zeron/App/AppConfig.swift
@@ -165,11 +165,14 @@ final class AppConfig: @unchecked Sendable {
         guard let token = await currentToken() else { return nil }
         var url = edgeURL.appending(path: "registry/\(orgId)/rows")
         var items = [URLQueryItem(name: "device", value: deviceId),
-                     URLQueryItem(name: "beat", value: "1"),
-                     URLQueryItem(name: "token", value: token)]
+                     URLQueryItem(name: "beat", value: "1")]
         if let since { items.append(URLQueryItem(name: "since", value: String(since))) }
         url.append(queryItems: items)
-        return URLRequest(url: url)
+        // Bearer header, never ?token=: HTTP supports headers (unlike WS
+        // upgrades), and query strings can reach request logs.
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
     }
 
     /// POST /registry/{orgId}/push — one op batch over plain HTTPS (LWW

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -1303,7 +1303,7 @@ impl WsDerivedRegistryTransport {
     async fn leaf_url(
         provider: &Arc<dyn zeron_sync::UrlProvider>,
         leaf: &str,
-    ) -> Result<reqwest::Url, zeron_sync::SyncError> {
+    ) -> Result<(reqwest::Url, Option<String>), zeron_sync::SyncError> {
         let ws = provider.url().await?;
         let mut u = reqwest::Url::parse(&ws)
             .map_err(|e| zeron_sync::SyncError::Protocol(format!("bad ws url: {e}")))?;
@@ -1315,7 +1315,23 @@ impl WsDerivedRegistryTransport {
         };
         let new_path = format!("{base}/{leaf}");
         u.set_path(&new_path);
-        Ok(u)
+        // Move the WS URL's ?token= into a bearer header (HTTP supports
+        // headers; query strings can reach request logs). Other params
+        // (device) stay.
+        let token = u
+            .query_pairs()
+            .find(|(k, _)| k == "token")
+            .map(|(_, v)| v.into_owned());
+        let kept: Vec<(String, String)> = u
+            .query_pairs()
+            .filter(|(k, _)| k != "token")
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        u.query_pairs_mut().clear();
+        for (k, v) in kept {
+            u.query_pairs_mut().append_pair(&k, &v);
+        }
+        Ok((u, token))
     }
 }
 
@@ -1327,12 +1343,15 @@ impl zeron_sync::RegistryTransport for WsDerivedRegistryTransport {
         let provider = self.url.clone();
         let client = self.client.clone();
         Box::pin(async move {
-            let mut u = Self::leaf_url(&provider, "rows").await?;
+            let (mut u, token) = Self::leaf_url(&provider, "rows").await?;
             u.query_pairs_mut()
                 .append_pair("since", &since.to_string())
                 .append_pair("beat", "1");
-            let resp = client
-                .get(u)
+            let mut req = client.get(u);
+            if let Some(token) = token {
+                req = req.bearer_auth(token);
+            }
+            let resp = req
                 .send()
                 .await
                 .map_err(|e| zeron_sync::SyncError::WebSocket(e.to_string()))?;
@@ -1355,11 +1374,15 @@ impl zeron_sync::RegistryTransport for WsDerivedRegistryTransport {
         let provider = self.url.clone();
         let client = self.client.clone();
         Box::pin(async move {
-            let u = Self::leaf_url(&provider, "push").await?;
-            let resp = client
+            let (u, token) = Self::leaf_url(&provider, "push").await?;
+            let mut req = client
                 .post(u)
                 .header("content-type", "application/json")
-                .body(body)
+                .body(body);
+            if let Some(token) = token {
+                req = req.bearer_auth(token);
+            }
+            let resp = req
                 .send()
                 .await
                 .map_err(|e| zeron_sync::SyncError::WebSocket(e.to_string()))?;

--- a/edge/src/chat-room.ts
+++ b/edge/src/chat-room.ts
@@ -196,16 +196,29 @@ export class ChatRoom implements DurableObject {
           frontier
         )
       ];
+      // Response cap: the WS path streams; this buffers, so bound the body.
+      // Past the cap the response ends WITHOUT rowsDone — clients apply what
+      // arrived, their cursor advances per row, and the next pull resumes
+      // from there (pagination by truncation).
+      const ROWS_BODY_CAP = 4 * 1024 * 1024;
+      let bodyBytes = 0;
+      let truncated = false;
       for (const row of rowsAfter(sql, after, exclude)) {
-        frames.push(
-          encodeFrame(
-            FRAME.row,
-            { seq: row.seq, device: row.device, batchId: row.batchId },
-            row.bytes
-          )
+        const frame = encodeFrame(
+          FRAME.row,
+          { seq: row.seq, device: row.device, batchId: row.batchId },
+          row.bytes
         );
+        bodyBytes += 4 + frame.length;
+        if (bodyBytes > ROWS_BODY_CAP) {
+          truncated = true;
+          break;
+        }
+        frames.push(frame);
       }
-      frames.push(encodeFrame(FRAME.rowsDone, { headSeq: headSeq(sql) }));
+      if (!truncated) {
+        frames.push(encodeFrame(FRAME.rowsDone, { headSeq: headSeq(sql) }));
+      }
       const total = frames.reduce((n, f) => n + 4 + f.length, 0);
       const body = new Uint8Array(total);
       const view = new DataView(body.buffer);
@@ -229,6 +242,13 @@ export class ChatRoom implements DurableObject {
       if (batchId === "" || batchId.length > 128) {
         this.recordPush(device, false);
         return json({ error: "bad_push" }, 400);
+      }
+      // Pre-read cap (the WS runtime closes 1 MiB messages before the DO
+      // runs; HTTP needs the explicit twin). appendRow re-checks post-read.
+      const declared = Number(request.headers.get("content-length") ?? "0");
+      if (declared > MAX_ROW_BYTES + 4096) {
+        this.recordPush(device, false);
+        return json({ error: "too_large" }, 413);
       }
       const payload = new Uint8Array(await request.arrayBuffer());
       if (!this.admitQuota(device, payload.byteLength)) {

--- a/edge/src/registry-room.ts
+++ b/edge/src/registry-room.ts
@@ -221,6 +221,11 @@ export class RegistryRoom implements DurableObject {
       // body. LWW clocks make replayed batches apply zero ops, so
       // at-least-once delivery (including 0-RTT/early-data replays) is safe.
       const device = url.searchParams.get("device") ?? "";
+      // Pre-read cap (the WS path gets this for free from MAX_FRAME_BYTES):
+      // a legitimate batch is bounded well under this by MAX_BATCH_OPS ×
+      // MAX_OP_BYTES; anything larger only burns this room's own CPU.
+      const declared = Number(request.headers.get("content-length") ?? "0");
+      if (declared > 2 * 1024 * 1024) return json({ error: "too_large" }, 413);
       let frame: Record<string, unknown>;
       try {
         frame = (await request.json()) as Record<string, unknown>;


### PR DESCRIPTION
Security audit follow-up to the pull-first transport PRs. Access control was verified intact (worker bearer gate → org claim → token-derived room / owner gate, same as WS; unauth probes 401 in prod). This closes the two hardening gaps found: tokens moved from query strings to Authorization headers on the paths that support them, and explicit body/response size caps on the new HTTP endpoints (self-DoS class; the WS runtime's 1 MiB message cap needed an HTTP twin). All edge suites and client tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789588565&installation_model_id=425430&pr_number=140&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F140&signature=d5dcb69750ea29a87831a718dd63e9a7307c3be923e9f8cf34fdb4d5561b0610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->