### PR TITLE
harness: grok subagent visualization via session-store tail

### DIFF
--- a/crates/harness/src/acp/grok_subagent.rs
+++ b/crates/harness/src/acp/grok_subagent.rs
@@ -1,0 +1,618 @@
+//! Grok subagent lifecycle: correlates `spawn_subagent` tool calls with the
+//! transcript grok writes to its session store, and feeds the per-subagent
+//! doc pipeline ([`AgentEvent::Subagent`]).
+//!
+//! Grok streams subagent interiors over ACP UNTAGGED — `parent_tool_use_id`
+//! is null on every frame (verified live, 1.0.0 and 1.0.4; the docs promise
+//! tagging but it is unimplemented) — so the wire alone cannot attribute
+//! nested traffic to its spawn chip, and for BACKGROUND subagents the
+//! interior never reaches the parent stream at all. The durable surface is
+//! the session store: grok appends each subagent's full transcript to
+//! `~/.grok/sessions/<urlenc-cwd>/<subagent_id>/chat_history.jsonl`
+//! incrementally (flush-verified mid-run), and the parent session dir gains
+//! `subagents/<subagent_id>/{meta.json,output.json}` — meta at spawn,
+//! output only at completion.
+//!
+//! One tail task per spawned subagent maps those typed JSONL lines onto
+//! tagged events: a message-level transcript (grok's disk granularity —
+//! token-level deltas don't exist on this surface), then exactly one tagged
+//! `Done` when the store marks the subagent finished. Correlation key: the
+//! spawn tool_call carries `_meta["x.ai/tool"].name == "spawn_subagent"`,
+//! and its completion update's `rawOutput.text` names the `subagent_id`.
+//! The cwd dir is FOUND (the dir whose name grok minted from the session
+//! cwd contains the parent session id) rather than re-deriving grok's
+//! URL-encoding — one convention to drift instead of two.
+//!
+//! The store format is vendor-private: every read here fails SOFT (drift
+//! degrades to chip-only, never errors the chat), and the tasks are aborted
+//! at run end so a wedged subagent can't hold the event channel open past
+//! its session.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio::sync::mpsc;
+
+use zeron_proto::{AgentEvent, DoneStatus, HarnessId, ToolCall};
+
+use super::normalize::{OUTPUT_CAP, cap_text};
+use crate::HarnessError;
+
+/// Poll cadence for the transcript tail. The disk is written at message
+/// granularity, so sub-second polling buys nothing.
+const POLL: Duration = Duration::from_millis(500);
+
+/// Bound on spawn-completion → the subagent's dirs existing on disk (live
+/// runs show ~1s). Past this the store layout has drifted: give up quietly.
+const DISCOVER_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The vendor marker riding every shaped update of the spawn tool call
+/// (`_meta["x.ai/tool"].name` + `subagentBackground` on the opening call).
+pub(crate) fn is_spawn(update: &Value) -> bool {
+    update
+        .get("_meta")
+        .and_then(|m| m.get("x.ai/tool"))
+        .and_then(|t| t.get("name"))
+        .and_then(Value::as_str)
+        == Some("spawn_subagent")
+}
+
+/// The spawned subagent's id, from the completion update's `rawOutput`
+/// (`{type: "Text", text: "Subagent started in background.\nsubagent_id:
+/// <uuid>\n…"}`). A first-class `rawOutput.subagent_id` is accepted too in
+/// case grok ever promotes it. The id becomes a doc-id suffix downstream,
+/// so anything shaped unlike an id is rejected rather than passed along.
+pub(crate) fn subagent_id_from_update(update: &Value) -> Option<String> {
+    let raw = update.get("rawOutput")?;
+    let id = raw
+        .get("subagent_id")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            raw.get("text")
+                .and_then(Value::as_str)?
+                .lines()
+                .find_map(|l| {
+                    l.strip_prefix("subagent_id:")
+                        .map(|rest| rest.trim().to_owned())
+                })
+        })?;
+    let plausible = !id.is_empty()
+        && id.len() <= 64
+        && id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+    plausible.then_some(id)
+}
+
+/// The per-notification entry: guards harness/session/shape, then scans.
+/// Must be called from EVERY path that folds live `session/update`s —
+/// besides the main notification arm, the turn-settle and steer-injection
+/// drains each replay updates the prompt response outraced (grok's
+/// `prompt_complete` settlement makes that the COMMON path for updates in
+/// a turn's tail, the spawn completion included). `session/load` replay is
+/// dropped during setup and never reaches any of them, so a resumed
+/// session never re-harvests subagents its doc already holds.
+pub(crate) fn scan_notification(
+    harness: HarnessId,
+    method: &str,
+    params: &Value,
+    session_id: &str,
+    event_tx: &mpsc::Sender<Result<AgentEvent, HarnessError>>,
+    pending_spawns: &mut HashSet<String>,
+    harvesters: &mut Vec<tokio::task::JoinHandle<()>>,
+) {
+    if harness == HarnessId::Grok
+        && method == "session/update"
+        && params.get("sessionId").and_then(Value::as_str) == Some(session_id)
+        && let Some(update) = params.get("update")
+    {
+        scan_update(update, session_id, event_tx, pending_spawns, harvesters);
+    }
+}
+
+/// Track spawn tool calls across a session's `session/update`s and launch a
+/// harvester when one resolves with a subagent id.
+fn scan_update(
+    update: &Value,
+    parent_session_id: &str,
+    event_tx: &mpsc::Sender<Result<AgentEvent, HarnessError>>,
+    pending_spawns: &mut HashSet<String>,
+    harvesters: &mut Vec<tokio::task::JoinHandle<()>>,
+) {
+    let Some(id) = update.get("toolCallId").and_then(Value::as_str) else {
+        return;
+    };
+    if is_spawn(update) {
+        pending_spawns.insert(id.to_owned());
+    }
+    if !pending_spawns.contains(id) {
+        return;
+    }
+    match update.get("status").and_then(Value::as_str) {
+        Some("completed") => {
+            pending_spawns.remove(id);
+            // A completion without a parseable id (foreground shape, format
+            // drift) harvests nothing — the chip resolves normally.
+            if let Some(subagent_id) = subagent_id_from_update(update) {
+                harvesters.push(tokio::spawn(harvest(
+                    event_tx.clone(),
+                    id.to_owned(),
+                    parent_session_id.to_owned(),
+                    subagent_id,
+                )));
+            }
+        }
+        Some("failed") => {
+            pending_spawns.remove(id);
+        }
+        _ => {}
+    }
+}
+
+/// The grok session store root. Overridable for tests and rigs.
+fn sessions_root() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("ZERON_GROK_SESSIONS_DIR") {
+        return Some(PathBuf::from(dir));
+    }
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    Some(home.join(".grok").join("sessions"))
+}
+
+/// The per-cwd dir holding this run's sessions: the one that contains the
+/// parent session's dir. Scanning sidesteps grok's cwd URL-encoding.
+async fn find_cwd_dir(root: &Path, parent_session_id: &str) -> Option<PathBuf> {
+    let mut entries = tokio::fs::read_dir(root).await.ok()?;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let dir = entry.path();
+        if tokio::fs::metadata(dir.join(parent_session_id))
+            .await
+            .is_ok_and(|m| m.is_dir())
+        {
+            return Some(dir);
+        }
+    }
+    None
+}
+
+fn tag(parent: &str, event: AgentEvent) -> AgentEvent {
+    AgentEvent::Subagent {
+        parent_tool_use_id: parent.to_owned(),
+        event: Box::new(event),
+    }
+}
+
+/// Tail one subagent to completion: locate its dirs, stream transcript
+/// lines as tagged events, close with a tagged `Done` when the parent
+/// session's `subagents/<id>/` entry reports a terminal status.
+async fn harvest(
+    event_tx: mpsc::Sender<Result<AgentEvent, HarnessError>>,
+    parent_tool_use_id: String,
+    parent_session_id: String,
+    subagent_id: String,
+) {
+    let Some(root) = sessions_root() else { return };
+    let deadline = tokio::time::Instant::now() + DISCOVER_TIMEOUT;
+    let cwd_dir = loop {
+        if let Some(dir) = find_cwd_dir(&root, &parent_session_id).await {
+            break dir;
+        }
+        if event_tx.is_closed() || tokio::time::Instant::now() >= deadline {
+            return;
+        }
+        tokio::time::sleep(POLL).await;
+    };
+    let transcript = cwd_dir.join(&subagent_id).join("chat_history.jsonl");
+    let lifecycle = cwd_dir
+        .join(&parent_session_id)
+        .join("subagents")
+        .join(&subagent_id);
+
+    let mut offset: u64 = 0;
+    let mut carry: Vec<u8> = Vec::new();
+    loop {
+        for event in drain_lines(&transcript, &mut offset, &mut carry).await {
+            if !send(&event_tx, tag(&parent_tool_use_id, event)).await {
+                return;
+            }
+        }
+        if let Some(done) = terminal_state(&lifecycle).await {
+            // The final transcript lines land before the output marker;
+            // one more drain keeps them ahead of the Done.
+            for event in drain_lines(&transcript, &mut offset, &mut carry).await {
+                if !send(&event_tx, tag(&parent_tool_use_id, event)).await {
+                    return;
+                }
+            }
+            let _ = send(&event_tx, tag(&parent_tool_use_id, done)).await;
+            return;
+        }
+        if event_tx.is_closed() {
+            return;
+        }
+        tokio::time::sleep(POLL).await;
+    }
+}
+
+async fn send(tx: &mpsc::Sender<Result<AgentEvent, HarnessError>>, ev: AgentEvent) -> bool {
+    tx.send(Ok(ev)).await.is_ok()
+}
+
+/// Read complete new lines past `offset`, mapping each to events. A partial
+/// trailing line (grok mid-append) carries over to the next poll.
+async fn drain_lines(transcript: &Path, offset: &mut u64, carry: &mut Vec<u8>) -> Vec<AgentEvent> {
+    let Ok(mut file) = tokio::fs::File::open(transcript).await else {
+        return Vec::new();
+    };
+    if file.seek(std::io::SeekFrom::Start(*offset)).await.is_err() {
+        return Vec::new();
+    }
+    let mut fresh = Vec::new();
+    let Ok(read) = file.read_to_end(&mut fresh).await else {
+        return Vec::new();
+    };
+    *offset += read as u64;
+    carry.extend_from_slice(&fresh);
+
+    let mut events = Vec::new();
+    while let Some(nl) = carry.iter().position(|&b| b == b'\n') {
+        let line: Vec<u8> = carry.drain(..=nl).collect();
+        if let Ok(value) = serde_json::from_slice::<Value>(&line[..nl]) {
+            events.extend(line_events(&value));
+        }
+    }
+    events
+}
+
+/// Terminal signal: `output.json` exists (written only at completion), or
+/// `meta.json` left the running state (covers cancellation shapes that may
+/// never produce output). Status → [`DoneStatus`] mapping is permissive —
+/// an unrecognized terminal word still closes the chip, as failed.
+async fn terminal_state(lifecycle: &Path) -> Option<AgentEvent> {
+    let meta_status = read_json(&lifecycle.join("meta.json"))
+        .await
+        .and_then(|m| m.get("status").and_then(Value::as_str).map(str::to_owned));
+    let output = read_json(&lifecycle.join("output.json"))
+        .await
+        .and_then(|o| o.get("output").and_then(Value::as_str).map(str::to_owned));
+
+    let status_word = match (&meta_status, &output) {
+        (Some(s), _) if !matches!(s.as_str(), "running" | "pending" | "started") => s.clone(),
+        (_, Some(_)) => meta_status.unwrap_or_else(|| "completed".into()),
+        _ => return None,
+    };
+    let status = match status_word.as_str() {
+        "completed" | "complete" | "succeeded" | "success" => DoneStatus::Completed,
+        "canceled" | "cancelled" | "interrupted" | "stopped" | "killed" => DoneStatus::Interrupted,
+        _ => DoneStatus::Errored,
+    };
+    Some(AgentEvent::Done {
+        status,
+        result: output.map(|o| cap_text(&o, OUTPUT_CAP)),
+        error: None,
+        session_id: None,
+    })
+}
+
+async fn read_json(path: &Path) -> Option<Value> {
+    let bytes = tokio::fs::read(path).await.ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Map one `chat_history.jsonl` line to transcript events. Message-level:
+/// an `assistant` line is its text (if any) plus its tool calls; a
+/// `reasoning` line is its summary; a `tool_result` resolves its call.
+/// `system`/`user` lines are context the spawn chip already names.
+fn line_events(line: &Value) -> Vec<AgentEvent> {
+    match line.get("type").and_then(Value::as_str) {
+        Some("assistant") => {
+            let mut events = Vec::new();
+            if let Some(text) = text_content(line.get("content")) {
+                events.push(AgentEvent::TextDelta {
+                    text: format!("{text}\n\n"),
+                });
+            }
+            for tc in line
+                .get("tool_calls")
+                .and_then(Value::as_array)
+                .map(|a| a.as_slice())
+                .unwrap_or_default()
+            {
+                let Some(id) = tc.get("id").and_then(Value::as_str) else {
+                    continue;
+                };
+                let name = tc.get("name").and_then(Value::as_str).unwrap_or("tool");
+                events.push(AgentEvent::ToolCall {
+                    id: id.to_owned(),
+                    call: typed_grok_tool(name, tool_arguments(tc)),
+                });
+            }
+            events
+        }
+        Some("reasoning") => {
+            let joined: Vec<&str> = line
+                .get("summary")
+                .and_then(Value::as_array)
+                .map(|a| a.as_slice())
+                .unwrap_or_default()
+                .iter()
+                .filter_map(|s| s.get("text").and_then(Value::as_str))
+                .filter(|t| !t.is_empty())
+                .collect();
+            if joined.is_empty() {
+                Vec::new()
+            } else {
+                vec![AgentEvent::ReasoningDelta {
+                    text: format!("{}\n\n", joined.join("\n\n")),
+                }]
+            }
+        }
+        Some("tool_result") => {
+            let Some(id) = line.get("tool_call_id").and_then(Value::as_str) else {
+                return Vec::new();
+            };
+            vec![AgentEvent::ToolResult {
+                id: id.to_owned(),
+                is_error: false,
+                output: text_content(line.get("content")).map(|t| cap_text(&t, OUTPUT_CAP)),
+                diff: None,
+            }]
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Grok stores tool arguments as a JSON-encoded STRING; accept an inline
+/// object too in case the encoding ever changes.
+fn tool_arguments(tc: &Value) -> Option<Value> {
+    match tc.get("arguments")? {
+        Value::String(s) => serde_json::from_str(s).ok(),
+        v @ Value::Object(_) => Some(v.clone()),
+        _ => None,
+    }
+}
+
+/// Content is a plain string or an array mixing strings and `{text}` blocks.
+fn text_content(content: Option<&Value>) -> Option<String> {
+    let joined = match content? {
+        Value::String(s) => s.clone(),
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| match item {
+                Value::String(s) => Some(s.as_str()),
+                obj => obj.get("text").and_then(Value::as_str),
+            })
+            .filter(|t| !t.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => return None,
+    };
+    (!joined.is_empty()).then_some(joined)
+}
+
+/// The handful of grok-internal tool names worth a typed chip; the rest
+/// render by name.
+fn typed_grok_tool(name: &str, input: Option<Value>) -> ToolCall {
+    let arg = |key: &str| -> Option<String> {
+        input
+            .as_ref()?
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+    };
+    match name {
+        "run_terminal_command" => ToolCall::Exec {
+            command: arg("command").unwrap_or_default(),
+        },
+        "read_file" => ToolCall::ReadFile {
+            path: arg("path")
+                .or_else(|| arg("file_path"))
+                .or_else(|| arg("target_file"))
+                .unwrap_or_default(),
+        },
+        _ => ToolCall::Unknown {
+            name: name.to_owned(),
+            input,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn spawn_call() -> Value {
+        json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-abc-1",
+            "title": "spawn_subagent",
+            "rawInput": { "description": "Probe sleeper", "subagent_type": "explore" },
+            "_meta": {
+                "x.ai/tool": { "name": "spawn_subagent", "kind": "task" },
+                "subagentBackground": true,
+            },
+        })
+    }
+
+    #[test]
+    fn spawn_marker_reads_vendor_meta() {
+        assert!(is_spawn(&spawn_call()));
+        assert!(!is_spawn(&json!({
+            "_meta": { "x.ai/tool": { "name": "get_command_or_subagent_output" } },
+        })));
+        assert!(!is_spawn(&json!({ "toolCallId": "t1" })));
+    }
+
+    #[test]
+    fn subagent_id_parses_from_raw_output_text() {
+        // Verbatim completion shape from a live grok 1.0.4 session.
+        let update = json!({
+            "toolCallId": "call-abc-1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "Text",
+                "text": "Subagent started in background.\nsubagent_id: 01a01457-4f92-78c3-8a4f-914b975717b6\ntype: explore\ndescription: Probe sleeper",
+            },
+        });
+        assert_eq!(
+            subagent_id_from_update(&update).as_deref(),
+            Some("01a01457-4f92-78c3-8a4f-914b975717b6")
+        );
+        // Promoted first-class field wins if it ever appears.
+        assert_eq!(
+            subagent_id_from_update(&json!({ "rawOutput": { "subagent_id": "abc-123" } }))
+                .as_deref(),
+            Some("abc-123")
+        );
+        // Id-shaped only: a path or sentence must not become a doc id.
+        assert_eq!(
+            subagent_id_from_update(&json!({
+                "rawOutput": { "text": "subagent_id: /tmp/evil path" },
+            })),
+            None
+        );
+        assert_eq!(subagent_id_from_update(&json!({ "rawOutput": {} })), None);
+    }
+
+    #[test]
+    fn assistant_line_maps_text_and_tool_calls() {
+        let line = json!({
+            "type": "assistant",
+            "content": "Reading the file now.",
+            "tool_calls": [{
+                "id": "call-t1",
+                "name": "read_file",
+                "arguments": "{\"path\":\"/tmp/a.txt\"}",
+            }],
+        });
+        let events = line_events(&line);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[0],
+            AgentEvent::TextDelta { text } if text == "Reading the file now.\n\n"
+        ));
+        assert!(matches!(
+            &events[1],
+            AgentEvent::ToolCall { id, call: ToolCall::ReadFile { path } }
+                if id == "call-t1" && path == "/tmp/a.txt"
+        ));
+    }
+
+    #[test]
+    fn assistant_array_content_and_exec_typing() {
+        let line = json!({
+            "type": "assistant",
+            "content": ["Done.", ""],
+            "tool_calls": [{
+                "id": "call-t2",
+                "name": "run_terminal_command",
+                "arguments": "{\"command\":\"ls -la\"}",
+            }],
+        });
+        let events = line_events(&line);
+        assert!(matches!(
+            &events[0],
+            AgentEvent::TextDelta { text } if text == "Done.\n\n"
+        ));
+        assert!(matches!(
+            &events[1],
+            AgentEvent::ToolCall { call: ToolCall::Exec { command }, .. } if command == "ls -la"
+        ));
+    }
+
+    #[test]
+    fn reasoning_summary_joins_to_one_delta() {
+        let line = json!({
+            "type": "reasoning",
+            "summary": [
+                { "type": "summary_text", "text": "First thought." },
+                { "type": "summary_text", "text": "Second thought." },
+            ],
+        });
+        let events = line_events(&line);
+        assert!(matches!(
+            &events[..],
+            [AgentEvent::ReasoningDelta { text }]
+                if text == "First thought.\n\nSecond thought.\n\n"
+        ));
+    }
+
+    #[test]
+    fn tool_result_resolves_call() {
+        let line = json!({
+            "type": "tool_result",
+            "tool_call_id": "call-t1",
+            "content": "1→hello",
+        });
+        let events = line_events(&line);
+        assert!(matches!(
+            &events[..],
+            [AgentEvent::ToolResult { id, is_error: false, output: Some(out), .. }]
+                if id == "call-t1" && out == "1→hello"
+        ));
+    }
+
+    #[test]
+    fn system_user_and_junk_lines_are_silent() {
+        assert!(line_events(&json!({ "type": "system", "content": "prompt" })).is_empty());
+        assert!(line_events(&json!({ "type": "user", "content": "hi" })).is_empty());
+        assert!(line_events(&json!({ "unexpected": true })).is_empty());
+        assert!(line_events(&json!("not an object")).is_empty());
+    }
+
+    #[tokio::test]
+    async fn scan_update_launches_harvester_on_spawn_completion() {
+        let (tx, _rx) = mpsc::channel(8);
+        let mut pending = HashSet::new();
+        let mut harvesters = Vec::new();
+
+        scan_update(&spawn_call(), "sess-1", &tx, &mut pending, &mut harvesters);
+        assert!(pending.contains("call-abc-1"));
+        assert!(harvesters.is_empty());
+
+        // Unrelated tool completing must not harvest.
+        scan_update(
+            &json!({ "toolCallId": "call-other", "status": "completed",
+                     "rawOutput": { "text": "subagent_id: not-for-you" } }),
+            "sess-1",
+            &tx,
+            &mut pending,
+            &mut harvesters,
+        );
+        assert!(harvesters.is_empty());
+
+        scan_update(
+            &json!({ "toolCallId": "call-abc-1", "status": "completed",
+                     "rawOutput": { "text": "Subagent started in background.\nsubagent_id: 01a-1\n" } }),
+            "sess-1",
+            &tx,
+            &mut pending,
+            &mut harvesters,
+        );
+        assert_eq!(harvesters.len(), 1);
+        assert!(!pending.contains("call-abc-1"));
+        for h in harvesters {
+            h.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_spawn_never_harvests() {
+        let (tx, _rx) = mpsc::channel(8);
+        let mut pending = HashSet::new();
+        let mut harvesters = Vec::new();
+        scan_update(&spawn_call(), "sess-1", &tx, &mut pending, &mut harvesters);
+        scan_update(
+            &json!({ "toolCallId": "call-abc-1", "status": "failed" }),
+            "sess-1",
+            &tx,
+            &mut pending,
+            &mut harvesters,
+        );
+        assert!(harvesters.is_empty());
+        assert!(pending.is_empty());
+    }
+}

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -26,6 +26,7 @@
 //! - Interrupt: `session/cancel`, escalating SIGTERM → SIGKILL; the stream
 //!   always ends with `Done { status: Interrupted }`.
 
+mod grok_subagent;
 mod normalize;
 
 use std::collections::VecDeque;
@@ -1612,7 +1613,6 @@ fn track_turn_signals(
     }
 }
 
-
 /// A mid-turn `_session/steering` call. `idleBehavior: promptRequired`
 /// covers the turn-ended race: the agent hands the text back instead of
 /// firing an untracked turn.
@@ -1893,6 +1893,12 @@ async fn run_session(session: Session) {
     let mut done_current = false;
     let mut done_after_interrupt = false;
     let mut escalation: Option<tokio::task::JoinHandle<()>> = None;
+    // Grok subagent bookkeeping: spawn tool calls awaiting their subagent
+    // id, and the per-subagent disk-tail tasks feeding tagged events (see
+    // `grok_subagent`). Tails hold an `event_tx` clone, so they are aborted
+    // at run end — a wedged subagent must not keep the event stream open.
+    let mut grok_spawns: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut grok_harvesters: Vec<tokio::task::JoinHandle<()>> = Vec::new();
     // Starved-turn recovery (2026-08-12 stuck-Working incident): a
     // `session/prompt` sent while the agent runs a SELF-CONTINUED turn (a
     // background-task re-invocation no prompt started) starves —
@@ -2017,7 +2023,10 @@ async fn run_session(session: Session) {
                 }
                 // Updates streamed before the prompt response are already
                 // queued in stdout order — fold them into the turn before
-                // closing it (responses bypass the incoming queue).
+                // closing it (responses bypass the incoming queue). With
+                // grok's prompt_complete settlement this drain is the COMMON
+                // path for a turn's tail, so subagent spawns must correlate
+                // here too.
                 let mut consumer_gone = false;
                 while let Ok(inc) = incoming.try_recv() {
                     match inc {
@@ -2027,6 +2036,15 @@ async fn run_session(session: Session) {
                             } else {
                                 Vec::new()
                             };
+                            grok_subagent::scan_notification(
+                                harness,
+                                &method,
+                                &params,
+                                &session_id,
+                                &event_tx,
+                                &mut grok_spawns,
+                                &mut grok_harvesters,
+                            );
                             for ev in events {
                                 if !send(&event_tx, ev).await {
                                     consumer_gone = true;
@@ -2186,6 +2204,21 @@ async fn run_session(session: Session) {
                     } else {
                         Vec::new()
                     };
+                    // Grok subagent spawns are correlated with the on-disk
+                    // transcript (the wire streams subagent interiors
+                    // untagged; the session store is the only attributable
+                    // surface). Mirrored in the turn-settle and
+                    // steer-injection drains — updates the prompt response
+                    // outraced fold there, not here.
+                    grok_subagent::scan_notification(
+                        harness,
+                        &method,
+                        &params,
+                        &session_id,
+                        &event_tx,
+                        &mut grok_spawns,
+                        &mut grok_harvesters,
+                    );
                     for ev in events {
                         track_turn_signals(&ev, &mut turn_content_seen, &mut open_tools);
                         if !send(&event_tx, ev).await {
@@ -2301,6 +2334,15 @@ async fn run_session(session: Session) {
                                     } else {
                                         Vec::new()
                                     };
+                                    grok_subagent::scan_notification(
+                                        harness,
+                                        &method,
+                                        &params,
+                                        &session_id,
+                                        &event_tx,
+                                        &mut grok_spawns,
+                                        &mut grok_harvesters,
+                                    );
                                     for ev in events {
                                         if !send(&event_tx, ev).await {
                                             consumer_gone = true;
@@ -2745,6 +2787,13 @@ async fn run_session(session: Session) {
     // waits the pid, a still-armed SIGTERM/SIGKILL timer would fire at a
     // freed (reusable) pid.
     if let Some(handle) = escalation {
+        handle.abort();
+    }
+    // Subagent tails die with the run: their `event_tx` clones would
+    // otherwise hold the event stream open indefinitely for a subagent
+    // whose terminal marker never lands. The engine's run-end sweep marks
+    // any still-running subagent doc failed.
+    for handle in grok_harvesters {
         handle.abort();
     }
     shutdown_child(&mut child, kill_grace).await;

--- a/crates/harness/src/acp/normalize.rs
+++ b/crates/harness/src/acp/normalize.rs
@@ -24,7 +24,7 @@ fn str_field(v: &Value, key: &str) -> String {
 }
 
 /// Truncate on a char boundary, marking the cut so the UI can say "truncated".
-fn cap_text(text: &str, cap: usize) -> String {
+pub(crate) fn cap_text(text: &str, cap: usize) -> String {
     if text.len() <= cap {
         return text.to_owned();
     }
@@ -261,6 +261,21 @@ fn typed_call(update: &Value) -> ToolCall {
                 }
             }
         }
+        // Grok's subagent spawn (vendor `_meta` marker): the chip is the
+        // subagent's index — name it, and the tab it opens, after the task
+        // description per the cross-driver `Agent: …` convention. Grok's
+        // mid-run update retitles the call to the BARE description with no
+        // rawInput; the marker rides every shaped update, so the prefix
+        // survives that refresh instead of being clobbered by the fallback
+        // arm.
+        _ if super::grok_subagent::is_spawn(update) => ToolCall::Unknown {
+            name: raw_str("description")
+                .or_else(|| (!title.is_empty()).then(|| title.clone()))
+                .filter(|d| d != "spawn_subagent")
+                .map(|d| format!("Agent: {d}"))
+                .unwrap_or_else(|| "Agent".into()),
+            input: raw.cloned(),
+        },
         _ if raw_str("_toolName").as_deref() == Some("task") => ToolCall::Unknown {
             name: raw_str("description")
                 .filter(|d| d != "Subagent task")
@@ -414,7 +429,6 @@ pub(crate) fn parse_commands(value: Option<&Value>) -> Vec<SlashCommand> {
         })
         .collect()
 }
-
 
 /// `session/request_permission` options (`{optionId, name, kind}`) → the
 /// preferred auto-approve choice: `allow_always` > `allow_once` > first.
@@ -815,5 +829,51 @@ mod tests {
                 },
             }]
         );
+    }
+
+    #[test]
+    fn grok_spawn_names_chip_after_description() {
+        // Verbatim opening shape from a live grok 1.0.4 session: the title
+        // is the bare tool name; the description rides rawInput.
+        let update = json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-abc-0",
+            "title": "spawn_subagent",
+            "rawInput": {
+                "description": "Probe sleeper",
+                "prompt": "Run the probe.",
+                "subagent_type": "explore",
+            },
+            "_meta": {
+                "x.ai/tool": { "name": "spawn_subagent", "kind": "task" },
+                "subagentBackground": true,
+            },
+        });
+        let events = map_update(&update);
+        assert!(matches!(
+            &events[0],
+            AgentEvent::ToolCall { id, call: ToolCall::Unknown { name, .. } }
+                if id == "call-abc-0" && name == "Agent: Probe sleeper"
+        ));
+    }
+
+    #[test]
+    fn grok_spawn_retitle_update_keeps_agent_prefix() {
+        // Grok's mid-run update retitles the call to the bare description
+        // (no rawInput); the vendor marker must keep the `Agent: ` genus so
+        // the refresh doesn't clobber the chip name.
+        let update = json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "call-abc-0",
+            "title": "Probe sleeper",
+            "kind": "other",
+            "_meta": { "x.ai/tool": { "name": "spawn_subagent", "kind": "task" } },
+        });
+        let events = map_update(&update);
+        assert!(matches!(
+            &events[0],
+            AgentEvent::ToolCall { call: ToolCall::Unknown { name, .. }, .. }
+                if name == "Agent: Probe sleeper"
+        ));
     }
 }

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -122,6 +122,22 @@ case "$promptline" in
   exec sleep 60
   ;;
 
+*scenario:subagent*)
+  # Background subagent spawn, grok shape (live-captured 1.0.4): the spawn
+  # tool completes immediately with the subagent id in rawOutput.text; the
+  # interior NEVER streams on the wire (untagged vendor gap) — the harness
+  # must correlate the id and tail the session store on disk (the test
+  # points ZERON_GROK_SESSIONS_DIR at a seeded temp store). The mid-run
+  # update retitles the call to the bare description, as grok does. Turn
+  # settles eagerly; the script idles before EOF so the tail can finish.
+  update '{"sessionUpdate":"tool_call","toolCallId":"call-sp-1","title":"spawn_subagent","rawInput":{"description":"Read the plan","prompt":"Read /w/PLAN.md and summarize.","subagent_type":"explore"},"_meta":{"x.ai/tool":{"version":1,"name":"spawn_subagent","kind":"task","namespace":"grok_build","label":"Subagent","read_only":false},"subagentBackground":true}}'
+  update '{"sessionUpdate":"tool_call_update","toolCallId":"call-sp-1","title":"Read the plan","kind":"other","_meta":{"x.ai/tool":{"version":1,"name":"spawn_subagent","kind":"task","namespace":"grok_build","label":"Subagent","read_only":false}}}'
+  update '{"sessionUpdate":"tool_call_update","toolCallId":"call-sp-1","status":"completed","rawOutput":{"type":"Text","text":"Subagent started in background.\nsubagent_id: sub-0001\ntype: explore\ndescription: Read the plan"}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  sleep 6
+  exit 0
+  ;;
+
 *scenario:happy*)
   update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello"}}'
   update '{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking"}}'

--- a/crates/harness/tests/grok_subagent.rs
+++ b/crates/harness/tests/grok_subagent.rs
@@ -1,0 +1,244 @@
+//! Grok subagent harvest, end to end against the fake ACP agent plus a
+//! seeded grok session store: the spawn tool_call correlates with the
+//! store via `rawOutput`'s subagent id, the transcript tails into tagged
+//! [`AgentEvent::Subagent`] traffic (growing mid-run, like grok writes it),
+//! and the store's completion markers close the chip with a tagged Done.
+//! Own test binary: `ZERON_GROK_SESSIONS_DIR` is process-global.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use futures::StreamExt;
+use tokio::sync::{mpsc, oneshot};
+
+use zeron_harness::{AcpHarness, CancellationToken, Harness, RunControls};
+use zeron_proto::{AgentEvent, DoneStatus, RunRequest, SandboxLevel, ToolCall};
+
+fn fixture_path() -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake-acp.sh");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
+    }
+    path
+}
+
+/// The parent session id the fake agent mints, and the subagent id its
+/// spawn completion names (see `scenario:subagent` in fake-acp.sh).
+const PARENT_SESSION: &str = "s-1";
+const SUBAGENT_ID: &str = "sub-0001";
+
+#[tokio::test]
+async fn spawned_subagent_tails_the_store_into_tagged_events() {
+    // Seed the store the way grok lays it out: a cwd dir (name is grok's
+    // url-encoding — arbitrary here, the harness FINDS it by the parent
+    // session dir inside), the child session dir with a growing
+    // chat_history.jsonl, and the parent's subagents/<id>/ lifecycle dir.
+    let store = tempfile::tempdir().expect("temp store");
+    let cwd_dir = store.path().join("%2Ftmp%2Fdemo");
+    let child_dir = cwd_dir.join(SUBAGENT_ID);
+    let lifecycle = cwd_dir
+        .join(PARENT_SESSION)
+        .join("subagents")
+        .join(SUBAGENT_ID);
+    std::fs::create_dir_all(&child_dir).expect("child dir");
+    std::fs::create_dir_all(&lifecycle).expect("lifecycle dir");
+    let transcript = child_dir.join("chat_history.jsonl");
+    std::fs::write(
+        &transcript,
+        concat!(
+            r#"{"type":"system","content":"You are a subagent."}"#,
+            "\n",
+            r#"{"type":"user","content":"Read /w/PLAN.md and summarize."}"#,
+            "\n",
+            r#"{"type":"reasoning","summary":[{"type":"summary_text","text":"Reading the plan."}],"status":"completed"}"#,
+            "\n",
+            r#"{"type":"assistant","content":"","tool_calls":[{"id":"call-r1","name":"read_file","arguments":"{\"path\":\"/w/PLAN.md\"}"}]}"#,
+            "\n",
+        ),
+    )
+    .expect("seed transcript");
+    std::fs::write(
+        lifecycle.join("meta.json"),
+        format!(
+            r#"{{"subagent_id":"{SUBAGENT_ID}","parent_session_id":"{PARENT_SESSION}","subagent_type":"explore","description":"Read the plan","status":"running"}}"#,
+        ),
+    )
+    .expect("seed meta");
+    // SAFETY: single-test binary — nothing else reads env concurrently.
+    unsafe {
+        std::env::set_var("ZERON_GROK_SESSIONS_DIR", store.path());
+    }
+
+    // Mid-run growth: the subagent "finishes" while the harness tails —
+    // final transcript lines land, then the terminal markers.
+    let finish_transcript = transcript.clone();
+    let finish_lifecycle = lifecycle.clone();
+    let finisher = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        use std::io::Write as _;
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&finish_transcript)
+            .expect("append transcript");
+        writeln!(
+            f,
+            r#"{{"type":"tool_result","tool_call_id":"call-r1","content":"1→plan body"}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","content":"The plan is sound.","tool_calls":[]}}"#
+        )
+        .unwrap();
+        drop(f);
+        std::fs::write(
+            finish_lifecycle.join("output.json"),
+            r#"{"schema_version":1,"output":"The plan is sound."}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            finish_lifecycle.join("meta.json"),
+            format!(
+                r#"{{"subagent_id":"{SUBAGENT_ID}","parent_session_id":"{PARENT_SESSION}","status":"completed"}}"#,
+            ),
+        )
+        .unwrap();
+    });
+
+    let (_steer_tx, steer_rx) = mpsc::channel(8);
+    let token = CancellationToken::new();
+    let controls = RunControls {
+        request_input: Box::new(move |_| {
+            let (tx, rx) = oneshot::channel();
+            let _ = tx.send(Vec::new());
+            rx
+        }),
+        steering: steer_rx,
+        interrupt: token.clone(),
+    };
+    let request = RunRequest {
+        prompt: "scenario:subagent".into(),
+        harness: None,
+        model: None,
+        reasoning: None,
+        model_options: serde_json::Map::new(),
+        cwd: "/tmp".into(),
+        sandbox: SandboxLevel::WorkspaceWrite,
+        auto_approve: true,
+        attachments: Vec::new(),
+        resume: None,
+    };
+    let harness = AcpHarness::grok().with_executable(fixture_path());
+    let stream = harness.run(request, controls).await.expect("run starts");
+    let events = tokio::time::timeout(
+        Duration::from_secs(20),
+        stream.map(|r| r.expect("stream event")).collect::<Vec<_>>(),
+    )
+    .await
+    .expect("run finished in time");
+    finisher.await.expect("finisher ran");
+
+    // The spawn chip registers under the cross-driver naming convention —
+    // both the opening call and grok's bare-description retitle.
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCall { id, call: ToolCall::Unknown { name, .. } }
+                if id == "call-sp-1" && name == "Agent: Read the plan"
+        )),
+        "spawn chip named after the task: {events:?}"
+    );
+
+    // Harvested interior, tagged to the spawn chip: reasoning, the typed
+    // read_file call + its result, and the closing text.
+    let tagged: Vec<&AgentEvent> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::Subagent {
+                parent_tool_use_id,
+                event,
+            } if parent_tool_use_id == "call-sp-1" => Some(event.as_ref()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        tagged.iter().any(|e| matches!(
+            e,
+            AgentEvent::ReasoningDelta { text } if text.contains("Reading the plan.")
+        )),
+        "tagged reasoning: {events:?}"
+    );
+    assert!(
+        tagged.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCall { id, call: ToolCall::ReadFile { path } }
+                if id == "call-r1" && path == "/w/PLAN.md"
+        )),
+        "tagged typed tool call: {events:?}"
+    );
+    assert!(
+        tagged.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolResult { id, output: Some(out), .. }
+                if id == "call-r1" && out.contains("plan body")
+        )),
+        "tagged tool result: {events:?}"
+    );
+    assert!(
+        tagged.iter().any(|e| matches!(
+            e,
+            AgentEvent::TextDelta { text } if text.contains("The plan is sound.")
+        )),
+        "tagged closing text: {events:?}"
+    );
+
+    // Exactly one tagged Done, completed, carrying the store's output —
+    // and it is the LAST tagged event (transcript drained ahead of it).
+    let dones: Vec<&AgentEvent> = tagged
+        .iter()
+        .filter(|e| matches!(e, AgentEvent::Done { .. }))
+        .copied()
+        .collect();
+    assert!(
+        matches!(
+            dones[..],
+            [AgentEvent::Done {
+                status: DoneStatus::Completed,
+                result: Some(r),
+                ..
+            }] if r == "The plan is sound."
+        ),
+        "single completed tagged Done: {events:?}"
+    );
+    assert!(
+        matches!(tagged.last(), Some(AgentEvent::Done { .. })),
+        "Done closes the tagged stream: {events:?}"
+    );
+
+    // The interior stays OUT of the parent feed: no untagged event carries
+    // the subagent's text (the pre-viz flat-fold bug).
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            AgentEvent::TextDelta { text } if text.contains("The plan is sound.")
+        )),
+        "interior leaked untagged into the parent feed: {events:?}"
+    );
+
+    // The parent turn itself still settles cleanly.
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Done {
+                status: DoneStatus::Completed,
+                ..
+            }
+        )),
+        "parent turn Done: {events:?}"
+    );
+}

--- a/crates/harness/tests/real_grok_subagent.rs
+++ b/crates/harness/tests/real_grok_subagent.rs
@@ -1,0 +1,135 @@
+//! LIVE grok subagent harvest: drives the real `grok` CLI end to end and
+//! asserts a background subagent's transcript arrives as tagged
+//! [`AgentEvent::Subagent`] traffic closed by a tagged Done — the whole
+//! session-store tail path against the vendor's actual disk format. Needs
+//! an installed+authenticated grok; skipped otherwise. Run explicitly:
+//!
+//!   cargo test -p zeron-harness --test real_grok_subagent -- --ignored --nocapture
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use tokio::sync::{mpsc, oneshot};
+
+use zeron_harness::{AcpHarness, CancellationToken, Harness, RunControls};
+use zeron_proto::{AgentEvent, DoneStatus, RunRequest, SandboxLevel, ToolCall, UserInputAnswer};
+
+const PROMPT: &str = "Use spawn_subagent to launch ONE subagent of type explore with \
+    description 'Probe listing' and prompt: 'Run the terminal command: ls /tmp and then \
+    reply with the word finished.'. Then wait for its result with \
+    get_command_or_subagent_output (positive timeout_ms) and summarize it in one line.";
+
+#[tokio::test]
+#[ignore = "drives the real grok binary; run with -- --ignored"]
+async fn real_grok_background_subagent_harvests() {
+    if std::process::Command::new("grok")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("SKIP: no grok binary on PATH");
+        return;
+    }
+
+    let cwd = tempfile::tempdir().expect("cwd");
+    let (steer_tx, steer_rx) = mpsc::channel(8);
+    let token = CancellationToken::new();
+    let controls = RunControls {
+        request_input: Box::new(move |questions| {
+            let (tx, rx) = oneshot::channel();
+            let answers: Vec<UserInputAnswer> = questions
+                .iter()
+                .map(|q| UserInputAnswer {
+                    question_id: q.id.clone(),
+                    labels: vec!["Yes".into()],
+                })
+                .collect();
+            let _ = tx.send(answers);
+            rx
+        }),
+        steering: steer_rx,
+        interrupt: token.clone(),
+    };
+    let request = RunRequest {
+        prompt: PROMPT.into(),
+        harness: None,
+        model: None,
+        reasoning: None,
+        model_options: serde_json::Map::new(),
+        cwd: cwd.path().display().to_string(),
+        sandbox: SandboxLevel::WorkspaceWrite,
+        auto_approve: true,
+        attachments: Vec::new(),
+        resume: None,
+    };
+
+    let harness = AcpHarness::grok();
+    let mut stream = harness.run(request, controls).await.expect("run starts");
+
+    // Consume live until the tagged Done lands (the subagent may finish
+    // before or after the parent turn settles), then end the run.
+    let mut events: Vec<AgentEvent> = Vec::new();
+    let mut tagged_done = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(240);
+    while !tagged_done {
+        let ev = tokio::select! {
+            ev = stream.next() => match ev {
+                Some(ev) => ev.expect("stream event"),
+                None => break,
+            },
+            _ = tokio::time::sleep_until(deadline) => break,
+        };
+        eprintln!("{ev:?}");
+        if let AgentEvent::Subagent { event, .. } = &ev {
+            tagged_done = matches!(event.as_ref(), AgentEvent::Done { .. });
+        }
+        events.push(ev);
+    }
+    drop(steer_tx);
+    token.cancel();
+    while let Some(ev) = stream.next().await {
+        if let Ok(ev) = ev {
+            events.push(ev);
+        }
+    }
+
+    // Registration: the spawn chip under the cross-driver name.
+    let spawn_id = events
+        .iter()
+        .find_map(|e| match e {
+            AgentEvent::ToolCall {
+                id,
+                call: ToolCall::Unknown { name, .. },
+            } if name.starts_with("Agent: ") => Some(id.clone()),
+            _ => None,
+        })
+        .expect("spawn chip named 'Agent: …'");
+
+    // Harvested interior, tagged to that chip, closed by a completed Done.
+    let tagged: Vec<&AgentEvent> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::Subagent {
+                parent_tool_use_id,
+                event,
+            } if *parent_tool_use_id == spawn_id => Some(event.as_ref()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        tagged
+            .iter()
+            .any(|e| !matches!(e, AgentEvent::Done { .. })),
+        "tagged transcript content arrived: {events:?}"
+    );
+    assert!(
+        tagged.iter().any(|e| matches!(
+            e,
+            AgentEvent::Done {
+                status: DoneStatus::Completed,
+                ..
+            }
+        )),
+        "tagged completed Done arrived: {events:?}"
+    );
+}


### PR DESCRIPTION
Grok subagents were the one holdover from #136: grok streams subagent interiors over ACP **untagged** (`parent_tool_use_id` is null on every frame — verified live on 1.0.0 and 1.0.4; the docs promise tagging but it's unimplemented), and for background subagents the interior never reaches the parent stream at all. So spawns rendered as bare tool rows — no chip, no tab, no transcript.

## Approach: tail the session store

The durable surface is grok's own session store. Each subagent gets a full session dir with an incrementally-written `chat_history.jsonl` (flush-verified mid-run), and the parent session dir gains `subagents/<id>/meta.json` at spawn + `output.json` only at completion.

- **Correlate:** the spawn `tool_call` carries `_meta["x.ai/tool"].name == "spawn_subagent"`; its completion update's `rawOutput.text` names the `subagent_id`. That maps spawn chip → on-disk transcript.
- **Harvest:** one tail task per subagent maps the typed JSONL lines onto tagged `AgentEvent::Subagent` traffic (message-level — token deltas don't exist on this surface), then emits exactly one tagged `Done` off the store's terminal markers. From there the existing #136 pipeline does the rest: chip lifecycle, per-subagent doc, freeze-to-blob, tab.
- **Fail soft:** the store format is vendor-private — every read degrades to chip-only, never errors the chat. Tails abort at run end so a wedged subagent can't hold the event stream open.
- The cwd dir is **found** (the sessions dir whose name grok minted from the cwd contains the parent session id) rather than re-deriving grok's URL-encoding — one vendor convention to drift instead of two.
- Chip/tab naming follows the cross-driver `Agent: <description>` convention; the vendor marker keeps the prefix across grok's bare-description retitle update.

The scan runs from **all three** live-update paths (main notification arm + the turn-settle and steer-injection drains). With grok's `prompt_complete` settlement the turn-settle drain is the *common* path for a turn's tail — the flake-checked integration test caught exactly that race.

## Tests

- Unit: vendor-marker detection, `subagent_id` parse (id-shaped only — it becomes a doc-id suffix), JSONL line mapping, scan lifecycle.
- Integration (`tests/grok_subagent.rs`): fake ACP agent + seeded store that grows mid-run; asserts registration naming, tagged interior (typed `read_file` + result + reasoning + text), exactly one tagged Done carrying the store's output, and **no untagged leakage into the parent feed**. Flake-checked 6×.
- Live (`tests/real_grok_subagent.rs`, `--ignored`): real grok 1.0.4, background subagent → tagged transcript + completed Done in ~12s.

## Rig validation (real grok, headless app)

The exact scenario from the report — "Run three subagents to read 3 random files":

**Chips register with names while the run streams** (previously: three bare `Tool` rows):

![chips](https://github.com/user-attachments/assets/131ca77a-0d3e-4042-a14b-95446b3a4a38)

**Running chip: spinner + Open subagent affordance:**

![running](https://github.com/user-attachments/assets/8f7b87b7-7c84-4cd5-be23-78921fa4d619)

**Subagent tab with the harvested transcript (tool group + full answer, frozen blob):**

![tab](https://github.com/user-attachments/assets/8be59b74-cb12-4ec3-ace7-022ba6743da6)

**Second subagent tab coexisting; its interior `sleep 20` + `read package.json` harvested:**

![tab2](https://github.com/user-attachments/assets/e9cf11f2-6fea-4150-aeaf-74b7b29fb478)

## Follow-ups

- Upstream ask to xAI stands: stamp the subagent id into `_meta` on tagged frames — would make grok wire-native like claude and retire the disk tail.
- Codex chips settling at run-end drain (pre-existing, noted on #136) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789641417&installation_model_id=425430&pr_number=148&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F148&signature=3e0bb6bba1f8b08ef470ee44b720517706d9672adde6f282b5adc0bdeff63ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->