### PR TITLE
cursor: in-app Connect via the SDK's browser login + accounts integration

### DIFF
--- a/crates/engine/src/agent_accounts.rs
+++ b/crates/engine/src/agent_accounts.rs
@@ -1,7 +1,7 @@
-//! AgentAccounts — the Claude Code / Codex CLI logins on this device
+//! AgentAccounts — the Claude Code / Codex / Cursor logins on this device
 //! (feature-inventory §3.7 "Agent accounts"; port of zeron's `agent-accounts.ts`).
 //!
-//! Each CLI stores exactly one live login:
+//! Each provider stores exactly one live login:
 //!
 //! - **Claude Code** — credentials in `~/.claude/.credentials.json`
 //!   (`$CLAUDE_CONFIG_DIR` relocates the dir) or, on macOS, the Keychain item
@@ -9,6 +9,10 @@
 //!   lives in `~/.claude.json`.
 //! - **Codex** — `$CODEX_HOME/auth.json` (default `~/.codex`): a ChatGPT OAuth
 //!   token set (identity inside the `id_token` JWT) or a raw API key.
+//! - **Cursor** — `~/.cursor/sdk/auth.json`: the Cursor SDK's credential store
+//!   (`StoredSdkCredentials`) holding the named, expiring user API key its
+//!   browser login mints. Deliberately SEPARATE from `cursor-agent login`'s
+//!   whole-account session tokens, which zeron never reads.
 //!
 //! Claude-swap mechanics:
 //!
@@ -80,6 +84,10 @@ pub struct AgentAccountsConfig {
     pub claude_config_file: PathBuf,
     /// Codex home (`$CODEX_HOME` or `~/.codex`) — holds `auth.json`.
     pub codex_home: PathBuf,
+    /// The Cursor SDK's credential store (`~/.cursor/sdk/auth.json`): the
+    /// named, expiring API key minted by its browser login. SEPARATE from
+    /// `cursor-agent login`'s session tokens — deliberately never read.
+    pub cursor_sdk_auth_file: PathBuf,
 }
 
 impl AgentAccountsConfig {
@@ -101,6 +109,7 @@ impl AgentAccountsConfig {
             claude_config_dir: claude_dir.unwrap_or_else(|| home_dir().join(".claude")),
             claude_config_file,
             codex_home: env_dir("CODEX_HOME").unwrap_or_else(|| home_dir().join(".codex")),
+            cursor_sdk_auth_file: home_dir().join(".cursor").join("sdk").join("auth.json"),
         }
     }
 
@@ -170,10 +179,15 @@ enum LoginFlow {
         verifier: String,
         started_at: Instant,
     },
-    Codex {
-        /// The `codex login` child; monitored (try_wait) + killable from cancel.
+    /// A spawned login child polled to completion: `codex login` against a
+    /// throwaway `CODEX_HOME`, or the cursor shim's login mode minting into a
+    /// throwaway store file. Either way the LIVE login is never touched;
+    /// completion is the credential file appearing under `home`.
+    Spawned {
+        harness: HarnessId,
+        /// The login child; monitored (try_wait) + killable from cancel.
         child: Arc<Mutex<Option<tokio::process::Child>>>,
-        /// Throwaway `CODEX_HOME` — the live `~/.codex` is never touched.
+        /// Throwaway credential dir, reclaimed on cancel/completion.
         home: PathBuf,
         started_at: Instant,
         output: Arc<Mutex<String>>,
@@ -185,7 +199,7 @@ enum LoginFlow {
 impl LoginFlow {
     fn started_at(&self) -> Instant {
         match self {
-            LoginFlow::Claude { started_at, .. } | LoginFlow::Codex { started_at, .. } => {
+            LoginFlow::Claude { started_at, .. } | LoginFlow::Spawned { started_at, .. } => {
                 *started_at
             }
         }
@@ -276,11 +290,24 @@ impl AgentAccounts {
             active_keys.insert(HarnessId::Codex, detected.account_key.clone());
             self.snapshot_detected(HarnessId::Codex, &detected)?;
         }
+        if let Some(detected) = self.detect_cursor() {
+            active_keys.insert(HarnessId::Cursor, detected.account_key.clone());
+            self.snapshot_detected(HarnessId::Cursor, &detected)?;
+            // The SDK's minted keys expire (90-day default) — an expired live
+            // key fails every run with an auth error, so say so up front.
+            if !self.cursor_live_usable() {
+                warnings.push(AgentAccountWarning {
+                    harness: HarnessId::Cursor,
+                    message: "The connected Cursor login's API key has expired — connect again."
+                        .into(),
+                });
+            }
+        }
 
         // Stable presentation order: provider, then slot creation order (never
         // active-first — switching must not reshuffle the cards).
         let mut accounts: Vec<AgentAccount> = Vec::new();
-        for harness in [HarnessId::ClaudeCode, HarnessId::Codex] {
+        for harness in [HarnessId::ClaudeCode, HarnessId::Codex, HarnessId::Cursor] {
             let active_key = active_keys.get(&harness).cloned();
             let slots = self.read_slots(harness);
             for slot in &slots {
@@ -346,6 +373,7 @@ impl AgentAccounts {
         match harness {
             HarnessId::ClaudeCode => self.activate_claude(&slot).await?,
             HarnessId::Codex => self.activate_codex(&slot)?,
+            HarnessId::Cursor => self.write_cursor_auth(&slot.credentials)?,
             other => {
                 return Err(EngineError::Other(format!(
                     "agent accounts are not supported for {other:?}"
@@ -455,6 +483,7 @@ impl AgentAccounts {
         match harness {
             HarnessId::ClaudeCode => Ok(self.start_claude_login()),
             HarnessId::Codex => self.start_codex_login().await,
+            HarnessId::Cursor => self.start_cursor_login().await,
             other => Err(EngineError::Other(format!(
                 "agent logins are not supported for {other:?}"
             ))),
@@ -493,19 +522,23 @@ impl AgentAccounts {
         }
     }
 
-    async fn start_codex_login(&self) -> Result<AgentLoginStart, EngineError> {
-        // At most ONE codex login flow at a time: `codex login` binds a fixed
-        // loopback OAuth port, so a lingering earlier flow makes every retry exit
-        // on EADDRINUSE. Starting a new flow supersedes — and reaps — any pending.
+    /// Supersede — and reap — any pending spawned flow for `harness` (codex:
+    /// `codex login` binds a fixed loopback OAuth port, so a lingering flow
+    /// makes every retry exit on EADDRINUSE; cursor: one flow is simply the
+    /// sane state).
+    fn reap_spawned_flows(&self, harness: HarnessId) {
         let stale: Vec<String> = lock(&self.inner.flows)
             .iter()
-            .filter(|(_, f)| matches!(f, LoginFlow::Codex { .. }))
+            .filter(|(_, f)| matches!(f, LoginFlow::Spawned { harness: h, .. } if *h == harness))
             .map(|(id, _)| id.clone())
             .collect();
         for id in stale {
             self.cancel_login(&id);
         }
+    }
 
+    async fn start_codex_login(&self) -> Result<AgentLoginStart, EngineError> {
+        self.reap_spawned_flows(HarnessId::Codex);
         let login_id = new_id();
         // A throwaway CODEX_HOME isolates the new login completely — the live
         // ~/.codex session is never touched until the user explicitly switches.
@@ -515,7 +548,7 @@ impl AgentAccounts {
             .root_dir()
             .join(format!(".login-{login_id}"));
         std::fs::create_dir_all(&home)?;
-        let mut child = match tokio::process::Command::new("codex")
+        let child = match tokio::process::Command::new("codex")
             .arg("login")
             .env("CODEX_HOME", &home)
             .stdin(std::process::Stdio::null())
@@ -539,68 +572,11 @@ impl AgentAccounts {
         // codex prints the authorize URL (to stderr as of 0.142 — scan both
         // streams) and usually opens the browser itself; grab it so the app can
         // open it too.
-        let output = Arc::new(Mutex::new(String::new()));
-        for pipe in [
-            child
-                .stdout
-                .take()
-                .map(|s| Box::new(s) as Box<dyn tokio::io::AsyncRead + Send + Unpin>),
-            child
-                .stderr
-                .take()
-                .map(|s| Box::new(s) as Box<dyn tokio::io::AsyncRead + Send + Unpin>),
-        ]
-        .into_iter()
-        .flatten()
-        {
-            let sink = output.clone();
-            tokio::spawn(async move {
-                use tokio::io::AsyncReadExt;
-                let mut pipe = pipe;
-                let mut buf = [0u8; 4096];
-                while let Ok(n) = pipe.read(&mut buf).await {
-                    if n == 0 {
-                        break;
-                    }
-                    lock(&sink).push_str(&String::from_utf8_lossy(&buf[..n]));
-                }
-            });
-        }
-
-        let child = Arc::new(Mutex::new(Some(child)));
-        let exit: Arc<Mutex<Option<Option<i32>>>> = Arc::new(Mutex::new(None));
-        {
-            // Monitor: poll try_wait so the child is reaped without owning it —
-            // the cancel path needs concurrent kill access.
-            let child = child.clone();
-            let exit = exit.clone();
-            tokio::spawn(async move {
-                loop {
-                    {
-                        let mut slot = lock(&child);
-                        match slot.as_mut().map(|c| c.try_wait()) {
-                            None => break,
-                            Some(Ok(Some(status))) => {
-                                *lock(&exit) = Some(status.code());
-                                *slot = None;
-                                break;
-                            }
-                            Some(Ok(None)) => {}
-                            Some(Err(_)) => {
-                                *lock(&exit) = Some(None);
-                                *slot = None;
-                                break;
-                            }
-                        }
-                    }
-                    tokio::time::sleep(Duration::from_millis(200)).await;
-                }
-            });
-        }
-
+        let (child, output, exit) = wire_login_child(child);
         lock(&self.inner.flows).insert(
             login_id.clone(),
-            LoginFlow::Codex {
+            LoginFlow::Spawned {
+                harness: HarnessId::Codex,
                 child,
                 home,
                 started_at: Instant::now(),
@@ -608,17 +584,60 @@ impl AgentAccounts {
                 exit: exit.clone(),
             },
         );
+        let url = await_login_url(&output, &exit, scan_openai_url).await;
+        Ok(AgentLoginStart {
+            login_id,
+            url,
+            mode: AgentLoginMode::Browser,
+        })
+    }
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        let url = loop {
-            if let Some(url) = scan_openai_url(&lock(&output)) {
-                break url;
+    /// Cursor: the SDK's own PKCE browser flow, driven through the zeron shim
+    /// in login mode. The minted key lands in a throwaway store file (never
+    /// the live `~/.cursor/sdk/auth.json`), then snapshots into a slot on
+    /// poll — mirroring codex's throwaway `CODEX_HOME`.
+    async fn start_cursor_login(&self) -> Result<AgentLoginStart, EngineError> {
+        self.reap_spawned_flows(HarnessId::Cursor);
+        let login_id = new_id();
+        let home = self
+            .inner
+            .config
+            .root_dir()
+            .join(format!(".login-{login_id}"));
+        std::fs::create_dir_all(&home)?;
+        let mut cmd = zeron_harness::cursor::login_command(&home.join("auth.json"))
+            .await
+            .map_err(|e| {
+                let _ = std::fs::remove_dir_all(&home);
+                EngineError::Other(format!("Could not start the Cursor login: {e}"))
+            })?;
+        let child = match cmd
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(err) => {
+                let _ = std::fs::remove_dir_all(&home);
+                return Err(EngineError::Other(format!(
+                    "Could not start the Cursor login: {err}"
+                )));
             }
-            if lock(&exit).is_some() || Instant::now() > deadline {
-                break String::new();
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
         };
+        let (child, output, exit) = wire_login_child(child);
+        lock(&self.inner.flows).insert(
+            login_id.clone(),
+            LoginFlow::Spawned {
+                harness: HarnessId::Cursor,
+                child,
+                home,
+                started_at: Instant::now(),
+                output: output.clone(),
+                exit: exit.clone(),
+            },
+        );
+        let url = await_login_url(&output, &exit, scan_cursor_url).await;
         Ok(AgentLoginStart {
             login_id,
             url,
@@ -789,7 +808,7 @@ impl AgentAccounts {
 
     pub async fn poll_login(&self, login_id: &str) -> Result<AgentLoginPoll, EngineError> {
         self.sweep_flows();
-        let (home, exit, output) = match lock(&self.inner.flows).get(login_id) {
+        let (harness, home, exit, output) = match lock(&self.inner.flows).get(login_id) {
             None => {
                 return Err(EngineError::Other(
                     "This sign-in attempt expired — start again.".into(),
@@ -801,12 +820,31 @@ impl AgentAccounts {
                     message: None,
                 });
             }
-            Some(LoginFlow::Codex {
-                home, exit, output, ..
-            }) => (home.clone(), exit.clone(), output.clone()),
+            Some(LoginFlow::Spawned {
+                harness,
+                home,
+                exit,
+                output,
+                ..
+            }) => (*harness, home.clone(), exit.clone(), output.clone()),
         };
-        if let Some(detected) = read_json(&home.join("auth.json")).and_then(parse_codex_auth) {
-            self.snapshot_detected(HarnessId::Codex, &detected)?;
+        let detected = read_json(&home.join("auth.json")).and_then(|auth| match harness {
+            HarnessId::Codex => parse_codex_auth(auth),
+            HarnessId::Cursor => parse_cursor_auth(auth),
+            _ => None,
+        });
+        if let Some(detected) = detected {
+            self.snapshot_detected(harness, &detected)?;
+            // Cursor "Connect" semantics: with no (usable) live login, the
+            // fresh key becomes the live one immediately — the page's CTA is
+            // "connect so runs work", not "add a spare". A live login stays
+            // untouched (switching remains explicit, codex parity).
+            if harness == HarnessId::Cursor
+                && !self.cursor_live_usable()
+                && let Some(credentials) = &detected.credentials
+            {
+                self.write_cursor_auth(credentials)?;
+            }
             self.cancel_login(login_id);
             return Ok(AgentLoginPoll {
                 status: AgentLoginStatus::Done,
@@ -817,14 +855,20 @@ impl AgentAccounts {
         if let Some(code) = exited {
             self.cancel_login(login_id);
             let message = if code == Some(0) {
-                "codex login finished without credentials.".to_string()
+                "The sign-in finished without credentials.".to_string()
             } else {
-                lock(&output)
-                    .trim()
-                    .lines()
-                    .last()
-                    .unwrap_or("sign-in failed")
-                    .to_string()
+                let output = lock(&output);
+                // The cursor shim reports failures as a JSONL fatal frame;
+                // codex prints plain text. Surface the human part.
+                scan_shim_fatal(&output)
+                    .unwrap_or_else(|| {
+                        output
+                            .trim()
+                            .lines()
+                            .last()
+                            .unwrap_or("sign-in failed")
+                            .to_string()
+                    })
             };
             return Ok(AgentLoginPoll {
                 status: AgentLoginStatus::Error,
@@ -837,11 +881,12 @@ impl AgentAccounts {
         })
     }
 
-    /// Drop a flow: kill a pending `codex login` child (it holds the fixed
-    /// loopback OAuth port) and reclaim its throwaway home dir. Idempotent.
+    /// Drop a flow: kill a pending login child (`codex login` holds the fixed
+    /// loopback OAuth port; the cursor shim polls Cursor's backend) and
+    /// reclaim its throwaway home dir. Idempotent.
     pub fn cancel_login(&self, login_id: &str) {
         let flow = lock(&self.inner.flows).remove(login_id);
-        if let Some(LoginFlow::Codex { child, home, .. }) = flow {
+        if let Some(LoginFlow::Spawned { child, home, .. }) = flow {
             if let Some(c) = lock(&child).as_mut() {
                 let _ = c.start_kill();
             }
@@ -911,6 +956,27 @@ impl AgentAccounts {
 
     fn detect_codex(&self) -> Option<Detected> {
         read_json(&self.inner.config.codex_auth_file()).and_then(parse_codex_auth)
+    }
+
+    fn detect_cursor(&self) -> Option<Detected> {
+        read_json(&self.inner.config.cursor_sdk_auth_file).and_then(parse_cursor_auth)
+    }
+
+    /// A live cursor login that runs can actually use: present, parseable,
+    /// and not past the minted key's expiry.
+    fn cursor_live_usable(&self) -> bool {
+        read_json(&self.inner.config.cursor_sdk_auth_file)
+            .is_some_and(|auth| cursor_key_usable(&auth))
+    }
+
+    fn write_cursor_auth(&self, credentials: &serde_json::Value) -> Result<(), EngineError> {
+        let file = &self.inner.config.cursor_sdk_auth_file;
+        if let Some(dir) = file.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        let json = serde_json::to_string_pretty(credentials)
+            .map_err(|e| EngineError::Other(format!("serialize cursor auth: {e}")))?;
+        write_file_atomic(file, json.as_bytes(), true)
     }
 
     /// Persist a detected login into its slot (refreshing stored tokens).
@@ -1425,6 +1491,52 @@ fn parse_codex_auth(auth: serde_json::Value) -> Option<Detected> {
 }
 
 /// ISO string (Claude) or unix seconds (Codex) → timestamp.
+/// The Cursor SDK's credential store (`StoredSdkCredentials`, version 1):
+/// the named user API key its browser login minted, plus identity/expiry.
+fn parse_cursor_auth(auth: serde_json::Value) -> Option<Detected> {
+    let api_key = str_field(&auth, "apiKey")?;
+    let email = str_field(&auth, "email");
+    let account_key = email.clone().unwrap_or_else(|| {
+        let digest = Sha256::digest(api_key.as_bytes());
+        format!("api-key:{}", &crate::repos::hex(&digest)[..12])
+    });
+    let expires_at = auth.get("apiKeyExpiresAtMs").and_then(|v| v.as_i64());
+    // The key's expiry doubles as the plan chip — with 90-day keys it is the
+    // one fact worth showing on the card.
+    let plan = expires_at.and_then(|ms| {
+        let when = DateTime::<Utc>::from_timestamp_millis(ms)?;
+        Some(if ms < now_ms() {
+            "Key expired".to_string()
+        } else {
+            format!("Key expires {}", when.format("%b %-d"))
+        })
+    });
+    Some(Detected {
+        account_key,
+        profile: SlotProfile {
+            email: email.unwrap_or_else(|| {
+                let tail: String = api_key.chars().skip(api_key.len().saturating_sub(4)).collect();
+                format!("API key ·…{tail}")
+            }),
+            display_name: None,
+            organization: None,
+            plan,
+            auth_kind: AgentAuthKind::Oauth,
+        },
+        credentials: Some(auth),
+        claude_config: None,
+    })
+}
+
+/// Present, parseable, and unexpired — what a run can actually use.
+fn cursor_key_usable(auth: &serde_json::Value) -> bool {
+    str_field(auth, "apiKey").is_some()
+        && auth
+            .get("apiKeyExpiresAtMs")
+            .and_then(|v| v.as_i64())
+            .is_none_or(|ms| ms > now_ms())
+}
+
 fn parse_when(value: Option<&serde_json::Value>) -> Option<DateTime<Utc>> {
     match value? {
         serde_json::Value::Number(n) => DateTime::<Utc>::from_timestamp(n.as_i64()?, 0),
@@ -1440,6 +1552,111 @@ fn scan_openai_url(output: &str) -> Option<String> {
     let rest = &output[start..];
     let end = rest.find(char::is_whitespace).unwrap_or(rest.len());
     Some(rest[..end].to_string())
+}
+
+/// First JSONL frame with the given `ev` in a cursor-shim output accumulator.
+fn scan_shim_event(output: &str, ev: &str) -> Option<serde_json::Value> {
+    output.lines().find_map(|line| {
+        let v: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+        (v.get("ev").and_then(|e| e.as_str()) == Some(ev)).then_some(v)
+    })
+}
+
+fn scan_cursor_url(output: &str) -> Option<String> {
+    str_field(&scan_shim_event(output, "auth-url")?, "url")
+}
+
+fn scan_shim_fatal(output: &str) -> Option<String> {
+    str_field(&scan_shim_event(output, "fatal")?, "message")
+}
+
+type LoginChildHandles = (
+    Arc<Mutex<Option<tokio::process::Child>>>,
+    Arc<Mutex<String>>,
+    Arc<Mutex<Option<Option<i32>>>>,
+);
+
+/// Wire a spawned login child: both pipes accumulate into one output buffer
+/// (the URL can land on either stream), and a monitor polls `try_wait` so the
+/// child is reaped without owning it — the cancel path needs concurrent kill
+/// access.
+fn wire_login_child(mut child: tokio::process::Child) -> LoginChildHandles {
+    let output = Arc::new(Mutex::new(String::new()));
+    for pipe in [
+        child
+            .stdout
+            .take()
+            .map(|s| Box::new(s) as Box<dyn tokio::io::AsyncRead + Send + Unpin>),
+        child
+            .stderr
+            .take()
+            .map(|s| Box::new(s) as Box<dyn tokio::io::AsyncRead + Send + Unpin>),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        let sink = output.clone();
+        tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            let mut pipe = pipe;
+            let mut buf = [0u8; 4096];
+            while let Ok(n) = pipe.read(&mut buf).await {
+                if n == 0 {
+                    break;
+                }
+                lock(&sink).push_str(&String::from_utf8_lossy(&buf[..n]));
+            }
+        });
+    }
+    let child = Arc::new(Mutex::new(Some(child)));
+    let exit: Arc<Mutex<Option<Option<i32>>>> = Arc::new(Mutex::new(None));
+    {
+        let child = child.clone();
+        let exit = exit.clone();
+        tokio::spawn(async move {
+            loop {
+                {
+                    let mut slot = lock(&child);
+                    match slot.as_mut().map(|c| c.try_wait()) {
+                        None => break,
+                        Some(Ok(Some(status))) => {
+                            *lock(&exit) = Some(status.code());
+                            *slot = None;
+                            break;
+                        }
+                        Some(Ok(None)) => {}
+                        Some(Err(_)) => {
+                            *lock(&exit) = Some(None);
+                            *slot = None;
+                            break;
+                        }
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+        });
+    }
+    (child, output, exit)
+}
+
+/// Wait briefly for the login child to print its authorize URL (empty when it
+/// exits or stays silent past the deadline — the flow still completes via
+/// poll; the UI just can't offer an open-browser button).
+async fn await_login_url(
+    output: &Arc<Mutex<String>>,
+    exit: &Arc<Mutex<Option<Option<i32>>>>,
+    scan: fn(&str) -> Option<String>,
+) -> String {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(url) = scan(&lock(output)) {
+            break url;
+        }
+        if lock(exit).is_some() || Instant::now() > deadline {
+            break String::new();
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 }
 
 /// Minimal percent-encoding for OAuth query params (matches `encodeURIComponent`
@@ -1508,6 +1725,58 @@ mod tests {
         assert_eq!(claude_plan(Some("free"), None), None);
         assert_eq!(codex_plan(Some("plus")).as_deref(), Some("ChatGPT Plus"));
         assert_eq!(codex_plan(None), None);
+    }
+
+    #[test]
+    fn cursor_auth_parses_and_gates_on_expiry() {
+        // The SDK's StoredSdkCredentials shape (credential-store.d.ts, 1.0.28).
+        let live = serde_json::json!({
+            "version": 1,
+            "backendUrl": "https://api2.cursor.sh",
+            "apiKey": "key_abc123",
+            "apiKeyExpiresAtMs": now_ms() + 86_400_000,
+            "email": "dev@example.com",
+            "createdAtMs": now_ms() - 1000,
+        });
+        let detected = parse_cursor_auth(live.clone()).expect("parses");
+        assert_eq!(detected.account_key, "dev@example.com");
+        assert_eq!(detected.profile.email, "dev@example.com");
+        assert_eq!(detected.profile.auth_kind, AgentAuthKind::Oauth);
+        assert!(detected.profile.plan.as_deref().unwrap().starts_with("Key expires"));
+        assert!(cursor_key_usable(&live));
+
+        let expired = serde_json::json!({
+            "version": 1,
+            "apiKey": "key_abc123",
+            "apiKeyExpiresAtMs": now_ms() - 1000,
+        });
+        let detected = parse_cursor_auth(expired.clone()).expect("expired still detects");
+        assert_eq!(detected.profile.plan.as_deref(), Some("Key expired"));
+        // No email → keyed (and labeled) off the key itself, codex-api-key style.
+        assert!(detected.account_key.starts_with("api-key:"));
+        assert!(!cursor_key_usable(&expired));
+
+        // No expiry field = never expires.
+        assert!(cursor_key_usable(&serde_json::json!({"apiKey": "k"})));
+        assert!(parse_cursor_auth(serde_json::json!({"version": 1})).is_none());
+    }
+
+    #[test]
+    fn cursor_shim_output_scan() {
+        let output = concat!(
+            "npm warn something unrelated\n",
+            "{\"ev\":\"auth-url\",\"url\":\"https://cursor.com/loginDeepControl?challenge=x\"}\n",
+        );
+        assert_eq!(
+            scan_cursor_url(output).as_deref(),
+            Some("https://cursor.com/loginDeepControl?challenge=x")
+        );
+        assert_eq!(scan_cursor_url("no frames here"), None);
+        assert_eq!(
+            scan_shim_fatal("{\"ev\":\"fatal\",\"message\":\"cursor login failed: boom\"}\n")
+                .as_deref(),
+            Some("cursor login failed: boom")
+        );
     }
 
     #[test]

--- a/crates/engine/tests/m5c_accounts_uploads_titles.rs
+++ b/crates/engine/tests/m5c_accounts_uploads_titles.rs
@@ -18,7 +18,10 @@ use zeron_engine::{
     worktree_branch_from_title,
 };
 use zeron_harness::mock::MockHarness;
-use zeron_proto::{AgentAccountsSnapshot, AgentEvent, DoneStatus, HarnessId, SandboxLevel};
+use zeron_proto::{
+    AgentAccountsSnapshot, AgentEvent, AgentLoginMode, AgentLoginStatus, DoneStatus, HarnessId,
+    SandboxLevel,
+};
 use zeron_rpc::methods;
 
 // ---------------------------------------------------------------------------
@@ -32,6 +35,7 @@ fn test_accounts(root: &Path) -> (AgentAccounts, AgentAccountsConfig) {
         claude_config_dir: root.join("claude"),
         claude_config_file: root.join("claude.json"),
         codex_home: root.join("codex"),
+        cursor_sdk_auth_file: root.join("cursor-sdk").join("auth.json"),
     };
     (AgentAccounts::new(config.clone()), config)
 }
@@ -827,4 +831,155 @@ async fn rpc_dispatch_for_m5c_methods() {
             .is_err()
     );
     core.shutdown().await;
+}
+
+fn write_cursor_login(config: &AgentAccountsConfig, email: &str, expires_in_ms: i64) {
+    let file = &config.cursor_sdk_auth_file;
+    std::fs::create_dir_all(file.parent().unwrap()).expect("cursor sdk dir");
+    std::fs::write(
+        file,
+        serde_json::json!({
+            "version": 1,
+            "backendUrl": "https://api2.cursor.sh",
+            "apiKey": format!("key-{email}"),
+            "apiKeyExpiresAtMs": now_ms_test() + expires_in_ms,
+            "email": email,
+            "createdAtMs": now_ms_test(),
+        })
+        .to_string(),
+    )
+    .expect("cursor auth");
+}
+
+fn now_ms_test() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64
+}
+
+#[tokio::test]
+async fn cursor_slot_swap_round_trip() {
+    let dir = tempfile::tempdir().expect("tmp");
+    let (accounts, config) = test_accounts(dir.path());
+
+    // Live SDK login = Erin; listing detects + auto-snapshots her slot.
+    write_cursor_login(&config, "erin@example.com", 86_400_000);
+    let snapshot = accounts.list(false).await.expect("list");
+    assert_eq!(
+        account_emails(&snapshot, HarnessId::Cursor),
+        vec![("erin@example.com".to_string(), true)]
+    );
+    assert!(snapshot.warnings.is_empty(), "{:?}", snapshot.warnings);
+    let erin_id = snapshot.accounts[snapshot
+        .accounts
+        .iter()
+        .position(|a| a.harness == HarnessId::Cursor)
+        .unwrap()]
+    .id
+    .clone();
+
+    // A second login (Frank) becomes live; both slots exist, Frank active.
+    write_cursor_login(&config, "frank@example.com", 86_400_000);
+    let snapshot = accounts.list(false).await.expect("list");
+    assert_eq!(
+        account_emails(&snapshot, HarnessId::Cursor),
+        vec![
+            ("erin@example.com".to_string(), false),
+            ("frank@example.com".to_string(), true),
+        ]
+    );
+
+    // Swap back to Erin: the SDK store file is rewritten from her slot.
+    let snapshot = accounts
+        .activate(HarnessId::Cursor, &erin_id)
+        .await
+        .expect("activate");
+    assert_eq!(
+        account_emails(&snapshot, HarnessId::Cursor),
+        vec![
+            ("erin@example.com".to_string(), true),
+            ("frank@example.com".to_string(), false),
+        ]
+    );
+    let live: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&config.cursor_sdk_auth_file).unwrap())
+            .unwrap();
+    assert_eq!(live["email"], "erin@example.com");
+
+    // An expired live key detects (card + slot survive) but warns.
+    write_cursor_login(&config, "erin@example.com", -1000);
+    let snapshot = accounts.list(false).await.expect("list");
+    assert!(
+        snapshot
+            .warnings
+            .iter()
+            .any(|w| w.harness == HarnessId::Cursor && w.message.contains("expired")),
+        "{:?}",
+        snapshot.warnings
+    );
+}
+
+#[tokio::test]
+async fn cursor_login_flow_spawns_shim_and_auto_activates() {
+    let dir = tempfile::tempdir().expect("tmp");
+    let (accounts, config) = test_accounts(dir.path());
+
+    // Fake shim: in login mode, emit the auth-url frame, write the minted
+    // store file where the engine pointed us, exit 0. Mirrors the real shim's
+    // `node <shim> login <store-path>` argv contract.
+    let shim = dir.path().join("fake-cursor-shim.sh");
+    std::fs::write(
+        &shim,
+        r#"#!/bin/sh
+[ "$1" = "login" ] || exit 1
+printf '%s\n' '{"ev":"auth-url","url":"https://cursor.com/loginDeepControl?challenge=fake"}'
+cat > "$2" <<JSON
+{"version":1,"backendUrl":"https://api2.cursor.sh","apiKey":"key-minted","apiKeyExpiresAtMs":99999999999999,"email":"grace@example.com","createdAtMs":1}
+JSON
+printf '%s\n' '{"ev":"logged-in","email":"grace@example.com"}'
+exit 0
+"#,
+    )
+    .expect("fake shim");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    unsafe { std::env::set_var("CURSOR_SDK_SHIM_EXECUTABLE", &shim) };
+
+    let start = accounts
+        .start_login(HarnessId::Cursor)
+        .await
+        .expect("start");
+    assert_eq!(start.mode, AgentLoginMode::Browser);
+    assert_eq!(start.url, "https://cursor.com/loginDeepControl?challenge=fake");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let poll = accounts.poll_login(&start.login_id).await.expect("poll");
+        match poll.status {
+            AgentLoginStatus::Done => break,
+            AgentLoginStatus::Pending => {}
+            AgentLoginStatus::Error => panic!("login errored: {:?}", poll.message),
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "login never landed"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // First connect on a device with no live login: the minted key was
+    // auto-activated, so runs work immediately.
+    let live: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&config.cursor_sdk_auth_file).unwrap())
+            .unwrap();
+    assert_eq!(live["email"], "grace@example.com");
+    let snapshot = accounts.list(false).await.expect("list");
+    assert_eq!(
+        account_emails(&snapshot, HarnessId::Cursor),
+        vec![("grace@example.com".to_string(), true)]
+    );
 }

--- a/crates/harness/src/cursor/mod.rs
+++ b/crates/harness/src/cursor/mod.rs
@@ -108,7 +108,7 @@ impl CursorHarness {
     /// (program, args) for the shim process: the test override, or node
     /// running the shim inside the managed SDK install (installing it on
     /// first use).
-    async fn resolve_shim(&self) -> Result<(PathBuf, Vec<String>), HarnessError> {
+    pub async fn resolve_shim(&self) -> Result<(PathBuf, Vec<String>), HarnessError> {
         if let Some(p) = &self.executable {
             return Ok((p.clone(), Vec::new()));
         }
@@ -123,6 +123,20 @@ impl CursorHarness {
                 .await?;
         crate::adapter_install::launch_for_entry(&shim)
     }
+}
+
+/// A ready-to-spawn command for the shim's LOGIN mode: the SDK's PKCE
+/// browser flow, minting the key into `store_path` (never the live
+/// `~/.cursor/sdk/auth.json` — the engine snapshots the store file as an
+/// account slot). Emits `{"ev":"auth-url"}` then `{"ev":"logged-in"}` /
+/// `{"ev":"fatal"}` JSONL on stdout; kill to cancel.
+pub async fn login_command(store_path: &std::path::Path) -> Result<Command, HarnessError> {
+    let (exe, args) = CursorHarness::default().resolve_shim().await?;
+    let mut cmd = Command::new(&exe);
+    cmd.args(&args);
+    crate::compose_child_path(&mut cmd, &exe);
+    cmd.arg("login").arg(store_path);
+    Ok(cmd)
 }
 
 #[async_trait]

--- a/crates/harness/src/cursor/shim.mjs
+++ b/crates/harness/src/cursor/shim.mjs
@@ -23,9 +23,18 @@
 //     {"ev":"turn","status":"finished"|"error"|"cancelled","error"?}
 //     {"ev":"fatal","message"}              unrecoverable (auth, SDK init)
 //
+// Login mode (`node <shim> login <store-path>`): no stdin protocol — runs the
+// SDK's PKCE browser flow (`Cursor.auth.login`) writing the minted key to
+// <store-path> instead of the live `~/.cursor/sdk/auth.json` (the engine
+// snapshots it as an account slot, mirroring codex's throwaway CODEX_HOME).
+//   stdout: {"ev":"auth-url","url"}         open/show this to the user
+//           {"ev":"logged-in","email"?,"expiresAtMs"?}   then exit 0
+//           {"ev":"fatal","message"}                     then exit 1
+//
 // Unknown SDK update kinds are ignored (never fatal): the SDK is beta and
 // its delta union grows; the engine treats a degraded stream as chip-only.
 
+import os from "node:os";
 import readline from "node:readline";
 
 const out = (o) => process.stdout.write(JSON.stringify(o) + "\n");
@@ -40,7 +49,32 @@ try {
 } catch (e) {
   fatal(`@cursor/sdk failed to load: ${e?.message ?? e}`);
 }
-const { Agent, Cursor } = sdk;
+const { Agent, Cursor, FileCredentialStore } = sdk;
+
+// ---- login mode -----------------------------------------------------------
+// The browser flow never opens a browser itself (the engine may be headless;
+// the URL can be opened on whichever device is viewing the app), and the
+// minted key lands in the engine-chosen store file, never the live login.
+if (process.argv[2] === "login") {
+  const storePath = process.argv[3];
+  if (!storePath) fatal("login mode needs a store path");
+  try {
+    const result = await Cursor.auth.login({
+      openBrowser: false,
+      onLoginUrl: (url) => out({ ev: "auth-url", url }),
+      store: new FileCredentialStore(storePath),
+      apiKeyName: `zeron — ${os.hostname()}`,
+    });
+    out({
+      ev: "logged-in",
+      ...(result?.email ? { email: result.email } : {}),
+      ...(result?.apiKeyExpiresAtMs ? { expiresAtMs: result.apiKeyExpiresAtMs } : {}),
+    });
+    process.exit(0);
+  } catch (e) {
+    fatal(`cursor login failed: ${e?.message ?? e}`);
+  }
+}
 
 let agent = null;
 let run = null;
@@ -115,8 +149,8 @@ function withAuthHint(message) {
   if (/api key|not authenticated|unauthorized/i.test(text)) {
     return (
       text +
-      " — the Cursor SDK's login is separate from `cursor-agent login`: " +
-      "set CURSOR_API_KEY (from cursor.com/settings) in zeron's environment."
+      " — connect Cursor in Settings → Accounts (its login is separate from " +
+      "`cursor-agent login`), or set CURSOR_API_KEY from cursor.com/settings."
     );
   }
   return text;
@@ -179,9 +213,9 @@ async function start(msg) {
     const auth = await Cursor.auth.status().catch(() => null);
     if (!process.env.CURSOR_API_KEY && auth?.status !== "logged-in") {
       fatal(
-        "Cursor SDK is not authenticated (its login is separate from " +
-          "`cursor-agent login`): set CURSOR_API_KEY from cursor.com/settings, " +
-          `then retry. (${e?.message ?? e})`,
+        "Cursor is not connected (its login is separate from " +
+          "`cursor-agent login`): connect it in Settings → Accounts, or set " +
+          `CURSOR_API_KEY from cursor.com/settings, then retry. (${e?.message ?? e})`,
       );
     }
     fatal(`cursor agent failed to start: ${e?.message ?? e}`);

--- a/crates/ui/src/settings/accounts.rs
+++ b/crates/ui/src/settings/accounts.rs
@@ -1,5 +1,5 @@
 //! Settings → Agents / accounts (feature-inventory §1.9): provider cards
-//! (Claude Code, Codex) with account rows — email, plan badge, Active, usage
+//! (Claude Code, Codex, Cursor) with account rows — email, plan badge, Active, usage
 //! meters (indigo → amber ≥80% → red ≥95%, reset time), Switch / Forget — plus
 //! the add-account dialogs (paste-code and browser-poll flows) and
 //! account-shaped loading skeletons. Zeron retargets devices from the settings
@@ -112,9 +112,10 @@ pub fn format_reset(resets_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> Opt
 
 /// The provider cards, in display order: (harness, name, CLI command — named
 /// in the empty-state copy, zeron settings.agents.tsx `PROVIDERS`).
-pub const PROVIDERS: [(HarnessId, &str, &str); 2] = [
+pub const PROVIDERS: [(HarnessId, &str, &str); 3] = [
     (HarnessId::ClaudeCode, "Claude Code", "claude"),
     (HarnessId::Codex, "Codex", "codex"),
+    (HarnessId::Cursor, "Cursor", "cursor-agent"),
 ];
 
 /// Accounts of one provider, active first (stable otherwise). Pure.
@@ -164,6 +165,7 @@ impl LoginFlow {
         };
         match harness {
             HarnessId::Codex => "Add Codex account",
+            HarnessId::Cursor => "Connect Cursor",
             _ => "Add Claude account",
         }
     }
@@ -1023,21 +1025,28 @@ impl AccountsPage {
                     .into_any_element()
             }
             LoginFlow::Browser {
+                harness,
                 start,
                 message,
                 error,
-                ..
             } => {
                 let has_error = error.is_some();
+                let body = match harness {
+                    HarnessId::Cursor => {
+                        "Finish signing in to Cursor in your browser. This mints a \
+                         zeron-named API key you can revoke any time from Cursor's \
+                         dashboard — it is separate from `cursor-agent login`."
+                    }
+                    _ => {
+                        "Finish signing in to OpenAI in your browser. The new login is \
+                         captured in an isolated profile — your current session is untouched \
+                         until you switch."
+                    }
+                };
                 div()
                     .flex()
                     .flex_col()
-                    .child(div().mt(px(8.0)).child(popover::dialog_body(
-                        &theme,
-                        "Finish signing in to OpenAI in your browser. The new login is \
-                         captured in an isolated profile — your current session is untouched \
-                         until you switch.",
-                    )))
+                    .child(div().mt(px(8.0)).child(popover::dialog_body(&theme, body)))
                     .child(url_link(
                         "login-open-url-browser",
                         "Reopen the sign-in page",
@@ -1233,6 +1242,7 @@ impl Render for AccountsPage {
                 .map(|(harness, name, _cli)| {
                     let skeleton_id = match harness {
                         HarnessId::Codex => "accounts-skeleton-codex",
+                        HarnessId::Cursor => "accounts-skeleton-cursor",
                         _ => "accounts-skeleton-claude",
                     };
                     div()
@@ -1319,6 +1329,19 @@ impl Render for AccountsPage {
                             .collect();
                         let add_id: SharedString = format!("add-account-{name}").into();
                         let card = widgets::section_card(&theme).mt(px(8.0));
+                        let empty_copy = match harness {
+                            // Cursor's app login is SEPARATE from `cursor-agent
+                            // login` — pointing at the CLI would send users to a
+                            // sign-in that does not light this up.
+                            HarnessId::Cursor => format!(
+                                "{name} isn't connected on this device — connect it to run \
+                                 Cursor sessions."
+                            ),
+                            _ => format!(
+                                "No {name} login detected on this device — sign in \
+                                 with \u{201C}{cli}\u{201D} or add an account."
+                            ),
+                        };
                         let card = if rows.is_empty() {
                             card.child(
                                 div()
@@ -1327,10 +1350,7 @@ impl Render for AccountsPage {
                                     .text_center()
                                     .text_size(px(14.0))
                                     .text_color(theme.text_muted.opacity(0.6))
-                                    .child(SharedString::from(format!(
-                                        "No {name} login detected on this device — sign in \
-                                         with \u{201C}{cli}\u{201D} or add an account."
-                                    ))),
+                                    .child(SharedString::from(empty_copy)),
                             )
                         } else {
                             card.children(rows)
@@ -1419,9 +1439,9 @@ impl Render for AccountsPage {
                     )
                     .child(widgets::page_subtitle(
                         &theme,
-                        "The Claude Code and Codex logins on this device. Zeron detects the \
-                         live session, keeps each account backed up, and can swap between \
-                         them.",
+                        "The Claude Code, Codex, and Cursor logins on this device. Zeron \
+                         detects the live session, keeps each account backed up, and can \
+                         swap between them.",
                     ))
                     .when_some(self.error.clone(), |el, message| {
                         el.child(


### PR DESCRIPTION
## What

The #136 move to `@cursor/sdk` left cursor effectively broken for real users: runs need `CURSOR_API_KEY`, the SDK's credentials are separate from `cursor-agent login`, and our only guidance was an error chip pointing at cursor.com/settings. This makes cursor connectable from inside the app — no manual key handling.

## The unlock

`@cursor/sdk` 1.0.28 ships its own PKCE browser login (`Cursor.auth.{login,status,logout}`, same flow as the Cursor CLI): it mints a **named, revocable, 90-day user API key**, persists it to `~/.cursor/sdk/auth.json` (0600), and exposes `openBrowser:false` + `onLoginUrl` specifically for embedders. The separation from `cursor-agent login` is deliberate credential scoping (narrow key vs whole-account session tokens), so we drive the SDK's flow rather than fighting it.

## How

- **Shim login mode** (`node <shim> login <store-path>`): runs `Cursor.auth.login` headlessly, streams `{"ev":"auth-url"}` → `"logged-in"`/`"fatal"` JSONL. The minted key lands in an engine-chosen throwaway store file — never the live login (codex's throwaway-`CODEX_HOME` pattern). Keys are dashboard-named `zeron — <hostname>` for recognizability/revocation.
- **Accounts integration**: cursor becomes a full provider in `agent_accounts` — detection reads the SDK's `StoredSdkCredentials` (email + key expiry on the card; an expired key shows "Key expired" + a warning strip instead of failing runs mysteriously), slots snapshot the store file, switching rewrites it. The codex login machinery is generalized (`LoginFlow::Codex` → `LoginFlow::Spawned` + shared child wiring) rather than duplicated.
- **First-connect auto-activation**: when no usable live login exists, the minted key becomes live immediately — the page CTA is "connect so runs work", not "add a spare". An existing live login is never clobbered; switching stays explicit (codex parity).
- **UI**: Cursor card on Settings → Accounts ("Connect Cursor", browser-poll dialog with cursor-specific copy), and run-time auth errors now point at Settings → Accounts (env `CURSOR_API_KEY` still wins as the headless/CI override).

Multi-device note: the login URL can be opened on whatever device is viewing the app — the poll runs on the run device, so headless run hosts connect fine.

## Testing

- Engine integration tests: cursor slot-swap round trip (detect → snapshot → second login → switch back → expired-key warning) and the full login flow against a fake shim via the `CURSOR_SDK_SHIM_EXECUTABLE` seam (auth-url surfaces, poll lands Done, auto-activation writes the live store).
- Unit tests: `StoredSdkCredentials` parsing/expiry gating, shim JSONL scans.
- Live: the real shim in login mode against the real SDK emits the `cursor.com/loginDeepControl` URL immediately and polls the backend (aborted before completion — no account on this box). **The one thing not exercised end-to-end is a real browser completion**; first manual connect will confirm the mint + auto-activate path that the fake-shim test simulates.
- Full workspace suite green (50 binaries).

## Notes

- First-ever connect on a device runs the managed `npm` install of the pinned SDK inside StartAgentLogin, so the dialog can take a few extra seconds to produce the URL that one time.
- No usage meters for cursor yet — the SDK exposes per-run token/cost, not plan windows; the card shows key expiry instead.
- `askQuestion` answer-channel gap from #136 is unrelated and remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789657035&installation_model_id=425430&pr_number=152&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F152&signature=0f4c3e2b199ffab0604cbf4bda930fe5d2b300c92ec0c05e8125d2ea88e477bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->