### PR TITLE
fix(macos): wait for managed daemon at startup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,12 +33,14 @@ gpui UI ─ in-proc/localhost RPC ─ engine A ══ DeviceRoom DO relay ══
 
 ### Headed / headless
 Single binary `zeron`:
-- `zeron` — headed. If a local engine daemon is already listening on the IPC port, connect to it;
-  otherwise run the engine **in-process** (RPC over an in-memory duplex — same protocol, zero
-  serialization shortcuts, so the boundary stays honest) **and serve that same engine on the IPC
-  port**. The embedded engine is not private: any other viewport can attach to the running app
-  without it first being restarted as a daemon. Binding is best-effort — if the port is taken the
-  window still opens, having lost only the ability to host peers.
+- `zeron` — headed. If a local engine daemon is already listening on the IPC port, connect to it.
+  If the background service is installed, it owns startup: wait for its IPC listener rather than
+  competing for the data directory. Without an installed service, run the engine **in-process**
+  (RPC over an in-memory duplex — same protocol, zero serialization shortcuts, so the boundary
+  stays honest) **and serve that same engine on the IPC port**. The embedded engine is not private:
+  any other viewport can attach to the running app without it first being restarted as a daemon.
+  Binding is best-effort — if the port is taken the window still opens, having lost only the ability
+  to host peers. Uninstalling the background service returns startup ownership to the headed app.
 - `zeron headless` — engine only. A clean installation immediately serves its local profile over localhost IPC; when a saved account selects the synced profile at startup and a bearer is available, it also hosts its DeviceRoom for remote control. A VPS can run this while a laptop's UI drives it.
 
 ### Local-first workspace profiles

--- a/apps/zeron/src/daemon.rs
+++ b/apps/zeron/src/daemon.rs
@@ -113,6 +113,15 @@ pub fn uninstall() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Whether an installed macOS LaunchAgent owns headed engine startup.
+pub fn owns_headed_startup() -> anyhow::Result<bool> {
+    if cfg!(target_os = "macos") {
+        Ok(launchd_plist_path()?.exists())
+    } else {
+        Ok(false)
+    }
+}
+
 pub fn start() -> anyhow::Result<()> {
     if cfg!(target_os = "macos") {
         let plist = launchd_plist_path()?;

--- a/apps/zeron/src/main.rs
+++ b/apps/zeron/src/main.rs
@@ -180,8 +180,11 @@ fn main() -> anyhow::Result<()> {
         },
         None => {
             let edge_token = std::env::var("ZERON_EDGE_TOKEN").ok();
-            // Headed: the UI probes ZERON_IPC_PORT and connects to a running
-            // daemon, or embeds the engine in-process (ARCHITECTURE §1).
+            let runtime_override = std::env::var_os("ZERON_DATA_DIR").is_some()
+                || std::env::var_os("ZERON_IPC_PORT").is_some();
+            // On macOS, the installed background service owns engine startup;
+            // explicit runtime overrides and other platforms retain the
+            // connect-or-embed behavior (ARCHITECTURE §1).
             zeron_ui::run_app(zeron_ui::UiConfig {
                 data_dir: std::env::var_os("ZERON_DATA_DIR")
                     .map(std::path::PathBuf::from)
@@ -190,6 +193,7 @@ fn main() -> anyhow::Result<()> {
                     .ok()
                     .and_then(|p| p.parse().ok())
                     .unwrap_or(27654),
+                managed_daemon: !runtime_override && daemon::owns_headed_startup()?,
                 edge_url: edge_url_from_env(),
                 workos_client_id: workos_client_id_from_env(&edge_token),
                 edge_token,

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -83,8 +83,10 @@ pub use zeron_proto::HarnessId;
 pub struct UiConfig {
     /// Data directory — engine stores + `ui-settings.json`.
     pub data_dir: PathBuf,
-    /// Localhost IPC port: connect if an engine daemon is listening, embed if not.
+    /// Localhost IPC port to connect to or serve.
     pub ipc_port: u16,
+    /// Wait for the installed background service instead of embedding an engine.
+    pub managed_daemon: bool,
     /// Edge base URL for the embedded engine.
     pub edge_url: String,
     /// Edge bearer; `None` runs offline.
@@ -103,6 +105,7 @@ impl UiConfig {
         EngineBootConfig {
             data_dir: self.data_dir.clone(),
             ipc_port: self.ipc_port,
+            managed_daemon: self.managed_daemon,
             edge_url: self.edge_url.clone(),
             edge_token: self.edge_token.clone(),
             org_id: self.org_id.clone(),
@@ -121,9 +124,9 @@ struct ReopenState {
 
 impl gpui::Global for ReopenState {}
 
-/// Run the headed app: tokio bridge up, engine bootstrap kicked off (probe →
-/// connect-or-embed), 1320×880 window (min 900×600) with [`shell::Shell`] as the
-/// root view, boot splash overlaid until the engine reports ready.
+/// Run the headed app: tokio bridge up, engine bootstrap kicked off, 1320×880
+/// window (min 900×600) with [`shell::Shell`] as the root view, boot splash
+/// overlaid until the engine reports ready.
 pub fn run_app(config: UiConfig) {
     let app = gpui_platform::application().with_assets(icons::Assets);
     // Dock-icon click with no window (⌘W closed it): rebuild the main window

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -6976,6 +6976,7 @@ mod tests {
         let boot = EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: port,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None,
             org_id: None,

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -4,9 +4,10 @@
 //! ## EngineHandle
 //! The UI talks the same typed RPC whether the engine is in-process or a separate
 //! daemon (ARCHITECTURE §1). [`EngineHandle::bootstrap`] probes the localhost IPC
-//! port, mirroring zeron: if an engine is listening it connects over WebSocket
-//! ([`RemoteEngine`]); otherwise it embeds one via [`EngineCore::assemble`] and an
-//! in-memory RPC transport ([`InProcessEngine`]) — same envelopes, same dispatch.
+//! port: if an engine is listening it connects over WebSocket ([`RemoteEngine`]);
+//! if an installed service owns startup it waits for that listener; otherwise it
+//! embeds one via [`EngineCore::assemble`] and an in-memory RPC transport
+//! ([`InProcessEngine`]) — same envelopes, same dispatch.
 //!
 //! ## Async bridging
 //! `bootstrap` runs on tokio via `gpui_tokio::Tokio::spawn`. Once an [`RpcClient`]
@@ -46,6 +47,8 @@ pub struct EngineBootConfig {
     pub data_dir: PathBuf,
     /// Localhost IPC port to probe / serve.
     pub ipc_port: u16,
+    /// Wait for the installed background service instead of embedding an engine.
+    pub managed_daemon: bool,
     /// Edge base URL for the embedded engine.
     pub edge_url: String,
     /// Bearer for edge room joins; `None` runs offline.
@@ -216,19 +219,24 @@ pub struct EngineHandle {
 }
 
 impl EngineHandle {
-    /// Probe the IPC port and connect (daemon listening) or embed (nothing there).
-    /// Must run on the tokio runtime (`Tokio::spawn`): both transports spawn
-    /// tokio tasks.
+    /// Reach the engine over IPC, waiting for an installed daemon or embedding
+    /// one when this process owns startup. Must run on the tokio runtime
+    /// (`Tokio::spawn`): both transports spawn tokio tasks.
     pub async fn bootstrap(config: EngineBootConfig) -> anyhow::Result<EngineHandle> {
-        // Invariant: at most one bootstrap in this process runs probe+embed at
-        // a time. The winner binds the deferred IPC listener before releasing
-        // the gate, so a concurrent viewport's probe finds it and attaches as
-        // Remote instead of racing it for the data dir.
+        // Invariant: at most one bootstrap in this process decides engine
+        // ownership at a time. An embedding winner binds the deferred IPC
+        // listener before releasing the gate, so a concurrent viewport finds
+        // it instead of racing for the data dir.
         static BOOTSTRAP_GATE: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-        let _gate = BOOTSTRAP_GATE.lock().await;
+        let gate = BOOTSTRAP_GATE.lock().await;
 
         if let Some(handle) = Self::attach_to_daemon(config.ipc_port).await {
             return Ok(handle);
+        }
+
+        if config.managed_daemon {
+            drop(gate);
+            return Ok(Self::wait_for_managed_daemon(config.ipc_port).await);
         }
 
         tracing::info!(data_dir = %config.data_dir.display(), "no daemon on port; embedding engine");
@@ -374,9 +382,23 @@ impl EngineHandle {
         Ok(handle)
     }
 
+    async fn wait_for_managed_daemon(ipc_port: u16) -> EngineHandle {
+        tracing::info!(ipc_port, "managed engine daemon not ready; waiting");
+        let mut retry_delay = std::time::Duration::from_millis(100);
+        loop {
+            tokio::time::sleep(retry_delay).await;
+            if let Some(handle) = Self::attach_to_daemon(ipc_port).await {
+                return handle;
+            }
+            retry_delay = retry_delay
+                .saturating_mul(2)
+                .min(std::time::Duration::from_secs(1));
+        }
+    }
+
     /// Probe the IPC port and, if a live engine answers, attach as a remote
-    /// viewport. `None` means embed: nothing listening, a non-engine listener,
-    /// or a listener without an identity.
+    /// viewport. `None` means nothing listening, a non-engine listener, or a
+    /// listener without an identity.
     async fn attach_to_daemon(ipc_port: u16) -> Option<EngineHandle> {
         let url = format!("ws://127.0.0.1:{ipc_port}");
         let probe = tokio::time::timeout(
@@ -427,16 +449,15 @@ impl EngineHandle {
                     tracing::warn!(
                         %url,
                         error = %err,
-                        "listener did not provide engine identity; embedding instead"
+                        "listener did not provide engine identity"
                     );
                     None
                 }
             },
             // Something is on the port but it is not an engine (or it is
-            // wedged). Fall through and embed: a stranger holding 27654
-            // should cost other viewports, not this window.
+            // wedged). The caller decides whether to retry or embed.
             Err(err) => {
-                tracing::warn!(%url, error = %err, "not an engine; embedding instead");
+                tracing::warn!(%url, error = %err, "not an engine");
                 None
             }
         }
@@ -1743,6 +1764,7 @@ mod tests {
         let handle = EngineHandle::bootstrap(EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: port,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None,
             org_id: None,
@@ -1773,6 +1795,7 @@ mod tests {
         let handle = EngineHandle::bootstrap(EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: free_port().await,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None, // offline
             org_id: None,
@@ -1801,6 +1824,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn managed_wait_does_not_claim_local_engine_ownership() {
+        let managed_dir = tempfile::tempdir().unwrap();
+        let managed_port = free_port().await;
+        let (start_daemon_tx, start_daemon_rx) = tokio::sync::oneshot::channel();
+        let (lock_available_tx, lock_available_rx) = tokio::sync::oneshot::channel();
+        let daemon_dir = managed_dir.path().to_path_buf();
+        let daemon = tokio::spawn(async move {
+            let _ = start_daemon_rx.await;
+            let lock = InstanceLock::acquire(&daemon_dir);
+            let _ = lock_available_tx.send(lock.is_ok());
+            let listener = tokio::net::TcpListener::bind(("127.0.0.1", managed_port))
+                .await
+                .unwrap();
+            zeron_rpc::serve_ws_listener(listener, Arc::new(LegacyIdentityRpc)).await;
+        });
+        let managed_wait = tokio::spawn(EngineHandle::bootstrap(EngineBootConfig {
+            data_dir: managed_dir.path().to_path_buf(),
+            ipc_port: managed_port,
+            managed_daemon: true,
+            edge_url: "http://127.0.0.1:1".into(),
+            edge_token: None,
+            org_id: None,
+            workos_client_id: None,
+            default_harness: HarnessId::Mock,
+        }));
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let local_dir = tempfile::tempdir().unwrap();
+        let local_boot = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            EngineHandle::bootstrap(EngineBootConfig {
+                data_dir: local_dir.path().to_path_buf(),
+                ipc_port: free_port().await,
+                managed_daemon: false,
+                edge_url: "http://127.0.0.1:1".into(),
+                edge_token: None,
+                org_id: None,
+                workos_client_id: None,
+                default_harness: HarnessId::Mock,
+            }),
+        )
+        .await;
+        let _ = start_daemon_tx.send(());
+
+        let managed = tokio::time::timeout(std::time::Duration::from_secs(3), managed_wait)
+            .await
+            .expect("managed viewport attaches when its daemon becomes ready")
+            .expect("managed bootstrap task completes")
+            .expect("managed daemon bootstrap succeeds");
+        let lock_available = lock_available_rx.await.unwrap();
+        let managed_is_remote = matches!(managed.mode(), EngineMode::Remote { .. });
+        managed.shutdown().await;
+        daemon.abort();
+
+        let local = local_boot
+            .expect("a passive managed wait must not hold the bootstrap gate")
+            .expect("unmanaged bootstrap succeeds");
+        assert_eq!(local.mode(), EngineMode::InProcess);
+        local.shutdown().await;
+        assert!(
+            lock_available,
+            "the waiting viewport must leave the engine lock to the daemon"
+        );
+        assert!(managed_is_remote);
+    }
+
+    #[tokio::test]
     async fn bootstrap_reports_local_assembly_failure_before_returning_a_handle() {
         let dir = tempfile::tempdir().unwrap();
         zeron_engine::EngineProfile::local(dir.path()).unwrap();
@@ -1811,6 +1901,7 @@ mod tests {
         let error = match EngineHandle::bootstrap(EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: port,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None,
             org_id: None,
@@ -1866,6 +1957,7 @@ mod tests {
         let handle = EngineHandle::bootstrap(EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: port,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None,
             org_id: None,
@@ -1904,6 +1996,7 @@ mod tests {
         let handle = EngineHandle::bootstrap(EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: port,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None, // offline
             org_id: None,
@@ -1946,6 +2039,7 @@ mod tests {
         let config = EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: port,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None, // offline
             org_id: None,
@@ -2006,6 +2100,7 @@ mod tests {
         let handle = EngineHandle::bootstrap(EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: port,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None,
             org_id: None,
@@ -2033,6 +2128,7 @@ mod tests {
         let handle = EngineHandle::bootstrap(EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: free_port().await,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None,
             org_id: None,
@@ -2084,6 +2180,7 @@ mod tests {
         let handle = EngineHandle::bootstrap(EngineBootConfig {
             data_dir: dir.path().to_path_buf(),
             ipc_port: free_port().await,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None,
             org_id: None,
@@ -2142,6 +2239,7 @@ mod tests {
         let handle = EngineHandle::bootstrap(EngineBootConfig {
             data_dir: ui_dir.path().to_path_buf(),
             ipc_port: port,
+            managed_daemon: false,
             edge_url: "http://127.0.0.1:1".into(),
             edge_token: None,
             org_id: None,


### PR DESCRIPTION
When macOS restores Comet after a restart, the GUI can start before the installed LaunchAgent daemon is listening.

The GUI currently treats an unavailable IPC port as a signal to start an embedded engine. This embedded engine claims the data-directory lock and can open the local-only profile instead of connecting to the profile managed by the daemon. Quitting and reopening the app works because the daemon has finished starting by then.

Proposed solution:
When the macOS background service is installed, it is treated as the owner of engine startup.
If the daemon is not ready yet, the GUI waits for its IPC listener with a capped backoff instead of starting an embedded engine. Once the daemon begins listening, the GUI connects normally.
There is intentionally no timeout that falls back to embedding, because that would recreate the same race on slower machines.
Explicit `ZERON_DATA_DIR` and `ZERON_IPC_PORT` launches keep the existing connect-or-embed behavior for isolated development runs. Other platforms are unchanged.

Changes
+ Detect whether the macOS LaunchAgent is installed.
+ Pass the startup-ownership decision into the UI engine bootstrap.
+ Wait for the managed daemon without holding the bootstrap gate or claiming the engine lock.
+ Add a regression test covering daemon lock ownership, eventual attachment, and unrelated local bootstraps.
+ Document the headed-app and background-service startup behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789664305&installation_model_id=425430&pr_number=156&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F156&signature=548d845c47bbcfd8e24946cc0cc20756e8f517cc3de121059ff4a3c8d8148dcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->