### PR TITLE
Add a context-window usage ring to the conversation composer

### DIFF
--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -407,9 +407,10 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
             }
         }
         // AvailableCommands feeds the engine's per-harness command cache, not
-        // the transcript.
+        // the transcript. ContextUsage feeds live session context indicators.
         AgentEvent::AssistantMessageCompleted { .. }
         | AgentEvent::Usage { .. }
+        | AgentEvent::ContextUsage { .. }
         | AgentEvent::AvailableCommands { .. } => {}
     }
 }

--- a/crates/doc/src/registry.rs
+++ b/crates/doc/src/registry.rs
@@ -1082,13 +1082,23 @@ impl RegistryDoc {
     /// Upsert a session-status row (writer discipline: each device writes only
     /// its own runs' rows). Staleness is checked client-side via `updatedAt`.
     pub fn upsert_session(&mut self, session: &Session) -> Result<(), DocError> {
-        let set = fields([
+        let mut set = fields([
             ("chatId", json!(session.chat_id)),
             ("deviceId", json!(session.device_id)),
             ("status", serde_json::to_value(session.status)?),
             ("startedAt", opt_ms(session.started_at)),
             ("updatedAt", json!(session.updated_at.timestamp_millis())),
         ]);
+        // Null deletes the field (`RowOp` contract), so a CLEARED gauge
+        // propagates instead of sticking on remote devices — mirrors the
+        // legacy Loro writer's delete-on-None.
+        set.insert(
+            "contextUsage".into(),
+            match &session.context_usage {
+                Some(cu) => serde_json::to_value(cu)?,
+                None => Value::Null,
+            },
+        );
         self.write(KIND_SESSIONS, &session.chat_id.clone(), OpKind::Upsert, set);
         Ok(())
     }

--- a/crates/doc/src/registry/tests.rs
+++ b/crates/doc/src/registry/tests.rs
@@ -295,6 +295,7 @@ fn session(chat_id: &str, device_id: &str, status: SessionStatus) -> Session {
         status,
         started_at: Some(ts(3_000)),
         updated_at: ts(3_500),
+        context_usage: None,
     }
 }
 

--- a/crates/doc/src/workspace.rs
+++ b/crates/doc/src/workspace.rs
@@ -438,6 +438,10 @@ impl WorkspaceDoc {
         row.insert("status", status_str(session.status))?;
         set_opt_ms(&row, "startedAt", session.started_at)?;
         row.insert("updatedAt", session.updated_at.timestamp_millis())?;
+        match &session.context_usage {
+            Some(cu) => row.insert("contextUsage", LoroValue::from(serde_json::to_value(cu)?))?,
+            None => row.delete("contextUsage")?,
+        }
         self.doc.commit();
         Ok(())
     }
@@ -684,6 +688,8 @@ pub(crate) struct RawSession {
     started_at: Option<i64>,
     #[serde(default)]
     updated_at: i64,
+    #[serde(default)]
+    context_usage: Option<zeron_proto::ContextUsage>,
 }
 
 impl From<RawSession> for Session {
@@ -694,6 +700,7 @@ impl From<RawSession> for Session {
             status: raw.status,
             started_at: raw.started_at.map(dt),
             updated_at: dt(raw.updated_at),
+            context_usage: raw.context_usage,
         }
     }
 }
@@ -765,6 +772,7 @@ mod tests {
             status,
             started_at: Some(ts(3_000)),
             updated_at: ts(3_500),
+            context_usage: None,
         }
     }
 

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -732,11 +732,22 @@ impl EngineRpc {
                 .set_chat_archived(&chat_id, archived)
                 .map_err(failed)
                 .map(drop),
-            MutateParams::SetChatConfig { chat_id, config } => self
-                .workspace
-                .set_chat_config(&chat_id, &config)
-                .map_err(failed)
-                .map(drop),
+            MutateParams::SetChatConfig { chat_id, config } => {
+                // A harness/model change resizes the context window the ring
+                // is scaled against — the old measurement is stale the moment
+                // the row changes (issue #137). A chat with no prior config
+                // is treated as changed: nothing proves the window held.
+                let stale_gauge = self.workspace.chat_config(&chat_id).is_none_or(|prev| {
+                    prev.harness != config.harness || prev.model != config.model
+                });
+                self.workspace
+                    .set_chat_config(&chat_id, &config)
+                    .map_err(failed)?;
+                if stale_gauge {
+                    self.sessions.set_context_usage(&chat_id, None);
+                }
+                Ok(())
+            }
             MutateParams::DeleteChat { chat_id } => {
                 self.workspace.delete_chat(&chat_id).map_err(failed)?;
                 self.doc_host.purge_chat(&chat_id);

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -94,6 +94,13 @@ struct RoutedSteer {
     message_id: String,
 }
 
+/// Dead-band state for one chat's context-usage row mirror.
+#[derive(Clone, Copy)]
+struct ContextMirror {
+    usage: zeron_proto::ContextUsage,
+    at: std::time::Instant,
+}
+
 struct Inner {
     device_id: String,
     journal: Arc<RunJournal>,
@@ -116,6 +123,11 @@ struct Inner {
     /// (zeron kept the same pair on `chats.harness_session_id`). An empty
     /// session id is the "do not resume" tombstone after a rejected resume.
     harness_sessions: Mutex<HashMap<String, HarnessSessionRef>>,
+    /// Last context-usage value mirrored into the workspace doc per chat.
+    /// Grok reports the gauge on EVERY streaming chunk, and a registry row
+    /// write per chunk is the chatty pattern `touch_session` throttles —
+    /// this is the dead-band state for the mirror (see `set_context_usage`).
+    context_mirrors: Mutex<HashMap<String, ContextMirror>>,
     /// Auto-titler for untitled chats (wired at engine assembly; absent in bare tests).
     titles: OnceLock<crate::titles::TitleGenerator>,
     /// Fired with `(chat_id, cwd)` when a user prompt starts a turn (fresh
@@ -155,6 +167,7 @@ impl SessionsEngine {
                 sessions_tx,
                 last_requests: Mutex::new(HashMap::new()),
                 harness_sessions: Mutex::new(HashMap::new()),
+                context_mirrors: Mutex::new(HashMap::new()),
                 titles: OnceLock::new(),
                 turn_listener: OnceLock::new(),
             }),
@@ -371,6 +384,13 @@ impl SessionsEngine {
         if request.resume.is_none() {
             request.resume = self.inner.resume_for(chat_id, &request.cwd);
             resume_injected = request.resume.is_some();
+        }
+        // Fresh harness session = no known context: the previous run's gauge
+        // is a stale measurement of a conversation this session does not
+        // have, so it must not present as current (issue #137). Resumed
+        // sessions keep it — the context carries over with the session id.
+        if request.resume.is_none() {
+            self.inner.set_context_usage(chat_id, None);
         }
         lock(&self.inner.last_requests).insert(chat_id.to_string(), request.clone());
 
@@ -722,6 +742,17 @@ impl SessionsEngine {
     fn set_status(&self, chat_id: &str, status: SessionStatus, fresh_start: bool) {
         self.inner.set_status(chat_id, status, fresh_start);
     }
+
+    /// Replace (or clear) the chat's context-window gauge. The SetChatConfig
+    /// path uses this to drop stale measurements after a model/harness
+    /// change; `drive_run` writes live reports through it.
+    pub(crate) fn set_context_usage(
+        &self,
+        chat_id: &str,
+        context_usage: Option<zeron_proto::ContextUsage>,
+    ) {
+        self.inner.set_context_usage(chat_id, context_usage);
+    }
 }
 
 impl Inner {
@@ -786,6 +817,7 @@ impl Inner {
                     status,
                     started_at: None,
                     updated_at: now,
+                    context_usage: None,
                 });
             // `started_at` is the elapsed-timer base and must only ever mean
             // "this turn". Entering Working from a settled state always
@@ -819,6 +851,66 @@ impl Inner {
         // Mirror the transition into the workspace doc's session-status row so
         // remote devices' sidebars show this run (staleness-checked client-side).
         if let Some(ws) = self.workspace() {
+            ws.record_session(&session);
+        }
+    }
+
+    fn set_context_usage(&self, chat_id: &str, context_usage: Option<zeron_proto::ContextUsage>) {
+        // Mirror dead-band (the `touch_session` lesson: grok reports the
+        // gauge on every streaming chunk, and a registry row write per chunk
+        // would be far too chatty): the workspace-doc mirror only moves when
+        // the gauge crosses 1% of the window or 10s have passed. The
+        // in-memory session and the WatchSessions stream always track live
+        // so the composer ring stays current, and clears always propagate.
+        const MIRROR_DEADBAND: f64 = 0.01;
+        const MIRROR_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+        let now = Utc::now();
+        let session = {
+            let mut statuses = lock(&self.statuses);
+            let entry = statuses
+                .entry(chat_id.to_string())
+                .or_insert_with(|| Session {
+                    chat_id: chat_id.to_string(),
+                    device_id: self.device_id.clone(),
+                    status: SessionStatus::Idle,
+                    started_at: None,
+                    updated_at: now,
+                    context_usage: None,
+                });
+            entry.context_usage = context_usage;
+            entry.updated_at = now;
+            let session = entry.clone();
+            let mut list: Vec<Session> = statuses.values().cloned().collect();
+            list.sort_by(|a, b| a.chat_id.cmp(&b.chat_id));
+            self.sessions_tx.send_replace(list);
+            session
+        };
+        let mirror = match context_usage {
+            // A clear is a state transition, never noise.
+            None => {
+                lock(&self.context_mirrors).remove(chat_id);
+                true
+            }
+            Some(usage) => {
+                let mut mirrors = lock(&self.context_mirrors);
+                let due = mirrors.get(chat_id).is_none_or(|last| {
+                    let window = usage.size.max(last.usage.size) as f64;
+                    let moved = (usage.used as f64 - last.usage.used as f64).abs();
+                    moved / window >= MIRROR_DEADBAND || last.at.elapsed() >= MIRROR_MIN_INTERVAL
+                });
+                if due {
+                    mirrors.insert(
+                        chat_id.to_string(),
+                        ContextMirror {
+                            usage,
+                            at: std::time::Instant::now(),
+                        },
+                    );
+                }
+                due
+            }
+        };
+        if mirror && let Some(ws) = self.workspace() {
             ws.record_session(&session);
         }
     }
@@ -1854,6 +1946,20 @@ async fn drive_run(
             }
             AgentEvent::InputResolved { .. } => {
                 inner.set_status(&chat_id, SessionStatus::Working, false);
+            }
+            AgentEvent::ContextUsage {
+                used,
+                size,
+                estimated,
+            } => {
+                inner.set_context_usage(
+                    &chat_id,
+                    Some(zeron_proto::ContextUsage {
+                        used: *used,
+                        size: *size,
+                        estimated: *estimated,
+                    }),
+                );
             }
             _ => {}
         }

--- a/crates/engine/tests/workspace_sync.rs
+++ b/crates/engine/tests/workspace_sync.rs
@@ -26,11 +26,13 @@ use zeron_rpc::methods;
 const VIEWER: &str = "viewer-device";
 
 /// Scripted harness: emits SessionStarted + text + Done with a per-event delay (so
-/// `Working` is observable across the bridge).
+/// `Working` is observable across the bridge). `context_usage` additionally emits
+/// a ContextUsage event mid-run (the composer ring's source).
 struct ScriptedHarness {
     id: HarnessId,
     text: &'static str,
     step_delay: Duration,
+    context_usage: Option<(u64, u64)>,
 }
 
 #[async_trait]
@@ -62,24 +64,30 @@ impl Harness for ScriptedHarness {
         let harness = self.id;
         let text = self.text;
         let delay = self.step_delay;
+        let context_usage = self.context_usage;
         tokio::spawn(async move {
-            let script = vec![
-                AgentEvent::SessionStarted {
-                    harness,
-                    model: "scripted-1".into(),
-                    tools: vec![],
-                    cwd: "/tmp".into(),
-                    session_id: "hs-1".into(),
-                    assistant_message_id: "a-1".into(),
-                },
-                AgentEvent::TextDelta { text: text.into() },
-                AgentEvent::Done {
-                    status: DoneStatus::Completed,
-                    result: None,
-                    error: None,
-                    session_id: Some("hs-1".into()),
-                },
-            ];
+            let mut script = vec![AgentEvent::SessionStarted {
+                harness,
+                model: "scripted-1".into(),
+                tools: vec![],
+                cwd: "/tmp".into(),
+                session_id: "hs-1".into(),
+                assistant_message_id: "a-1".into(),
+            }];
+            if let Some((used, size)) = context_usage {
+                script.push(AgentEvent::ContextUsage {
+                    used,
+                    size,
+                    estimated: false,
+                });
+            }
+            script.push(AgentEvent::TextDelta { text: text.into() });
+            script.push(AgentEvent::Done {
+                status: DoneStatus::Completed,
+                result: None,
+                error: None,
+                session_id: Some("hs-1".into()),
+            });
             for event in script {
                 if tx.send(Ok(event)).await.is_err() {
                     return;
@@ -100,11 +108,13 @@ fn registry() -> Arc<HarnessRegistry> {
         id: HarnessId::Mock,
         text: "Hello",
         step_delay: Duration::from_millis(60),
+        context_usage: Some((84_000, 200_000)),
     }));
     registry.register(Arc::new(ScriptedHarness {
         id: HarnessId::Cursor,
         text: "From cursor",
         step_delay: Duration::from_millis(10),
+        context_usage: None,
     }));
     Arc::new(registry)
 }
@@ -539,6 +549,133 @@ async fn chat_config_selects_the_run_harness() {
     a.shutdown().await;
 }
 
+/// The context ring's data flow end to end (issue #137): a ContextUsage event
+/// from the harness lands in the engine's session state (WatchSessions), the
+/// registry row carries it to the second device, and a MODEL change on the
+/// chat config clears the stale measurement everywhere — a gauge sized for
+/// the old model's window must never present as current.
+#[tokio::test]
+async fn context_usage_updates_the_session_watch_and_clears_on_model_change() {
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+    let a = assemble(dir_a.path(), "dev-a");
+    let b = assemble(dir_b.path(), "dev-b");
+    let link = bridge(&a, &b).await;
+
+    let client_a = zeron_rpc::memory_client(a.rpc_service());
+    client_a
+        .call(
+            methods::MUTATE,
+            serde_json::json!({
+                "op": "createSpace", "spaceId": "space-ctx", "deviceId": "dev-a", "path": "/tmp"
+            }),
+        )
+        .await
+        .expect("create space");
+    let config = serde_json::json!({
+        "harness": "mock", "model": "scripted-1", "reasoning": null,
+        "modelOptions": {}, "sandbox": "workspace-write"
+    });
+    client_a
+        .call(
+            methods::MUTATE,
+            serde_json::json!({
+                "op": "createChat", "chatId": "chat-ctx", "spaceId": "space-ctx", "config": config
+            }),
+        )
+        .await
+        .expect("create chat");
+    wait_for(
+        || b.workspace.chat("chat-ctx").ok().flatten().is_some(),
+        "chat row on B",
+    )
+    .await;
+
+    // The scripted Mock harness reports a gauge mid-run.
+    queue_run(&a, "chat-ctx", "cmd-ctx-1", "m-1");
+    let gauge = zeron_proto::ContextUsage {
+        used: 84_000,
+        size: 200_000,
+        estimated: false,
+    };
+    // (a) the event updates the engine's live session watch…
+    let mut watch = a.sessions.watch_sessions();
+    wait_for(
+        || {
+            watch
+                .borrow_and_update()
+                .iter()
+                .any(|s| s.chat_id == "chat-ctx" && s.context_usage == Some(gauge))
+        },
+        "gauge in WatchSessions",
+    )
+    .await;
+    // …and the run settles (nothing after Done re-reports the gauge).
+    wait_for(
+        || {
+            watch
+                .borrow()
+                .iter()
+                .any(|s| s.chat_id == "chat-ctx" && s.status == SessionStatus::Idle)
+        },
+        "run settles Idle",
+    )
+    .await;
+
+    // (b) the registry row carries the same value to the second device.
+    wait_for(
+        || {
+            b.workspace
+                .read_sessions()
+                .unwrap_or_default()
+                .iter()
+                .any(|s| s.chat_id == "chat-ctx" && s.context_usage == Some(gauge))
+        },
+        "gauge on B's session row",
+    )
+    .await;
+
+    // (d) A model change clears the stale gauge — locally and on B.
+    client_a
+        .call(
+            methods::MUTATE,
+            serde_json::json!({
+                "op": "setChatConfig", "chatId": "chat-ctx",
+                "config": {
+                    "harness": "mock", "model": "scripted-2", "reasoning": null,
+                    "modelOptions": {}, "sandbox": "workspace-write"
+                }
+            }),
+        )
+        .await
+        .expect("model change");
+    wait_for(
+        || {
+            watch
+                .borrow_and_update()
+                .iter()
+                .any(|s| s.chat_id == "chat-ctx" && s.context_usage.is_none())
+        },
+        "gauge cleared in WatchSessions",
+    )
+    .await;
+    wait_for(
+        || {
+            b.workspace
+                .read_sessions()
+                .unwrap_or_default()
+                .iter()
+                .any(|s| s.chat_id == "chat-ctx" && s.context_usage.is_none())
+        },
+        "gauge cleared on B's session row",
+    )
+    .await;
+
+    drop(link);
+    a.shutdown().await;
+    b.shutdown().await;
+}
+
 /// Live-edge variant: the same convergence through a real workspace room. Requires
 /// the TS edge (`wrangler dev` in `edge/` with AUTH_MODE=dev):
 ///
@@ -672,6 +809,7 @@ async fn legacy_workspace_doc_migrates_instantly_on_first_boot() {
                 status: SessionStatus::Idle,
                 started_at: Some(now),
                 updated_at: now,
+                context_usage: None,
             })
             .unwrap();
         store

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -1385,27 +1385,45 @@ fn session_update_events(
 /// Grok's session responses carry the current model's context window at
 /// `models.availableModels[]._meta.totalContextTokens`, keyed by
 /// `models.currentModelId`.
-fn grok_context_window(session_response: &Value) -> Option<u64> {
+fn grok_context_window(session_response: &Value, preferred: Option<&str>) -> Option<u64> {
     let models = session_response.get("models")?;
-    let current = models.get("currentModelId").and_then(Value::as_str)?;
-    model_context_window(session_response, current)
-}
-
-/// The advertised context window of a SPECIFIC model id. Used when a model
-/// config-option set is queued: `currentModelId` still names the PREVIOUS
-/// model at `session/new` time, so the ring must be sized against the model
-/// the run asked for, not the one the session booted with.
-fn model_context_window(session_response: &Value, model_id: &str) -> Option<u64> {
-    session_response
-        .get("models")?
-        .get("availableModels")?
-        .as_array()?
-        .iter()
-        .find(|m| m.get("modelId").and_then(Value::as_str) == Some(model_id))
-        .and_then(|m| m.get("_meta"))
-        .and_then(|meta| meta.get("totalContextTokens"))
-        .and_then(Value::as_u64)
-        .filter(|size| *size > 0)
+    // Wire shapes seen across grok builds: the window rides `_meta`
+    // (`totalContextTokens`) or the model object itself, under either
+    // spelling. Accept all placements; filter zero/absent.
+    let window_for = |model_id: &str| -> Option<u64> {
+        let window = models
+            .get("availableModels")?
+            .as_array()?
+            .iter()
+            .find(|m| m.get("modelId").and_then(Value::as_str) == Some(model_id))
+            .and_then(|m| {
+                m.get("_meta")
+                    .or(Some(m))
+                    .and_then(|meta| meta.get("totalContextTokens"))
+                    .or_else(|| m.get("contextWindow"))
+                    .and_then(Value::as_u64)
+            })
+            .filter(|size| *size > 0);
+        if window.is_none() {
+            tracing::debug!(
+                target: "zeron_harness::acp",
+                model = model_id,
+                "grok session state carries no context window; ring disabled until a window is advertised"
+            );
+        }
+        window
+    };
+    // The preferred model (the one a config set is about to make current)
+    // wins; an unlisted/unknown id falls back to the session's current.
+    preferred
+        .filter(|m| !m.is_empty())
+        .and_then(window_for)
+        .or_else(|| {
+            models
+                .get("currentModelId")
+                .and_then(Value::as_str)
+                .and_then(window_for)
+        })
 }
 
 /// [`session_update_events`] plus grok's live context gauge: grok emits no
@@ -1828,33 +1846,43 @@ async fn run_session(session: Session) {
                 "session/new returned no sessionId".into(),
             ));
         }
-        // Grok's model state rides the session response — the current
-        // model's context window sizes the ContextUsage ring events.
-        // Computed before the snapshot move below; a queued model set may
-        // override it with the REQUESTED model's window.
-        let current_window = grok_context_window(&session_response);
         // Apply the run's model + effort + model options through the
         // session's advertised config options (ACP has no per-prompt model
         // field). Best-effort: a rejected set is logged, never fatal — the
         // agent's default runs.
         let efforts = effort_values(request.reasoning, request.model.as_deref());
         let requested_model = request.model.as_deref();
-        let mut options_snapshot = session_response;
+        let options_snapshot = session_response;
         let option_sets = config_option_sets(
             &options_snapshot,
             requested_model,
             &efforts,
             &request.model_options,
         );
-        // A queued model set means the run will NOT run under
-        // `currentModelId` — size the ring against the requested model's
-        // advertised window instead (a model change with no advertised
-        // window honestly disables the ring rather than mis-sizing it).
-        let context_window = if option_sets.iter().any(|(id, _)| id == "model") {
-            requested_model.and_then(|m| model_context_window(&options_snapshot, m))
-        } else {
-            current_window
-        };
+        // Grok's model state rides the session response — but the session's
+        // `currentModelId` predates the config sets below. When a model set
+        // is queued, the window must come from the model that WILL be
+        // current (the requested one), not the one the session booted with.
+        let model_option_id = options_snapshot
+            .get("configOptions")
+            .and_then(Value::as_array)
+            .and_then(|opts| {
+                opts.iter()
+                    .find(|o| {
+                        o.get("type").and_then(Value::as_str) == Some("select")
+                            && o.get("category").and_then(Value::as_str) == Some("model")
+                    })
+                    .and_then(|o| o.get("id").and_then(Value::as_str))
+            });
+        let effective_model = model_option_id
+            .zip(requested_model)
+            .and_then(|(id, model)| {
+                option_sets
+                    .iter()
+                    .any(|(config_id, _)| config_id == id)
+                    .then_some(model)
+            });
+        let context_window = grok_context_window(&options_snapshot, effective_model);
         for (config_id, payload) in option_sets {
             let mut params = serde_json::Map::new();
             params.insert("sessionId".into(), session_id.clone().into());
@@ -3100,7 +3128,7 @@ mod tests {
     }
 
     #[test]
-    fn grok_context_window_reads_the_current_model_state() {
+    fn grok_context_window_reads_the_effective_model_state() {
         let response = json!({
             "sessionId": "s-1",
             "models": {
@@ -3111,30 +3139,22 @@ mod tests {
                 ],
             },
         });
-        assert_eq!(grok_context_window(&response), Some(200000));
-        assert_eq!(grok_context_window(&json!({ "sessionId": "s-1" })), None);
-    }
-
-    #[test]
-    fn model_context_window_reads_the_requested_model_not_the_current_one() {
-        // A queued model set means the run leaves `currentModelId` behind:
-        // the ring must be sized by the REQUESTED model's window.
-        let response = json!({
-            "sessionId": "s-1",
-            "models": {
-                "currentModelId": "zai-glm-5-2",
-                "availableModels": [
-                    { "modelId": "grok-4.5", "_meta": { "totalContextTokens": 500000 } },
-                    { "modelId": "zai-glm-5-2", "_meta": { "totalContextTokens": 200000 } },
-                ],
-            },
-        });
-        assert_eq!(model_context_window(&response, "grok-4.5"), Some(500000));
-        // A model with no advertised window honestly yields none — never a
-        // fallback to the current model's (wrong) window.
-        assert_eq!(model_context_window(&response, "grok-4-fast"), None);
+        // No preferred model → the session's current one.
+        assert_eq!(grok_context_window(&response, None), Some(200000));
+        // A preferred model (the run switches to it) wins over currentModelId —
+        // the session response predates the config sets that apply the switch.
         assert_eq!(
-            model_context_window(&json!({ "sessionId": "s-1" }), "grok-4.5"),
+            grok_context_window(&response, Some("grok-4.5")),
+            Some(500000)
+        );
+        // Unknown / empty preferred falls back to the current model.
+        assert_eq!(
+            grok_context_window(&response, Some("missing-model")),
+            Some(200000)
+        );
+        assert_eq!(grok_context_window(&response, Some("")), Some(200000));
+        assert_eq!(
+            grok_context_window(&json!({ "sessionId": "s-1" }), None),
             None
         );
     }

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -1382,6 +1382,88 @@ fn session_update_events(
     }
 }
 
+/// Grok's session responses carry the current model's context window at
+/// `models.availableModels[]._meta.totalContextTokens`, keyed by
+/// `models.currentModelId`.
+fn grok_context_window(session_response: &Value) -> Option<u64> {
+    let models = session_response.get("models")?;
+    let current = models.get("currentModelId").and_then(Value::as_str)?;
+    model_context_window(session_response, current)
+}
+
+/// The advertised context window of a SPECIFIC model id. Used when a model
+/// config-option set is queued: `currentModelId` still names the PREVIOUS
+/// model at `session/new` time, so the ring must be sized against the model
+/// the run asked for, not the one the session booted with.
+fn model_context_window(session_response: &Value, model_id: &str) -> Option<u64> {
+    session_response
+        .get("models")?
+        .get("availableModels")?
+        .as_array()?
+        .iter()
+        .find(|m| m.get("modelId").and_then(Value::as_str) == Some(model_id))
+        .and_then(|m| m.get("_meta"))
+        .and_then(|meta| meta.get("totalContextTokens"))
+        .and_then(Value::as_u64)
+        .filter(|size| *size > 0)
+}
+
+/// [`session_update_events`] plus grok's live context gauge: grok emits no
+/// `usage_update`; every streaming chunk carries the running context total
+/// in `update._meta.totalTokens` — the same counter grok's own `/context`
+/// bar uses (the last model-reported context length plus a bytes/4 estimate
+/// of results since), sized here against the session model's window.
+fn session_update_events_with_context(
+    method: &str,
+    params: &Value,
+    session_id: &str,
+    subagents: &mut SubagentTracker,
+    harness: HarnessId,
+    context_window: Option<u64>,
+) -> Vec<AgentEvent> {
+    let mut events = session_update_events(method, params, session_id, subagents);
+    if let (HarnessId::Grok, Some(size)) = (harness, context_window)
+        && method == "session/update"
+        && params.get("sessionId").and_then(Value::as_str) == Some(session_id)
+        // Zero totals are grok's cancelled / queue-removed mis-report (the
+        // settled-prompt path filters the same shape) — never a real 0%.
+        && let Some(used) = params
+            .get("update")
+            .and_then(|u| u.get("_meta"))
+            .and_then(|m| m.get("totalTokens"))
+            .and_then(Value::as_u64)
+            .filter(|used| *used > 0)
+    {
+        // Capped at the window: grok compacts before the context crosses it,
+        // so a larger value is a mis-report, not a real gauge.
+        events.push(AgentEvent::ContextUsage {
+            used: used.min(size),
+            size,
+            // The chunk counter is the model-reported length plus a bytes/4
+            // estimate of results since — an estimate, not a measurement.
+            estimated: true,
+        });
+    }
+    events
+}
+
+/// The live context total from a settled `session/prompt` response: grok
+/// reports it as `_meta.totalTokens` (the same counter the chunks carry) or,
+/// failing that, as the last model call's `_meta.inputTokens +
+/// _meta.outputTokens`. `_meta.usage.totalTokens` is deliberately NOT read:
+/// that object is a per-turn billing ledger summing every model call (each
+/// resends the whole context), which routinely exceeds the window on
+/// tool-using turns.
+fn response_total_tokens(res: &Result<Value, HarnessError>) -> Option<u64> {
+    let resp = res.as_ref().ok()?;
+    let meta = resp.get("_meta")?;
+    let field = |key: &str| meta.get(key).and_then(Value::as_u64);
+    field("totalTokens").or_else(|| {
+        let (input, output) = (field("inputTokens"), field("outputTokens"));
+        (input.is_some() || output.is_some()).then(|| input.unwrap_or(0) + output.unwrap_or(0))
+    })
+}
+
 /// Per-turn token usage from a settled `session/prompt` response, when the
 /// adapter attaches it (tolerant of both field spellings; absent → nothing).
 fn usage_from_response(res: &Result<Value, HarnessError>) -> Option<AgentEvent> {
@@ -1582,7 +1664,6 @@ fn handle_server_request_live(
     Vec::new()
 }
 
-
 /// Await a setup request while draining incoming messages, so a `session/load`
 /// whose replay outruns the incoming channel's capacity can't deadlock the
 /// reader. Replayed `session/update`s are dropped (the doc already holds the
@@ -1649,7 +1730,6 @@ fn track_turn_signals(
         _ => {}
     }
 }
-
 
 /// A mid-turn `_session/steering` call. `idleBehavior: promptRequired`
 /// covers the turn-ended race: the agent hands the text back instead of
@@ -1748,6 +1828,11 @@ async fn run_session(session: Session) {
                 "session/new returned no sessionId".into(),
             ));
         }
+        // Grok's model state rides the session response — the current
+        // model's context window sizes the ContextUsage ring events.
+        // Computed before the snapshot move below; a queued model set may
+        // override it with the REQUESTED model's window.
+        let current_window = grok_context_window(&session_response);
         // Apply the run's model + effort + model options through the
         // session's advertised config options (ACP has no per-prompt model
         // field). Best-effort: a rejected set is logged, never fatal — the
@@ -1755,12 +1840,22 @@ async fn run_session(session: Session) {
         let efforts = effort_values(request.reasoning, request.model.as_deref());
         let requested_model = request.model.as_deref();
         let mut options_snapshot = session_response;
-        for (config_id, payload) in config_option_sets(
+        let option_sets = config_option_sets(
             &options_snapshot,
             requested_model,
             &efforts,
             &request.model_options,
-        ) {
+        );
+        // A queued model set means the run will NOT run under
+        // `currentModelId` — size the ring against the requested model's
+        // advertised window instead (a model change with no advertised
+        // window honestly disables the ring rather than mis-sizing it).
+        let context_window = if option_sets.iter().any(|(id, _)| id == "model") {
+            requested_model.and_then(|m| model_context_window(&options_snapshot, m))
+        } else {
+            current_window
+        };
+        for (config_id, payload) in option_sets {
             let mut params = serde_json::Map::new();
             params.insert("sessionId".into(), session_id.clone().into());
             params.insert("configId".into(), config_id.clone().into());
@@ -1783,13 +1878,14 @@ async fn run_session(session: Session) {
                 );
             }
         }
-        Ok::<(String, bool, Vec<SlashCommand>), HarnessError>((
+        Ok::<(String, bool, Vec<SlashCommand>, Option<u64>), HarnessError>((
             session_id,
             steer_ext,
             init_commands,
+            context_window,
         ))
     };
-    let (session_id, steer_ext, init_commands) = tokio::select! {
+    let (session_id, steer_ext, init_commands, context_window) = tokio::select! {
         res = tokio::time::timeout(handshake_timeout, setup) => {
             let res = res.unwrap_or_else(|_| {
                 // A hung handshake (agent waiting on a login it can never
@@ -1910,8 +2006,7 @@ async fn run_session(session: Session) {
         prompt_stall.map(|d| tokio::time::Instant::now() + d);
     let mut turn: Option<BoxFuture<'static, Result<Value, HarnessError>>> = Some({
         prompt_seq += 1;
-        current_prompt_id =
-            prompt_complete_extension.then(|| format!("zeron-p{prompt_seq}"));
+        current_prompt_id = prompt_complete_extension.then(|| format!("zeron-p{prompt_seq}"));
         prompt_turn(
             client.clone(),
             session_id.clone(),
@@ -2066,7 +2161,14 @@ async fn run_session(session: Session) {
                     match inc {
                         Incoming::Notification { method, params } => {
                             let events =
-                                session_update_events(&method, &params, &session_id, &mut subagents);
+                                session_update_events_with_context(
+                                    &method,
+                                    &params,
+                                    &session_id,
+                                    &mut subagents,
+                                    harness,
+                                    context_window,
+                                );
                             for ev in events {
                                 if !send(&event_tx, ev).await {
                                     consumer_gone = true;
@@ -2111,6 +2213,25 @@ async fn run_session(session: Session) {
                 // with it (claude-agent-acp and codex-acp both do).
                 if let Some(usage) = usage_from_response(&res)
                     && !send(&event_tx, usage).await
+                {
+                    break 'main;
+                }
+                // Grok's settled prompt carries the live context total — the
+                // turn-final ring update. A zero total (grok zeroes
+                // `_meta.totalTokens` on cancelled / queue-removed turns)
+                // must not wipe the last known gauge.
+                if let Some(size) = context_window
+                    && let Some(used) = response_total_tokens(&res).filter(|used| *used > 0)
+                    && !send(
+                        &event_tx,
+                        AgentEvent::ContextUsage {
+                            used: used.min(size),
+                            size,
+                            // Same estimate-backed counter the chunks carry.
+                            estimated: true,
+                        },
+                    )
+                    .await
                 {
                     break 'main;
                 }
@@ -2222,7 +2343,14 @@ async fn run_session(session: Session) {
                     // Other notifications (other sessions, agent noise) are
                     // tolerated by design.
                     let events =
-                        session_update_events(&method, &params, &session_id, &mut subagents);
+                        session_update_events_with_context(
+                            &method,
+                            &params,
+                            &session_id,
+                            &mut subagents,
+                            harness,
+                            context_window,
+                        );
                     for ev in events {
                         track_turn_signals(&ev, &mut turn_content_seen, &mut open_tools);
                         if !send(&event_tx, ev).await {
@@ -2334,7 +2462,14 @@ async fn run_session(session: Session) {
                             match inc {
                                 Incoming::Notification { method, params } => {
                                     let events =
-                                        session_update_events(&method, &params, &session_id, &mut subagents);
+                                        session_update_events_with_context(
+                                            &method,
+                                            &params,
+                                            &session_id,
+                                            &mut subagents,
+                                            harness,
+                                            context_window,
+                                        );
                                     for ev in events {
                                         if !send(&event_tx, ev).await {
                                             consumer_gone = true;
@@ -2798,6 +2933,210 @@ mod tests {
         assert!(!steering_supported(&json!({
             "_meta": { "steering": { "supported": false } },
         })));
+    }
+
+    /// A tracker with no subagent traffic to observe — the context-gauge
+    /// tests never spawn subagents, so an unwatched sink suffices.
+    fn plain_tracker(session_id: &str) -> SubagentTracker {
+        let (tx, _rx) = mpsc::channel(16);
+        SubagentTracker::new(
+            session_id.to_owned(),
+            tx,
+            Some(std::env::temp_dir().join("zeron-acp-tests")),
+        )
+    }
+
+    #[test]
+    fn grok_chunk_total_tokens_feeds_the_context_ring() {
+        let params = json!({
+            "sessionId": "s-1",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "type": "text", "text": "pong" },
+                "_meta": { "totalTokens": 13667, "chunkId": 14 },
+            },
+        });
+        let events = session_update_events_with_context(
+            "session/update",
+            &params,
+            "s-1",
+            &mut plain_tracker("s-1"),
+            HarnessId::Grok,
+            Some(200000),
+        );
+        // The chunk counter is marked estimated — never presented as exact.
+        assert!(events.contains(&AgentEvent::ContextUsage {
+            used: 13667,
+            size: 200000,
+            estimated: true,
+        }));
+        // Without a window (session state missing) no ring estimate is
+        // invented.
+        assert!(
+            !session_update_events_with_context(
+                "session/update",
+                &params,
+                "s-1",
+                &mut plain_tracker("s-1"),
+                HarnessId::Grok,
+                None,
+            )
+            .iter()
+            .any(|ev| matches!(ev, AgentEvent::ContextUsage { .. }))
+        );
+        // Another session's update never maps.
+        let foreign = json!({
+            "sessionId": "s-other",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "_meta": { "totalTokens": 5 },
+            },
+        });
+        assert!(
+            session_update_events_with_context(
+                "session/update",
+                &foreign,
+                "s-1",
+                &mut plain_tracker("s-1"),
+                HarnessId::Grok,
+                Some(200000),
+            )
+            .is_empty()
+        );
+        // Chunk totals are grok's shape; another harness's chunks with the
+        // same meta stay unmapped.
+        assert!(
+            !session_update_events_with_context(
+                "session/update",
+                &params,
+                "s-1",
+                &mut plain_tracker("s-1"),
+                HarnessId::Codex,
+                Some(200000),
+            )
+            .iter()
+            .any(|ev| matches!(ev, AgentEvent::ContextUsage { .. }))
+        );
+        // A mis-reported total above the window is capped, never 318k/200k.
+        let inflated = json!({
+            "sessionId": "s-1",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "_meta": { "totalTokens": 318000 },
+            },
+        });
+        assert!(
+            session_update_events_with_context(
+                "session/update",
+                &inflated,
+                "s-1",
+                &mut plain_tracker("s-1"),
+                HarnessId::Grok,
+                Some(200000),
+            )
+            .contains(&AgentEvent::ContextUsage {
+                used: 200000,
+                size: 200000,
+                estimated: true,
+            })
+        );
+        // A zero total is grok's cancelled / queue-removed mis-report — it
+        // must not snap the ring to 0%.
+        let zeroed = json!({
+            "sessionId": "s-1",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "_meta": { "totalTokens": 0 },
+            },
+        });
+        assert!(
+            !session_update_events_with_context(
+                "session/update",
+                &zeroed,
+                "s-1",
+                &mut plain_tracker("s-1"),
+                HarnessId::Grok,
+                Some(200000),
+            )
+            .iter()
+            .any(|ev| matches!(ev, AgentEvent::ContextUsage { .. }))
+        );
+    }
+
+    #[test]
+    fn grok_prompt_response_context_total_skips_the_billing_ledger() {
+        // Live context total (13667) alongside a per-turn BILLING ledger
+        // (41001 = several model calls summed — each resends the whole
+        // context). The ledger must never feed the context ring.
+        let res: Result<Value, HarnessError> = Ok(json!({
+            "stopReason": "end_turn",
+            "_meta": {
+                "totalTokens": 13667,
+                "inputTokens": 13650,
+                "outputTokens": 17,
+                "usage": { "totalTokens": 41001 },
+            },
+        }));
+        assert_eq!(response_total_tokens(&res), Some(13667));
+        // Without `_meta.totalTokens` the last call's input+output is the
+        // live total.
+        let no_total = json!({
+            "stopReason": "end_turn",
+            "_meta": { "inputTokens": 13650, "outputTokens": 17 },
+        });
+        assert_eq!(response_total_tokens(&Ok(no_total)), Some(13667));
+        // Grok zeroes `_meta.totalTokens` on cancelled turns; the caller
+        // filters that so the last known gauge survives.
+        let cancelled = json!({
+            "stopReason": "cancelled",
+            "_meta": { "totalTokens": 0 },
+        });
+        assert_eq!(response_total_tokens(&Ok(cancelled)), Some(0));
+        // No _meta at all → nothing.
+        assert_eq!(
+            response_total_tokens(&Ok(json!({ "stopReason": "end_turn" }))),
+            None
+        );
+    }
+
+    #[test]
+    fn grok_context_window_reads_the_current_model_state() {
+        let response = json!({
+            "sessionId": "s-1",
+            "models": {
+                "currentModelId": "zai-glm-5-2",
+                "availableModels": [
+                    { "modelId": "grok-4.5", "_meta": { "totalContextTokens": 500000 } },
+                    { "modelId": "zai-glm-5-2", "_meta": { "totalContextTokens": 200000 } },
+                ],
+            },
+        });
+        assert_eq!(grok_context_window(&response), Some(200000));
+        assert_eq!(grok_context_window(&json!({ "sessionId": "s-1" })), None);
+    }
+
+    #[test]
+    fn model_context_window_reads_the_requested_model_not_the_current_one() {
+        // A queued model set means the run leaves `currentModelId` behind:
+        // the ring must be sized by the REQUESTED model's window.
+        let response = json!({
+            "sessionId": "s-1",
+            "models": {
+                "currentModelId": "zai-glm-5-2",
+                "availableModels": [
+                    { "modelId": "grok-4.5", "_meta": { "totalContextTokens": 500000 } },
+                    { "modelId": "zai-glm-5-2", "_meta": { "totalContextTokens": 200000 } },
+                ],
+            },
+        });
+        assert_eq!(model_context_window(&response, "grok-4.5"), Some(500000));
+        // A model with no advertised window honestly yields none — never a
+        // fallback to the current model's (wrong) window.
+        assert_eq!(model_context_window(&response, "grok-4-fast"), None);
+        assert_eq!(
+            model_context_window(&json!({ "sessionId": "s-1" }), "grok-4.5"),
+            None
+        );
     }
 
     #[test]

--- a/crates/harness/src/acp/normalize.rs
+++ b/crates/harness/src/acp/normalize.rs
@@ -94,11 +94,7 @@ fn tool_diff(update: &Value) -> Option<ToolDiff> {
 /// The grok-native tool name stamped on a tool call's `_meta` (`x.ai/tool`,
 /// present on every grok tool_call — verified live, 1.0.4).
 pub(crate) fn xai_tool_name(update: &Value) -> Option<&str> {
-    update
-        .get("_meta")?
-        .get("x.ai/tool")?
-        .get("name")?
-        .as_str()
+    update.get("_meta")?.get("x.ai/tool")?.get("name")?.as_str()
 }
 
 /// First location path (`locations: [{path, line?}]`), for read/edit calls.
@@ -385,12 +381,26 @@ pub(crate) fn map_update(update: &Value) -> Vec<AgentEvent> {
             let commands = parse_commands(update.get("availableCommands"));
             vec![AgentEvent::AvailableCommands { commands }]
         }
-        // Context-window gauge, not per-turn input/output tokens — zeron's
-        // Usage event feeds rate-limit probes, so a wrong mapping is worse
-        // than none. Mode/config/session-info updates carry nothing we render.
-        "usage_update" | "current_mode_update" | "config_option_update" | "session_info_update" => {
-            Vec::new()
+        // Context-window gauge (used / size) -> AgentEvent::ContextUsage.
+        // Kept separate from per-turn input/output tokens (AgentEvent::Usage).
+        "usage_update" => {
+            let used = update.get("used").and_then(Value::as_u64);
+            let size = update.get("size").and_then(Value::as_u64);
+            match (used, size) {
+                (Some(used), Some(size)) if size > 0 => {
+                    vec![AgentEvent::ContextUsage {
+                        used,
+                        size,
+                        // ACP's gauge is an exact measurement (grok's chunk
+                        // counter is the estimated one).
+                        estimated: false,
+                    }]
+                }
+                _ => Vec::new(),
+            }
         }
+        // Mode/config/session-info updates carry nothing we render.
+        "current_mode_update" | "config_option_update" | "session_info_update" => Vec::new(),
         _ => Vec::new(),
     }
 }
@@ -433,7 +443,6 @@ pub(crate) fn parse_commands(value: Option<&Value>) -> Vec<SlashCommand> {
         })
         .collect()
 }
-
 
 /// `session/request_permission` options (`{optionId, name, kind}`) → the
 /// preferred auto-approve choice: `allow_always` > `allow_once` > first.
@@ -623,6 +632,30 @@ mod tests {
                 },
             }
         );
+    }
+
+    #[test]
+    fn usage_update_maps_to_context_usage() {
+        let update = json!({
+            "sessionUpdate": "usage_update",
+            "used": 42000,
+            "size": 200000,
+        });
+        assert_eq!(
+            map_update(&update),
+            vec![AgentEvent::ContextUsage {
+                used: 42000,
+                size: 200000,
+                estimated: false,
+            }]
+        );
+
+        let invalid = json!({
+            "sessionUpdate": "usage_update",
+            "used": 42000,
+            "size": 0,
+        });
+        assert!(map_update(&invalid).is_empty());
     }
 
     #[test]

--- a/crates/harness/src/claude/normalize.rs
+++ b/crates/harness/src/claude/normalize.rs
@@ -4,7 +4,7 @@
 use serde_json::Value;
 use zeron_proto::{AgentEvent, DoneStatus, HarnessId, TodoItem, ToolCall};
 
-use super::wire::{ContentBlock, Frame};
+use super::wire::{ContentBlock, Frame, result_context_window};
 
 /// Human-readable text for the CLI's assistant-level error codes. These arrive
 /// as a terse `error` field on an `assistant` frame — usually with NO text
@@ -404,10 +404,24 @@ impl Normalizer {
                 if let Some(id) = &f.session_id {
                     self.session_id = Some(id.clone());
                 }
-                let usage = AgentEvent::Usage {
+                // Turn-end context gauge (exact, agent-reported): the result
+                // frame's usage includes both cache tiers — the true window
+                // fill — and modelUsage carries the model's contextWindow.
+                let mut events = Vec::new();
+                let used = f.usage.context_consumption();
+                if let Some(size) = result_context_window(&f.model_usage)
+                    && used > 0
+                {
+                    events.push(AgentEvent::ContextUsage {
+                        used: used.min(size),
+                        size,
+                        estimated: false,
+                    });
+                }
+                events.push(AgentEvent::Usage {
                     input_tokens: f.usage.input_tokens,
                     output_tokens: f.usage.output_tokens,
-                };
+                });
                 let done = if f.subtype == "success" {
                     AgentEvent::Done {
                         status: if interrupted {
@@ -469,7 +483,8 @@ impl Normalizer {
                         session_id: f.session_id,
                     }
                 };
-                vec![usage, done]
+                events.push(done);
+                events
             }
 
             // Control frames are handled by the run loop, not normalized.
@@ -537,6 +552,35 @@ mod tests {
         let events = normalize_one(raw);
         assert_eq!(events.len(), 2, "usage + done");
         events.into_iter().nth(1).expect("done event")
+    }
+
+    #[test]
+    fn result_frame_emits_the_context_gauge_when_the_window_is_reported() {
+        // Live shape (2.1.228): usage carries both cache tiers, modelUsage
+        // the model's contextWindow. The gauge is exact and rides ahead of
+        // the Usage/Done pair.
+        let raw = r#"{"type":"result","subtype":"success","result":"ok","errors":[],"usage":{"input_tokens":10,"cache_creation_input_tokens":2000,"cache_read_input_tokens":30000,"output_tokens":20},"modelUsage":{"claude-haiku-4-5-20251001":{"inputTokens":10,"outputTokens":20,"contextWindow":200000}},"session_id":"s-1"}"#;
+        let events = normalize_one(raw);
+        assert_eq!(events.len(), 3, "gauge + usage + done");
+        assert_eq!(
+            events[0],
+            AgentEvent::ContextUsage {
+                used: 32_030,
+                size: 200_000,
+                estimated: false
+            }
+        );
+    }
+
+    #[test]
+    fn result_frame_without_window_emits_no_gauge() {
+        // Older/no-modelUsage shapes: usage + done only, never a guessed ring.
+        let raw = r#"{"type":"result","subtype":"success","result":"ok","errors":[],"usage":{"input_tokens":10,"cache_creation_input_tokens":2000,"cache_read_input_tokens":30000,"output_tokens":20},"session_id":"s-1"}"#;
+        let events = normalize_one(raw);
+        assert_eq!(events.len(), 2, "usage + done");
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ContextUsage { .. })));
     }
 
     #[test]

--- a/crates/harness/src/claude/wire.rs
+++ b/crates/harness/src/claude/wire.rs
@@ -141,6 +141,8 @@ pub(crate) struct ResultFrame {
     pub errors: Vec<Value>,
     #[serde(default)]
     pub usage: UsageBody,
+    #[serde(default, rename = "modelUsage")]
+    pub model_usage: Option<Value>,
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -151,6 +153,38 @@ pub(crate) struct UsageBody {
     pub input_tokens: u64,
     #[serde(default)]
     pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
+}
+
+impl UsageBody {
+    /// The turn's true context consumption: everything the model was fed
+    /// (input + both cache tiers count against the window) plus what it
+    /// produced. This is what Claude Code's own `/context` bar measures.
+    pub fn context_consumption(&self) -> u64 {
+        self.input_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+            + self.output_tokens
+    }
+}
+
+/// The model's advertised context window from a result frame's `modelUsage`
+/// (keyed by model id; `contextWindow` on the entry). Any entry wins — the
+/// map is single-model in practice.
+pub(crate) fn result_context_window(model_usage: &Option<Value>) -> Option<u64> {
+    model_usage
+        .as_ref()?
+        .as_object()?
+        .values()
+        .find_map(|entry| {
+            entry
+                .get("contextWindow")
+                .and_then(Value::as_u64)
+                .filter(|size| *size > 0)
+        })
 }
 
 /// A CLI→client control request (`can_use_tool` is the one we act on).

--- a/crates/harness/src/codex/mod.rs
+++ b/crates/harness/src/codex/mod.rs
@@ -61,8 +61,8 @@ use crate::jsonrpc::{Incoming, RpcClient};
 use crate::{Harness, HarnessError, RunControls};
 use catalog::{REASONING_LEVELS, sandbox_mode, sandbox_policy_value, static_models, to_effort};
 use normalize::{
-    ChildRoute, Phase, delta_text, item_id, item_type, map_item, notification_thread_id,
-    route_child_notification, turn_error_message, turn_id, usage_event,
+    ChildRoute, Phase, context_gauge_event, delta_text, item_id, item_type, map_item,
+    notification_thread_id, route_child_notification, turn_error_message, turn_id, usage_event,
 };
 
 /// Locate the device's installed Codex CLI: `CODEX_EXECUTABLE`, then our own
@@ -822,6 +822,14 @@ async fn run_session(session: Session) {
                     "thread/tokenUsage/updated" => {
                         if let Some(usage) = usage_event(&params) {
                             pending_usage = Some(usage);
+                        }
+                        // Live context gauge (exact: agent-reported fill +
+                        // window); flows straight through — the engine
+                        // dead-bands the mirror per #137.
+                        if let Some(gauge) = context_gauge_event(&params)
+                            && !send(&event_tx, gauge).await
+                        {
+                            break 'main;
                         }
                     }
 

--- a/crates/harness/src/codex/normalize.rs
+++ b/crates/harness/src/codex/normalize.rs
@@ -74,6 +74,28 @@ pub(crate) fn usage_event(params: &Value) -> Option<AgentEvent> {
     })
 }
 
+/// `thread/tokenUsage/updated` → the live context gauge (`ContextUsage`).
+/// Codex reports both halves exactly: the last call's context consumption
+/// (`last.totalTokens` — input includes cache-read, so this IS the window
+/// fill) and the model's window (`modelContextWindow`). Emitted live (not
+/// held for Done) so the ring tracks the turn. A zero total is the CLI's
+/// cancel/reset shape — never wipe the last gauge with it.
+pub(crate) fn context_gauge_event(params: &Value) -> Option<AgentEvent> {
+    let usage = field(params, &["tokenUsage", "token_usage"])?;
+    let last = usage.get("last")?;
+    let used = field(last, &["totalTokens", "total_tokens"])
+        .and_then(Value::as_u64)
+        .filter(|used| *used > 0)?;
+    let size = field(usage, &["modelContextWindow", "model_context_window"])
+        .and_then(Value::as_u64)
+        .filter(|size| *size > 0)?;
+    Some(AgentEvent::ContextUsage {
+        used: used.min(size),
+        size,
+        estimated: false,
+    })
+}
+
 /// Tool-shaped Codex items must always close the lifecycle they open: started
 /// opens the ToolCall, completed refreshes its metadata and resolves the same
 /// stable id (port of codex.ts `toolLifecycle`).
@@ -423,8 +445,57 @@ mod tests {
     }
 
     #[test]
-    fn usage_reads_last_snapshot_under_both_spellings() {
+    fn context_gauge_reads_fill_and_window_and_guards_zero() {
+        // Live shape (0.146.1): last.totalTokens is the context fill,
+        // modelContextWindow the model's window — exact, uncapped source.
+        let params = json!({
+            "tokenUsage": {
+                "last": { "totalTokens": 13837, "inputTokens": 13747, "outputTokens": 90 },
+                "modelContextWindow": 258400
+            }
+        });
         assert_eq!(
+            context_gauge_event(&params),
+            Some(AgentEvent::ContextUsage {
+                used: 13837,
+                size: 258400,
+                estimated: false
+            })
+        );
+        // A fill above the window is a mis-report: capped, like grok's.
+        let inflated = json!({
+            "tokenUsage": {
+                "last": { "totalTokens": 300_000 },
+                "modelContextWindow": 258400
+            }
+        });
+        assert_eq!(
+            context_gauge_event(&inflated),
+            Some(AgentEvent::ContextUsage {
+                used: 258400,
+                size: 258400,
+                estimated: false
+            })
+        );
+        // Zero fill (cancel/reset shape) never wipes the last gauge.
+        let zeroed = json!({
+            "tokenUsage": {
+                "last": { "totalTokens": 0 },
+                "modelContextWindow": 258400
+            }
+        });
+        assert_eq!(context_gauge_event(&zeroed), None);
+        // No window advertised → no ring (never guess a denominator).
+        let windowless = json!({
+            "tokenUsage": {
+                "last": { "totalTokens": 13837 }
+            }
+        });
+        assert_eq!(context_gauge_event(&windowless), None);
+    }
+
+    #[test]
+    fn usage_reads_last_snapshot_under_both_spellings() {        assert_eq!(
             usage_event(&json!({"tokenUsage": {"last": {"inputTokens": 42, "outputTokens": 7}}})),
             Some(AgentEvent::Usage {
                 input_tokens: 42,

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -7,9 +7,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot};
 
-use zeron_harness::{
-    AcpHarness, CancellationToken, Harness, RunControls, SteerMessage,
-};
+use zeron_harness::{AcpHarness, CancellationToken, Harness, RunControls, SteerMessage};
 use zeron_proto::{
     AgentEvent, DoneStatus, HarnessId, RunRequest, SandboxLevel, SteeringMode, TodoItem, ToolCall,
     UserInputAnswer,
@@ -227,6 +225,52 @@ async fn config_options_apply_requested_model_and_effort() {
     );
     assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)]);
 }
+
+#[tokio::test]
+async fn grok_context_ring_maps_live_totals_not_the_billing_ledger() {
+    let (controls, _steer, _token) = controls();
+    let events = run_to_end(&harness(), request("scenario:grok-context"), controls).await;
+    // Grok's context shape: chunk `_meta.totalTokens` mid-turn (ring) and
+    // the settled prompt's LIVE `_meta.totalTokens` at the end — sized to
+    // the model's advertised window. The fixture's currentModelId is
+    // grok-4-fast (no advertised window) while the test requests grok-4.5
+    // (200k), so these events prove the window follows the REQUESTED
+    // model, not the session's boot-time current. The fixture's
+    // `_meta.usage` is a per-turn billing ledger totaling 41001 across
+    // several model calls; it must never feed the ring (the 318k/200k
+    // nonsense).
+    let ring = events
+        .iter()
+        .filter(|ev| matches!(ev, AgentEvent::ContextUsage { .. }))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ring,
+        vec![
+            &AgentEvent::ContextUsage {
+                used: 5174,
+                size: 200000,
+                estimated: true,
+            },
+            &AgentEvent::ContextUsage {
+                used: 6000,
+                size: 200000,
+                estimated: true,
+            },
+            &AgentEvent::ContextUsage {
+                used: 13667,
+                size: 200000,
+                estimated: true,
+            },
+        ],
+        "{events:?}"
+    );
+    assert!(
+        ring.iter()
+            .all(|ev| matches!(ev, AgentEvent::ContextUsage { used, size, .. } if used <= size)),
+        "{events:?}"
+    );
+}
+
 #[tokio::test]
 async fn permission_requests_auto_accept_the_preferred_allow_option() {
     let (controls, _steer, _token) = controls();
@@ -764,8 +808,9 @@ async fn grok_subagent_lifecycle_tails_the_disk_transcript_into_tagged_events() 
         )
     })
     .expect("tool result tailed");
-    let text = pos(&|e| matches!(e, AgentEvent::TextDelta { text } if text.starts_with("two files")))
-        .expect("mid-run append tailed");
+    let text =
+        pos(&|e| matches!(e, AgentEvent::TextDelta { text } if text.starts_with("two files")))
+            .expect("mid-run append tailed");
     let done = pos(&|e| {
         matches!(
             e,

--- a/crates/harness/tests/claude.rs
+++ b/crates/harness/tests/claude.rs
@@ -202,6 +202,13 @@ async fn happy_path_normalizes_events_and_tags_subagents() {
         input_tokens: 10,
         output_tokens: 20
     }));
+    // Turn-end context gauge from the result frame: usage including BOTH
+    // cache tiers is the true window fill; modelUsage carries the window.
+    assert!(events.contains(&AgentEvent::ContextUsage {
+        used: 32_030,
+        size: 200_000,
+        estimated: false
+    }));
     assert_eq!(
         events.last(),
         Some(&AgentEvent::Done {

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -258,6 +258,13 @@ async fn happy_path_maps_deltas_items_usage_and_done() {
             )
         })
         .expect("usage emitted");
+    // The live context gauge (exact: last.totalTokens + modelContextWindow)
+    // flows through the same notification, live rather than turn-held.
+    assert!(events.contains(&AgentEvent::ContextUsage {
+        used: 49,
+        size: 128_000,
+        estimated: false
+    }));
     let done_pos = events
         .iter()
         .position(|e| matches!(e, AgentEvent::Done { .. }))

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -57,8 +57,12 @@ elif has "$line" '"method":"session/new"'; then
   # Advertise config options: model (current differs from the tests' request,
   # forcing a set) and thought_level (current high). The model config option
   # feeds discovery first; the first-class `models` state (SessionModelState)
-  # is the legacy fallback — codex-acp enumerates model × effort there.
-  emit "{\"id\":$(rid "$line"),\"result\":{\"sessionId\":\"s-1\",\"models\":{\"availableModels\":[{\"modelId\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\",\"description\":\"Fast tier\"},{\"modelId\":\"grok-4.5\",\"name\":\"Grok 4.5\"}],\"currentModelId\":\"grok-4.5\"},\"configOptions\":[{\"id\":\"model\",\"name\":\"Model\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":\"grok-4-fast\",\"options\":[{\"value\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\",\"description\":\"Fast tier\"},{\"value\":\"grok-4.5\",\"name\":\"Grok 4.5\"}]},{\"id\":\"effort\",\"name\":\"Reasoning effort\",\"category\":\"thought_level\",\"type\":\"select\",\"currentValue\":\"high\",\"options\":[{\"value\":\"low\",\"name\":\"Low\"},{\"value\":\"medium\",\"name\":\"Medium\"},{\"value\":\"high\",\"name\":\"High\"}]}]}}"
+  # is the legacy fallback — codex-acp enumerates model × effort there. The
+  # models state's currentModelId deliberately matches the config option's
+  # currentValue: the ring's 200k window must come from the REQUESTED model
+  # (grok-4.5's _meta), not the boot-time current (grok-4-fast, which
+  # advertises none).
+  emit "{\"id\":$(rid "$line"),\"result\":{\"sessionId\":\"s-1\",\"models\":{\"availableModels\":[{\"modelId\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\",\"description\":\"Fast tier\"},{\"modelId\":\"grok-4.5\",\"name\":\"Grok 4.5\",\"_meta\":{\"totalContextTokens\":200000}}],\"currentModelId\":\"grok-4-fast\"},\"configOptions\":[{\"id\":\"model\",\"name\":\"Model\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":\"grok-4-fast\",\"options\":[{\"value\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\",\"description\":\"Fast tier\"},{\"value\":\"grok-4.5\",\"name\":\"Grok 4.5\"}]},{\"id\":\"effort\",\"name\":\"Reasoning effort\",\"category\":\"thought_level\",\"type\":\"select\",\"currentValue\":\"high\",\"options\":[{\"value\":\"low\",\"name\":\"Low\"},{\"value\":\"medium\",\"name\":\"Medium\"},{\"value\":\"high\",\"name\":\"High\"}]}]}}"
 else
   exit 1
 fi
@@ -86,6 +90,17 @@ case "$promptline" in
   else
     emit "{\"id\":$pid,\"result\":{\"stopReason\":\"refusal\"}}"
   fi
+  ;;
+
+*scenario:grok-context*)
+  # Grok's context shape: chunks carry the live context total in
+  # `update._meta.totalTokens`; the settled prompt carries the same live
+  # total in `_meta.totalTokens` while `_meta.usage` is a per-turn BILLING
+  # ledger (several model calls summed — larger than the live total) that
+  # must never feed the ring.
+  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"pong"},"_meta":{"totalTokens":5174,"chunkId":14}}'
+  update '{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"hmm"},"_meta":{"totalTokens":6000}}'
+  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\",\"_meta\":{\"totalTokens\":13667,\"inputTokens\":13650,\"outputTokens\":17,\"usage\":{\"inputTokens\":40950,\"outputTokens\":51,\"totalTokens\":41001}}}}"
   ;;
 
 *scenario:many*)

--- a/crates/harness/tests/fixtures/fake-claude.sh
+++ b/crates/harness/tests/fixtures/fake-claude.sh
@@ -31,7 +31,7 @@ case "$first" in
   emit '{"type":"user","parent_tool_use_id":null,"message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","is_error":false},{"type":"tool_result","tool_use_id":"tool-2","is_error":true}]}}'
   # Informational rate-limit status: stays quiet.
   emit '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed"}}'
-  emit '{"type":"result","subtype":"success","result":"done!","errors":[],"usage":{"input_tokens":10,"output_tokens":20},"session_id":"sess-1","total_cost_usd":0.01}'
+  emit '{"type":"result","subtype":"success","result":"done!","errors":[],"usage":{"input_tokens":10,"cache_creation_input_tokens":2000,"cache_read_input_tokens":30000,"output_tokens":20},"modelUsage":{"claude-sonnet-4-5":{"inputTokens":10,"outputTokens":20,"contextWindow":200000}},"session_id":"sess-1","total_cost_usd":0.01}'
   ;;
 
 *scenario:wake*)

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -84,7 +84,7 @@ case "$turnline" in
   emit '{"method":"item/completed","params":{"item":{"id":"m2","type":"agentMessage","text":"unstreamed tail"}}}'
   # Unknown notification methods must be tolerated.
   emit '{"method":"some/unknownNotification","params":{"x":1}}'
-  emit '{"method":"thread/tokenUsage/updated","params":{"tokenUsage":{"last":{"inputTokens":42,"outputTokens":7}}}}'
+  emit '{"method":"thread/tokenUsage/updated","params":{"tokenUsage":{"last":{"inputTokens":42,"outputTokens":7,"totalTokens":49},"modelContextWindow":128000}}}'
   emit '{"method":"turn/completed","params":{"turn":{"id":"t-1"}}}'
   ;;
 

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -289,6 +289,17 @@ pub enum AgentEvent {
         input_tokens: u64,
         output_tokens: u64,
     },
+    /// Live context-window consumption (ACP `usage_update`); never persisted to transcript docs.
+    #[serde(rename_all = "camelCase")]
+    ContextUsage {
+        used: u64,
+        size: u64,
+        /// Estimate marker (grok's chunk counter) — carried through to the
+        /// session's `ContextUsage` so the ring can render `~`. Defaulted
+        /// for old-wire compatibility.
+        #[serde(default)]
+        estimated: bool,
+    },
     /// The agent advertised (or changed) its slash-command set — ACP
     /// `available_commands_update`. The engine caches the latest list per
     /// harness for the composer's `/` popup; never persisted to docs.
@@ -348,6 +359,27 @@ mod tests {
         };
         let json = serde_json::to_string(&ev).unwrap();
         assert_eq!(serde_json::from_str::<AgentEvent>(&json).unwrap(), ev);
+
+        let context_ev = AgentEvent::ContextUsage {
+            used: 42_000,
+            size: 200_000,
+            estimated: true,
+        };
+        let json = serde_json::to_string(&context_ev).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AgentEvent>(&json).unwrap(),
+            context_ev
+        );
+        // Old-wire JSON without the flag parses (additive compat).
+        let legacy = r#"{"type":"contextUsage","used":42,"size":200}"#;
+        assert_eq!(
+            serde_json::from_str::<AgentEvent>(legacy).unwrap(),
+            AgentEvent::ContextUsage {
+                used: 42,
+                size: 200,
+                estimated: false
+            }
+        );
     }
 
     #[test]

--- a/crates/proto/src/entities.rs
+++ b/crates/proto/src/entities.rs
@@ -180,6 +180,19 @@ pub enum SessionStatus {
     Errored,
 }
 
+/// Context window usage measurement for a chat session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextUsage {
+    pub used: u64,
+    pub size: u64,
+    /// True when `used` is a harness-side estimate (grok's chunk counter)
+    /// rather than an exact ACP `usage_update` measurement — rendered with
+    /// a `~` so estimates never present as exact.
+    #[serde(default)]
+    pub estimated: bool,
+}
+
 /// Live run status for a chat — drives the Working indicator and sidebar status dots.
 /// Staleness-checked client-side against `updated_at` so a crashed backend never shows
 /// an eternal "Working".
@@ -191,6 +204,8 @@ pub struct Session {
     pub status: SessionStatus,
     pub started_at: Option<DateTime<Utc>>,
     pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_usage: Option<ContextUsage>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/sync/tests/registry_client.rs
+++ b/crates/sync/tests/registry_client.rs
@@ -117,6 +117,7 @@ async fn two_clients_converge_and_stream_live_updates() {
             status: SessionStatus::Working,
             started_at: Some(ts(3_000)),
             updated_at: ts(3_500),
+            context_usage: None,
         })
         .unwrap();
     }
@@ -129,6 +130,93 @@ async fn two_clients_converge_and_stream_live_updates() {
             .unwrap()
             .first()
             .is_some_and(|s| s.status == SessionStatus::Working)
+    })
+    .await;
+
+    client_a.shutdown().await;
+    client_b.shutdown().await;
+}
+
+#[tokio::test]
+async fn context_usage_converges_and_clears_across_clients() {
+    let server = MockRegistryServer::start().await;
+    let doc_a = new_doc("dev-a");
+    let doc_b = new_doc("dev-b");
+
+    {
+        let mut doc = doc_a.lock().unwrap();
+        doc.upsert_chat(&chat("chat-1", "dev-a")).unwrap();
+    }
+    let client_a = RegistryClient::connect(&server.url(), doc_a.clone(), "dev-a")
+        .await
+        .expect("a connects");
+    client_a.nudge();
+    wait_until(|| doc_a.lock().unwrap().pending_len() == 0).await;
+
+    let client_b = RegistryClient::connect(&server.url(), doc_b.clone(), "dev-b")
+        .await
+        .expect("b connects");
+    wait_until(|| doc_b.lock().unwrap().read_chats().unwrap().len() == 1).await;
+
+    // A reports a live gauge; B's session row converges on the exact value.
+    {
+        let mut doc = doc_a.lock().unwrap();
+        doc.upsert_session(&Session {
+            chat_id: "chat-1".into(),
+            device_id: "dev-a".into(),
+            status: SessionStatus::Working,
+            started_at: Some(ts(3_000)),
+            updated_at: ts(3_500),
+            context_usage: Some(zeron_proto::ContextUsage {
+                used: 168_000,
+                size: 200_000,
+                estimated: false,
+            }),
+        })
+        .unwrap();
+    }
+    client_a.nudge();
+    wait_until(|| {
+        doc_b
+            .lock()
+            .unwrap()
+            .read_sessions()
+            .unwrap()
+            .first()
+            .is_some_and(|s| {
+                s.context_usage
+                    == Some(zeron_proto::ContextUsage {
+                        used: 168_000,
+                        size: 200_000,
+                        estimated: false,
+                    })
+            })
+    })
+    .await;
+
+    // A clears the gauge (model change / fresh session); the clear — a null
+    // field write, not an omitted one — must reach B too.
+    {
+        let mut doc = doc_a.lock().unwrap();
+        doc.upsert_session(&Session {
+            chat_id: "chat-1".into(),
+            device_id: "dev-a".into(),
+            status: SessionStatus::Idle,
+            started_at: None,
+            updated_at: ts(4_000),
+            context_usage: None,
+        })
+        .unwrap();
+    }
+    client_a.nudge();
+    wait_until(|| {
+        doc_b
+            .lock()
+            .unwrap()
+            .read_sessions()
+            .unwrap()
+            .first()
+            .is_some_and(|s| s.context_usage.is_none())
     })
     .await;
 
@@ -428,6 +516,7 @@ async fn churn_stays_bounded_no_history_growth() {
                 },
                 started_at: Some(ts(i)),
                 updated_at: ts(i + 1),
+                context_usage: None,
             })
             .unwrap();
         }

--- a/crates/sync/tests/registry_edge.rs
+++ b/crates/sync/tests/registry_edge.rs
@@ -82,6 +82,7 @@ async fn two_rust_clients_converge_through_a_real_registry_do() {
             status: SessionStatus::Working,
             started_at: Some(ts(3_000)),
             updated_at: ts(3_500),
+            context_usage: None,
         })
         .unwrap();
     }
@@ -202,6 +203,7 @@ async fn cursor_delta_and_churn_stay_bounded_on_a_real_do() {
                 },
                 started_at: Some(ts(i)),
                 updated_at: ts(i + 1),
+                context_usage: None,
             })
             .unwrap();
         }

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -5514,6 +5514,16 @@ impl Render for Composer {
         self.last_rendered_height = pill_height;
 
         let send_button = self.render_send_button(mode, cx);
+        let context_usage = {
+            let state = self.state.read(cx);
+            state
+                .selected_chat
+                .as_deref()
+                .and_then(|chat_id| state.session_for(chat_id))
+                .and_then(|s| s.context_usage)
+        };
+        let context_ring =
+            context_usage.map(|cu| crate::context_ring::render_context_usage_ring(cu, &theme));
         // Attach button — opens the native image picker (the original's hidden
         // `<input type=file accept="image/*" multiple>`); paste/drop also feed
         // the same strip. `ml-1` per the source cluster — chips→attach reads
@@ -5686,10 +5696,11 @@ impl Render for Composer {
         ));
         // Branch/worktree toolbar under the pill (t3code BranchToolbar): the
         // checkout-kind selector + ref picker for new sessions, read-only
-        // labels once the session exists. Git spaces only.
+        // labels once the session exists. Git spaces only. The context ring
+        // rides this row beside the branch (moved out of the pill cluster).
         let footer = self
             .pickers
-            .update(cx, |pickers, cx| pickers.render_footer(cx));
+            .update(cx, |pickers, cx| pickers.render_footer(context_ring, cx));
         let container = match footer {
             Some(footer) => container.child(footer),
             None => container,

--- a/crates/ui/src/context_ring.rs
+++ b/crates/ui/src/context_ring.rs
@@ -1,0 +1,451 @@
+//! Context-window usage ring for the conversation composer.
+//!
+//! Renders a circular progress indicator displaying the percentage of the
+//! active context window consumed (`used / size`), with exact values in a
+//! tooltip and clear color thresholds (normal neutral, warning orange >= 80%,
+//! critical red >= 95%).
+
+use gpui::{
+    AnyElement, Hsla, InteractiveElement, IntoElement, ParentElement, PathBuilder, SharedString,
+    StatefulInteractiveElement, Styled, canvas, div, hsla, point, px,
+};
+use zeron_proto::ContextUsage;
+
+use crate::theme::Theme;
+
+/// Thresholds per issue #137:
+/// - Normal: < 80%
+/// - Warning: 80%–94%
+/// - Critical: >= 95%
+pub const WARNING_THRESHOLD: f32 = 0.80;
+pub const CRITICAL_THRESHOLD: f32 = 0.95;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextUsageSeverity {
+    Normal,
+    Warning,
+    Critical,
+}
+
+pub fn context_usage_ratio(usage: &ContextUsage) -> f32 {
+    if usage.size == 0 {
+        return 0.0;
+    }
+    (usage.used as f32 / usage.size as f32).clamp(0.0, 1.0)
+}
+
+pub fn context_usage_percentage(usage: &ContextUsage) -> u32 {
+    let ratio = context_usage_ratio(usage);
+    (ratio * 100.0).round() as u32
+}
+
+pub fn context_usage_severity(usage: &ContextUsage) -> ContextUsageSeverity {
+    // Thresholded on the ROUNDED percentage — the same number the tooltip
+    // and label show — so the ring's color can never disagree with the
+    // "80%"/"95%" the user reads at an edge.
+    let pct = context_usage_percentage(usage);
+    if pct as f32 / 100.0 >= CRITICAL_THRESHOLD {
+        ContextUsageSeverity::Critical
+    } else if pct as f32 / 100.0 >= WARNING_THRESHOLD {
+        ContextUsageSeverity::Warning
+    } else {
+        ContextUsageSeverity::Normal
+    }
+}
+
+pub fn format_tokens(tokens: u64) -> String {
+    if tokens >= 1_000_000 {
+        let val = tokens as f64 / 1_000_000.0;
+        if (val * 10.0).round() % 10.0 == 0.0 {
+            format!("{:.0}M", val)
+        } else {
+            format!("{:.1}M", val)
+        }
+    } else if tokens >= 1_000 {
+        let val = tokens as f64 / 1_000.0;
+        if (val * 10.0).round() % 10.0 == 0.0 {
+            format!("{:.0}K", val)
+        } else {
+            format!("{:.1}K", val)
+        }
+    } else {
+        tokens.to_string()
+    }
+}
+
+pub fn context_tooltip_text(usage: &ContextUsage) -> String {
+    let used = format_tokens(usage.used);
+    let size = format_tokens(usage.size);
+    let pct = context_usage_percentage(usage);
+    // `~` marks a harness-side estimate (grok's chunk counter) so it never
+    // presents as an exact measurement.
+    let marker = if usage.estimated { "~" } else { "" };
+    // The state word keeps warning/critical distinguishable without
+    // relying on the ring's color alone.
+    let state = match context_usage_severity(usage) {
+        ContextUsageSeverity::Normal => "",
+        ContextUsageSeverity::Warning => " — warning",
+        ContextUsageSeverity::Critical => " — critical",
+    };
+    format!("{marker}{used} / {size} context used ({pct}%){state}")
+}
+
+pub fn context_accessible_label(usage: &ContextUsage) -> String {
+    let used = format_tokens(usage.used);
+    let size = format_tokens(usage.size);
+    let pct = context_usage_percentage(usage);
+    let marker = if usage.estimated { "~" } else { "" };
+    match context_usage_severity(usage) {
+        ContextUsageSeverity::Normal => format!("Context usage: {pct}%, {marker}{used} of {size}"),
+        ContextUsageSeverity::Warning => {
+            format!("Context usage warning: {pct}%, {marker}{used} of {size}")
+        }
+        ContextUsageSeverity::Critical => {
+            format!("Context usage critical: {pct}%, {marker}{used} of {size}")
+        }
+    }
+}
+
+pub fn context_ring_color(usage: &ContextUsage, theme: &Theme) -> Hsla {
+    match context_usage_severity(usage) {
+        ContextUsageSeverity::Normal => theme.text_muted,
+        // Amber/orange warning
+        ContextUsageSeverity::Warning => hsla(38.0 / 360.0, 0.92, 0.50, 1.0),
+        // Red critical
+        ContextUsageSeverity::Critical => hsla(0.0 / 360.0, 0.72, 0.51, 1.0),
+    }
+}
+
+/// Hover-fade key shared by the ring's `on_hover` listener and the
+/// tooltip-visibility read in [`render_context_usage_ring`].
+const HOVER_KEY: &str = "composer-context-usage";
+
+/// Tooltip card pinned to the LEFT of the ring. gpui's built-in `.tooltip()`
+/// tracks the cursor with no direction control, so the ring renders its own
+/// hover card instead, anchored by an absolute offset inside its relative box.
+fn context_tooltip_card(text: SharedString, theme: &Theme) -> gpui::Div {
+    div()
+        .absolute()
+        // Vertically centered on the 28px ring: 24px card → top 2px.
+        .top(px(2.0))
+        // The card's RIGHT edge parks 6px left of the ring's left edge and
+        // grows leftward — a fixed direction, never cursor-following.
+        .right(px(34.0))
+        .h(px(24.0))
+        .flex()
+        .items_center()
+        .px(px(8.0))
+        .rounded(px(5.0))
+        .border_1()
+        .border_color(theme.border_strong)
+        .bg(theme.surface_raised)
+        .text_size(px(11.0))
+        .font_weight(gpui::FontWeight::MEDIUM)
+        .text_color(theme.text)
+        .child(text)
+}
+
+/// Render the circular gauge for context usage; lives in the composer footer
+/// row beside the branch chip, with a hover tooltip pinned to its left.
+pub fn render_context_usage_ring(usage: ContextUsage, theme: &Theme) -> AnyElement {
+    let aria_label: SharedString = context_accessible_label(&usage).into();
+    let ring_color = context_ring_color(&usage, theme);
+    let track_color = crate::theme::ink(0.08);
+    let ratio = context_usage_ratio(&usage);
+
+    // Dimensions: 28px hit container, 14px outer circle with 2px stroke.
+    let size_px = 28.0;
+    let radius = 6.0;
+    let stroke_width = 1.75;
+
+    // The hover fade doubles as the show delay: the card mounts only once the
+    // 150ms fade has settled, so a pass-through swipe never flashes it, and
+    // re-renders mid-hover (streaming updates) can't kill it — the fade state
+    // is keyed globally, not per element instance.
+    let tooltip = (crate::motion::hover_t(HOVER_KEY) >= 0.999)
+        .then(|| context_tooltip_card(context_tooltip_text(&usage).into(), theme));
+
+    div()
+        .id(HOVER_KEY)
+        // Progress indicator semantics: the label carries the percentage,
+        // values, and state so the gauge is usable without the ring's color.
+        .role(gpui::Role::ProgressIndicator)
+        .aria_label(aria_label)
+        .relative()
+        .size(px(size_px))
+        .flex_none()
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded_full()
+        .cursor_default()
+        .on_hover(crate::motion::hover_listener(HOVER_KEY))
+        .children(tooltip)
+        .child(
+            canvas(
+                move |_, _, _| {},
+                move |bounds, _, window, _| {
+                    let center_x = bounds.origin.x + px(size_px / 2.0);
+                    let center_y = bounds.origin.y + px(size_px / 2.0);
+
+                    // 1. Draw background track circle
+                    let mut track_builder = PathBuilder::stroke(px(stroke_width));
+                    track_builder.move_to(point(center_x + px(radius), center_y));
+                    track_builder.arc_to(
+                        point(px(radius), px(radius)),
+                        px(0.),
+                        false,
+                        true,
+                        point(center_x - px(radius), center_y),
+                    );
+                    track_builder.arc_to(
+                        point(px(radius), px(radius)),
+                        px(0.),
+                        false,
+                        true,
+                        point(center_x + px(radius), center_y),
+                    );
+                    if let Ok(path) = track_builder.build() {
+                        window.paint_path(path, track_color);
+                    }
+
+                    // 2. Draw progress arc starting from top (-90 degrees / 12 o'clock)
+                    if ratio > 0.001 {
+                        let mut arc_builder = PathBuilder::stroke(px(stroke_width));
+                        let start_angle = -std::f32::consts::FRAC_PI_2;
+                        let sweep_angle = ratio * std::f32::consts::TAU;
+
+                        let start_x = center_x + px(radius * start_angle.cos());
+                        let start_y = center_y + px(radius * start_angle.sin());
+                        arc_builder.move_to(point(start_x, start_y));
+
+                        if ratio >= 0.999 {
+                            // Full circle: two semicircles
+                            arc_builder.arc_to(
+                                point(px(radius), px(radius)),
+                                px(0.),
+                                false,
+                                true,
+                                point(center_x, center_y + px(radius)),
+                            );
+                            arc_builder.arc_to(
+                                point(px(radius), px(radius)),
+                                px(0.),
+                                false,
+                                true,
+                                point(start_x, start_y),
+                            );
+                        } else {
+                            let end_angle = start_angle + sweep_angle;
+                            let end_x = center_x + px(radius * end_angle.cos());
+                            let end_y = center_y + px(radius * end_angle.sin());
+                            let large_arc = sweep_angle > std::f32::consts::PI;
+
+                            arc_builder.arc_to(
+                                point(px(radius), px(radius)),
+                                px(0.),
+                                large_arc,
+                                true,
+                                point(end_x, end_y),
+                            );
+                        }
+
+                        if let Ok(path) = arc_builder.build() {
+                            window.paint_path(path, ring_color);
+                        }
+                    }
+                },
+            )
+            .size(px(size_px)),
+        )
+        .into_any_element()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_usage_calculations_and_thresholds() {
+        let normal = ContextUsage {
+            used: 42_000,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_percentage(&normal), 21);
+        assert_eq!(
+            context_usage_severity(&normal),
+            ContextUsageSeverity::Normal
+        );
+        assert_eq!(
+            context_tooltip_text(&normal),
+            "42K / 200K context used (21%)"
+        );
+        assert_eq!(
+            context_accessible_label(&normal),
+            "Context usage: 21%, 42K of 200K"
+        );
+
+        let warning = ContextUsage {
+            used: 168_000,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_percentage(&warning), 84);
+        assert_eq!(
+            context_usage_severity(&warning),
+            ContextUsageSeverity::Warning
+        );
+        assert_eq!(
+            context_tooltip_text(&warning),
+            "168K / 200K context used (84%) — warning"
+        );
+        assert_eq!(
+            context_accessible_label(&warning),
+            "Context usage warning: 84%, 168K of 200K"
+        );
+
+        let critical = ContextUsage {
+            used: 194_000,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_percentage(&critical), 97);
+        assert_eq!(
+            context_usage_severity(&critical),
+            ContextUsageSeverity::Critical
+        );
+        assert_eq!(
+            context_tooltip_text(&critical),
+            "194K / 200K context used (97%) — critical"
+        );
+        assert_eq!(
+            context_accessible_label(&critical),
+            "Context usage critical: 97%, 194K of 200K"
+        );
+
+        // Estimates carry the `~` marker in both surfaces.
+        let estimated = ContextUsage {
+            used: 13_667,
+            size: 200_000,
+            estimated: true,
+        };
+        assert_eq!(
+            context_tooltip_text(&estimated),
+            "~13.7K / 200K context used (7%)"
+        );
+        assert_eq!(
+            context_accessible_label(&estimated),
+            "Context usage: 7%, ~13.7K of 200K"
+        );
+    }
+
+    #[test]
+    fn severity_thresholds_follow_the_rounded_percentage() {
+        // Exactly the issue's suggested edges: 80% warns, 94% still warns,
+        // 95% goes critical.
+        let at_80 = ContextUsage {
+            used: 160_000,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_percentage(&at_80), 80);
+        assert_eq!(
+            context_usage_severity(&at_80),
+            ContextUsageSeverity::Warning
+        );
+
+        let at_94 = ContextUsage {
+            used: 188_000,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_percentage(&at_94), 94);
+        assert_eq!(
+            context_usage_severity(&at_94),
+            ContextUsageSeverity::Warning
+        );
+
+        let at_95 = ContextUsage {
+            used: 190_000,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_percentage(&at_95), 95);
+        assert_eq!(
+            context_usage_severity(&at_95),
+            ContextUsageSeverity::Critical
+        );
+
+        // A ratio that rounds UP to the threshold takes the threshold's
+        // state — the color can never disagree with the displayed "80%".
+        let rounds_to_80 = ContextUsage {
+            used: 159_999,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_percentage(&rounds_to_80), 80);
+        assert_eq!(
+            context_usage_severity(&rounds_to_80),
+            ContextUsageSeverity::Warning
+        );
+
+        let rounds_to_95 = ContextUsage {
+            used: 189_999,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_percentage(&rounds_to_95), 95);
+        assert_eq!(
+            context_usage_severity(&rounds_to_95),
+            ContextUsageSeverity::Critical
+        );
+
+        // Just under the threshold (displays 79%) stays normal.
+        let at_79 = ContextUsage {
+            used: 158_600,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_percentage(&at_79), 79);
+        assert_eq!(context_usage_severity(&at_79), ContextUsageSeverity::Normal);
+    }
+
+    #[test]
+    fn ratio_edges_zero_window_and_overfull_gauge() {
+        // Zero window is "unavailable", never a divide-by-zero.
+        let zero = ContextUsage {
+            used: 0,
+            size: 0,
+            estimated: false,
+        };
+        assert_eq!(context_usage_ratio(&zero), 0.0);
+        assert_eq!(context_usage_percentage(&zero), 0);
+        assert_eq!(context_usage_severity(&zero), ContextUsageSeverity::Normal);
+
+        // used > size (a mis-report that slipped past the harness cap)
+        // clamps to a full ring, never >100%.
+        let overfull = ContextUsage {
+            used: 318_000,
+            size: 200_000,
+            estimated: false,
+        };
+        assert_eq!(context_usage_ratio(&overfull), 1.0);
+        assert_eq!(context_usage_percentage(&overfull), 100);
+        assert_eq!(
+            context_usage_severity(&overfull),
+            ContextUsageSeverity::Critical
+        );
+    }
+
+    #[test]
+    fn format_tokens_scale() {
+        assert_eq!(format_tokens(500), "500");
+        assert_eq!(format_tokens(1_000), "1K");
+        assert_eq!(format_tokens(42_000), "42K");
+        assert_eq!(format_tokens(200_000), "200K");
+        assert_eq!(format_tokens(1_000_000), "1M");
+        assert_eq!(format_tokens(1_200_000), "1.2M");
+        assert_eq!(format_tokens(2_000_000), "2M");
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -19,6 +19,7 @@ pub mod badges;
 pub mod changes;
 pub mod comments;
 pub mod composer;
+pub mod context_ring;
 pub mod edge_fade;
 pub mod frost;
 pub mod history;

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -2225,10 +2225,15 @@ impl Pickers {
     }
 
     /// The composer footer row: checkout-kind + ref, LEFT-aligned, only when
-    /// the picked (or session's) project has git. Device + project moved to
-    /// the new-session canvas ([`Self::render_target_selectors`]); sessions
+    /// the picked (or session's) project has git, plus the context-usage ring
+    /// beside the branch (rendered even without git). Device + project moved
+    /// to the new-session canvas ([`Self::render_target_selectors`]); sessions
     /// name their target in the titlebar.
-    pub fn render_footer(&mut self, cx: &mut Context<Self>) -> Option<AnyElement> {
+    pub fn render_footer(
+        &mut self,
+        context_ring: Option<AnyElement>,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
         let theme = Theme::of(cx).clone();
         // A selected chat whose workspace row hasn't synced yet (the moment
         // right after send mints it) still renders the DRAFT footer — the
@@ -2261,13 +2266,21 @@ impl Pickers {
                 .px(px(10.0))
                 .mb(px(-8.0))
         };
+        // No git chips to anchor against — still surface the context ring
+        // alone, right-aligned where the branch chip would sit.
+        let ring_only = |ring: AnyElement| -> AnyElement {
+            row()
+                .child(div().min_w_0())
+                .child(div().flex().flex_row().items_center().min_w_0().child(ring))
+                .into_any_element()
+        };
 
         if let Some(chat) = &session {
             // Sessions never move: read-only checkout-kind + ref labels,
             // LEFT-aligned, only when the session's project has git. The
             // target (project @ device) lives in the titlebar now.
             let Some(space) = space.as_ref().filter(|s| s.git_detected) else {
-                return None;
+                return context_ring.map(ring_only);
             };
             let is_worktree = chat.cwd.as_deref().is_some_and(|cwd| cwd != space.path);
             let (icon_path, label) = if is_worktree {
@@ -2292,6 +2305,9 @@ impl Pickers {
                 .flex_row()
                 .items_center()
                 .min_w_0()
+                .gap(px(6.0))
+                // Context ring LEFT of the branch label (user request).
+                .children(context_ring)
                 .child(Self::footer_label(
                     crate::icons::GIT_BRANCH,
                     chat.branch
@@ -2307,7 +2323,7 @@ impl Pickers {
         // project live under the canvas logo now).
         let git = space.as_ref().is_some_and(|s| s.git_detected);
         if !git {
-            return None;
+            return context_ring.map(ring_only);
         }
         // Refs feed the draft labels — eager + idempotent.
         self.ensure_refs(false, cx);
@@ -2366,6 +2382,10 @@ impl Pickers {
             .flex_row()
             .items_center()
             .min_w_0()
+            .gap(px(6.0))
+            // Context ring LEFT of the branch chip (user request); the chip
+            // stays rightmost so its popover anchor is unchanged.
+            .children(context_ring)
             .child(attach_overlay_end(
                 ref_chip,
                 &mut overlay,

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -2228,6 +2228,7 @@ mod tests {
             status,
             started_at: None,
             updated_at: now - TimeDelta::seconds(updated_secs_ago),
+            context_usage: None,
         }
     }
 


### PR DESCRIPTION
Closes #137.

## What

A dedicated context-window consumption gauge (used / size) for the composer, kept strictly separate from per-turn token accounting and plan quotas, as the issue specifies.

**Data flow:** a new `AgentEvent::ContextUsage { used, size, estimated }` feeds `Session.context_usage` in the engine (replace, never sum), mirrors across devices through the workspace registry, and clears when a chat's harness/model config changes. Sources per harness:

- **ACP `usage_update`** (issue's suggested path): used/size verbatim, exact (`estimated: false`).
- **Grok**: no `usage_update` — the live context total rides `_meta.totalTokens` on streaming chunks and on the settled `session/prompt` response (`estimated: true`). The per-turn billing ledger (`_meta.usage`, which sums every model call and routinely exceeds the window — the "318k/200k" nonsense) is deliberately not read; totals are capped at the window and zero-total mis-reports (cancelled turns) never wipe the gauge. The window follows the effective model: the requested one when a model config set is queued, else `currentModelId`; tolerant of the wire placements seen across builds; a session with no advertised window disables the ring rather than guessing.
- **Codex (native driver):** `thread/tokenUsage/updated` carries the live fill and `modelContextWindow` — exact gauge, emitted live per notification.
- **Claude (native driver):** the result frame's usage (both cache tiers = true window fill) with `modelUsage.contextWindow` — exact gauge ahead of Usage/Done; no advertised window means no ring.
- Cursor's shim reports no window; the ring stays hidden there by design.

**UI:** `crates/ui/src/context_ring.rs` renders a 28px ring in the composer footer row, left of the branch chip — neutral under 80%, orange 80–94%, red ≥95% (thresholded on the rounded percentage so color can never disagree with the displayed number). Hover shows a card pinned to the LEFT of the ring (gpui's built-in tooltip is cursor-anchored with no direction control, so this is a custom hover overlay). Hidden when no gauge exists; non-git workspaces still get the ring alone in the footer position. Accessibility: `role=ProgressIndicator` with a label carrying percentage, values, and state ("warning"/"critical" words, not color alone).

## Tests

- `grok_context_ring_maps_live_totals_not_the_billing_ledger` — end-to-end over the fake ACP fixture: exactly three ContextUsage events (chunk, chunk, settled prompt), all `used <= size`, ledger ignored.
- Unit tests: chunk mapping (capped 318k→200k, zero-total mis-reports filtered, foreign sessions ignored), settled-response parsing (live total preferred over billing ledger), effective-model window lookup.
- Native-driver emission tests in `tests/codex.rs` / `tests/claude.rs` over their fixtures.
- `context_usage_updates_the_session_watch_and_clears_on_model_change` — engine-level: event lands in WatchSessions state, mirrors to a second device, and a model change clears it everywhere.
- Ring formatting/threshold tests; registry serialization round-trips.

`cargo test --workspace` green (50 suites).
<img width="1313" height="883" alt="Screenshot From 2026-08-18 21-32-52" src="https://github.com/user-attachments/assets/8f80020b-9695-4ef8-9235-bc628465b9de" />

