### PR TITLE
fix(ui): round project picker section corners

### DIFF
--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -1443,10 +1443,12 @@ impl Shell {
         // Header and footer sit a shade DEEPER than the body (the shared
         // recessed-band tone) — the bands frame the folder list, which stays
         // on the brighter tint.
+        let card_radius = 14.0;
         let band = popover::band();
         let input_row = div()
             .h(px(46.0))
             .flex_none()
+            .rounded_t(px(card_radius))
             .pl(px(12.0))
             .pr(px(10.0))
             .flex()
@@ -1828,6 +1830,7 @@ impl Shell {
         // ── footer: the shared key-cap legend voice (popover::key_hint).
         let footer = div()
             .flex_none()
+            .rounded_b(px(card_radius))
             .bg(band)
             .border_t_1()
             .border_color(hairline)
@@ -1861,7 +1864,7 @@ impl Shell {
             div()
                 .id("add-space-palette")
                 .w(px(680.0))
-                .rounded(px(14.0))
+                .rounded(px(card_radius))
                 .border_1()
                 .border_color(crate::theme::hairline(0.10))
                 // The popover_card glass recipe: a translucent tint over the
@@ -1901,7 +1904,7 @@ impl Shell {
             "add-space-dialog",
             viewport,
             card,
-            14.0,
+            card_radius,
         ))
     }
 


### PR DESCRIPTION
## Summary

- round the project picker header and footer bands with the same shared radius as the outer card
- reuse that radius for the frosted backdrop mask so every painted layer agrees
- prevent the rectangular band backgrounds from bleeding into all four rounded corners

## Cause

The outer card and frosted backdrop were rounded, but the darker header and footer bands still had square corners. The card's `overflow_hidden()` did not apply a rounded content mask to those child backgrounds, leaving bright crescent-shaped pixels at the corners.

## Testing

- `cargo fmt -p zeron-ui -- --check`
- `cargo check -p zeron-ui`
- `cargo test -p zeron-ui` — 442 passed
- `cargo clippy -p zeron-ui --all-targets` — passed with existing repository warnings
- isolated native app launch with a separate data directory and IPC port

`cargo test --workspace` was also attempted on current `main`; it remains blocked by the pre-existing engine E2E failures `processed_commands_are_skipped_on_redelivery` and `recover_stale_journal_stamps_aborted_on_boot`. The changed file is in `zeron-ui` and is not compiled into those engine test targets.

Automated pixel capture was unavailable because the macOS automation host did not have Screen Recording or Accessibility permission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789601032&installation_model_id=425430&pr_number=141&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F141&signature=c57834957051c51c62e45e55774e85fcb349ac2e1ec7845a634d0e3edc3f2a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->