### PR TITLE
accounts: keep the list order stable — always

### DIFF
--- a/crates/engine/src/agent_accounts.rs
+++ b/crates/engine/src/agent_accounts.rs
@@ -1063,8 +1063,14 @@ impl AgentAccounts {
             }
         }
         // Creation order — stable across switches (saved_at churns on every
-        // auto-snapshot; created_at never does).
-        slots.sort_by_key(|s| s.created_at.unwrap_or(s.saved_at));
+        // auto-snapshot; created_at never does). Slot id breaks creation-time
+        // ties: two logins saved in the same millisecond otherwise land in
+        // read_dir order, which is filesystem-arbitrary for UUID-named files
+        // and reshuffles the page between restarts (issue #161).
+        slots.sort_by(|a, b| {
+            (a.created_at.unwrap_or(a.saved_at), &a.id)
+                .cmp(&(b.created_at.unwrap_or(b.saved_at), &b.id))
+        });
         slots
     }
 
@@ -1079,7 +1085,20 @@ impl AgentAccounts {
         full.created_at = existing
             .and_then(|e| e.created_at.or(Some(e.saved_at)))
             .or(slot.created_at)
-            .or(Some(slot.saved_at));
+            .or_else(|| {
+                // A brand-new slot: stamp it strictly after every sibling, so
+                // two logins inside the same millisecond still list in the
+                // order they were saved (creation order is the page's sort
+                // key; ms-resolution ties otherwise fall to read_dir order).
+                let floor = self
+                    .read_slots(slot.harness)
+                    .iter()
+                    .map(|s| s.created_at.unwrap_or(s.saved_at))
+                    .max()
+                    .map(|newest| newest + 1)
+                    .unwrap_or(slot.saved_at);
+                Some(floor.max(slot.saved_at))
+            });
         let json = serde_json::to_string_pretty(&full)
             .map_err(|e| EngineError::Other(format!("serialize slot: {e}")))?;
         // Atomic + 0600 from birth: tokens must never be world-readable, and a

--- a/crates/harness/examples/opencode_subagent_probe.rs
+++ b/crates/harness/examples/opencode_subagent_probe.rs
@@ -58,6 +58,7 @@ async fn main() {
         auto_approve: true,
         attachments: Vec::new(),
         resume: None,
+        worktree: None,
     };
     let mut stream = AcpHarness::opencode()
         .run(request, controls)

--- a/crates/ui/src/settings/accounts.rs
+++ b/crates/ui/src/settings/accounts.rs
@@ -118,18 +118,19 @@ pub const PROVIDERS: [(HarnessId, &str, &str); 3] = [
     (HarnessId::Cursor, "Cursor", "cursor-agent"),
 ];
 
-/// Accounts of one provider, active first (stable otherwise). Pure.
+/// Accounts of one provider, in the engine's order (slot creation). No
+/// active-first re-sort: switching accounts must not move the switched-to
+/// card — the Active badge already says which one is live, and a list that
+/// reshuffles under the click reads as broken. Pure.
 pub fn provider_accounts(
     snapshot: &AgentAccountsSnapshot,
     harness: HarnessId,
 ) -> Vec<&AgentAccount> {
-    let mut accounts: Vec<&AgentAccount> = snapshot
+    snapshot
         .accounts
         .iter()
         .filter(|a| a.harness == harness)
-        .collect();
-    accounts.sort_by_key(|a| !a.active);
-    accounts
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -1540,7 +1541,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_grouping_puts_active_first() {
+    fn provider_grouping_keeps_engine_order_even_when_active_is_later() {
         let account = |id: &str, harness: HarnessId, active: bool| AgentAccount {
             id: id.into(),
             harness,
@@ -1564,7 +1565,11 @@ mod tests {
         };
         let claude = provider_accounts(&snapshot, HarnessId::ClaudeCode);
         let ids: Vec<&str> = claude.iter().map(|a| a.id.as_str()).collect();
-        assert_eq!(ids, ["c2", "c1"], "active account leads");
+        assert_eq!(
+            ids,
+            ["c1", "c2"],
+            "engine (creation) order holds — switching must not move a card"
+        );
         assert_eq!(provider_accounts(&snapshot, HarnessId::Codex).len(), 1);
         assert!(provider_accounts(&snapshot, HarnessId::Cursor).is_empty());
     }


### PR DESCRIPTION
Fixes #161, plus the related UX complaint: switching accounts moved the switched-to card to the top of the accounts page.

## Two reshuffle sources, both removed

**Same-millisecond logins (#161).** The page sorts slots by `created_at`, which has millisecond resolution. Two logins saved back-to-back tie, and the stable sort then preserves *input* order — which is `read_dir` enumeration, filesystem-arbitrary for UUID-named slot files. That's the `cursor_slot_swap_round_trip` flip (`[frank, erin]` vs `[erin, frank]`), and it equally means a user's page could reorder between restarts. Fix: `write_slot` stamps a brand-new slot strictly after every sibling (max+1 bump), so creation stamps are collision-free going forward; the sort also carries the slot id as a deterministic tie-break for any pre-existing collided files.

**Active-first re-sort.** The engine deliberately lists in creation order — its comment says "never active-first — switching must not reshuffle the cards" — but the UI's `provider_accounts` re-sorted active-first, defeating it. Removed; the Active badge already marks the live account. The UI test that enshrined the old behavior now asserts the opposite (`provider_grouping_keeps_engine_order_even_when_active_is_later`).

## Also: workspace build repair

`cargo test --workspace` was failing to compile on main: #159 added `RunRequest.worktree` and updated every initializer except the opencode probe example that landed in parallel via #157 (no CI job builds examples). One-line fix included here.

## Validation

- `m5c_accounts_uploads_titles` green 5/5 consecutive runs (previously order-dependent).
- Full workspace suite: **925 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789676510&installation_model_id=425430&pr_number=162&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F162&signature=05870e2c5ac9d791319398b4bfd9dc63fe4e94638104b7d2582a2a3318434d4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->