### PR TITLE
cursor: live model discovery + typed model options actually applied

### DIFF
--- a/crates/harness/examples/cursor_models_probe.rs
+++ b/crates/harness/examples/cursor_models_probe.rs
@@ -1,0 +1,16 @@
+//! Live probe: real cursor model discovery through the harness path.
+use zeron_harness::{CursorHarness, Harness};
+
+#[tokio::main]
+async fn main() {
+    let models = CursorHarness::new().models().await.expect("models");
+    println!("count={}", models.len());
+    for m in models.iter().take(6) {
+        let opts: Vec<String> = m
+            .options
+            .iter()
+            .map(|o| format!("{}[{}→{}]", o.id, o.choices.len(), o.default_choice))
+            .collect();
+        println!("{} | {} | {}", m.id, m.label, opts.join(" "));
+    }
+}

--- a/crates/harness/src/cursor/mod.rs
+++ b/crates/harness/src/cursor/mod.rs
@@ -77,6 +77,9 @@ pub struct CursorHarness {
     executable: Option<PathBuf>,
     interrupt_grace: Duration,
     kill_grace: Duration,
+    /// Discovery cache: only a successful, non-empty catalog is cached, so a
+    /// failed probe (offline, SDK churn) retries on the next picker open.
+    models_cache: tokio::sync::OnceCell<Vec<Model>>,
 }
 
 impl Default for CursorHarness {
@@ -85,6 +88,7 @@ impl Default for CursorHarness {
             executable: None,
             interrupt_grace: Duration::from_secs(2),
             kill_grace: Duration::from_secs(3),
+            models_cache: tokio::sync::OnceCell::new(),
         }
     }
 }
@@ -103,6 +107,38 @@ impl CursorHarness {
         self.interrupt_grace = interrupt_grace;
         self.kill_grace = kill_grace;
         self
+    }
+
+    /// Spawn the shim in models mode and map its one catalog frame.
+    async fn discover_models(&self) -> Result<Vec<Model>, HarnessError> {
+        let (exe, args) = self.resolve_shim().await?;
+        let mut cmd = Command::new(&exe);
+        cmd.args(&args);
+        crate::compose_child_path(&mut cmd, &exe);
+        cmd.arg("models")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+        let run = async {
+            let output = cmd
+                .output()
+                .await
+                .map_err(|e| HarnessError::Protocol(format!("cursor models probe: {e}")))?;
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let items = stdout
+                .lines()
+                .filter_map(|line| serde_json::from_str::<Value>(line.trim()).ok())
+                .find(|v| v.get("ev").and_then(Value::as_str) == Some("models"))
+                .and_then(|v| v.get("items").cloned())
+                .ok_or_else(|| {
+                    HarnessError::Protocol("cursor models probe returned no catalog".into())
+                })?;
+            Ok::<_, HarnessError>(map_model_items(&items))
+        };
+        tokio::time::timeout(Duration::from_secs(15), run)
+            .await
+            .map_err(|_| HarnessError::Protocol("cursor models probe timed out".into()))?
     }
 
     /// (program, args) for the shim process: the test override, or node
@@ -169,43 +205,21 @@ impl Harness for CursorHarness {
         true
     }
 
-    /// Static catalog (the SDK's `Cursor.models.list()` needs its own auth;
-    /// well-known public ids keep the picker useful without it).
+    /// Live catalog via the shim's models mode (`Cursor.models.list()` —
+    /// public, no auth; verified live on 1.0.28). Falls back to a minimal
+    /// static pair when the probe fails, UNCACHED so the next picker open
+    /// retries.
     async fn models(&self) -> Result<Vec<Model>, HarnessError> {
-        Ok(vec![
-            Model {
-                id: "auto".into(),
-                label: "Auto".into(),
-                description: Some("Cursor picks the model per request".into()),
-                reasoning_levels: Vec::new(),
-                options: vec![ModelOption {
-                    id: "optimizeFor".into(),
-                    label: "Optimize for".into(),
-                    choices: vec![
-                        ModelOptionChoice {
-                            id: "balanced".into(),
-                            label: "Balanced".into(),
-                        },
-                        ModelOptionChoice {
-                            id: "speed".into(),
-                            label: "Speed".into(),
-                        },
-                        ModelOptionChoice {
-                            id: "intelligence".into(),
-                            label: "Intelligence".into(),
-                        },
-                    ],
-                    default_choice: "balanced".into(),
-                }],
-            },
-            Model {
-                id: "composer-2.5".into(),
-                label: "Composer 2.5".into(),
-                description: Some("Cursor's own fast coding model".into()),
-                reasoning_levels: Vec::new(),
-                options: Vec::new(),
-            },
-        ])
+        if let Some(models) = self.models_cache.get() {
+            return Ok(models.clone());
+        }
+        match self.discover_models().await {
+            Ok(models) if !models.is_empty() => {
+                let _ = self.models_cache.set(models.clone());
+                Ok(models)
+            }
+            Ok(_) | Err(_) => Ok(static_models()),
+        }
     }
 
     async fn run(
@@ -259,6 +273,9 @@ impl Harness for CursorHarness {
             "prompt": request.prompt,
             "cwd": request.cwd,
             "model": request.model,
+            // Typed parameter picks (thinking/context/effort/fast/…) — the
+            // shim folds them into the SDK's ModelSelection params.
+            "modelOptions": request.model_options,
             "resume": request.resume,
         });
         let _ = stdin_tx.send(first.to_string());
@@ -282,6 +299,111 @@ impl Harness for CursorHarness {
         })
         .boxed())
     }
+}
+
+/// The fallback pair when discovery fails: well-known ids that resolve as
+/// aliases in Cursor's real catalog, so a degraded picker still runs.
+fn static_models() -> Vec<Model> {
+    vec![
+        Model {
+            id: "auto".into(),
+            label: "Auto".into(),
+            description: Some("Cursor picks the model per request".into()),
+            reasoning_levels: Vec::new(),
+            options: Vec::new(),
+        },
+        Model {
+            id: "composer-2.5".into(),
+            label: "Composer 2.5".into(),
+            description: Some("Cursor's own fast coding model".into()),
+            reasoning_levels: Vec::new(),
+            options: Vec::new(),
+        },
+    ]
+}
+
+/// `Cursor.models.list()` items → picker models. Item shape (1.0.28
+/// `options.d.ts` `ModelListItem`): `{id, displayName, description?,
+/// aliases?, parameters?: [{id, displayName?, values: [{value,
+/// displayName?}]}], variants?: [{params: [{id, value}], isDefault?}]}`.
+fn map_model_items(items: &Value) -> Vec<Model> {
+    let str_of = |v: &Value, key: &str| -> Option<String> {
+        v.get(key)
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+    };
+    items
+        .as_array()
+        .map(|a| a.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|item| {
+            let id = str_of(item, "id")?;
+            // `default` is a bare alias twin of the parameterized Auto entry
+            // (`auto-smart`) — two "Auto" rows would just confuse the picker.
+            if id == "default" {
+                return None;
+            }
+            let label = str_of(item, "displayName").unwrap_or_else(|| id.clone());
+            // A variant marked default carries the catalog's preferred value
+            // for each parameter (e.g. Auto's optimize_for=balanced).
+            let default_variant = item
+                .get("variants")
+                .and_then(Value::as_array)
+                .map(|a| a.as_slice())
+                .unwrap_or_default()
+                .iter()
+                .find(|v| v.get("isDefault").and_then(Value::as_bool) == Some(true))
+                .and_then(|v| v.get("params").and_then(Value::as_array).cloned())
+                .unwrap_or_default();
+            let options: Vec<ModelOption> = item
+                .get("parameters")
+                .and_then(Value::as_array)
+                .map(|a| a.as_slice())
+                .unwrap_or_default()
+                .iter()
+                .filter_map(|p| {
+                    let pid = str_of(p, "id")?;
+                    let choices: Vec<ModelOptionChoice> = p
+                        .get("values")
+                        .and_then(Value::as_array)
+                        .map(|a| a.as_slice())
+                        .unwrap_or_default()
+                        .iter()
+                        .filter_map(|c| {
+                            let cid = str_of(c, "value")?;
+                            Some(ModelOptionChoice {
+                                label: str_of(c, "displayName").unwrap_or_else(|| cid.clone()),
+                                id: cid,
+                            })
+                        })
+                        .collect();
+                    if choices.is_empty() {
+                        return None;
+                    }
+                    let default_choice = default_variant
+                        .iter()
+                        .find(|dv| dv.get("id").and_then(Value::as_str) == Some(pid.as_str()))
+                        .and_then(|dv| str_of(dv, "value"))
+                        .unwrap_or_else(|| choices[0].id.clone());
+                    Some(ModelOption {
+                        label: str_of(p, "displayName").unwrap_or_else(|| pid.clone()),
+                        id: pid,
+                        choices,
+                        default_choice,
+                    })
+                })
+                .collect();
+            Some(Model {
+                id,
+                label,
+                description: str_of(item, "description"),
+                reasoning_levels: Vec::new(),
+                options,
+            })
+        })
+        .collect()
 }
 
 async fn stdin_writer(mut stdin: ChildStdin, mut rx: mpsc::UnboundedReceiver<String>) {

--- a/crates/harness/src/cursor/shim.mjs
+++ b/crates/harness/src/cursor/shim.mjs
@@ -11,7 +11,7 @@
 //
 // Protocol: JSONL, one frame per line.
 //   stdin  (engine → shim):
-//     {"op":"run","prompt","cwd","model"?,"resume"?}   start / first turn
+//     {"op":"run","prompt","cwd","model"?,"modelOptions"?,"resume"?}   start / first turn
 //     {"op":"user","prompt"}                            next turn (parked)
 //     {"op":"interrupt"}                                cancel the live run
 //   stdout (shim → engine):
@@ -22,6 +22,9 @@
 //     {"ev":"usage","input","output"}
 //     {"ev":"turn","status":"finished"|"error"|"cancelled","error"?}
 //     {"ev":"fatal","message"}              unrecoverable (auth, SDK init)
+//
+// Models mode (`node <shim> models`): prints {"ev":"models","items":[…]} —
+// the live `Cursor.models.list()` catalog — and exits.
 //
 // Login mode (`node <shim> login <store-path>`): no stdin protocol — runs the
 // SDK's PKCE browser flow (`Cursor.auth.login`) writing the minted key to
@@ -50,6 +53,21 @@ try {
   fatal(`@cursor/sdk failed to load: ${e?.message ?? e}`);
 }
 const { Agent, Cursor, FileCredentialStore } = sdk;
+
+// ---- models mode ----------------------------------------------------------
+// `node <shim> models`: print the live catalog (`Cursor.models.list()` — no
+// auth required, verified live on 1.0.28) as one frame and exit. The harness
+// maps items (id/displayName/parameters/variants) into its picker models.
+if (process.argv[2] === "models") {
+  try {
+    const listed = await Cursor.models.list();
+    const items = Array.isArray(listed) ? listed : (listed?.items ?? []);
+    out({ ev: "models", items });
+    process.exit(0);
+  } catch (e) {
+    fatal(`cursor model discovery failed: ${e?.message ?? e}`);
+  }
+}
 
 // ---- login mode -----------------------------------------------------------
 // The browser flow never opens a browser itself (the engine may be headless;
@@ -193,8 +211,26 @@ async function runTurn(prompt) {
   });
 }
 
+// The run's ModelSelection: id + typed parameter values (thinking / context /
+// effort / fast / optimize_for — ids from the discovered catalog). Legacy
+// sessions may still carry the pre-discovery static option ("optimizeFor",
+// choice "speed") — translate rather than send an id the backend never knew.
+function modelSelection(msg) {
+  const id = msg.model || "auto";
+  const params = [];
+  for (const [key, value] of Object.entries(msg.modelOptions ?? {})) {
+    if (typeof value !== "string" || !value) continue;
+    if (key === "optimizeFor") {
+      params.push({ id: "optimize_for", value: value === "speed" ? "cost" : value });
+    } else {
+      params.push({ id: key, value });
+    }
+  }
+  return params.length ? { id, params } : { id };
+}
+
 async function start(msg) {
-  const model = msg.model ? { id: msg.model } : { id: "auto" };
+  const model = modelSelection(msg);
   const options = {
     model,
     // askQuestion has no public answer channel in this SDK (SDKRequestMessage

--- a/crates/harness/tests/cursor.rs
+++ b/crates/harness/tests/cursor.rs
@@ -288,3 +288,30 @@ async fn shim_crash_mid_run_reports_stderr_tail() {
         other => panic!("expected errored done, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn model_discovery_maps_the_live_catalog() {
+    let models = harness().models().await.expect("models");
+    // Parameterized Auto first; its bare `default` alias twin skipped.
+    assert_eq!(models.len(), 2, "{models:?}");
+    assert_eq!(models[0].id, "auto-smart");
+    assert_eq!(models[0].label, "Auto");
+    let optimize = &models[0].options[0];
+    assert_eq!(optimize.id, "optimize_for");
+    assert_eq!(optimize.label, "Optimize For");
+    assert_eq!(
+        optimize
+            .choices
+            .iter()
+            .map(|c| c.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["intelligence", "balanced", "cost"]
+    );
+    // The default comes from the isDefault variant, not the first value.
+    assert_eq!(optimize.default_choice, "balanced");
+    assert_eq!(models[1].id, "claude-fable-5");
+    assert_eq!(models[1].description.as_deref(), Some("Anthropic frontier"));
+    // A parameter without displayName labels by id; default = first value.
+    assert_eq!(models[1].options[0].id, "thinking");
+    assert_eq!(models[1].options[0].default_choice, "enabled");
+}

--- a/crates/harness/tests/fixtures/fake-cursor-shim.sh
+++ b/crates/harness/tests/fixtures/fake-cursor-shim.sh
@@ -5,6 +5,14 @@
 
 emit() { printf '%s\n' "$1"; }
 
+# Models mode (argv, no stdin protocol): one catalog frame, real 1.0.28
+# shapes — parameterized Auto + its bare `default` alias twin (skipped by the
+# harness) + a plain model.
+if [ "$1" = "models" ]; then
+  emit '{"ev":"models","items":[{"id":"auto-smart","displayName":"Auto","parameters":[{"id":"optimize_for","displayName":"Optimize For","values":[{"value":"intelligence","displayName":"Intelligence"},{"value":"balanced","displayName":"Balance"},{"value":"cost","displayName":"Cost"}]}],"variants":[{"params":[{"id":"optimize_for","value":"balanced"}],"displayName":"Auto","isDefault":true}]},{"id":"default","displayName":"Auto","aliases":["auto"]},{"id":"claude-fable-5","displayName":"Claude Fable 5","description":"Anthropic frontier","parameters":[{"id":"thinking","values":[{"value":"enabled"},{"value":"disabled"}]}]}]}'
+  exit 0
+fi
+
 read -r first || exit 1
 case "$first" in
 *'"op":"run"'*) ;;


### PR DESCRIPTION
## What

The cursor model picker showed only Auto + Composer 2.5. That was #136's static catalog, built on the assumption that `Cursor.models.list()` needs its own auth — **it doesn't** (verified live on 1.0.28, logged out): the endpoint publicly returns the full catalog — 37 models with typed parameter definitions (`thinking`, `context` 1M, `effort`, `reasoning`, `fast`, Auto's `optimize_for`), display names, aliases, and default variants.

## How

- **Shim `models` mode**: prints the live `Cursor.models.list()` catalog as one JSONL frame (same argv-mode pattern as `login`).
- **`CursorHarness::models()`**: spawns it with a 15s bound and maps `ModelListItem` → picker `Model` — parameters become `ModelOption` choice sets with display names, `isDefault` variants set the default choice, and the bare `default` alias twin of the parameterized Auto entry is skipped (two "Auto" rows). Non-empty catalogs cache per-process; failures fall back to a minimal static pair, uncached so the next picker open retries.
- **Model options now actually apply.** Found while wiring this: the run frame never carried `model_options`, so the old static "Optimize for" choice was pure picker decoration. The run frame now includes them and the shim folds them into the SDK's `ModelSelection.params`. Legacy stored `optimizeFor`/`speed` picks translate to `optimize_for`/`cost` rather than sending ids the backend never knew.

## Testing

- Fake-shim models mode with real 1.0.28 shapes: mapping, default-variant → default choice, `default`-twin skip, label fallbacks.
- Live end-to-end through the real harness path (real node + managed SDK): 36 models with options and catalog defaults — `claude-opus-5 | thinking[2→true] context[2→1m] effort[5→high] fast[2→false]` etc. Probe kept at `examples/cursor_models_probe.rs` for pin-bump revalidation.
- Full harness suite green (117 tests).

## Notes

- Discovery is one extra shim spawn on first picker open per process (~1-2s, then cached). If the SDK later gates the endpoint behind auth, the fallback pair keeps the picker functional and the error path is the same as today.
- Whether a chosen model/param combo is *entitled* for the connected account is enforced at run time by Cursor's backend, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789659346&installation_model_id=425430&pr_number=153&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F153&signature=29f3ada8ed16c75cc0a4edd4a080fae846ddc09f6efe527abeb51ddc87d22bcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->