### PR TITLE
cursor: isolate each SDK run's agent store — concurrent runs no longer lock

### DIFF
--- a/crates/harness/src/cursor/shim.mjs
+++ b/crates/harness/src/cursor/shim.mjs
@@ -37,7 +37,10 @@
 // Unknown SDK update kinds are ignored (never fatal): the SDK is beta and
 // its delta union grows; the engine treats a degraded stream as chip-only.
 
+import crypto from "node:crypto";
+import fs from "node:fs";
 import os from "node:os";
+import path from "node:path";
 import readline from "node:readline";
 
 const out = (o) => process.stdout.write(JSON.stringify(o) + "\n");
@@ -52,7 +55,57 @@ try {
 } catch (e) {
   fatal(`@cursor/sdk failed to load: ${e?.message ?? e}`);
 }
-const { Agent, Cursor, FileCredentialStore } = sdk;
+const { Agent, Cursor, FileCredentialStore, JsonlLocalAgentStore } = sdk;
+
+// ---- per-run agent store --------------------------------------------------
+// The SDK's default local store is SQLite keyed by WORKSPACE
+// (`getDefaultSdkStateRoot(cwd)`), designed for one process per workspace.
+// Zeron runs concurrent shims on the same cwd as a matter of course — the
+// chat turn and its title generation start together, and two chats can share
+// a worktree — and the second `Agent.create` dies with "database is locked"
+// (reproduced live, 1.0.28). The shared-root JSONL backend is no better: its
+// writes are only serialized process-WIDE and updates rewrite whole files.
+//
+// So each run gets its OWN JsonlLocalAgentStore directory (one agent per
+// store — the "huge catalog" caveat never applies), and a one-writer marker
+// file maps agentId → store dir so `Agent.resume` from a later process finds
+// it. Agents created before this scheme have no marker and fall back to the
+// SDK default store, which is where they live.
+const STATE_BASE =
+  process.env.ZERON_CURSOR_STATE_DIR || path.join(os.homedir(), ".zeron", "cursor-state");
+
+function agentDirMarker(agentId) {
+  return path.join(STATE_BASE, "by-agent", String(agentId));
+}
+
+function newRunStore() {
+  const dir = path.join(STATE_BASE, "agents", crypto.randomUUID());
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return { dir, store: new JsonlLocalAgentStore(dir) };
+}
+
+function storeForResume(agentId) {
+  try {
+    const dir = fs.readFileSync(agentDirMarker(agentId), "utf8").trim();
+    if (dir && fs.existsSync(dir)) return { dir, store: new JsonlLocalAgentStore(dir) };
+  } catch {
+    // No marker: a pre-isolation agent living in the SDK's default store.
+  }
+  return null;
+}
+
+function rememberAgentDir(agentId, dir) {
+  try {
+    const marker = agentDirMarker(agentId);
+    fs.mkdirSync(path.dirname(marker), { recursive: true, mode: 0o700 });
+    const tmp = `${marker}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, dir);
+    fs.renameSync(tmp, marker);
+  } catch {
+    // Fail soft: the run still works; only a future resume degrades to the
+    // default store (and surfaces as a fresh session, not a crash).
+  }
+}
 
 // ---- models mode ----------------------------------------------------------
 // `node <shim> models`: print the live catalog (`Cursor.models.list()` — no
@@ -231,13 +284,29 @@ function modelSelection(msg) {
 
 async function start(msg) {
   const model = modelSelection(msg);
+  const local = { cwd: msg.cwd || process.cwd(), enableAgentRetries: true };
+  // Isolated per-run store (see the header above). Resume looks the agent's
+  // store up by marker; a markerless (pre-isolation) agent resumes from the
+  // SDK's default store exactly as before.
+  let runDir = null;
+  if (msg.resume) {
+    const found = storeForResume(msg.resume);
+    if (found) {
+      local.store = found.store;
+      runDir = found.dir;
+    }
+  } else {
+    const fresh = newRunStore();
+    local.store = fresh.store;
+    runDir = fresh.dir;
+  }
   const options = {
     model,
     // askQuestion has no public answer channel in this SDK (SDKRequestMessage
     // carries only a request id) — a question would block the run forever.
     // generateImage has nowhere to land in a zeron session (ACP parity).
     disallowedTools: ["askQuestion", "generateImage"],
-    local: { cwd: msg.cwd || process.cwd(), enableAgentRetries: true },
+    local,
   };
   try {
     agent = msg.resume
@@ -256,6 +325,7 @@ async function start(msg) {
     }
     fatal(`cursor agent failed to start: ${e?.message ?? e}`);
   }
+  if (runDir) rememberAgentDir(agent.agentId, runDir);
   out({ ev: "ready", agentId: agent.agentId, model: agent.model?.id ?? model.id });
   await runTurn(msg.prompt ?? "");
 }


### PR DESCRIPTION
## The bug

"cursor agent failed to start: database is locked" on a normal chat send. The user's hypothesis was right in substance: the title-generation run and the chat turn start two shim processes concurrently on the same cwd. The SDK's default local store is SQLite keyed by **workspace** (`getDefaultSdkStateRoot(cwd)`, "open once per workspace and reuse" per its own docs) — the second `Agent.create` finds `index.db` locked and dies. Reproduced live: 3 concurrent shims on one cwd → one `ready`, two fatal with exactly the reported error. Note it's broader than titling — two chats sharing a worktree collide the same way, and whichever process loses the race errors (in the report, the user-facing chat lost to the title run).

## Why not the literal suggestion

The floated fix was "separate stateRoot or use the JSONL store." A **shared** JSONL store doesn't survive scrutiny: `JsonlLocalAgentStore` documents process-wide (not cross-process) write serialization and rewrites whole files on update — that trades a clean lock error for silent corruption. And a bare per-run stateRoot breaks `Agent.resume`: the agent's state lives in whichever store created it, so a later process must be able to find that store.

## The fix

Both halves combined, per-run + findable:

- Every run gets its **own** `JsonlLocalAgentStore` directory under `~/.zeron/cursor-state/agents/<uuid>/`. One agent per store — the JSONL backend's small-catalog caveat never applies, concurrent runs never touch each other's files, and the native `sqlite3` dependency drops out of the picture.
- After `Agent.create`, a marker file (`by-agent/<agentId>` → store dir, atomic tmp+rename, single writer) records where the agent lives. `Agent.resume` looks the marker up in a fresh process.
- Agents created **before** this scheme have no marker and resume from the SDK default store — exactly where they live, so existing sessions restore unchanged.
- `ZERON_CURSOR_STATE_DIR` overrides the base for tests.

## Validation (live, real SDK 1.0.28)

- Before: 3 concurrent creates, same cwd → 1 ready / 2 × "database is locked".
- After: 4 concurrent creates, same cwd → 4 × ready, per-run dirs + markers on disk.
- Resume: fresh shim process resumes a marker'd agentId from its isolated store → ready with the same id; markerless resume routes to the default store (legacy path).
- Full harness suite green (117 tests).

## Notes

- Store dirs accumulate one small JSONL dir per agent (chat session); no GC yet — same posture as the CLIs' own session state. Candidate for a later sweep.
- Title runs get isolated stores too and are never resumed; their dirs are just part of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789661156&installation_model_id=425430&pr_number=154&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F154&signature=e8866131c4ed963a3ad723ecf2f9845db91d6c1fddc0e23f8d486ac5cda18290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->