### PR TITLE
grok: subagent visualization — lifecycle wire events + disk-tailed transcripts

### DIFF
--- a/crates/harness/examples/grok_subagent_probe.rs
+++ b/crates/harness/examples/grok_subagent_probe.rs
@@ -1,0 +1,93 @@
+//! Live probe: drive the real grok CLI through AcpHarness and print the
+//! event stream, verifying subagent spawn correlation + the disk-tailed
+//! transcript end-to-end. Needs a logged-in `grok` on PATH.
+//!
+//!     cargo run -p zeron-harness --example grok_subagent_probe -- /tmp/probe-dir
+
+use futures::StreamExt;
+use tokio::sync::{mpsc, oneshot};
+use zeron_harness::{AcpHarness, CancellationToken, Harness, RunControls};
+use zeron_proto::{AgentEvent, RunRequest, SandboxLevel, UserInputAnswer};
+
+#[tokio::main]
+async fn main() {
+    let cwd = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/tmp/probe-grok-viz".into());
+    std::fs::create_dir_all(&cwd).unwrap();
+    let (_steer_tx, steering) = mpsc::channel(8);
+    let controls = RunControls {
+        request_input: Box::new(move |questions| {
+            let (tx, rx) = oneshot::channel();
+            let answers: Vec<UserInputAnswer> = questions
+                .iter()
+                .map(|q| UserInputAnswer {
+                    question_id: q.id.clone(),
+                    labels: q.options.first().cloned().into_iter().collect(),
+                })
+                .collect();
+            let _ = tx.send(answers);
+            rx
+        }),
+        steering,
+        interrupt: CancellationToken::new(),
+    };
+    let request = RunRequest {
+        prompt: "Use spawn_subagent to launch ONE subagent of type general with description \
+                 'Viz probe' and prompt: 'Run the terminal command: echo viz-probe-ok && sleep 3. \
+                 Then reply with the word finished.'. Wait for it with \
+                 get_command_or_subagent_output and tell me its result."
+            .into(),
+        harness: None,
+        model: None,
+        reasoning: None,
+        model_options: serde_json::Map::new(),
+        cwd,
+        sandbox: SandboxLevel::WorkspaceWrite,
+        auto_approve: true,
+        attachments: Vec::new(),
+        resume: None,
+    };
+    let mut stream = AcpHarness::grok()
+        .run(request, controls)
+        .await
+        .expect("run starts");
+    // stderr is unbuffered; a SIGTERM'd run still shows everything.
+    let mut tagged = 0u32;
+    let mut parent_done = false;
+    loop {
+        // After the parent turn settles the session stays alive for the
+        // steering mailbox — bound the wait for the subagent's tagged Done.
+        let ev = match tokio::time::timeout(std::time::Duration::from_secs(90), stream.next()).await
+        {
+            Ok(Some(ev)) => ev,
+            Ok(None) => break,
+            Err(_) => {
+                eprintln!("--- timed out waiting (parent_done={parent_done}, tagged={tagged})");
+                std::process::exit(2);
+            }
+        };
+        match ev {
+            Ok(AgentEvent::Subagent {
+                parent_tool_use_id,
+                event,
+            }) => {
+                tagged += 1;
+                eprintln!("SUB[{parent_tool_use_id}] {event:?}");
+                if matches!(*event, AgentEvent::Done { .. }) && parent_done {
+                    eprintln!("--- tagged events total: {tagged}");
+                    std::process::exit(0);
+                }
+            }
+            Ok(AgentEvent::Done { status, .. }) => {
+                parent_done = true;
+                eprintln!("EV Done({status:?}) [parent]");
+            }
+            Ok(AgentEvent::TextDelta { text }) => eprintln!("TXT {}", text.trim_end()),
+            Ok(AgentEvent::ReasoningDelta { .. }) => {}
+            Ok(other) => eprintln!("EV {other:?}"),
+            Err(e) => eprintln!("ERR {e}"),
+        }
+    }
+    eprintln!("--- stream ended; tagged events total: {tagged}");
+}

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -27,6 +27,7 @@
 //!   always ends with `Done { status: Interrupted }`.
 
 mod normalize;
+mod subagent;
 
 use std::collections::VecDeque;
 use std::path::PathBuf;
@@ -50,6 +51,7 @@ use zeron_proto::{
 use crate::jsonrpc::{Incoming, RpcClient};
 use crate::{Harness, HarnessError, RunControls, Signal, send_signal, shutdown_child};
 use normalize::{map_update, parse_commands, preferred_allow_option};
+use subagent::SubagentTracker;
 
 /// Per-agent configuration: which binary to spawn and what to tell the picker.
 struct AcpAgentSpec {
@@ -420,6 +422,9 @@ enum Launch {
 pub struct AcpHarness {
     spec: AcpAgentSpec,
     executable: Option<PathBuf>,
+    /// Override of the agent's on-disk sessions root (grok's
+    /// `~/.grok/sessions`), where subagent transcripts are tailed from.
+    sessions_root: Option<PathBuf>,
     /// Grace between `session/cancel` and SIGTERM.
     interrupt_grace: Duration,
     /// Grace between SIGTERM and SIGKILL.
@@ -439,6 +444,7 @@ impl AcpHarness {
         Self {
             spec,
             executable: None,
+            sessions_root: None,
             interrupt_grace: Duration::from_secs(2),
             kill_grace: Duration::from_secs(3),
             // Generous: the handshake is local work for every agent
@@ -469,6 +475,14 @@ impl AcpHarness {
     /// Use a fixed agent binary instead of PATH/known-location resolution.
     pub fn with_executable(mut self, path: impl Into<PathBuf>) -> Self {
         self.executable = Some(path.into());
+        self
+    }
+
+    /// Test seam: tail subagent transcripts from this sessions root instead
+    /// of the agent's real one (`~/.grok/sessions`).
+    #[doc(hidden)]
+    pub fn with_sessions_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.sessions_root = Some(root.into());
         self
     }
 
@@ -1064,6 +1078,7 @@ impl Harness for AcpHarness {
             effort_values: self.spec.effort_values,
             prompt_complete_extension: self.spec.prompt_complete_extension,
             prompt_stall: self.spec.prompt_stall,
+            sessions_root: self.sessions_root.clone(),
             interrupt_grace: self.interrupt_grace,
             kill_grace: self.kill_grace,
             handshake_timeout: self.handshake_timeout,
@@ -1092,6 +1107,8 @@ struct Session {
     agent_name: &'static str,
     prompt_complete_extension: bool,
     prompt_stall: Option<Duration>,
+    /// Sessions-root override for the subagent transcript tail (tests).
+    sessions_root: Option<PathBuf>,
     prompt_transform: fn(Option<ReasoningLevel>, &str) -> String,
     effort_values: fn(Option<ReasoningLevel>, Option<&str>) -> Vec<&'static str>,
     interrupt_grace: Duration,
@@ -1336,12 +1353,33 @@ fn config_option_sets(
     sets
 }
 
-/// The events of one `session/update` notification, session-filtered.
-fn session_update_events(params: &Value, session_id: &str) -> Vec<AgentEvent> {
+/// The events of one notification, session-filtered. `session/update` maps
+/// per [`map_update`]; `_x.ai/session_notification` is grok's extension
+/// channel — same `{sessionId, update}` envelope, but its updates (the
+/// `subagent_*` lifecycle) render nothing directly. The subagent tracker sees
+/// both first (spawn/finished correlation + transcript tails); its tagged
+/// events flow from its own tasks, not this return value.
+fn session_update_events(
+    method: &str,
+    params: &Value,
+    session_id: &str,
+    subagents: &mut SubagentTracker,
+) -> Vec<AgentEvent> {
     if params.get("sessionId").and_then(Value::as_str) != Some(session_id) {
         return Vec::new();
     }
-    map_update(params.get("update").unwrap_or(&Value::Null))
+    let update = params.get("update").unwrap_or(&Value::Null);
+    match method {
+        "session/update" => {
+            subagents.observe(update);
+            map_update(update)
+        }
+        "_x.ai/session_notification" => {
+            subagents.observe(update);
+            Vec::new()
+        }
+        _ => Vec::new(),
+    }
 }
 
 /// Per-turn token usage from a settled `session/prompt` response, when the
@@ -1643,6 +1681,7 @@ async fn run_session(session: Session) {
         agent_name,
         prompt_complete_extension,
         prompt_stall,
+        sessions_root,
         prompt_transform,
         effort_values,
         interrupt_grace,
@@ -1846,6 +1885,10 @@ async fn run_session(session: Session) {
         return;
     }
 
+    // Grok subagent correlation + transcript tails; inert for agents that
+    // never emit the `subagent_*` extension updates.
+    let mut subagents = SubagentTracker::new(session_id.clone(), event_tx.clone(), sessions_root);
+
     // ---- main loop --------------------------------------------------------
     // Prompt-completion settlement state (the prompt-complete extension):
     // one prompt is outstanding at a time, identified by `current_prompt_id`;
@@ -2022,11 +2065,8 @@ async fn run_session(session: Session) {
                 while let Ok(inc) = incoming.try_recv() {
                     match inc {
                         Incoming::Notification { method, params } => {
-                            let events = if method == "session/update" {
-                                session_update_events(&params, &session_id)
-                            } else {
-                                Vec::new()
-                            };
+                            let events =
+                                session_update_events(&method, &params, &session_id, &mut subagents);
                             for ev in events {
                                 if !send(&event_tx, ev).await {
                                     consumer_gone = true;
@@ -2181,11 +2221,8 @@ async fn run_session(session: Session) {
                     }
                     // Other notifications (other sessions, agent noise) are
                     // tolerated by design.
-                    let events = if method == "session/update" {
-                        session_update_events(&params, &session_id)
-                    } else {
-                        Vec::new()
-                    };
+                    let events =
+                        session_update_events(&method, &params, &session_id, &mut subagents);
                     for ev in events {
                         track_turn_signals(&ev, &mut turn_content_seen, &mut open_tools);
                         if !send(&event_tx, ev).await {
@@ -2296,11 +2333,8 @@ async fn run_session(session: Session) {
                         while let Ok(inc) = incoming.try_recv() {
                             match inc {
                                 Incoming::Notification { method, params } => {
-                                    let events = if method == "session/update" {
-                                        session_update_events(&params, &session_id)
-                                    } else {
-                                        Vec::new()
-                                    };
+                                    let events =
+                                        session_update_events(&method, &params, &session_id, &mut subagents);
                                     for ev in events {
                                         if !send(&event_tx, ev).await {
                                             consumer_gone = true;

--- a/crates/harness/src/acp/normalize.rs
+++ b/crates/harness/src/acp/normalize.rs
@@ -24,7 +24,7 @@ fn str_field(v: &Value, key: &str) -> String {
 }
 
 /// Truncate on a char boundary, marking the cut so the UI can say "truncated".
-fn cap_text(text: &str, cap: usize) -> String {
+pub(crate) fn cap_text(text: &str, cap: usize) -> String {
     if text.len() <= cap {
         return text.to_owned();
     }
@@ -89,6 +89,16 @@ fn tool_diff(update: &Value) -> Option<ToolDiff> {
             DIFF_TEXT_CAP,
         ),
     })
+}
+
+/// The grok-native tool name stamped on a tool call's `_meta` (`x.ai/tool`,
+/// present on every grok tool_call — verified live, 1.0.4).
+pub(crate) fn xai_tool_name(update: &Value) -> Option<&str> {
+    update
+        .get("_meta")?
+        .get("x.ai/tool")?
+        .get("name")?
+        .as_str()
 }
 
 /// First location path (`locations: [{path, line?}]`), for read/edit calls.
@@ -261,6 +271,15 @@ fn typed_call(update: &Value) -> ToolCall {
                 }
             }
         }
+        // Grok's subagent spawn: name the chip — and the subagent tab it
+        // opens — after the task, matching the claude driver's "Agent: {d}"
+        // (the bare tool name says nothing in a tab strip).
+        _ if xai_tool_name(update) == Some("spawn_subagent") => ToolCall::Unknown {
+            name: raw_str("description")
+                .map(|d| format!("Agent: {d}"))
+                .unwrap_or_else(|| "Agent".into()),
+            input: raw.cloned(),
+        },
         _ if raw_str("_toolName").as_deref() == Some("task") => ToolCall::Unknown {
             name: raw_str("description")
                 .filter(|d| d != "Subagent task")

--- a/crates/harness/src/acp/subagent.rs
+++ b/crates/harness/src/acp/subagent.rs
@@ -1,0 +1,712 @@
+//! Grok subagent visualization on the ACP path.
+//!
+//! Grok's wire frames carry no `parent_tool_use_id` (the docs promise
+//! tagging; unimplemented as of 1.0.4), and a subagent's interior transcript
+//! never appears on the parent's ACP stream — the wire only carries the
+//! lifecycle extension updates `subagent_spawned` / `subagent_progress` /
+//! `subagent_finished` (verified live, 1.0.4). The transcript itself is
+//! written incrementally to the child session's `chat_history.jsonl` under
+//! `~/.grok/sessions/<urlencoded-cwd>/<child_session_id>/`.
+//!
+//! So the tracker correlates the `spawn_subagent` tool call with its
+//! `subagent_spawned` update, tails the child's `chat_history.jsonl` into
+//! tagged [`AgentEvent::Subagent`] events (the engine routes those to the
+//! subagent's own doc and flips the spawn chip), and settles the chip with a
+//! tagged `Done` from `subagent_finished`. The on-disk format is
+//! vendor-private: every parse fails soft, degrading to chip + final output
+//! (from the wire's `subagent_finished`) rather than erroring the run.
+
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::sync::{mpsc, oneshot};
+use zeron_proto::{AgentEvent, DoneStatus, ToolCall};
+
+use crate::HarnessError;
+
+use super::normalize::{cap_text, xai_tool_name, OUTPUT_CAP};
+
+/// Cadence of the transcript tail (the CLI appends at message granularity, so
+/// sub-second polling is plenty "live").
+const TAIL_POLL: Duration = Duration::from_millis(250);
+/// Post-`subagent_finished` drain: the wire signal can beat the CLI's last
+/// disk flush, so keep reading briefly before settling the tagged Done.
+const DRAIN_POLLS: u32 = 6;
+const DRAIN_POLL: Duration = Duration::from_millis(200);
+
+/// The default grok sessions root (`~/.grok/sessions`).
+fn default_sessions_root() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_default()
+        .join(".grok")
+        .join("sessions")
+}
+
+/// Wrap an event as subagent-attributed traffic.
+fn tag(parent: &str, event: AgentEvent) -> AgentEvent {
+    AgentEvent::Subagent {
+        parent_tool_use_id: parent.to_owned(),
+        event: Box::new(event),
+    }
+}
+
+fn done_status(status: &str) -> DoneStatus {
+    match status {
+        "failed" | "error" | "errored" => DoneStatus::Errored,
+        "cancelled" | "canceled" | "killed" | "stopped" | "interrupted" => DoneStatus::Interrupted,
+        _ => DoneStatus::Completed,
+    }
+}
+
+/// A spawn chip (`spawn_subagent` tool call) not yet bound to a subagent id.
+struct PendingSpawn {
+    tool_call_id: String,
+    description: String,
+}
+
+/// The `subagent_finished` payload handed to a live tail.
+struct TailFinish {
+    status: DoneStatus,
+    output: String,
+}
+
+/// A `subagent_spawned` update that arrived before any chip could be bound
+/// (defensive: not an ordering grok exhibits today).
+struct SpawnedUnbound {
+    child_session_id: String,
+}
+
+pub(crate) struct SubagentTracker {
+    /// The parent ACP session — `subagent_spawned` for a NESTED spawn (a
+    /// subagent's own subagent) must not bind to this feed's chips.
+    session_id: String,
+    event_tx: mpsc::Sender<Result<AgentEvent, HarnessError>>,
+    sessions_root: PathBuf,
+    /// Spawn chips seen on the wire, FIFO, awaiting a subagent id.
+    pending: VecDeque<PendingSpawn>,
+    /// subagent_id → the spawn chip's tool-use id.
+    bound: HashMap<String, String>,
+    /// `subagent_spawned` payloads that could not bind yet.
+    spawned_unbound: HashMap<String, SpawnedUnbound>,
+    /// subagent_id → finished-signal for the live tail task.
+    tails: HashMap<String, oneshot::Sender<TailFinish>>,
+}
+
+impl SubagentTracker {
+    pub(crate) fn new(
+        session_id: String,
+        event_tx: mpsc::Sender<Result<AgentEvent, HarnessError>>,
+        sessions_root: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            session_id,
+            event_tx,
+            sessions_root: sessions_root.unwrap_or_else(default_sessions_root),
+            pending: VecDeque::new(),
+            bound: HashMap::new(),
+            spawned_unbound: HashMap::new(),
+            tails: HashMap::new(),
+        }
+    }
+
+    /// Inspect one `session/update` payload's `update` object. Pure
+    /// bookkeeping — tagged events flow from the spawned tail tasks, which
+    /// hold their own `event_tx` clones (they outlive the turn: a background
+    /// subagent keeps streaming to its doc after the parent's Done, and the
+    /// event stream stays open until every tail settles).
+    pub(crate) fn observe(&mut self, update: &Value) {
+        match update.get("sessionUpdate").and_then(Value::as_str) {
+            Some("tool_call") | Some("tool_call_update") => self.observe_tool_call(update),
+            Some("subagent_spawned") => self.observe_spawned(update),
+            Some("subagent_finished") => self.observe_finished(update),
+            _ => {}
+        }
+    }
+
+    fn observe_tool_call(&mut self, update: &Value) {
+        let id = update
+            .get("toolCallId")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if id.is_empty() {
+            return;
+        }
+        if xai_tool_name(update) == Some("spawn_subagent") {
+            let description = update
+                .get("rawInput")
+                .and_then(|r| r.get("description"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            match self.pending.iter_mut().find(|p| p.tool_call_id == id) {
+                Some(p) if p.description.is_empty() => p.description = description.to_owned(),
+                Some(_) => {}
+                None => self.pending.push_back(PendingSpawn {
+                    tool_call_id: id.to_owned(),
+                    description: description.to_owned(),
+                }),
+            }
+        }
+        // The spawn's completion echoes the minted id in its output text
+        // ("subagent_id: <uuid>") — the completed update carries no _meta, so
+        // key off membership in `pending` instead. Background spawns complete
+        // here BEFORE `subagent_spawned` arrives; sync spawns after.
+        if update.get("status").and_then(Value::as_str) == Some("completed")
+            && self.pending.iter().any(|p| p.tool_call_id == id)
+            && let Some(sub_id) = spawn_output_subagent_id(update)
+        {
+            self.pending.retain(|p| p.tool_call_id != id);
+            self.bound.insert(sub_id.clone(), id.to_owned());
+            if let Some(spawned) = self.spawned_unbound.remove(&sub_id) {
+                self.start_tail(&sub_id, &spawned.child_session_id);
+            }
+        }
+    }
+
+    fn observe_spawned(&mut self, update: &Value) {
+        // A nested spawn (a subagent spawning its own subagent) would carry
+        // the CHILD's session id here — never bind it to this feed's chips.
+        if let Some(parent) = update.get("parent_session_id").and_then(Value::as_str)
+            && parent != self.session_id
+        {
+            return;
+        }
+        let Some(sub_id) = update
+            .get("subagent_id")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+        else {
+            return;
+        };
+        let child_session_id = update
+            .get("child_session_id")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(sub_id)
+            .to_owned();
+        if !self.bound.contains_key(sub_id) {
+            // Sync spawns: the chip hasn't completed yet — bind by
+            // description (FIFO across identical descriptions, matching
+            // grok's spawn order), else the oldest pending spawn.
+            let description = update
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let ix = self
+                .pending
+                .iter()
+                .position(|p| !description.is_empty() && p.description == description)
+                .or(if self.pending.is_empty() { None } else { Some(0) });
+            match ix.and_then(|i| self.pending.remove(i)) {
+                Some(p) => {
+                    self.bound.insert(sub_id.to_owned(), p.tool_call_id);
+                }
+                None => {
+                    // No chip candidate on the wire (yet): stash — the
+                    // spawn completion's id echo binds it later.
+                    self.spawned_unbound.insert(
+                        sub_id.to_owned(),
+                        SpawnedUnbound { child_session_id },
+                    );
+                    return;
+                }
+            }
+        }
+        self.start_tail(sub_id, &child_session_id);
+    }
+
+    fn observe_finished(&mut self, update: &Value) {
+        let Some(sub_id) = update.get("subagent_id").and_then(Value::as_str) else {
+            return;
+        };
+        let finish = TailFinish {
+            status: done_status(
+                update
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or("completed"),
+            ),
+            output: update
+                .get("output")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned(),
+        };
+        self.spawned_unbound.remove(sub_id);
+        if let Some(tx) = self.tails.remove(sub_id) {
+            let _ = tx.send(finish);
+        } else if let Some(parent) = self.bound.get(sub_id).cloned() {
+            // No tail ever started (the chip bound but `subagent_spawned`
+            // never arrived, or the tail task failed to spawn): the wire's
+            // final output still makes a transcript, and the chip settles.
+            let event_tx = self.event_tx.clone();
+            tokio::spawn(async move {
+                if !finish.output.is_empty() {
+                    let _ = event_tx
+                        .send(Ok(tag(
+                            &parent,
+                            AgentEvent::TextDelta {
+                                text: finish.output,
+                            },
+                        )))
+                        .await;
+                }
+                let _ = event_tx
+                    .send(Ok(tag(
+                        &parent,
+                        AgentEvent::Done {
+                            status: finish.status,
+                            result: None,
+                            error: None,
+                            session_id: None,
+                        },
+                    )))
+                    .await;
+            });
+        }
+    }
+
+    fn start_tail(&mut self, sub_id: &str, child_session_id: &str) {
+        let Some(parent) = self.bound.get(sub_id).cloned() else {
+            return;
+        };
+        if self.tails.contains_key(sub_id) {
+            return;
+        }
+        let (finished_tx, finished_rx) = oneshot::channel();
+        self.tails.insert(sub_id.to_owned(), finished_tx);
+        tokio::spawn(tail_task(
+            self.event_tx.clone(),
+            self.sessions_root.clone(),
+            child_session_id.to_owned(),
+            parent,
+            finished_rx,
+        ));
+    }
+}
+
+/// `subagent_id: <id>` from the spawn tool call's completion output.
+fn spawn_output_subagent_id(update: &Value) -> Option<String> {
+    let text = update
+        .get("rawOutput")
+        .and_then(|r| r.get("text"))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            update
+                .get("content")?
+                .as_array()?
+                .iter()
+                .find_map(|c| c.get("content")?.get("text")?.as_str())
+        })?;
+    text.lines().find_map(|line| {
+        let id = line.trim().strip_prefix("subagent_id:")?.trim();
+        (!id.is_empty()).then(|| id.to_owned())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Disk tail
+// ---------------------------------------------------------------------------
+
+/// The child session's `chat_history.jsonl`, located by session id ONE level
+/// under the sessions root (`<root>/<urlencoded-cwd>/<child_session_id>/`) —
+/// scanning dodges reimplementing grok's cwd encoding, and the child's cwd
+/// can differ from the parent's anyway.
+fn locate_history(root: &Path, child_session_id: &str) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(root).ok()?;
+    for entry in entries.flatten() {
+        let candidate = entry
+            .path()
+            .join(child_session_id)
+            .join("chat_history.jsonl");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Incremental line reader over an append-only JSONL file. A partial trailing
+/// line (a write raced mid-append) carries over to the next poll.
+struct TailReader {
+    path: PathBuf,
+    offset: u64,
+    carry: Vec<u8>,
+}
+
+impl TailReader {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            offset: 0,
+            carry: Vec::new(),
+        }
+    }
+
+    /// New complete entries since the last poll; io/parse failures read as
+    /// "nothing new" (fail soft — the format is vendor-private).
+    fn read_new(&mut self) -> Vec<Value> {
+        use std::io::{Read as _, Seek as _};
+        let Ok(mut file) = std::fs::File::open(&self.path) else {
+            return Vec::new();
+        };
+        if file.seek(std::io::SeekFrom::Start(self.offset)).is_err() {
+            return Vec::new();
+        }
+        let mut bytes = Vec::new();
+        let Ok(read) = file.read_to_end(&mut bytes) else {
+            return Vec::new();
+        };
+        self.offset += read as u64;
+        self.carry.extend_from_slice(&bytes);
+        let mut entries = Vec::new();
+        while let Some(nl) = self.carry.iter().position(|b| *b == b'\n') {
+            let line: Vec<u8> = self.carry.drain(..=nl).collect();
+            if let Ok(v) = serde_json::from_slice::<Value>(&line) {
+                entries.push(v);
+            }
+        }
+        entries
+    }
+}
+
+/// Map one `chat_history.jsonl` entry to (untagged) transcript events.
+/// Message-granularity by construction — grok only writes settled messages;
+/// the trailing `\n\n` keeps consecutive message-level chunks readable when
+/// the fold concatenates them.
+fn entry_events(entry: &Value) -> Vec<AgentEvent> {
+    let mut events = Vec::new();
+    match entry.get("type").and_then(Value::as_str) {
+        Some("reasoning") => {
+            let text: Vec<&str> = entry
+                .get("summary")
+                .and_then(Value::as_array)
+                .map(|a| a.as_slice())
+                .unwrap_or_default()
+                .iter()
+                .filter(|s| s.get("type").and_then(Value::as_str) == Some("summary_text"))
+                .filter_map(|s| s.get("text").and_then(Value::as_str))
+                .filter(|t| !t.is_empty())
+                .collect();
+            if !text.is_empty() {
+                events.push(AgentEvent::ReasoningDelta {
+                    text: format!("{}\n\n", text.join("\n")),
+                });
+            }
+        }
+        Some("assistant") => {
+            if let Some(text) = entry
+                .get("content")
+                .and_then(Value::as_str)
+                .filter(|t| !t.is_empty())
+            {
+                events.push(AgentEvent::TextDelta {
+                    text: format!("{text}\n\n"),
+                });
+            }
+            for tc in entry
+                .get("tool_calls")
+                .and_then(Value::as_array)
+                .map(|a| a.as_slice())
+                .unwrap_or_default()
+            {
+                let id = tc.get("id").and_then(Value::as_str).unwrap_or_default();
+                let name = tc.get("name").and_then(Value::as_str).unwrap_or_default();
+                if id.is_empty() || name.is_empty() {
+                    continue;
+                }
+                // `arguments` is a JSON-encoded STRING on disk.
+                let args = tc
+                    .get("arguments")
+                    .and_then(Value::as_str)
+                    .and_then(|a| serde_json::from_str::<Value>(a).ok())
+                    .unwrap_or(Value::Null);
+                events.push(AgentEvent::ToolCall {
+                    id: id.to_owned(),
+                    call: grok_tool_call(name, &args),
+                });
+            }
+        }
+        Some("tool_result") => {
+            if let Some(id) = entry
+                .get("tool_call_id")
+                .and_then(Value::as_str)
+                .filter(|i| !i.is_empty())
+            {
+                let output = entry
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .filter(|t| !t.is_empty())
+                    .map(|t| cap_text(t, OUTPUT_CAP));
+                events.push(AgentEvent::ToolResult {
+                    id: id.to_owned(),
+                    is_error: false,
+                    output,
+                    diff: None,
+                });
+            }
+        }
+        // system prompt / user prompt / synthetic reminders: not transcript.
+        _ => {}
+    }
+    events
+}
+
+/// Type a grok-native tool invocation (disk names, not ACP kinds).
+fn grok_tool_call(name: &str, args: &Value) -> ToolCall {
+    let s = |keys: &[&str]| {
+        keys.iter()
+            .find_map(|k| args.get(*k))
+            .and_then(Value::as_str)
+            .filter(|v| !v.is_empty())
+            .map(str::to_owned)
+    };
+    match name {
+        "run_terminal_command" => ToolCall::Exec {
+            command: s(&["command"]).unwrap_or_default(),
+        },
+        "read_file" => ToolCall::ReadFile {
+            path: s(&["target_file", "file_path", "path"]).unwrap_or_default(),
+        },
+        "write_file" => ToolCall::WriteFile {
+            path: s(&["target_file", "file_path", "path"]).unwrap_or_default(),
+            content: s(&["contents", "content"]),
+        },
+        "search_replace" => ToolCall::EditFile {
+            path: s(&["file_path", "target_file", "path"]).unwrap_or_default(),
+            old_string: s(&["old_string"]),
+            new_string: s(&["new_string"]),
+        },
+        "grep" => ToolCall::Search {
+            pattern: s(&["pattern"]).unwrap_or_default(),
+            path: s(&["path"]),
+        },
+        "glob" => ToolCall::Glob {
+            pattern: s(&["pattern", "glob_pattern"]).unwrap_or_default(),
+        },
+        "web_search" => ToolCall::WebSearch {
+            query: s(&["query", "search_term"]).unwrap_or_default(),
+        },
+        // A nested spawn inside the subagent: same naming as the parent chip
+        // (no recursive tail — it renders as a plain chip in the child doc).
+        "spawn_subagent" => ToolCall::Unknown {
+            name: s(&["description"])
+                .map(|d| format!("Agent: {d}"))
+                .unwrap_or_else(|| "Agent".into()),
+            input: (!args.is_null()).then(|| args.clone()),
+        },
+        _ => ToolCall::Unknown {
+            name: name.to_owned(),
+            input: (!args.is_null()).then(|| args.clone()),
+        },
+    }
+}
+
+/// One subagent's transcript tail: poll the child's `chat_history.jsonl`
+/// into tagged events until `subagent_finished` (or tracker teardown), then
+/// drain briefly and settle the chip with a tagged Done. Holds its own
+/// `event_tx` clone, so the run's event stream stays open until the tail
+/// settles — an agent that dies mid-subagent still gets its chip closed.
+async fn tail_task(
+    event_tx: mpsc::Sender<Result<AgentEvent, HarnessError>>,
+    root: PathBuf,
+    child_session_id: String,
+    parent_tool_use_id: String,
+    mut finished_rx: oneshot::Receiver<TailFinish>,
+) {
+    let mut reader: Option<TailReader> = None;
+    let mut emitted = false;
+    let pump = |reader: &mut Option<TailReader>| -> Vec<AgentEvent> {
+        if reader.is_none() {
+            *reader = locate_history(&root, &child_session_id).map(TailReader::new);
+        }
+        reader
+            .as_mut()
+            .map(|r| r.read_new())
+            .unwrap_or_default()
+            .iter()
+            .flat_map(entry_events)
+            .collect()
+    };
+
+    let finish = loop {
+        for ev in pump(&mut reader) {
+            emitted = true;
+            if event_tx
+                .send(Ok(tag(&parent_tool_use_id, ev)))
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+        if event_tx.is_closed() {
+            return;
+        }
+        tokio::select! {
+            fin = &mut finished_rx => {
+                // A dropped sender is session teardown with the subagent
+                // still running: settle the chip as interrupted rather than
+                // leaving it spinning forever.
+                break fin.unwrap_or(TailFinish {
+                    status: DoneStatus::Interrupted,
+                    output: String::new(),
+                });
+            }
+            _ = tokio::time::sleep(TAIL_POLL) => {}
+        }
+    };
+
+    // The finished signal can beat the CLI's last disk flush: drain until a
+    // quiet poll (or the budget), then settle.
+    for i in 0..DRAIN_POLLS {
+        let events = pump(&mut reader);
+        for ev in events.iter().cloned() {
+            emitted = true;
+            if event_tx
+                .send(Ok(tag(&parent_tool_use_id, ev)))
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+        if events.is_empty() && i > 0 {
+            break;
+        }
+        tokio::time::sleep(DRAIN_POLL).await;
+    }
+    if !emitted && !finish.output.is_empty() {
+        // The tail never found (or never parsed) the transcript: the wire's
+        // final output alone still makes a useful doc.
+        if event_tx
+            .send(Ok(tag(
+                &parent_tool_use_id,
+                AgentEvent::TextDelta {
+                    text: finish.output,
+                },
+            )))
+            .await
+            .is_err()
+        {
+            return;
+        }
+    }
+    let _ = event_tx
+        .send(Ok(tag(
+            &parent_tool_use_id,
+            AgentEvent::Done {
+                status: finish.status,
+                result: None,
+                error: None,
+                session_id: None,
+            },
+        )))
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn spawn_completion_output_yields_the_subagent_id() {
+        let update = json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "t1",
+            "status": "completed",
+            "rawOutput": {"type": "Text", "text": "Subagent started in background.\nsubagent_id: 01a0-abc\ntype: explore"},
+        });
+        assert_eq!(
+            spawn_output_subagent_id(&update).as_deref(),
+            Some("01a0-abc")
+        );
+        // content-block fallback when rawOutput is absent.
+        let update = json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "t1",
+            "status": "completed",
+            "content": [{"type": "content", "content": {"type": "text", "text": "subagent_id: xyz"}}],
+        });
+        assert_eq!(spawn_output_subagent_id(&update).as_deref(), Some("xyz"));
+    }
+
+    #[test]
+    fn chat_history_entries_map_to_transcript_events() {
+        // Real shapes from ~/.grok/sessions (grok 1.0.4).
+        let reasoning = json!({
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "The user wants a probe.\n"}],
+            "encrypted_content": "opaque", "status": "completed",
+        });
+        assert!(matches!(
+            entry_events(&reasoning).as_slice(),
+            [AgentEvent::ReasoningDelta { text }] if text.starts_with("The user wants a probe.")
+        ));
+
+        let assistant = json!({
+            "type": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call-1-0",
+                "name": "read_file",
+                "arguments": "{\"target_file\":\"/w/README.md\",\"limit\":80}",
+            }],
+            "model_id": "grok-4.6-build",
+        });
+        assert!(matches!(
+            entry_events(&assistant).as_slice(),
+            [AgentEvent::ToolCall { id, call: ToolCall::ReadFile { path } }]
+                if id == "call-1-0" && path == "/w/README.md"
+        ));
+
+        let result = json!({
+            "type": "tool_result",
+            "tool_call_id": "call-1-0",
+            "content": "1→# zeron — Architecture",
+        });
+        assert!(matches!(
+            entry_events(&result).as_slice(),
+            [AgentEvent::ToolResult { id, is_error: false, output: Some(o), .. }]
+                if id == "call-1-0" && o.contains("Architecture")
+        ));
+
+        let closing = json!({"type": "assistant", "content": "finished", "model_id": "m"});
+        assert!(matches!(
+            entry_events(&closing).as_slice(),
+            [AgentEvent::TextDelta { text }] if text == "finished\n\n"
+        ));
+
+        // Non-transcript entries are skipped.
+        for t in ["system", "user"] {
+            assert!(entry_events(&json!({"type": t, "content": "x"})).is_empty());
+        }
+    }
+
+    #[test]
+    fn grok_tool_names_type_the_common_calls() {
+        let call = grok_tool_call("run_terminal_command", &json!({"command": "ls -la"}));
+        assert_eq!(call, ToolCall::Exec { command: "ls -la".into() });
+        let call = grok_tool_call("grep", &json!({"pattern": "0\\.1", "glob": "*.rs"}));
+        assert_eq!(call, ToolCall::Search { pattern: "0\\.1".into(), path: None });
+        let call = grok_tool_call(
+            "search_replace",
+            &json!({"file_path": "/w/a.rs", "old_string": "a", "new_string": "b"}),
+        );
+        assert_eq!(
+            call,
+            ToolCall::EditFile {
+                path: "/w/a.rs".into(),
+                old_string: Some("a".into()),
+                new_string: Some("b".into()),
+            }
+        );
+        let call = grok_tool_call("spawn_subagent", &json!({"description": "Scan crates"}));
+        assert!(matches!(call, ToolCall::Unknown { name, .. } if name == "Agent: Scan crates"));
+        let call = grok_tool_call("mystery_tool", &json!({"x": 1}));
+        assert!(matches!(call, ToolCall::Unknown { name, input: Some(_) } if name == "mystery_tool"));
+    }
+}

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -674,3 +674,114 @@ async fn stale_prompt_complete_never_settles_a_newer_turn() {
         output_tokens: 4
     }));
 }
+
+#[tokio::test]
+async fn grok_subagent_lifecycle_tails_the_disk_transcript_into_tagged_events() {
+    // The child session's chat_history.jsonl, one level under the sessions
+    // root exactly like grok's `<root>/<urlencoded-cwd>/<session-id>/` layout
+    // (entry shapes captured from a real 1.0.4 run).
+    let tmp = tempfile::tempdir().unwrap();
+    let child_dir = tmp.path().join("%2Ftmp").join("sub-1");
+    std::fs::create_dir_all(&child_dir).unwrap();
+    let history = child_dir.join("chat_history.jsonl");
+    std::fs::write(
+        &history,
+        concat!(
+            "{\"type\":\"system\",\"content\":\"You are a Grok Build subagent\"}\n",
+            "{\"type\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Count the files.\"}],\"prompt_index\":0}\n",
+            "{\"type\":\"reasoning\",\"id\":\"rs-1\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Listing the directory.\"}],\"encrypted_content\":\"opaque\",\"status\":\"completed\"}\n",
+            "{\"type\":\"assistant\",\"content\":\"\",\"tool_calls\":[{\"id\":\"call-1-0\",\"name\":\"run_terminal_command\",\"arguments\":\"{\\\"command\\\":\\\"ls\\\"}\"}],\"model_id\":\"grok-4.6-build\"}\n",
+            "{\"type\":\"tool_result\",\"tool_call_id\":\"call-1-0\",\"content\":\"a.txt\\nb.txt\"}\n",
+        ),
+    )
+    .unwrap();
+    // A mid-run append: the tail must pick it up incrementally, before the
+    // wire's subagent_finished lands (the fake agent sleeps 1.4s).
+    let append_to = history.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(700)).await;
+        use std::io::Write as _;
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(append_to)
+            .unwrap();
+        writeln!(
+            f,
+            "{}",
+            "{\"type\":\"assistant\",\"content\":\"two files\",\"model_id\":\"grok-4.6-build\"}"
+        )
+        .unwrap();
+    });
+
+    let (controls, _steer, _token) = controls();
+    let harness = harness().with_sessions_root(tmp.path());
+    let events = run_to_end(&harness, request("scenario:subagent"), controls).await;
+
+    // The spawn chip is named after the task, claude-driver parity.
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCall { id, call: ToolCall::Unknown { name, .. } }
+                if id == "sp1" && name == "Agent: Count files"
+        )),
+        "{events:?}"
+    );
+
+    // Tagged transcript: every wrapped event attributes to the spawn chip,
+    // and the disk entries surfaced in order — reasoning, the typed tool
+    // call + result, the mid-run append — then the lifecycle Done.
+    let tagged: Vec<&AgentEvent> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::Subagent {
+                parent_tool_use_id,
+                event,
+            } => {
+                assert_eq!(parent_tool_use_id, "sp1", "{events:?}");
+                Some(event.as_ref())
+            }
+            _ => None,
+        })
+        .collect();
+    let pos = |pred: &dyn Fn(&AgentEvent) -> bool| tagged.iter().position(|e| pred(e));
+    let reasoning = pos(&|e| {
+        matches!(e, AgentEvent::ReasoningDelta { text } if text.starts_with("Listing the directory."))
+    })
+    .expect("reasoning entry tailed");
+    let tool = pos(&|e| {
+        matches!(
+            e,
+            AgentEvent::ToolCall { id, call: zeron_proto::ToolCall::Exec { command } }
+                if id == "call-1-0" && command == "ls"
+        )
+    })
+    .expect("tool call typed from disk");
+    let result = pos(&|e| {
+        matches!(
+            e,
+            AgentEvent::ToolResult { id, is_error: false, output: Some(o), .. }
+                if id == "call-1-0" && o.contains("a.txt")
+        )
+    })
+    .expect("tool result tailed");
+    let text = pos(&|e| matches!(e, AgentEvent::TextDelta { text } if text.starts_with("two files")))
+        .expect("mid-run append tailed");
+    let done = pos(&|e| {
+        matches!(
+            e,
+            AgentEvent::Done {
+                status: DoneStatus::Completed,
+                ..
+            }
+        )
+    })
+    .expect("tagged done from subagent_finished");
+    assert!(
+        reasoning < tool && tool < result && result < text && text < done,
+        "{tagged:?}"
+    );
+    // The nested spawned update (another parent session) bound nothing —
+    // every wrapped event attributed to sp1 (the assert in the filter) — and
+    // the parent's own turn settled cleanly with its single untagged Done.
+    assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)]);
+}

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -15,6 +15,12 @@ update() { # $1 = update json object body
   emit "{\"method\":\"session/update\",\"params\":{\"sessionId\":\"$SID\",\"update\":$1}}"
 }
 
+xnotify() { # $1 = update json object body — grok's extension channel (the
+  # subagent lifecycle rides _x.ai/session_notification, NOT session/update;
+  # same {sessionId, update} envelope. Verified live, 1.0.4.)
+  emit "{\"method\":\"_x.ai/session_notification\",\"params\":{\"sessionId\":\"$SID\",\"update\":$1}}"
+}
+
 # ---- handshake -------------------------------------------------------------
 read -r line || exit 1 # initialize
 has "$line" '"method":"initialize"' || exit 1
@@ -120,6 +126,24 @@ case "$promptline" in
   # TOTAL silence after the prompt — the leader-wedge signature. Nothing is
   # ever emitted; the harness's prompt-stall watchdog must error the run.
   exec sleep 60
+  ;;
+
+*scenario:subagent*)
+  # Grok's background subagent lifecycle (wire shapes captured live, 1.0.4):
+  # spawn tool_call tagged _meta["x.ai/tool"], completion echoing the minted
+  # subagent_id in its output text, then the subagent_spawned/finished
+  # extension updates. The transcript itself never rides the wire — the test
+  # seeds/app ends a chat_history.jsonl under the harness's sessions root
+  # and the tail turns it into tagged events during the sleep window.
+  update '{"sessionUpdate":"tool_call","toolCallId":"sp1","title":"spawn_subagent","rawInput":{"description":"Count files","prompt":"Count the files.","subagent_type":"explore"},"_meta":{"x.ai/tool":{"version":1,"name":"spawn_subagent","kind":"task","namespace":"grok_build","label":"Subagent","read_only":false},"subagentBackground":true}}'
+  update '{"sessionUpdate":"tool_call_update","toolCallId":"sp1","status":"completed","content":[{"type":"content","content":{"type":"text","text":"Subagent started in background.\nsubagent_id: sub-1\ntype: explore"}}],"rawOutput":{"type":"Text","text":"Subagent started in background.\nsubagent_id: sub-1\ntype: explore"}}'
+  xnotify "{\"sessionUpdate\":\"subagent_spawned\",\"subagent_id\":\"sub-1\",\"parent_session_id\":\"$SID\",\"child_session_id\":\"sub-1\",\"subagent_type\":\"explore\",\"description\":\"Count files\"}"
+  # A NESTED spawned update (another parent session) must not bind here.
+  xnotify '{"sessionUpdate":"subagent_spawned","subagent_id":"sub-nested","parent_session_id":"sub-1","child_session_id":"sub-nested","subagent_type":"explore","description":"Count files"}'
+  sleep 1.4
+  xnotify '{"sessionUpdate":"subagent_finished","subagent_id":"sub-1","child_session_id":"sub-1","status":"completed","tool_calls":1,"turns":1,"output":"two files","will_wake":false}'
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"done"}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
   ;;
 
 *scenario:happy*)


### PR DESCRIPTION
## What

Grok subagents were the one harness left out of the subagent visualization that shipped in #136 — they rendered as plain tool calls. This wires them in on the ACP path.

## Why they were missing

Three wire facts (all verified live against grok 1.0.4):

1. **No tagging.** Grok's frames carry `parent_tool_use_id: null` everywhere (the docs promise tagging; unimplemented), so the engine could never attribute nested traffic.
2. **No interior on the wire.** The subagent's own transcript (text/reasoning/tool calls) never appears on the parent's ACP stream — only lifecycle extension updates do.
3. **Wrong channel.** Those lifecycle updates (`subagent_spawned` / `subagent_progress` / `subagent_finished`) ride `_x.ai/session_notification`, not `session/update` — the harness dropped that method entirely. (This was the live-probe surprise; the same `{sessionId, update}` envelope, different method.)

## How

New `acp::subagent::SubagentTracker`, observed on both notification channels:

- **Correlation:** the `spawn_subagent` tool call (detected via `_meta["x.ai/tool"]`) binds to its `subagent_spawned` update through the `subagent_id:` echoed in the spawn's completion output; sync spawns fall back to description-FIFO matching. Nested spawns (`parent_session_id` ≠ ours) are ignored.
- **Transcript:** a per-subagent task tails the child session's `chat_history.jsonl` (located by session id one glob level under `~/.grok/sessions` — no reimplementing grok's cwd urlencoding) into tagged `AgentEvent::Subagent` events: reasoning summaries, assistant text, typed tool calls (`run_terminal_command`→Exec, `read_file`→ReadFile, `search_replace`→EditFile, …), tool results. The engine's existing generic routing does the rest — per-subagent doc, spawn chip flip, frozen blob on completion.
- **Settlement:** `subagent_finished` → bounded drain → tagged `Done` (status-mapped). Tails hold their own event-channel clone, so a background subagent keeps streaming past the parent's turn end, and session teardown settles running tails as `Interrupted` instead of stranding chips.
- **Fail-soft:** the disk format is vendor-private; every parse failure degrades to chip + final output (from the wire), never an error.
- Spawn chips/tabs are named `Agent: {description}` — claude-driver parity.

## Testing

- Unit tests: spawn-id parsing, chat-history entry mapping (shapes captured from real 1.0.4 session files), tool-name typing.
- Integration test (`fake-acp.sh scenario:subagent` + temp sessions root): full lifecycle over the real wire shapes, including a mid-run disk append picked up incrementally and a nested-spawn decoy that must not bind.
- Live validation (`examples/grok_subagent_probe.rs`, kept for revalidation on grok bumps): real background subagent produced the full tagged stream — reasoning → text → `Exec("echo viz-probe-ok && sleep 3")` → result (`viz-probe-ok`) → `Done{Completed}` — attributed to the spawn chip, parent turn settling cleanly.
- Full workspace suite green.

## Notes / follow-ups

- `subagent_progress` is deliberately ignored (stats only; minting docs off it would create empty transcripts).
- If xAI ships the promised `_meta` tagging, the untagged-interior caveat disappears and the disk tail can become a fallback; the upstream ask still stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789641938&installation_model_id=425430&pr_number=149&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F149&signature=dc559bd2a4a55b0a2ebbb0ca199967be8c054c99f6ecc451816d2c4fe0ed6aae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->