### PR TITLE
chat2: claim rooms on HTTP first-contact — fixes remote new-chat "Sending…" hang

### DIFF
--- a/edge/src/chat-room.ts
+++ b/edge/src/chat-room.ts
@@ -136,9 +136,13 @@ export class ChatRoom implements DurableObject {
       return json({ ok: true, seqFloor: outcome.seqFloor, pruned: outcome.pruned });
     }
 
-    // Everything below reads a claimed room.
-    if (!owner) return json({ error: "not_found" }, 404);
-    if (owner !== userId) return json({ error: "forbidden" }, 403);
+    // Claim-on-first-contact for the HTTP surface too — same client-minted-id
+    // discipline as /ws. The /rows twins predate the pull-first HTTPS
+    // transport and 404'd an unclaimed room, which deadlocked a brand-new
+    // chat on WS-hostile networks: the sender's push 404s, the host's pull
+    // 404s, and the only claimants (WS join, checkpoint heal) never run.
+    if (!owner) setMeta(sql, "owner", userId);
+    else if (owner !== userId) return json({ error: "forbidden" }, 403);
 
     if (url.pathname === "/checkpoint" && request.method === "GET") {
       const bytes = this.blobs.get(CHECKPOINT_BLOB);


### PR DESCRIPTION
## Symptom

Starting a session on a remote machine from another device hangs on **"Sending…"** and never finishes — repeatedly, while existing chats keep syncing fine. Retrying in fresh chats sometimes works (whenever a WS dial happens to land in time).

## Root cause

Regression by composition between two commits:

- `3bc63f7` created the ChatRoom DO with claim-on-first-**WS-join** ownership: everything below the `/ws` and `/checkpoint POST` routes returns `404 not_found` for an unclaimed room.
- `22b5a67` later added the pull-first HTTPS transport (`/rows` GET/POST, "WS demoted to enhancement") — but never taught those HTTP twins to claim.

So a **brand-new** chat whose first contact rides the HTTP fallback deadlocks airtight:

1. Sender's HTTP push → 404 (room unclaimed; push doesn't claim).
2. Host is nudged, opens the doc, HTTP pull → 404 (pull doesn't claim either).
3. The host's bootstrap-checkpoint heal *would* claim via `/checkpoint POST`, but it's gated on `server_known` — state it can only learn from the pull that keeps 404ing.
4. Both sides retry at backoff cadence, 404 forever, and the sender's UI sits on "Sending…" until some WS upgrade finally passes.

Host-side log signature on personal-metal (2026-08-18): `chat2: http push failed … 404` / `http pull failed … 404`, plus nudged rooms that stayed rowless (`21ceeacc`, `e97dba76`) while attempts a minute later sailed through in ~2s once a WS dial succeeded.

## Fix

Claim-on-first-contact for the authed HTTP surface too — the same client-minted-id discipline `/ws` already applies (first authed toucher owns the room, everyone else gets 403). This does not widen the trust model: anyone who could pre-claim a room via HTTP could already do so via a WS dial.

## Verification

- `npm run typecheck` + both vitest tiers green (36 unit + 11 workerd).
- Live against `wrangler dev`: fresh-room HTTP pull → 200 (was 404), fresh-room HTTP push with no prior WS → `{"batchId":"b1","seq":1}` (was 404 — the deadlock), foreign-user push → 403.

Needs an edge deploy (main CI wrangler deploy) to take effect — server-side only, old clients are fixed by it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789640980&installation_model_id=425430&pr_number=147&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F147&signature=77b9401468545dfcb2b117236c7f119a93c21b757efaea1a3e13aea87f67e2fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->