### PR TITLE
Spawn chips open the subagent tab directly (no accordion)

### DIFF
--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -407,10 +407,12 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
             }
         }
         // AvailableCommands feeds the engine's per-harness command cache, not
-        // the transcript.
+        // the transcript. UserMessage becomes its own doc ENTRY (the engine's
+        // subagent sink writes it), never a part of the assistant message.
         AgentEvent::AssistantMessageCompleted { .. }
         | AgentEvent::Usage { .. }
-        | AgentEvent::AvailableCommands { .. } => {}
+        | AgentEvent::AvailableCommands { .. }
+        | AgentEvent::UserMessage { .. } => {}
     }
 }
 

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -26,7 +26,7 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
 use zeron_doc::{
     DocError, MessagePart, MessageRole, MessageStatus, STREAM_COMMIT_MS, SegmentWriter, SessionDoc,
-    fold_event_into_parts, sanitize_tool_call,
+    SessionMessageEntry, fold_event_into_parts, sanitize_tool_call,
 };
 use zeron_harness::{CancellationToken, Harness, RunControls, SteerMessage};
 use zeron_proto::{
@@ -1015,6 +1015,49 @@ impl SubagentSink {
         self.dirty = false;
     }
 
+    /// A parent→subagent steer ([`AgentEvent::UserMessage`], tagged): close
+    /// the open assistant segment (it reads Complete above the steer), write
+    /// the steer as its own USER entry, and reset so the next tagged delta
+    /// opens a fresh assistant entry below it — the subagent transcript then
+    /// reads like any steered chat.
+    fn push_user(&mut self, device_id: &str, text: &str) {
+        let rendered = render_parts(&self.folded);
+        let closed = match self.entry_index.take() {
+            Some(ix) => SegmentWriter::resume(&self.doc, ix, std::mem::take(&mut self.written))
+                .finish(&rendered, MessageStatus::Complete),
+            None if !self.folded.is_empty() => {
+                match SegmentWriter::begin(&self.doc, &self.entry_id, device_id, self.started_at) {
+                    Ok(w) => w.finish(&rendered, MessageStatus::Complete),
+                    Err(e) => Err(e),
+                }
+            }
+            None => Ok(()),
+        };
+        if let Err(err) = closed {
+            tracing::warn!(doc = %self.doc_id, error = %err, "subagent segment close failed");
+        }
+        let entry = SessionMessageEntry {
+            id: new_id(),
+            role: MessageRole::User,
+            parts: vec![MessagePart::Text {
+                id: "t0".into(),
+                text: text.to_owned(),
+            }],
+            created_at: now_ms(),
+            device_id: device_id.to_owned(),
+            status: Some(MessageStatus::Complete),
+            continuation_of: None,
+        };
+        if let Err(err) = self.doc.push_message(&entry) {
+            tracing::warn!(doc = %self.doc_id, error = %err, "subagent steer write failed");
+        }
+        self.entry_id = new_id();
+        self.started_at = now_ms();
+        self.written = Vec::new();
+        self.folded = Vec::new();
+        self.dirty = false;
+    }
+
     /// Final flush + entry finalize; returns the transcript JSON for the
     /// frozen blob (entries as the client renders them).
     fn finish(mut self, device_id: &str, status: MessageStatus) -> Option<String> {
@@ -1539,6 +1582,12 @@ async fn drive_run(
             }
             let done = matches!(sub_event.as_ref(), AgentEvent::Done { .. });
             if let Some(sink) = subagents.get_mut(parent_tool_use_id) {
+                if let AgentEvent::UserMessage { text } = sub_event.as_ref() {
+                    // A steer splits ENTRIES, not parts — handled at the
+                    // sink level (the fold ignores UserMessage).
+                    sink.push_user(&device_id, text);
+                    continue;
+                }
                 zeron_doc::fold_event_into_parts(&mut sink.folded, sub_event);
                 sink.dirty = true;
                 if !chip_streaming && done {

--- a/crates/harness/src/acp/subagent.rs
+++ b/crates/harness/src/acp/subagent.rs
@@ -448,7 +448,23 @@ fn entry_events(entry: &Value) -> Vec<AgentEvent> {
                 });
             }
         }
-        // system prompt / user prompt / synthetic reminders: not transcript.
+        Some("user") => {
+            // The message INTO the subagent — its spawn prompt (and any
+            // future steer): its own user entry in the subagent doc, like
+            // the chat it is. Synthetic context injections (reminder-style
+            // tagged blocks) are not conversation.
+            if let Some(text) = entry
+                .get("content")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|t| !t.is_empty() && !t.starts_with('<'))
+            {
+                events.push(AgentEvent::UserMessage {
+                    text: text.to_owned(),
+                });
+            }
+        }
+        // system prompt / synthetic reminders: not transcript.
         _ => {}
     }
     events
@@ -680,10 +696,17 @@ mod tests {
             [AgentEvent::TextDelta { text }] if text == "finished\n\n"
         ));
 
-        // Non-transcript entries are skipped.
-        for t in ["system", "user"] {
-            assert!(entry_events(&json!({"type": t, "content": "x"})).is_empty());
-        }
+        // The message INTO the subagent is its own user entry; system
+        // entries and reminder-style synthetic injections are skipped.
+        assert!(matches!(
+            entry_events(&json!({"type": "user", "content": "scan the fold path"})).as_slice(),
+            [AgentEvent::UserMessage { text }] if text == "scan the fold path"
+        ));
+        assert!(entry_events(&json!({"type": "system", "content": "x"})).is_empty());
+        assert!(
+            entry_events(&json!({"type": "user", "content": "<system-reminder>tick</system-reminder>"}))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/harness/src/acp/subagent_opencode.rs
+++ b/crates/harness/src/acp/subagent_opencode.rs
@@ -605,7 +605,32 @@ fn part_snapshot_events(child: &mut ChildState, part: &Value) -> Vec<AgentEvent>
     let kind = part.get("type").and_then(Value::as_str).unwrap_or_default();
     match kind {
         "text" | "reasoning" => {
-            // The child's own prompt arrives as a user-message text part.
+            // A user-role text part is the message INTO the child — its
+            // spawn prompt (and any future steer). opencode's own UI renders
+            // these, so we do too: one UserMessage per part (posted
+            // atomically — there is no user delta channel), which the engine
+            // writes as its own user entry.
+            if kind == "text" && child.assistant_messages.get(message_id) == Some(&false) {
+                let text = part.get("text").and_then(Value::as_str).unwrap_or_default();
+                if text.trim().is_empty() {
+                    return Vec::new();
+                }
+                let entry = child
+                    .parts
+                    .entry(part_id.to_owned())
+                    .or_insert_with(|| PartState {
+                        kind: kind.to_owned(),
+                        ..PartState::default()
+                    });
+                if entry.emitted > 0 {
+                    return Vec::new();
+                }
+                entry.emitted = text.len();
+                child.saw_transcript = true;
+                return vec![AgentEvent::UserMessage {
+                    text: text.to_owned(),
+                }];
+            }
             if child.assistant_messages.get(message_id) != Some(&true) {
                 return Vec::new();
             }
@@ -917,6 +942,14 @@ mod tests {
                 "id": "prt_u", "messageID": "msg_u", "sessionID": "ses_child",
                 "type": "text", "text": "run the probe",
             }}});
+            // The message INTO the child (its prompt / a steer) forwards as
+            // a UserMessage — once: a re-delivered snapshot must not double
+            // the entry.
+            assert!(matches!(
+                handle_bus_event(&mut state, &user_part).as_slice(),
+                [AgentEvent::Subagent { event, .. }]
+                    if matches!(event.as_ref(), AgentEvent::UserMessage { text } if text == "run the probe")
+            ));
             assert!(handle_bus_event(&mut state, &user_part).is_empty());
 
             let asst_msg = json!({"type": "message.updated", "properties": {"info": {

--- a/crates/harness/src/claude/normalize.rs
+++ b/crates/harness/src/claude/normalize.rs
@@ -330,9 +330,28 @@ impl Normalizer {
                     .message
                     .blocks()
                     .filter(|b: &ContentBlock| b.kind == "tool_use")
-                    .map(|b| AgentEvent::ToolCall {
-                        id: b.id.clone(),
-                        call: decode_tool_use(&b.name, &b.input),
+                    .flat_map(|b| {
+                        let call = AgentEvent::ToolCall {
+                            id: b.id.clone(),
+                            call: decode_tool_use(&b.name, &b.input),
+                        };
+                        // A spawn's `prompt` is the subagent's opening user
+                        // message — the wire never echoes it on the child
+                        // feed (child user frames carry tool results and
+                        // steers only), so seed it here and the subagent
+                        // transcript starts the way every chat does.
+                        let opening = matches!(b.name.as_str(), "Agent" | "Task")
+                            .then(|| b.input.get("prompt"))
+                            .flatten()
+                            .and_then(Value::as_str)
+                            .filter(|p| !p.trim().is_empty())
+                            .map(|prompt| tag(
+                                &b.id,
+                                AgentEvent::UserMessage {
+                                    text: prompt.to_owned(),
+                                },
+                            ));
+                        std::iter::once(call).chain(opening)
                     })
                     .collect();
                 // A failed turn (usage limit, billing, auth, overloaded, …)
@@ -655,6 +674,37 @@ mod tests {
                 }),
             }]
         );
+    }
+
+    #[test]
+    fn spawn_prompt_seeds_the_subagent_opening_user_message() {
+        // The wire never echoes a Task's prompt on the child feed, so the
+        // spawn itself seeds the subagent's opening user entry.
+        let ev = normalize_one(
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_sub","name":"Task","input":{"description":"probe","prompt":"scan the fold path"}}]}}"#,
+        );
+        assert!(matches!(
+            &ev[..],
+            [
+                AgentEvent::ToolCall { id, .. },
+                AgentEvent::Subagent { parent_tool_use_id, event },
+                AgentEvent::AssistantMessageCompleted { .. },
+            ] if id == "toolu_sub"
+                && parent_tool_use_id == "toolu_sub"
+                && matches!(event.as_ref(), AgentEvent::UserMessage { text } if text == "scan the fold path")
+        ));
+        // No prompt → no synthetic opening; ordinary tools never spawn one.
+        for frame in [
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Task","input":{"description":"probe"}}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"ls","prompt":"red herring"}}]}}"#,
+        ] {
+            let ev = normalize_one(frame);
+            assert!(
+                !ev.iter()
+                    .any(|e| matches!(e, AgentEvent::Subagent { .. })),
+                "{frame}: {ev:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/harness/src/claude/normalize.rs
+++ b/crates/harness/src/claude/normalize.rs
@@ -356,7 +356,7 @@ impl Normalizer {
                 if let Some(parent) = &f.parent_tool_use_id {
                     // A subagent's tool results echo on the main channel too;
                     // they belong to its transcript, attributed like its calls.
-                    return f
+                    let mut out: Vec<AgentEvent> = f
                         .message
                         .blocks()
                         .filter(|b: &ContentBlock| b.kind == "tool_result")
@@ -372,6 +372,21 @@ impl Normalizer {
                             )
                         })
                         .collect();
+                    // A tagged user frame's TEXT blocks are the parent
+                    // steering its subagent (SendMessage-style follow-ups —
+                    // tool results ride their own blocks, filtered above).
+                    // Synthetic harness injections are not conversation.
+                    out.extend(
+                        f.message
+                            .blocks()
+                            .filter(|b: &ContentBlock| {
+                                b.kind == "text"
+                                    && !b.text.trim().is_empty()
+                                    && !b.text.trim_start().starts_with("<system-reminder>")
+                            })
+                            .map(|b| tag(parent, AgentEvent::UserMessage { text: b.text })),
+                    );
+                    return out;
                 }
                 f.message
                     .blocks()
@@ -640,6 +655,47 @@ mod tests {
                 }),
             }]
         );
+    }
+
+    #[test]
+    fn tagged_user_text_becomes_a_subagent_steer() {
+        // A tagged user frame's TEXT block is the parent steering its
+        // subagent — forwarded as a tagged UserMessage so the subagent doc
+        // grows a user entry.
+        let ev = normalize_one(
+            r#"{"type":"user","parent_tool_use_id":"toolu_sub","message":{"content":[{"type":"text","text":"Also check the rebuild path."}]}}"#,
+        );
+        assert_eq!(
+            ev,
+            vec![AgentEvent::Subagent {
+                parent_tool_use_id: "toolu_sub".into(),
+                event: Box::new(AgentEvent::UserMessage {
+                    text: "Also check the rebuild path.".into(),
+                }),
+            }]
+        );
+        // Synthetic harness injections are not conversation, and blank text
+        // is noise; an UNTAGGED user text frame is not a steer at all (the
+        // parent chat's user messages come from doc commands).
+        for frame in [
+            r#"{"type":"user","parent_tool_use_id":"toolu_sub","message":{"content":[{"type":"text","text":"<system-reminder>tick</system-reminder>"}]}}"#,
+            r#"{"type":"user","parent_tool_use_id":"toolu_sub","message":{"content":[{"type":"text","text":"   "}]}}"#,
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"typed into the parent"}]}}"#,
+        ] {
+            assert_eq!(normalize_one(frame), Vec::new(), "frame: {frame}");
+        }
+        // Mixed frames keep both: the tool result AND the steer text.
+        let ev = normalize_one(
+            r#"{"type":"user","parent_tool_use_id":"toolu_sub","message":{"content":[{"type":"tool_result","tool_use_id":"t1","is_error":false},{"type":"text","text":"Keep going."}]}}"#,
+        );
+        assert!(matches!(
+            &ev[..],
+            [
+                AgentEvent::Subagent { event: first, .. },
+                AgentEvent::Subagent { event: second, .. },
+            ] if matches!(first.as_ref(), AgentEvent::ToolResult { .. })
+                && matches!(second.as_ref(), AgentEvent::UserMessage { text } if text == "Keep going.")
+        ));
     }
 
     #[test]

--- a/crates/harness/src/codex/mod.rs
+++ b/crates/harness/src/codex/mod.rs
@@ -62,7 +62,7 @@ use crate::{Harness, HarnessError, RunControls};
 use catalog::{REASONING_LEVELS, sandbox_mode, sandbox_policy_value, static_models, to_effort};
 use normalize::{
     ChildRoute, Phase, delta_text, item_id, item_type, map_item, notification_thread_id,
-    route_child_notification, turn_error_message, turn_id, usage_event,
+    route_child_notification, turn_error_message, turn_id, usage_event, user_message_text,
 };
 
 /// Locate the device's installed Codex CLI: `CODEX_EXECUTABLE`, then our own
@@ -784,6 +784,25 @@ async fn run_session(session: Session) {
                                             vec![AgentEvent::TextDelta {
                                                 text: "\n\n".into(),
                                             }]
+                                        } else if matches!(
+                                            item_type(&item),
+                                            "userMessage" | "user_message"
+                                        ) {
+                                            // A CHILD thread's user message
+                                            // is the parent steering it (the
+                                            // collab send_message path) —
+                                            // its own entry in the subagent
+                                            // doc. Completed only: both
+                                            // lifecycle events carry the
+                                            // full item.
+                                            if phase == Phase::Completed {
+                                                user_message_text(&item)
+                                                    .map(|text| AgentEvent::UserMessage { text })
+                                                    .into_iter()
+                                                    .collect()
+                                            } else {
+                                                Vec::new()
+                                            }
                                         } else {
                                             map_item(phase, &item)
                                         }

--- a/crates/harness/src/codex/normalize.rs
+++ b/crates/harness/src/codex/normalize.rs
@@ -234,9 +234,32 @@ pub(crate) fn map_item(phase: Phase, item: &Value) -> Vec<AgentEvent> {
                 matches!(str_field(item, &["kind"]).as_str(), "failed" | "errored"),
             )
         }
-        // userMessage / reasoning / agentMessage flow through delta channels.
+        // reasoning / agentMessage flow through delta channels; the PARENT
+        // feed's userMessage items are echoes of prompts we sent (already in
+        // the doc). A CHILD thread's userMessage is different — the parent
+        // steering its subagent — and is mapped where child items route
+        // (mod.rs child branch), not here.
         _ => Vec::new(),
     }
+}
+
+/// The text of a `userMessage` thread item. Codex builds have carried both
+/// shapes: a plain `text` field and a `content` array of text blocks.
+pub(crate) fn user_message_text(item: &Value) -> Option<String> {
+    let text = str_field(item, &["text"]);
+    if !text.trim().is_empty() {
+        return Some(text);
+    }
+    let joined: String = item
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|a| a.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|b| b.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    (!joined.trim().is_empty()).then_some(joined)
 }
 
 /// The thread a notification is addressed to: `thread/started` carries it at
@@ -329,6 +352,23 @@ pub(crate) fn route_child_notification(method: &str) -> ChildRoute {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn user_message_text_accepts_both_shapes() {
+        assert_eq!(
+            user_message_text(&json!({"text": "steer"})),
+            Some("steer".into())
+        );
+        assert_eq!(
+            user_message_text(&json!({"content": [
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "b"},
+            ]})),
+            Some("a\n\nb".into())
+        );
+        assert_eq!(user_message_text(&json!({"text": "  "})), None);
+        assert_eq!(user_message_text(&json!({})), None);
+    }
 
     #[test]
     fn delta_accepts_both_spellings() {

--- a/crates/harness/src/cursor/mod.rs
+++ b/crates/harness/src/cursor/mod.rs
@@ -782,10 +782,34 @@ fn map_shim_frame(frame: &Value, interrupted: bool) -> Vec<AgentEvent> {
             let name = frame.get("name").and_then(Value::as_str).unwrap_or("tool");
             let args = frame.get("args").cloned().unwrap_or(Value::Null);
             match frame.get("phase").and_then(Value::as_str) {
-                Some("start") => vec![tag(AgentEvent::ToolCall {
-                    id,
-                    call: decode_tool(name, &args),
-                })],
+                Some("start") => {
+                    let mut events = vec![tag(AgentEvent::ToolCall {
+                        id: id.clone(),
+                        call: decode_tool(name, &args),
+                    })];
+                    // A spawn's prompt is the subagent's opening user
+                    // message — the SDK's nested stream never carries it
+                    // (only the child's own updates), so seed it at the
+                    // spawn and the subagent transcript starts the way
+                    // every chat does. Top-level spawns only: nested
+                    // spawns' interiors share their parent's doc.
+                    if name == "task" && parent.is_none() {
+                        if let Some(prompt) = args
+                            .get("prompt")
+                            .or_else(|| args.get("description"))
+                            .and_then(Value::as_str)
+                            .filter(|p| !p.trim().is_empty())
+                        {
+                            events.push(AgentEvent::Subagent {
+                                parent_tool_use_id: id,
+                                event: Box::new(AgentEvent::UserMessage {
+                                    text: prompt.to_owned(),
+                                }),
+                            });
+                        }
+                    }
+                    events
+                }
                 Some("end") => {
                     let is_error = frame.get("error").and_then(Value::as_bool) == Some(true);
                     let mut events = vec![
@@ -894,6 +918,30 @@ mod tests {
             decode_tool("somethingNew", &json!({})),
             ToolCall::Unknown { .. }
         ));
+    }
+
+    #[test]
+    fn task_start_seeds_the_subagent_opening_user_message() {
+        let frame: Value = serde_json::from_str(
+            r#"{"ev":"tool","phase":"start","id":"call_task_1","name":"task","args":{"description":"probe","prompt":"scan the fold path"}}"#,
+        )
+        .unwrap();
+        let events = map_shim_frame(&frame, false);
+        assert!(matches!(
+            &events[..],
+            [
+                AgentEvent::ToolCall { id, .. },
+                AgentEvent::Subagent { parent_tool_use_id, event },
+            ] if id == "call_task_1"
+                && parent_tool_use_id == "call_task_1"
+                && matches!(event.as_ref(), AgentEvent::UserMessage { text } if text == "scan the fold path")
+        ));
+        // A NESTED spawn's interior shares its parent's doc: no seeding.
+        let nested: Value = serde_json::from_str(
+            r#"{"ev":"tool","phase":"start","id":"call_task_2","name":"task","args":{"prompt":"inner"},"parent":"call_task_1"}"#,
+        )
+        .unwrap();
+        assert_eq!(map_shim_frame(&nested, false).len(), 1);
     }
 
     #[test]

--- a/crates/harness/src/mock.rs
+++ b/crates/harness/src/mock.rs
@@ -348,6 +348,49 @@ impl Harness for MockHarness {
                             text: "Commits land on the 120ms cadence; no commit carried more than one burst.".into(),
                         },
                     ),
+                    // A parent→subagent steer: splits the transcript into a
+                    // user entry + fresh assistant segment (like the claude
+                    // driver's tagged user text blocks).
+                    tag(
+                        "mock-sub-2",
+                        AgentEvent::UserMessage {
+                            text: "Also verify the cadence holds while a steer lands mid-burst.".into(),
+                        },
+                    ),
+                    tag(
+                        "mock-sub-2",
+                        AgentEvent::TextDelta {
+                            text: "Re-running with a mid-burst steer injected.\n\n".into(),
+                        },
+                    ),
+                    tag(
+                        "mock-sub-2",
+                        AgentEvent::ToolCall {
+                            id: "sub2-steer-burst".into(),
+                            call: zeron_proto::ToolCall::Exec {
+                                command: "cargo test -p zeron-doc cadence_steer -- --nocapture"
+                                    .into(),
+                            },
+                        },
+                    ),
+                    tag("mock-sub-2", resolve("sub2-steer-burst")),
+                    tag(
+                        "mock-sub-2",
+                        AgentEvent::TextDelta {
+                            text: "Watching the commit log while the burst drains: ".into(),
+                        },
+                    ),
+                    tag("mock-sub-2", AgentEvent::TextDelta { text: "batch 1 clean, ".into() }),
+                    tag("mock-sub-2", AgentEvent::TextDelta { text: "batch 2 clean, ".into() }),
+                    tag("mock-sub-2", AgentEvent::TextDelta { text: "batch 3 clean, ".into() }),
+                    tag("mock-sub-2", AgentEvent::TextDelta { text: "batch 4 clean, ".into() }),
+                    tag("mock-sub-2", AgentEvent::TextDelta { text: "batch 5 clean — ".into() }),
+                    tag(
+                        "mock-sub-2",
+                        AgentEvent::TextDelta {
+                            text: "every window under 120ms.\n\nSteer landed between commits; the cadence held.".into(),
+                        },
+                    ),
                     tag("mock-sub-2", done),
                 ]
             })
@@ -418,12 +461,27 @@ impl Harness for MockHarness {
                 })
                 .collect(),
         };
-        if delay_ms == 0 {
+        // Dev/testing knob: `ZERON_MOCK_SUBAGENT_DELAY_MS` paces TAGGED
+        // (subagent) events on their own clock — the parent turn settles at
+        // `ZERON_MOCK_DELAY_MS` speed while the background subagents stream
+        // on slowly, which is exactly the eager-done shape live tabs are
+        // observed under (and the only way a rig click can reliably land
+        // inside a subagent's streaming window).
+        let sub_delay_ms = std::env::var("ZERON_MOCK_SUBAGENT_DELAY_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok());
+        if delay_ms == 0 && sub_delay_ms.is_none() {
             return Ok(futures::stream::iter(events).boxed());
         }
         Ok(futures::stream::iter(events)
             .then(move |event| async move {
-                tokio::time::sleep(delay).await;
+                let pause = match (&event, sub_delay_ms) {
+                    (Ok(AgentEvent::Subagent { .. }), Some(ms)) => {
+                        std::time::Duration::from_millis(ms)
+                    }
+                    _ => delay,
+                };
+                tokio::time::sleep(pause).await;
                 event
             })
             .boxed())

--- a/crates/harness/src/mock.rs
+++ b/crates/harness/src/mock.rs
@@ -247,6 +247,112 @@ impl Harness for MockHarness {
             )
             .into(),
         });
+        // Dev/testing knob: `ZERON_MOCK_SUBAGENT=1` appends two spawn chips
+        // whose nested traffic arrives as tagged `AgentEvent::Subagent`
+        // events — the only data-side way to put spawn chips (running → done)
+        // AND their openable subagent docs on screen with the mock harness.
+        // The second subagent finishes after a beat of nested activity, so a
+        // paced run (`ZERON_MOCK_DELAY_MS`) holds a Running chip long enough
+        // to observe.
+        let mock_subagent = std::env::var("ZERON_MOCK_SUBAGENT")
+            .ok()
+            .is_some_and(|v| !v.is_empty() && v != "0");
+        let subagent_events = mock_subagent
+            .then(|| {
+                let tag = |parent: &str, event: AgentEvent| AgentEvent::Subagent {
+                    parent_tool_use_id: parent.into(),
+                    event: Box::new(event),
+                };
+                let spawn = |id: &str, description: &str, prompt: &str| AgentEvent::ToolCall {
+                    id: id.into(),
+                    // The claude-driver spawn shape: `Agent: {description}`
+                    // with the task in the input (names the chip AND the tab).
+                    call: zeron_proto::ToolCall::Unknown {
+                        name: format!("Agent: {description}"),
+                        input: Some(serde_json::json!({
+                            "description": description,
+                            "prompt": prompt,
+                        })),
+                    },
+                };
+                let resolve = |id: &str| AgentEvent::ToolResult {
+                    id: id.into(),
+                    is_error: false,
+                    output: None,
+                    diff: None,
+                };
+                let done = AgentEvent::Done {
+                    status: DoneStatus::Completed,
+                    result: None,
+                    error: None,
+                    session_id: None,
+                };
+                vec![
+                    AgentEvent::TextDelta {
+                        text: "\n### Subagent check\n\nFanning out two scouts before the fold rewrite.\n\n".into(),
+                    },
+                    spawn(
+                        "mock-sub-1",
+                        "Audit the fold path",
+                        "Read crates/doc and list every call site of fold_event_into_parts, checking each holds the byte cap.",
+                    ),
+                    spawn(
+                        "mock-sub-2",
+                        "Verify the commit cadence",
+                        "Measure the 120ms coalesced commit cadence under a scripted delta burst.",
+                    ),
+                    tag(
+                        "mock-sub-1",
+                        AgentEvent::TextDelta {
+                            text: "Scanning `crates/doc` for fold call sites.\n\n".into(),
+                        },
+                    ),
+                    tag(
+                        "mock-sub-1",
+                        AgentEvent::ToolCall {
+                            id: "sub1-grep".into(),
+                            call: zeron_proto::ToolCall::Exec {
+                                command: "grep -rn fold_event_into_parts crates".into(),
+                            },
+                        },
+                    ),
+                    tag("mock-sub-1", resolve("sub1-grep")),
+                    tag(
+                        "mock-sub-1",
+                        AgentEvent::TextDelta {
+                            text: "Three call sites: the live fold, the rebuild, and the subagent sink — every one applies the byte cap before persisting.".into(),
+                        },
+                    ),
+                    resolve("mock-sub-1"),
+                    tag("mock-sub-1", done.clone()),
+                    tag(
+                        "mock-sub-2",
+                        AgentEvent::TextDelta {
+                            text: "Driving a 2k-delta burst through the writer.\n\n".into(),
+                        },
+                    ),
+                    tag(
+                        "mock-sub-2",
+                        AgentEvent::ToolCall {
+                            id: "sub2-burst".into(),
+                            call: zeron_proto::ToolCall::Exec {
+                                command: "cargo test -p zeron-doc cadence_burst -- --nocapture".into(),
+                            },
+                        },
+                    ),
+                    resolve("mock-sub-2"),
+                    tag("mock-sub-2", resolve("sub2-burst")),
+                    tag(
+                        "mock-sub-2",
+                        AgentEvent::TextDelta {
+                            text: "Commits land on the 120ms cadence; no commit carried more than one burst.".into(),
+                        },
+                    ),
+                    tag("mock-sub-2", done),
+                ]
+            })
+            .into_iter()
+            .flatten();
         // With the code knob, also exercise a MULTILINE Exec command — the
         // round-9 chip breaker shape ("set -e\nfixture_in_original=0"): the
         // Run chip must stay one 30px line.
@@ -275,6 +381,7 @@ impl Harness for MockHarness {
             .take(body.len() * repeat)
             .cloned()
             .chain(code_tool_events)
+            .chain(subagent_events)
             .chain(code_event)
             .chain(table_event)
             .chain(mend_event)

--- a/crates/harness/src/mock.rs
+++ b/crates/harness/src/mock.rs
@@ -301,6 +301,20 @@ impl Harness for MockHarness {
                         "Verify the commit cadence",
                         "Measure the 120ms coalesced commit cadence under a scripted delta burst.",
                     ),
+                    // The spawn prompts seed each subagent's opening user
+                    // entry (like the claude driver's Task-prompt seeding).
+                    tag(
+                        "mock-sub-1",
+                        AgentEvent::UserMessage {
+                            text: "Read crates/doc and list every call site of fold_event_into_parts, checking each holds the byte cap.".into(),
+                        },
+                    ),
+                    tag(
+                        "mock-sub-2",
+                        AgentEvent::UserMessage {
+                            text: "Measure the 120ms coalesced commit cadence under a scripted delta burst.".into(),
+                        },
+                    ),
                     tag(
                         "mock-sub-1",
                         AgentEvent::TextDelta {

--- a/crates/harness/tests/claude.rs
+++ b/crates/harness/tests/claude.rs
@@ -525,12 +525,34 @@ async fn captured_live_background_subagent_frames_replay_correctly() {
             _ => None,
         })
         .expect("Agent spawn tool call in the parent feed");
+    // The synthesized opening user message rides WITH the spawn (before the
+    // eager done); the child's own interior streams between the two dones.
+    let opening: Vec<usize> = events
+        .iter()
+        .enumerate()
+        .filter_map(|(i, e)| {
+            matches!(
+                e,
+                AgentEvent::Subagent { parent_tool_use_id, event }
+                    if *parent_tool_use_id == spawn_id
+                        && matches!(event.as_ref(), AgentEvent::UserMessage { .. })
+            )
+            .then_some(i)
+        })
+        .collect();
+    assert_eq!(opening.len(), 1, "one seeded opening prompt: {events:?}");
+    assert!(opening[0] < dones[0], "opening rides with the spawn");
     let tagged: Vec<usize> = events
         .iter()
         .enumerate()
         .filter_map(|(i, e)| {
-            matches!(e, AgentEvent::Subagent { parent_tool_use_id, .. } if *parent_tool_use_id == spawn_id)
-                .then_some(i)
+            matches!(
+                e,
+                AgentEvent::Subagent { parent_tool_use_id, event }
+                    if *parent_tool_use_id == spawn_id
+                        && !matches!(event.as_ref(), AgentEvent::UserMessage { .. })
+            )
+            .then_some(i)
         })
         .collect();
     assert!(!tagged.is_empty(), "tagged subagent traffic: {events:?}");

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -666,6 +666,28 @@ async fn child_thread_routing_tags_and_never_settles_parent() {
             diff: None,
         }),
     }));
+    // The parent's steer (a userMessage item on the CHILD thread) arrives as
+    // exactly one tagged UserMessage — completed only, never doubled by the
+    // started lifecycle event, never leaked untagged.
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(
+                e,
+                AgentEvent::Subagent { parent_tool_use_id, event }
+                    if parent_tool_use_id == "call_alpha"
+                        && matches!(event.as_ref(), AgentEvent::UserMessage { text } if text == "also check the rebuild")
+            ))
+            .count(),
+        1,
+        "{events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::UserMessage { .. })),
+        "steer leaked into the parent feed: {events:?}"
+    );
     assert!(
         !events
             .iter()

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -110,6 +110,10 @@ case "$turnline" in
   emit '{"method":"item/agentMessage/delta","params":{"threadId":"child-1","itemId":"cm1","delta":"child says hi"}}'
   emit '{"method":"item/started","params":{"threadId":"child-1","item":{"id":"cs1","type":"commandExecution","command":"echo hi"}}}'
   emit '{"method":"item/completed","params":{"threadId":"child-1","item":{"id":"cs1","type":"commandExecution","command":"echo hi","status":"completed","exitCode":0}}}'
+  # The parent steering the child (collab send_message): a userMessage item
+  # on the CHILD thread — tagged UserMessage, emitted once (completed only).
+  emit '{"method":"item/started","params":{"threadId":"child-1","item":{"id":"cu1","type":"userMessage","text":"also check the rebuild"}}}'
+  emit '{"method":"item/completed","params":{"threadId":"child-1","item":{"id":"cu1","type":"userMessage","text":"also check the rebuild"}}}'
   # The child settles ITS turn — the parent turn must keep running.
   emit '{"method":"turn/completed","params":{"threadId":"child-1","turn":{"id":"ct-1"}}}'
   emit '{"method":"item/agentMessage/delta","params":{"threadId":"th-1","itemId":"m1","delta":"parent still going"}}'

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -342,6 +342,17 @@ pub enum AgentEvent {
         error: Option<String>,
         session_id: Option<String>,
     },
+    /// A USER-role message injected into a running session — today only seen
+    /// wrapped in [`AgentEvent::Subagent`]: the PARENT agent steering its
+    /// subagent mid-run (claude: a tagged user frame's text blocks). The
+    /// engine writes it to the subagent doc as its own user entry, closing
+    /// the streaming assistant segment above it — the subagent transcript
+    /// then reads like any steered chat. Never emitted untagged (the parent
+    /// chat's user messages come from doc commands, not the wire).
+    #[serde(rename_all = "camelCase")]
+    UserMessage {
+        text: String,
+    },
     /// An event belonging to a SUBAGENT's nested transcript, attributed to
     /// the spawning tool call (`parent_tool_use_id` = the parent-feed
     /// `ToolCall::id` that launched it). Never folded into the parent chat

--- a/crates/ui/assets/icons/arrow-up-right.svg
+++ b/crates/ui/assets/icons/arrow-up-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6.5 17.5L17.5 6.5m0 0h-8.5m8.5 0v8.5"/></svg>

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -75,6 +75,9 @@ icon_assets![
     // arrow-up mirrored (like the sidebar flip) — the Solar Linear set here
     // has no plain arrow-down.
     (ARROW_DOWN, "arrow-down"),
+    // arrow-up rotated 45° — the "opens elsewhere" glyph on spawn chips;
+    // the set has no diagonal arrow.
+    (ARROW_UP_RIGHT, "arrow-up-right"),
     // Hand-drawn return/enter arrow in the Solar Linear style (like the
     // terminal/plus/close ports) — the set has no return glyph.
     (RETURN, "return"),

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -1402,10 +1402,14 @@ pub struct Transcript {
     chat_id: Option<String>,
     /// `Some(doc_id)` pins this instance to a SUBAGENT doc: rows come from
     /// `AppState::sub_transcript(doc_id)` instead of the selected chat, and
-    /// the instance is READ-ONLY — no echoes, no own-turn hold, no working
-    /// trailer, and no global attachment protection (that set is shared with
-    /// the primary transcript and overwritten wholesale).
+    /// the instance is READ-ONLY — no echoes, no own-turn hold, and no global
+    /// attachment protection (that set is shared with the primary transcript
+    /// and overwritten wholesale).
     doc_override: Option<String>,
+    /// Whether an override instance watches a LIVE doc (`for_doc(follow)`):
+    /// only then may the working trailer render — a frozen snapshot must
+    /// never spin, whatever its entries claim.
+    doc_live: bool,
     /// One-shot "open at the latest content" for UNPINNED (frozen) override
     /// instances: rows land ASYNC after the tab opens (watch replay / blob
     /// fetch), so the end-scroll fires on the first non-empty sync, then
@@ -1608,6 +1612,7 @@ impl Transcript {
             // instance must not reset (or re-pin) on selection changes.
             chat_id: doc_override.clone(),
             land_end_pending: doc_override.is_some() && !follow,
+            doc_live: doc_override.is_some() && follow,
             doc_override,
             row_cache: HashMap::new(),
             live_parsers: HashMap::new(),
@@ -2805,34 +2810,53 @@ impl Transcript {
     /// scrolls away with it. The spinner drives this entity's frames, which
     /// keeps the elapsed timer ticking through delta-quiet tool runs.
     fn render_working_trailer(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
-        // A subagent doc has no Session row — `indicator_for` would read the
-        // PARENT chat's live state into a frozen tab.
-        if self.doc_override.is_some() {
-            return None;
-        }
-        let chat_id = self.chat_id.clone()?;
         let now = chrono::Utc::now();
-        let (sending, elapsed_secs) = {
-            let state = self.state.read(cx);
-            if state.indicator_for(&chat_id, now) != crate::state::Indicator::Working {
+        let (sending, elapsed_secs, seed) = if let Some(doc_id) = &self.doc_override {
+            // A subagent doc has no Session row — `indicator_for` would read
+            // the PARENT chat's live state into this tab. Liveness rides the
+            // doc itself instead: the sink's assistant entry streams until
+            // the subagent settles (run teardown finalizes abandoned sinks),
+            // and a trailing USER entry is a steer still awaiting its reply
+            // segment. Frozen snapshots never spin, whatever they claim.
+            if !self.doc_live {
                 return None;
             }
-            // During the send→turn window the session row's `started_at`
-            // still belongs to the PREVIOUS turn — a timer based on the send
-            // counted the round-trip and then restarted when the turn
-            // actually began (user report). Bridge it as "Sending…" with no
-            // timer instead; the word + timer start with the turn.
-            let turn_started = state.session_for(&chat_id).and_then(|s| s.started_at);
-            let sending = sending_bridge(state.pending_send_started(&chat_id, now), turn_started);
-            let elapsed = turn_started
-                .map(|t| now.signed_duration_since(t).num_seconds().max(0))
-                .unwrap_or(0);
-            (sending, elapsed)
+            let state = self.state.read(cx);
+            let last = state.sub_transcript(doc_id).last()?;
+            let live = last.status == Some(MessageStatus::Streaming)
+                || last.role == MessageRole::User;
+            if !live {
+                return None;
+            }
+            let elapsed = ((now.timestamp_millis() - last.created_at).max(0) / 1000) as i64;
+            (false, elapsed, flavour_seed(doc_id))
+        } else {
+            let chat_id = self.chat_id.clone()?;
+            let (sending, elapsed) = {
+                let state = self.state.read(cx);
+                if state.indicator_for(&chat_id, now) != crate::state::Indicator::Working {
+                    return None;
+                }
+                // During the send→turn window the session row's `started_at`
+                // still belongs to the PREVIOUS turn — a timer based on the
+                // send counted the round-trip and then restarted when the
+                // turn actually began (user report). Bridge it as "Sending…"
+                // with no timer instead; the word + timer start with the
+                // turn.
+                let turn_started = state.session_for(&chat_id).and_then(|s| s.started_at);
+                let sending =
+                    sending_bridge(state.pending_send_started(&chat_id, now), turn_started);
+                let elapsed = turn_started
+                    .map(|t| now.signed_duration_since(t).num_seconds().max(0))
+                    .unwrap_or(0);
+                (sending, elapsed)
+            };
+            (sending, elapsed, flavour_seed(&chat_id))
         };
         let word = if sending {
             "Sending"
         } else {
-            flavour_word(flavour_seed(&chat_id), elapsed_secs)
+            flavour_word(seed, elapsed_secs)
         };
         let theme = Theme::of(cx).clone();
         Some(

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -1098,21 +1098,13 @@ pub fn detail_height(detail: &ToolDetail) -> f32 {
 /// open detail whose full payload lives in the sidecar (chat2-sync A3).
 pub const BLOB_AFFORDANCE_HEIGHT: f32 = 24.0;
 
-/// What an open chip's [`BLOB_AFFORDANCE_HEIGHT`] row offers. One slot, so
-/// the analytic height sums stay a single `is_some` check.
+/// What an open chip's [`BLOB_AFFORDANCE_HEIGHT`] row offers: a lazy sidecar
+/// fetch ("Show full output/diff"). One slot, so the analytic height sums
+/// stay a single `is_some` check.
 #[derive(Clone)]
-enum ChipAffordance {
-    /// Lazy sidecar fetch ("Show full output/diff").
-    Blob {
-        blob_ref: SharedString,
-        label: SharedString,
-    },
-    /// The spawn chip's subagent transcript, opened as a right-pane tab.
-    Subagent {
-        doc_id: SharedString,
-        title: SharedString,
-        frozen: bool,
-    },
+struct ChipAffordance {
+    blob_ref: SharedString,
+    label: SharedString,
 }
 
 /// Line cap for a FETCHED full output (a defensive ceiling, not a doc cap —
@@ -3285,6 +3277,12 @@ impl Transcript {
         let details: Vec<Option<Arc<ToolDetail>>> = tools
             .iter()
             .map(|tool| {
+                // Spawn chips never expand — the subagent doc is the record
+                // of what the tool did, and an inline body would only repeat
+                // it. The whole chip is the "open that doc" click instead.
+                if tool.subagent_ref.is_some() {
+                    return None;
+                }
                 // Among fetched blobs, the most recently REQUESTED one wins —
                 // a tool can carry both a diff and an output ref, and the
                 // user's last click decides which upgrade is showing.
@@ -3302,8 +3300,14 @@ impl Transcript {
             .collect();
         // Full-invocation blocks — with them, EVERY chip expands: the click
         // always answers "what exactly was this call?", output or not.
-        let invocations: Vec<Option<Arc<ToolDetail>>> =
-            tools.iter().map(|tool| tool.invocation.clone()).collect();
+        let invocations: Vec<Option<Arc<ToolDetail>>> = tools
+            .iter()
+            .map(|tool| {
+                tool.invocation
+                    .clone()
+                    .filter(|_| tool.subagent_ref.is_none())
+            })
+            .collect();
         // Fetch affordance under each open detail whose full payload is still
         // sidecar-only: `(ref, label)`. Diff offered first (the richer
         // upgrade), then the output — a fetched ref hands the affordance to
@@ -3312,18 +3316,6 @@ impl Transcript {
         let affordances: Vec<Option<ChipAffordance>> = tools
             .iter()
             .map(|tool| {
-                // A spawn chip's transcript wins the slot outright — the
-                // subagent doc is the richer record of what the tool did.
-                if let Some(doc_id) = &tool.subagent_ref {
-                    return Some(ChipAffordance::Subagent {
-                        doc_id: doc_id.clone(),
-                        title: subagent_tab_title(&tool.call),
-                        frozen: matches!(
-                            tool.subagent_status,
-                            Some(SubagentStatus::Done) | Some(SubagentStatus::Failed)
-                        ),
-                    });
-                }
                 // The currently-displayed ref (same recency rule as
                 // `details` above): its affordance is spent; any OTHER
                 // Ready ref stays offered as a no-fetch toggle.
@@ -3361,7 +3353,7 @@ impl Transcript {
                             None => format!("Show full {what}"),
                         },
                     };
-                    return Some(ChipAffordance::Blob {
+                    return Some(ChipAffordance {
                         blob_ref: blob_ref.clone(),
                         label: SharedString::from(label),
                     });
@@ -3473,6 +3465,33 @@ impl Transcript {
             .flex_col()
             .gap(px(CHIP_GAP))
             .children(tools.iter().enumerate().map(|(ix, tool)| {
+                // Spawn chips are LINKS, not accordions: the click opens the
+                // subagent's transcript as a right-pane tab (the shell hosts
+                // the surface — the chip only announces which doc it indexes).
+                if let Some(doc_id) = &tool.subagent_ref {
+                    let chat_id = self.chat_id.clone().unwrap_or_default();
+                    let doc_id = doc_id.clone();
+                    let title = subagent_tab_title(&tool.call);
+                    let frozen = matches!(
+                        tool.subagent_status,
+                        Some(SubagentStatus::Done) | Some(SubagentStatus::Failed)
+                    );
+                    return subagent_chip(
+                        tool,
+                        SharedString::from(format!("{row_id}#s{ix}")),
+                        cx.listener(move |_, _, _, cx| {
+                            cx.emit(TranscriptEvent::OpenSubagent {
+                                chat_id: chat_id.clone(),
+                                doc_id: doc_id.to_string(),
+                                title: title.to_string(),
+                                frozen,
+                            });
+                        }),
+                        theme,
+                        cx.entity_id(),
+                        cx,
+                    );
+                }
                 let detail = details[ix].clone();
                 let invocation = invocations[ix].clone();
                 if detail.is_none() && invocation.is_none() {
@@ -3579,8 +3598,12 @@ impl Transcript {
                             )
                             .child(detail_body(detail, detail_highlights[ix].clone(), theme));
                     }
-                    if let Some(affordance) = affordance {
-                        let base = div()
+                    if let Some(ChipAffordance { blob_ref, label }) = affordance {
+                        let loading = matches!(
+                            self.blob_details.get(&blob_ref),
+                            Some(BlobFetch::Loading(_))
+                        );
+                        let mut row = div()
                             .id(SharedString::from(format!("{key}-blob")))
                             .h(px(BLOB_AFFORDANCE_HEIGHT))
                             .flex_none()
@@ -3588,47 +3611,17 @@ impl Transcript {
                             .flex()
                             .items_center()
                             .text_size(px(10.5))
-                            .text_color(theme.text_faint);
-                        let row = match affordance {
-                            ChipAffordance::Blob { blob_ref, label } => {
-                                let loading = matches!(
-                                    self.blob_details.get(&blob_ref),
-                                    Some(BlobFetch::Loading(_))
-                                );
-                                let mut row = base.child(label);
-                                if !loading {
-                                    row = row
-                                        .cursor_pointer()
-                                        .hover(|s| s.text_color(theme.text_muted))
-                                        .on_click(cx.listener(move |this, _, _, cx| {
-                                            this.spawn_blob_fetch(blob_ref.clone(), cx);
-                                            cx.notify();
-                                        }));
-                                }
-                                row
-                            }
-                            ChipAffordance::Subagent {
-                                doc_id,
-                                title,
-                                frozen,
-                            } => {
-                                // The shell hosts the surface — the chip only
-                                // announces which doc (and blob key base) it
-                                // indexes.
-                                let chat_id = self.chat_id.clone().unwrap_or_default();
-                                base.child(SharedString::from("Open subagent"))
-                                    .cursor_pointer()
-                                    .hover(|s| s.text_color(theme.text_muted))
-                                    .on_click(cx.listener(move |_, _, _, cx| {
-                                        cx.emit(TranscriptEvent::OpenSubagent {
-                                            chat_id: chat_id.clone(),
-                                            doc_id: doc_id.to_string(),
-                                            title: title.to_string(),
-                                            frozen,
-                                        });
-                                    }))
-                            }
-                        };
+                            .text_color(theme.text_faint)
+                            .child(label);
+                        if !loading {
+                            row = row
+                                .cursor_pointer()
+                                .hover(|s| s.text_color(theme.text_muted))
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    this.spawn_blob_fetch(blob_ref.clone(), cx);
+                                    cx.notify();
+                                }));
+                        }
                         card = card.child(row);
                     }
                 }
@@ -4024,9 +4017,18 @@ fn detail_body(
     }
 }
 
-/// The chip's content row: icon tile + label + detail line (+ chevron tile
-/// when the chip expands). Shared between the plain chip and the header of an
-/// expandable chip card.
+/// The trailing tile on a chip header, when it has one.
+enum ChipTrail {
+    /// Expand/collapse chevron — flipped while the detail body is open.
+    Chevron { open: bool },
+    /// Top-right "opens elsewhere" arrow — the spawn chip's link to its
+    /// subagent tab.
+    OpenArrow,
+}
+
+/// The chip's content row: icon tile + label + detail line (+ trailing tile
+/// when the chip expands or links out). Shared between the plain chip, the
+/// header of an expandable chip card, and the spawn link chip.
 ///
 /// Spawn chips carry their subagent's lifecycle VISUALLY, in the chip's own
 /// language: while running the mini working spinner (the sidebar's) pulses
@@ -4035,7 +4037,7 @@ fn detail_body(
 /// header rewriting itself per stream delta read as noise — user report).
 fn chip_header_row(
     tool: &ToolItem,
-    chevron: Option<bool>,
+    trail: Option<ChipTrail>,
     theme: &Theme,
     view: gpui::EntityId,
     cx: &mut gpui::App,
@@ -4101,33 +4103,41 @@ fn chip_header_row(
             // The sidebar working-row spinner, in the chip's trailing slot —
             // paint-local (fixed footprint), so it never moves the layout.
             row.child(
-                div().flex_none().child(crate::loaders::mini_gradient_spinner(
-                    format!(
-                        "subagent-chip-{}",
-                        tool.subagent_ref.as_deref().unwrap_or_default()
-                    ),
-                    2.0,
-                    view,
-                    cx,
-                )),
+                div()
+                    .flex_none()
+                    .child(crate::loaders::mini_gradient_spinner(
+                        format!(
+                            "subagent-chip-{}",
+                            tool.subagent_ref.as_deref().unwrap_or_default()
+                        ),
+                        2.0,
+                        view,
+                        cx,
+                    )),
             )
         })
-        .when_some(chevron, |row, open| {
-            // Output/diff affordance: a chevron tile matching the group
-            // header's, flipped while the detail body is open.
-            row.child(
-                div()
-                    .size(px(18.0))
-                    .flex_none()
-                    .rounded(px(5.0))
-                    .bg(crate::theme::ink(0.06))
-                    .flex()
-                    .items_center()
-                    .justify_center()
+        .when_some(trail, |row, trail| {
+            // Trailing tile matching the group header's: a chevron for the
+            // output/diff accordion, or the open-arrow for spawn chips.
+            let tile = div()
+                .size(px(18.0))
+                .flex_none()
+                .rounded(px(5.0))
+                .bg(crate::theme::ink(0.06))
+                .flex()
+                .items_center()
+                .justify_center()
+                .text_color(theme.text_muted.opacity(0.8));
+            row.child(match trail {
+                ChipTrail::Chevron { open } => tile
                     .text_size(px(10.0))
-                    .text_color(theme.text_muted.opacity(0.8))
                     .child(SharedString::from(if open { "▾" } else { "▸" })),
-            )
+                ChipTrail::OpenArrow => tile.child(
+                    crate::icons::icon(crate::icons::ARROW_UP_RIGHT)
+                        .size(px(11.0))
+                        .text_color(theme.text_muted.opacity(0.8)),
+                ),
+            })
         })
 }
 
@@ -4139,7 +4149,7 @@ fn chip_header(
     view: gpui::EntityId,
     cx: &mut gpui::App,
 ) -> gpui::Div {
-    chip_header_row(tool, Some(open), theme, view, cx)
+    chip_header_row(tool, Some(ChipTrail::Chevron { open }), theme, view, cx)
 }
 
 /// Max chars a subagent tab title keeps. The strip chip is fixed-width and
@@ -4238,6 +4248,60 @@ fn tool_chip(
                 .border_color(crate::theme::hairline(0.07))
                 .bg(crate::theme::ink(0.03))
                 .child(chip_header_row(tool, None, theme, view, cx)),
+        )
+        .into_any_element()
+}
+
+/// A spawn chip: same card as [`tool_chip`], but the WHOLE card is the
+/// "open the subagent tab" click (open-arrow tile in the trailing slot).
+/// No accordion — an inline body would only repeat the subagent's own
+/// transcript.
+fn subagent_chip(
+    tool: &ToolItem,
+    id: SharedString,
+    on_open: impl Fn(&gpui::ClickEvent, &mut Window, &mut gpui::App) + 'static,
+    theme: &Theme,
+    view: gpui::EntityId,
+    cx: &mut gpui::App,
+) -> AnyElement {
+    div()
+        .h(px(CHIP_HEIGHT))
+        .w_full()
+        .flex_none()
+        .flex()
+        .flex_row()
+        .items_center()
+        // Guide rail: hairline centered under the header's chevron tile.
+        .child(
+            div()
+                .ml(px(12.0))
+                .h_full()
+                .w(px(1.0))
+                .flex_none()
+                .bg(crate::theme::ink(0.08)),
+        )
+        .child(
+            div()
+                .id(id)
+                .ml(px(12.0))
+                .h(px(CHIP_CARD_HEIGHT))
+                .min_w_0()
+                .flex_1()
+                .overflow_hidden()
+                .rounded(px(9.0))
+                .border_1()
+                .border_color(crate::theme::hairline(0.07))
+                .bg(crate::theme::ink(0.03))
+                .cursor_pointer()
+                .hover(|s| s.bg(crate::theme::ink(0.05)))
+                .on_click(on_open)
+                .child(chip_header_row(
+                    tool,
+                    Some(ChipTrail::OpenArrow),
+                    theme,
+                    view,
+                    cx,
+                )),
         )
         .into_any_element()
 }


### PR DESCRIPTION
## What

Subagent spawn chips were accordions: expanding one only repeated the same text (the tool invocation / the subagent's own result), with a small "Open subagent" footer row as the actual way into the transcript.

Now the whole chip is the link — clicking anywhere on a spawn chip opens the subagent's transcript as a right-pane tab, and the trailing triangle chevron is replaced with a top-right open-arrow tile (new `arrow-up-right` icon: `arrow-up` rotated 45°, same stroke family as the other hand-drawn glyphs).

- `crates/ui/src/transcript.rs` — spawn chips render via a new `subagent_chip` (plain card, `cursor_pointer`, whole-card `OpenSubagent` click, `ChipTrail::OpenArrow` trailing tile). They're excluded from the detail/invocation accordion analytics, so group heights stay honest. `ChipAffordance` collapses to the blob-fetch struct now that its `Subagent` variant is gone.
- `crates/ui/src/icons.rs` + `crates/ui/assets/icons/arrow-up-right.svg` — the new glyph.
- `crates/harness/src/mock.rs` — `ZERON_MOCK_SUBAGENT=1` knob: the mock run fans out two scripted subagents as tagged `AgentEvent::Subagent` traffic, which is what made the rig shots below possible offline (the engine mints real subagent docs, so the chip → tab flow works end-to-end).

Before a subagent has streamed anything (no doc yet, `subagent_ref` unset) the chip still renders as an ordinary expandable chip; it becomes a link chip the moment the ref lands — same instant the old design got its "Open subagent" row.

## Before

The expanded accordion doubling the chip's own text, "Open subagent" tucked at the bottom:

<img src="https://github.com/user-attachments/assets/9fd4bf58-8044-401f-8cb0-a7b770d3fe1e" width="720">

## After

Spawn chips are flat link chips with the open-arrow tile:

<img src="https://github.com/user-attachments/assets/f4eb36df-7592-4833-968d-d3032c97ce94" width="720">

Mid-run: the first scout already done (arrow), the second still pre-spawn (ordinary chip), spinner riding the running chip:

<img src="https://github.com/user-attachments/assets/86480bb5-5387-4907-968b-ddf56e47e2ea" width="720">

Clicking the chip opens the subagent tab:

<img src="https://github.com/user-attachments/assets/f01bd262-b97d-4255-bc52-3d5f9d52ddd7" width="900">

Full window for context:

<img src="https://github.com/user-attachments/assets/0d0cf28d-9fda-4e71-8247-f9eeada60afa" width="900">

## Subagent tab: working trailer (second commit)

The subagent transcript shows the same in-flow loading indicator as the main transcript. A subagent doc has no Session row, so liveness rides the doc itself: the sink's assistant entry streams until the subagent settles (run teardown finalizes abandoned sinks, so it can't dangle), and a trailing user entry counts as live — a steer or opening prompt still awaiting its reply segment. Frozen snapshots never spin (`doc_live` gates on the tab's follow mode). Timers and flavour words are per-surface: below, the parent ticks "Puzzling… 2m 5s" while the tab's own segment reads "Musing… 24s" (and the active tab chip carries the mini spinner):

<img src="https://github.com/user-attachments/assets/3c99f60b-eb59-4063-8998-f32cc1cbfce5" width="900">

## Steering messages from the main agent (second + third commits)

Investigated whether main-agent messages reach subagent transcripts: **they didn't, on any driver** — and `AgentEvent` had no user-message variant to carry them anyway. The full audit:

| driver | child feed carries user messages? | was |
|---|---|---|
| claude | yes — tagged user frames' text blocks (SendMessage follow-ups) | only `tool_result` blocks forwarded |
| codex | yes — `userMessage` items on the child thread (collab `send_message`) | dropped by the `map_item` fall-through (its "flows through delta channels" comment is only true for the parent feed — user messages have no delta channel) |
| opencode | yes — user-role messages on the child's event bus | deliberately filtered ("user prompt echoes must not render") |
| grok | on disk — `chat_history.jsonl` user entries | deliberately skipped ("user prompt: not transcript") |
| cursor | no — the SDK's nested stream carries only the child's own updates | n/a |

Now plumbed end-to-end:

- `zeron-proto`: new `AgentEvent::UserMessage` — only ever emitted tagged inside `Subagent`.
- codex driver: child-thread `userMessage` items map to tagged steers (completed-only so the started lifecycle event never doubles them; both wire shapes of the text read). Fixture-tested in the `scenario:subagent` routing test.
- claude driver: tagged user frames' text blocks are forwarded as steers (blank text and `<system-reminder>` injections filtered; untagged user text is still never a wire event — the parent chat's user messages come from doc commands). Unit-tested, including the mixed tool_result+text frame.
- engine sink: a steer closes the streaming assistant segment (it reads Complete above the steer), writes its own user-role entry, and opens a fresh assistant entry below — so the subagent transcript reads like any steered chat, in live tabs and frozen blobs alike.

Prompt, first segment, steer bubble, and the reply segment streaming under the trailer:

<img src="https://github.com/user-attachments/assets/05094588-edc7-4ee9-9a1d-3432bed97b02" width="640">

Settled — full steered conversation, no spinner:

<img src="https://github.com/user-attachments/assets/a585beeb-a86e-4bc1-a5cd-04dcb5561204" width="640">

Rig support: the mock script includes a scripted steer, and `ZERON_MOCK_SUBAGENT_DELAY_MS` paces tagged traffic on its own clock — the parent settles fast while subagents stream on, which is the eager-done shape live tabs are actually observed under (and the only way a rig click reliably lands inside a subagent's streaming window).

## Subagent transcripts open with their prompt (fourth commit)

Review feedback: opencode's own UI renders the child's user messages, and the tabs used to start mid-conversation — the initial prompt was missing. Now every subagent transcript begins with its opening user message, per driver:

- **claude** — the wire never echoes a Task's prompt on the child feed, so the spawn seeds a tagged `UserMessage` from the tool input (unit-tested; the captured-live replay test now pins the seeded opening riding *with* the spawn while the child's interior still streams strictly between the eager and wake dones).
- **cursor** — same seeding at the `task` tool start (top-level spawns only; nested spawns share their parent's doc).
- **codex** — the child thread's own `userMessage` items already cover it (third commit).
- **opencode** — user-role text parts forward as `UserMessage`, replacing the "user prompt echoes must not render" filter — matching opencode's own rendering. Once per part; there is no user delta channel.
- **grok** — the store tail's user entries forward too; reminder-style synthetic injections stay filtered.

The tab now opens like any chat — prompt first, trailer waiting beneath it until the subagent speaks:

<img src="https://github.com/user-attachments/assets/a366fbbc-d8cb-498b-8121-f4bd604c6179" width="640">

## Validation

- `cargo test`: zeron-ui 444, zeron-harness --lib 74 (incl. new steer normalize tests), zeron-doc 73, zeron-proto 19, zeron-engine --lib 67 — all green.
- Headless rig (sway + mock engine + `ZERON_MOCK_SUBAGENT=1`): chips render with the arrow tile, click opens the tab (frozen transcript loads), running chip keeps the spinner, done chips stay quiet — screenshots above are from that rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789679177&installation_model_id=425430&pr_number=163&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F163&signature=ef727a68523d362aeae983c73a4f4dbf12f7c922504917451ae180540241a768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->




