### PR TITLE
harness: native drivers rediscover slash commands

### DIFF
--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -1022,8 +1022,11 @@ impl RpcService for EngineRpc {
             }
             methods::LIST_COMMANDS => {
                 // Same shape as ListModels: forces a lazy resolve, then the
-                // harness's own (cached) discovery. Non-ACP harnesses return
-                // an empty list from the trait default.
+                // harness's own (cached) discovery — ACP agents advertise
+                // availableCommands, claude answers the initialize control
+                // request, codex lists skills; only harnesses whose wire has
+                // no listing (cursor, mock) fall through to the trait's
+                // empty default.
                 let p: ListModelsParams = parse_params(params)?;
                 let harness = self
                     .registry

--- a/crates/harness/src/claude/mod.rs
+++ b/crates/harness/src/claude/mod.rs
@@ -49,8 +49,8 @@ use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::mpsc;
 
 use zeron_proto::{
-    AgentEvent, DoneStatus, HarnessId, Model, ReasoningLevel, RunRequest, SteeringMode,
-    UserInputAnswer, UserInputQuestion,
+    AgentEvent, DoneStatus, HarnessId, Model, ReasoningLevel, RunRequest, SlashCommand,
+    SteeringMode, UserInputAnswer, UserInputQuestion,
 };
 
 use crate::{Harness, HarnessError, RunControls, Signal, send_signal, shutdown_child};
@@ -119,6 +119,9 @@ pub struct ClaudeHarness {
     interrupt_grace: Duration,
     /// Grace between SIGTERM and SIGKILL.
     kill_grace: Duration,
+    /// Command discovery cache: only a successful probe is cached, so a
+    /// broken CLI retries on the next picker open (ACP-harness parity).
+    commands: tokio::sync::OnceCell<Vec<SlashCommand>>,
 }
 
 impl Default for ClaudeHarness {
@@ -127,6 +130,7 @@ impl Default for ClaudeHarness {
             executable: None,
             interrupt_grace: Duration::from_secs(2),
             kill_grace: Duration::from_secs(3),
+            commands: tokio::sync::OnceCell::new(),
         }
     }
 }
@@ -240,6 +244,118 @@ impl ClaudeHarness {
             .kill_on_drop(true);
         cmd
     }
+
+    /// Short-lived discovery probe: spawn the CLI in stream-json mode, send
+    /// the `initialize` control request, and read the commands out of its
+    /// control_response. No user message is ever written, so no turn (and no
+    /// API call) happens; the child is torn down as soon as the response
+    /// lands.
+    async fn discover_commands(&self) -> Result<Vec<SlashCommand>, HarnessError> {
+        let exe = self.resolve_executable()?;
+        let mut cmd = Command::new(&exe);
+        crate::compose_child_path(&mut cmd, &exe);
+        cmd.args([
+            "--print",
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            // Mandatory with --print + stream-json output; without it the
+            // CLI exits immediately with a usage error.
+            "--verbose",
+        ]);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                HarnessError::NotInstalled(exe.display().to_string())
+            } else {
+                HarnessError::Io(e)
+            }
+        })?;
+        let (Some(mut stdin), Some(stdout)) = (child.stdin.take(), child.stdout.take()) else {
+            shutdown_child(&mut child, self.kill_grace).await;
+            return Err(HarnessError::Protocol("claude child has no stdio".into()));
+        };
+        const PROBE_ID: &str = "zeron-command-probe";
+        let discovery = async {
+            let request = serde_json::json!({
+                "type": "control_request",
+                "request_id": PROBE_ID,
+                "request": { "subtype": "initialize" },
+            });
+            stdin
+                .write_all(format!("{request}\n").as_bytes())
+                .await
+                .map_err(HarnessError::Io)?;
+            stdin.flush().await.map_err(HarnessError::Io)?;
+            let mut lines = BufReader::new(stdout).lines();
+            while let Some(line) = lines.next_line().await.map_err(HarnessError::Io)? {
+                let Ok(frame) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+                if frame.get("type").and_then(Value::as_str) != Some("control_response") {
+                    continue;
+                }
+                let response = frame.get("response").cloned().unwrap_or(Value::Null);
+                if response.get("request_id").and_then(Value::as_str) != Some(PROBE_ID) {
+                    continue;
+                }
+                if response.get("subtype").and_then(Value::as_str) == Some("error") {
+                    let msg = response
+                        .get("error")
+                        .and_then(Value::as_str)
+                        .unwrap_or("initialize control request failed");
+                    return Err(HarnessError::Protocol(msg.into()));
+                }
+                return Ok(parse_initialize_commands(&response));
+            }
+            Err(HarnessError::Protocol(
+                "claude exited before answering the initialize control request".into(),
+            ))
+        };
+        let result = tokio::time::timeout(Duration::from_secs(10), discovery).await;
+        shutdown_child(&mut child, self.kill_grace).await;
+        match result {
+            Ok(inner) => inner,
+            Err(_) => Err(HarnessError::Protocol("command discovery timed out".into())),
+        }
+    }
+}
+
+/// `commands` out of an `initialize` control_response payload
+/// (`response.response.commands`: name / description / argumentHint).
+fn parse_initialize_commands(response: &Value) -> Vec<SlashCommand> {
+    response
+        .get("response")
+        .and_then(|r| r.get("commands"))
+        .and_then(Value::as_array)
+        .map(|a| a.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|c| {
+            let name = c.get("name").and_then(Value::as_str)?.trim();
+            if name.is_empty() {
+                return None;
+            }
+            Some(SlashCommand {
+                name: name.to_owned(),
+                description: c
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned(),
+                input_hint: c
+                    .get("argumentHint")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|h| !h.is_empty())
+                    .map(str::to_owned),
+            })
+        })
+        .collect()
 }
 
 #[async_trait]
@@ -279,6 +395,18 @@ impl Harness for ClaudeHarness {
     async fn models(&self) -> Result<Vec<Model>, HarnessError> {
         self.resolve_executable()?;
         Ok(static_models())
+    }
+
+    /// Slash commands from the CLI's `initialize` control-request handshake —
+    /// the same channel the Claude Agent SDK's `query()` opens. The response
+    /// carries every command with description + argument hint and involves no
+    /// model turn (verified live, 2.1.228: the control_response is the first
+    /// stdout line, well before any API traffic). Cached on success.
+    async fn commands(&self) -> Result<Vec<SlashCommand>, HarnessError> {
+        self.commands
+            .get_or_try_init(|| self.discover_commands())
+            .await
+            .cloned()
     }
 
     async fn run(

--- a/crates/harness/src/codex/mod.rs
+++ b/crates/harness/src/codex/mod.rs
@@ -53,8 +53,8 @@ use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 
 use zeron_proto::{
-    AgentEvent, DoneStatus, HarnessId, Model, ReasoningLevel, RunRequest, SteeringMode,
-    UserInputAnswer, UserInputQuestion,
+    AgentEvent, DoneStatus, HarnessId, Model, ReasoningLevel, RunRequest, SlashCommand,
+    SteeringMode, UserInputAnswer, UserInputQuestion,
 };
 
 use crate::jsonrpc::{Incoming, RpcClient};
@@ -115,6 +115,9 @@ pub struct CodexHarness {
     interrupt_grace: Duration,
     /// Grace between SIGTERM and SIGKILL.
     kill_grace: Duration,
+    /// Command discovery cache: only a successful probe is cached, so a
+    /// broken CLI retries on the next picker open (ACP-harness parity).
+    commands: tokio::sync::OnceCell<Vec<SlashCommand>>,
 }
 
 impl Default for CodexHarness {
@@ -123,6 +126,7 @@ impl Default for CodexHarness {
             executable: None,
             interrupt_grace: Duration::from_secs(2),
             kill_grace: Duration::from_secs(3),
+            commands: tokio::sync::OnceCell::new(),
         }
     }
 }
@@ -159,6 +163,107 @@ impl CodexHarness {
             )
         })
     }
+
+    /// Short-lived discovery probe: a `codex app-server` handshake followed by
+    /// `skills/list` — the only invocable-listing method the 0.146.x wire has
+    /// (custom `~/.codex/prompts` are NOT exposed; the TUI-only built-ins
+    /// aren't either). Skills are what the codex TUI itself surfaces as
+    /// slash-invocables, listed per-cwd and deduped by name here.
+    async fn discover_commands(&self) -> Result<Vec<SlashCommand>, HarnessError> {
+        let exe = self.resolve_executable()?;
+        let mut cmd = Command::new(&exe);
+        cmd.arg("app-server");
+        crate::compose_child_path(&mut cmd, &exe);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                HarnessError::NotInstalled(exe.display().to_string())
+            } else {
+                HarnessError::Io(e)
+            }
+        })?;
+        let (Some(stdin), Some(stdout)) = (child.stdin.take(), child.stdout.take()) else {
+            shutdown_child(&mut child, self.kill_grace).await;
+            return Err(HarnessError::Protocol("codex child has no stdio".into()));
+        };
+        // The receiver must stay alive for the client's reader loop; agent →
+        // client traffic during the probe is ignored.
+        let (client, _incoming) = RpcClient::new(stdin, stdout);
+        let discovery = async {
+            client
+                .request(
+                    "initialize",
+                    json!({
+                        "clientInfo": {
+                            "name": "zeron-native",
+                            "title": "Zeron",
+                            "version": env!("CARGO_PKG_VERSION"),
+                        },
+                        "capabilities": { "experimentalApi": true },
+                    }),
+                )
+                .await?;
+            client.notify("initialized", None);
+            let skills = client.request("skills/list", json!({})).await?;
+            Ok::<Vec<SlashCommand>, HarnessError>(parse_skill_commands(&skills))
+        };
+        let result = tokio::time::timeout(Duration::from_secs(10), discovery).await;
+        shutdown_child(&mut child, self.kill_grace).await;
+        match result {
+            Ok(inner) => inner,
+            Err(_) => Err(HarnessError::Protocol("command discovery timed out".into())),
+        }
+    }
+}
+
+/// `skills/list` result → picker commands. `data` groups skills by cwd; the
+/// same skill appears under every root, so dedupe by name keeping first
+/// appearance order. The interface's shortDescription is picker-sized; the
+/// top-level description is a model-facing paragraph, kept only as fallback.
+fn parse_skill_commands(result: &Value) -> Vec<SlashCommand> {
+    let mut seen = std::collections::HashSet::new();
+    let mut commands = Vec::new();
+    for group in result
+        .get("data")
+        .and_then(Value::as_array)
+        .map(|a| a.as_slice())
+        .unwrap_or_default()
+    {
+        for skill in group
+            .get("skills")
+            .and_then(Value::as_array)
+            .map(|a| a.as_slice())
+            .unwrap_or_default()
+        {
+            let Some(name) = skill
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|n| !n.is_empty())
+            else {
+                continue;
+            };
+            if !seen.insert(name.to_owned()) {
+                continue;
+            }
+            let interface = skill.get("interface");
+            let description = interface
+                .and_then(|i| i.get("shortDescription"))
+                .and_then(Value::as_str)
+                .filter(|d| !d.is_empty())
+                .or_else(|| skill.get("description").and_then(Value::as_str))
+                .unwrap_or_default();
+            commands.push(SlashCommand {
+                name: name.to_owned(),
+                description: description.to_owned(),
+                input_hint: None,
+            });
+        }
+    }
+    commands
 }
 
 #[async_trait]
@@ -198,6 +303,15 @@ impl Harness for CodexHarness {
     async fn models(&self) -> Result<Vec<Model>, HarnessError> {
         self.resolve_executable()?;
         Ok(static_models())
+    }
+
+    /// Skills from a short-lived `skills/list` probe (see
+    /// [`Self::discover_commands`]); cached on success.
+    async fn commands(&self) -> Result<Vec<SlashCommand>, HarnessError> {
+        self.commands
+            .get_or_try_init(|| self.discover_commands())
+            .await
+            .cloned()
     }
 
     async fn run(

--- a/crates/harness/src/cursor/mod.rs
+++ b/crates/harness/src/cursor/mod.rs
@@ -222,6 +222,10 @@ impl Harness for CursorHarness {
         }
     }
 
+    // No `commands()` override: @cursor/sdk 1.0.28 exposes no slash-command
+    // listing (the cursor-agent TUI's slash commands are client-side only),
+    // so the trait's empty default is the honest answer, not a gap.
+
     async fn run(
         &self,
         request: RunRequest,

--- a/crates/harness/tests/claude.rs
+++ b/crates/harness/tests/claude.rs
@@ -585,3 +585,36 @@ async fn live_real_cli_single_turn() {
         })
     ));
 }
+
+// ---------------------------------------------------------------------------
+// Slash-command discovery
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn commands_come_from_the_initialize_control_request() {
+    let h = harness();
+    let commands = h.commands().await.expect("discovery succeeds");
+    assert_eq!(commands.len(), 2, "nameless entries are dropped: {commands:?}");
+    assert_eq!(commands[0].name, "review");
+    assert_eq!(commands[0].description, "Review a pull request");
+    assert_eq!(commands[0].input_hint.as_deref(), Some("[pr number]"));
+    assert_eq!(commands[1].name, "compact");
+    assert_eq!(commands[1].input_hint, None, "empty hint reads as None");
+
+    // Cached: the second call reuses the first probe's result (the fake has
+    // exited; a re-probe against a dead binary path would still work here,
+    // but object identity of the cached list is the cheap assertion).
+    let again = h.commands().await.expect("cache hit");
+    assert_eq!(again, commands);
+}
+
+/// Live smoke against the real CLI: `cargo test -p zeron-harness --test
+/// claude -- --ignored live_commands`. No model turn, no API cost.
+#[tokio::test]
+#[ignore]
+async fn live_commands_discovery() {
+    let h = ClaudeHarness::new();
+    let commands = h.commands().await.expect("live discovery");
+    assert!(!commands.is_empty());
+    eprintln!("{} commands, first: {:?}", commands.len(), commands.first());
+}

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -747,3 +747,39 @@ async fn live_real_app_server_single_turn() {
         })
     ));
 }
+
+// ---------------------------------------------------------------------------
+// Slash-command discovery
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn commands_come_from_skills_list() {
+    let h = harness();
+    let commands = h.commands().await.expect("discovery succeeds");
+    assert_eq!(
+        commands.len(),
+        2,
+        "same-name skills across cwd groups dedupe: {commands:?}"
+    );
+    assert_eq!(commands[0].name, "imagegen");
+    assert_eq!(
+        commands[0].description, "Generate or edit images",
+        "interface.shortDescription wins over the model-facing paragraph"
+    );
+    assert_eq!(commands[1].name, "bare");
+    assert_eq!(
+        commands[1].description, "No interface block",
+        "top-level description is the fallback"
+    );
+    assert_eq!(h.commands().await.expect("cache hit"), commands);
+}
+
+/// Live smoke against the real CLI: `cargo test -p zeron-harness --test
+/// codex -- --ignored live_commands`.
+#[tokio::test]
+#[ignore]
+async fn live_commands_discovery() {
+    let h = CodexHarness::new();
+    let commands = h.commands().await.expect("live discovery");
+    eprintln!("{} commands, first: {:?}", commands.len(), commands.first());
+}

--- a/crates/harness/tests/fixtures/fake-claude.sh
+++ b/crates/harness/tests/fixtures/fake-claude.sh
@@ -101,6 +101,16 @@ case "$first" in
   exec sleep 30
   ;;
 
+*'"subtype":"initialize"'*)
+  # Command discovery: the initialize control request arrives as the FIRST
+  # stdin line (no user message ever follows). Shape mirrors 2.1.228's
+  # control_response: commands under response.response.
+  rid=$(printf '%s\n' "$first" | sed 's/.*"request_id":"\([^"]*\)".*/\1/')
+  emit "{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":\"$rid\",\"response\":{\"commands\":[{\"name\":\"review\",\"description\":\"Review a pull request\",\"argumentHint\":\"[pr number]\"},{\"name\":\"compact\",\"description\":\"Compact the conversation\",\"argumentHint\":\"\"},{\"name\":\"\",\"description\":\"nameless: dropped\"}],\"output_style\":\"default\"}}}"
+  # Stay alive until the driver tears us down, like the real CLI would.
+  exec sleep 30
+  ;;
+
 *scenario:error*)
   emit '{"type":"system","subtype":"init","model":"claude-fable-5","tools":[],"cwd":"/tmp","session_id":"sess-err"}'
   # Terse assistant-level error code with no content.

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -27,6 +27,12 @@ has "$line" '"method":"initialized"' || exit 1
 # ---- thread start / resume -------------------------------------------------
 read -r line || exit 1
 thread_line="$line"
+if has "$line" '"method":"skills/list"'; then
+  # Command discovery probe: answer with two cwd groups sharing one skill
+  # (dedupe by name) and settle; no thread ever starts.
+  emit "{\"id\":$(rid "$line"),\"result\":{\"data\":[{\"cwd\":\"/w\",\"skills\":[{\"name\":\"imagegen\",\"description\":\"Model-facing paragraph about images.\",\"interface\":{\"displayName\":\"Image Gen\",\"shortDescription\":\"Generate or edit images\"}},{\"name\":\"bare\",\"description\":\"No interface block\"}]},{\"cwd\":\"/x\",\"skills\":[{\"name\":\"imagegen\",\"description\":\"dupe\",\"interface\":{\"shortDescription\":\"dupe\"}}]}]}}"
+  exec sleep 30
+fi
 if has "$line" '"method":"thread/resume"'; then
   if has "$line" '"threadId":"resume-fail"'; then
     # Missing/foreign rollout: reject, expect the fresh-start fallback.


### PR DESCRIPTION
Fixes the slash-command regression from the native-driver cutover (#136): the composer's `/` popover has been empty for **Claude Code, Codex, and Cursor** since their ACP adapters (which advertised `availableCommands`) were replaced — while grok/hermes/pi and now opencode kept working through `AcpHarness::discover_commands`. The native drivers simply inherited the trait's empty `commands()` default; the engine's ListCommands plumbing was fine all along.

## What each wire actually offers (probed live)

| harness | source | result |
|---|---|---|
| claude 2.1.228 | `initialize` control request on the stream-json channel | 48 commands w/ descriptions + argument hints, **zero model turns** — the control_response is the first stdout line |
| codex 0.146.1 | `codex app-server` → `skills/list` | skills w/ picker-sized `interface.shortDescription`; custom `~/.codex/prompts` are not exposed by any app-server method (verified against the full method-variant list) |
| cursor sdk 1.0.28 | — | no slash-command surface exists; documented no-op, stays empty |

Both probes are short-lived children, 10s-bounded, cached on success only (ACP-harness parity: a mis-configured CLI retries on the next picker open).

## Validation

- Fake-CLI tests: parsing, nameless-entry drop, argument-hint mapping, cross-cwd skill dedupe, shortDescription-over-paragraph, caching.
- Live `#[ignore]`d smokes green against the real binaries (claude: 48 commands in ~1.0s; codex in ~0.5s).
- End-to-end through a real daemon via `rpc_probe ListCommands`: claude-code → 48, codex → 6 (`imagegen`, `openai-docs`, `plugin-creator`, `review-agent`, `skill-creator`, `skill-installer`), cursor → `[]`.
- Full workspace suite green except `cursor_slot_swap_round_trip` (m5c), which fails identically on clean main — a pre-existing account-list ordering instability (same two slots, flipped order), unrelated to this change.

One trap fixed en route: `--print --output-format stream-json` hard-requires `--verbose`; without it the CLI exits with a usage error before answering the control request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789674992&installation_model_id=425430&pr_number=160&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F160&signature=b840013a1eeccec3d5f201e7a83af07ecafd059819bf63381a5d43d0657e026e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->