### PR TITLE
attachments: 10x chunks, parallel window, overall deadline, live progress

### DIFF
--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use futures::TryStreamExt as _;
 use gpui::{
     AnyElement, BackgroundExecutor, Image, ImageFormat, ObjectFit, SharedString, Size,
     StyledImage as _, div, img, prelude::*, px,
@@ -29,9 +30,14 @@ use zeron_rpc::methods;
 
 /// use-attachments.ts `MAX_ATTACHMENT_BYTES`.
 pub const MAX_ATTACHMENT_BYTES: u64 = 24 * 1024 * 1024;
-/// Base64 chars per `UploadChunk` (zeron state.ts `UPLOAD_CHUNK` — sized for
-/// the relay when the target device is remote).
-pub const UPLOAD_CHUNK_B64_CHARS: usize = 60_000;
+/// Base64 chars per `UploadChunk`, sized against the relay's hard ceiling:
+/// Cloudflare caps a WebSocket message at 1 MiB, and a chunk rides one relay
+/// frame (JSON envelope + uleb header add ~150 bytes) — 680 000 chars ≈
+/// 510 KB binary leaves ~35% headroom. Multiple of 4 so a slice of the
+/// whole-file base64 stays independently decodable. The old 60 000 (45 KB)
+/// made a 3 MB screenshot ~70 sequential round trips — each one a stall
+/// opportunity on a flaky link.
+pub const UPLOAD_CHUNK_B64_CHARS: usize = 680_000;
 /// state.ts `MAX_ATTACHMENT_READ_CHUNKS` — bounds the read-back loop.
 const MAX_READ_CHUNKS: usize = 1_000;
 
@@ -293,76 +299,138 @@ pub(crate) async fn call_with_timeout(
     }
 }
 
-/// Chunked upload: base64 the bytes, `UploadChunk{uploadId,seq,data}` per 60KB
-/// slice (positional `seq` makes the cheap retry idempotent), then
+/// Chunks in flight at once. `seq` slots are idempotent engine-side, so
+/// completion order doesn't matter; a small window hides per-chunk latency
+/// without flooding the relay socket.
+const UPLOAD_CONCURRENCY: usize = 3;
+
+/// Whole-attachment deadline. Per-chunk timeouts + retries bound each CALL,
+/// but on a flapping link chunks that succeed on attempt 2-of-3 never trip
+/// the 3-consecutive-failure abort — an upload could lawfully crawl for hours
+/// reading "Sending…" (2026-08-18 user report). Scaled with size, capped:
+/// past this, fail the send with the banner instead of spinning.
+fn attachment_deadline(n_chunks: usize) -> Duration {
+    Duration::from_secs((120 + 15 * n_chunks as u64).min(900))
+}
+
+/// The `(seq, b64 byte-range)` plan for a file's chunks. An empty file still
+/// sends one empty chunk (the commit needs the uploadId staged).
+fn chunk_ranges(b64_len: usize) -> Vec<(u64, std::ops::Range<usize>)> {
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    let mut seq = 0u64;
+    loop {
+        let end = (start + UPLOAD_CHUNK_B64_CHARS).min(b64_len);
+        ranges.push((seq, start..end));
+        start = end;
+        seq += 1;
+        if start >= b64_len {
+            break;
+        }
+    }
+    ranges
+}
+
+/// Chunked upload: base64 the bytes, `UploadChunk{uploadId,seq,data}` per
+/// [`UPLOAD_CHUNK_B64_CHARS`] slice (positional `seq` makes the cheap retry
+/// idempotent), a few chunks in flight at once, then
 /// `UploadCommit{uploadId,fileName}` → the durable absolute path on the target
-/// device. Errors return the raw cause (the composer shows friendly copy).
+/// device. `progress` (when given) accumulates uploaded BINARY bytes — the
+/// composer's "Uploading… N%" reads it every paint. Errors return the raw
+/// cause (the composer shows friendly copy).
 pub async fn upload_attachment(
     engine: &EngineHandle,
     executor: &BackgroundExecutor,
     target_device_id: Option<&str>,
     attachment: &StagedAttachment,
+    progress: Option<Arc<std::sync::atomic::AtomicU64>>,
 ) -> Result<String, String> {
     let b64 = BASE64.encode(attachment.bytes());
     let upload_id = uuid::Uuid::new_v4().to_string();
-    let mut start = 0usize;
-    let mut seq = 0u64;
-    loop {
-        let end = (start + UPLOAD_CHUNK_B64_CHARS).min(b64.len());
+    let ranges = chunk_ranges(b64.len());
+    let deadline = executor.timer(attachment_deadline(ranges.len()));
+    let upload = async {
+        futures::stream::iter(ranges.iter().cloned().map(Ok::<_, String>))
+            .try_for_each_concurrent(UPLOAD_CONCURRENCY, |(seq, range)| {
+                let progress = progress.clone();
+                let upload_id = &upload_id;
+                let b64 = &b64;
+                async move {
+                    let params = with_target(
+                        serde_json::json!({
+                            "uploadId": upload_id,
+                            "seq": seq,
+                            "data": &b64[range.clone()],
+                        }),
+                        target_device_id,
+                    );
+                    // The first WINDOW (not just seq 0) gets the cold-dial
+                    // allowance — its chunks all start before the link is warm.
+                    let timeout = if seq < UPLOAD_CONCURRENCY as u64 {
+                        FIRST_CHUNK_TIMEOUT
+                    } else {
+                        CHUNK_TIMEOUT
+                    };
+                    // One transient blip must not abort the upload; `seq`
+                    // slots are idempotent engine-side, so a blind re-send is
+                    // safe (timeouts retry too).
+                    let mut attempt = 0u32;
+                    loop {
+                        match call_with_timeout(
+                            engine,
+                            executor,
+                            methods::UPLOAD_CHUNK,
+                            params.clone(),
+                            timeout,
+                        )
+                        .await
+                        {
+                            Ok(_) => break,
+                            Err(err) if attempt < 2 => {
+                                attempt += 1;
+                                tracing::debug!(error = %err, seq, "upload chunk retry");
+                            }
+                            Err(err) => return Err(err),
+                        }
+                    }
+                    if let Some(progress) = &progress {
+                        // b64 → binary bytes (final chunk's padding rounds up
+                        // by ≤2 bytes — irrelevant for a percentage).
+                        progress.fetch_add(
+                            (range.len() * 3 / 4) as u64,
+                            std::sync::atomic::Ordering::Relaxed,
+                        );
+                    }
+                    Ok(())
+                }
+            })
+            .await?;
         let params = with_target(
-            serde_json::json!({ "uploadId": upload_id, "seq": seq, "data": &b64[start..end] }),
+            serde_json::json!({ "uploadId": upload_id, "fileName": attachment.name }),
             target_device_id,
         );
-        let timeout = if seq == 0 {
-            FIRST_CHUNK_TIMEOUT
-        } else {
-            CHUNK_TIMEOUT
-        };
-        // One transient blip must not abort a ~400-chunk upload; `seq` slots
-        // are idempotent engine-side, so a blind re-send is safe (timeouts
-        // retry too, like the original's per-chunk `withTimeout` + retry ×2).
-        let mut attempt = 0u32;
-        loop {
-            match call_with_timeout(
-                engine,
-                executor,
-                methods::UPLOAD_CHUNK,
-                params.clone(),
-                timeout,
-            )
-            .await
-            {
-                Ok(_) => break,
-                Err(err) if attempt < 2 => {
-                    attempt += 1;
-                    tracing::debug!(error = %err, seq, "upload chunk retry");
-                }
-                Err(err) => return Err(err),
-            }
-        }
-        start = end;
-        seq += 1;
-        if start >= b64.len() {
-            break;
-        }
+        let reply = call_with_timeout(
+            engine,
+            executor,
+            methods::UPLOAD_COMMIT,
+            params,
+            COMMIT_TIMEOUT,
+        )
+        .await?;
+        reply
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| "upload commit returned no path".to_string())
+    };
+    futures::pin_mut!(upload);
+    match futures::future::select(upload, deadline).await {
+        futures::future::Either::Left((result, _)) => result,
+        futures::future::Either::Right(_) => Err(format!(
+            "attachment upload exceeded {}s",
+            attachment_deadline(ranges.len()).as_secs()
+        )),
     }
-    let params = with_target(
-        serde_json::json!({ "uploadId": upload_id, "fileName": attachment.name }),
-        target_device_id,
-    );
-    let reply = call_with_timeout(
-        engine,
-        executor,
-        methods::UPLOAD_COMMIT,
-        params,
-        COMMIT_TIMEOUT,
-    )
-    .await?;
-    reply
-        .get("path")
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
-        .ok_or_else(|| "upload commit returned no path".to_string())
 }
 
 /// A transcript image read back from the owning device.
@@ -800,5 +868,46 @@ mod tests {
         assert_eq!(retry_delay(2), Duration::from_millis(8_000));
         assert_eq!(retry_delay(3), Duration::from_millis(15_000));
         assert_eq!(retry_delay(9), Duration::from_millis(15_000));
+    }
+
+    #[test]
+    fn upload_chunk_fits_the_relay_frame_ceiling() {
+        // Cloudflare caps a WebSocket message at 1 MiB; the chunk rides one
+        // relay frame with a small JSON envelope + uleb header.
+        assert!(UPLOAD_CHUNK_B64_CHARS + 1_024 < 1_048_576);
+        // A slice of the whole-file base64 must stay independently decodable.
+        assert_eq!(UPLOAD_CHUNK_B64_CHARS % 4, 0);
+    }
+
+    #[test]
+    fn chunk_ranges_cover_the_buffer_exactly() {
+        // Empty file: one empty chunk (the commit needs the id staged).
+        assert_eq!(chunk_ranges(0), vec![(0, 0..0)]);
+        // Exact multiple: no trailing empty chunk.
+        let exact = chunk_ranges(UPLOAD_CHUNK_B64_CHARS * 2);
+        assert_eq!(exact.len(), 2);
+        assert_eq!(exact[1], (1, UPLOAD_CHUNK_B64_CHARS..UPLOAD_CHUNK_B64_CHARS * 2));
+        // Partial tail.
+        let partial = chunk_ranges(UPLOAD_CHUNK_B64_CHARS + 7);
+        assert_eq!(partial.len(), 2);
+        assert_eq!(
+            partial[1],
+            (1, UPLOAD_CHUNK_B64_CHARS..UPLOAD_CHUNK_B64_CHARS + 7)
+        );
+        // Ranges tile the buffer: contiguous, in order, fully covering.
+        let mut expected_start = 0;
+        for (seq, range) in &partial {
+            assert_eq!(range.start, expected_start, "seq {seq} contiguous");
+            expected_start = range.end;
+        }
+        assert_eq!(expected_start, UPLOAD_CHUNK_B64_CHARS + 7);
+    }
+
+    #[test]
+    fn attachment_deadline_scales_and_caps() {
+        // A one-chunk screenshot fails within ~2 minutes, not hours.
+        assert_eq!(attachment_deadline(1), Duration::from_secs(135));
+        // A max-size upload is still bounded.
+        assert_eq!(attachment_deadline(1_000), Duration::from_secs(900));
     }
 }

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -4700,12 +4700,28 @@ impl Composer {
                 let mut content = text.clone();
                 let mut attachment_paths: Vec<String> = Vec::new();
                 if !staged.is_empty() {
+                    // Publish upload progress so the working label can read
+                    // "Uploading… N%" instead of an opaque "Sending…" while
+                    // the chunks cross the relay.
+                    let progress = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+                    let total: u64 = staged.iter().map(|a| a.bytes().len() as u64).sum();
+                    {
+                        let progress = progress.clone();
+                        this.update(cx, |composer, cx| {
+                            composer.state.update(cx, |s, cx| {
+                                s.begin_upload_progress(total, progress);
+                                cx.notify();
+                            });
+                        })
+                        .ok();
+                    }
                     for att in &staged {
                         match attachments::upload_attachment(
                             &engine,
                             cx.background_executor(),
                             host_device_id.as_deref(),
                             att,
+                            Some(progress.clone()),
                         )
                         .await
                         {
@@ -4792,6 +4808,9 @@ impl Composer {
             .await;
             this.update(cx, |composer, cx| {
                 composer.sending = false;
+                composer
+                    .state
+                    .update(cx, |s, _| s.end_upload_progress());
                 if let Err(message) = result {
                     // Failure: red banner, echo removed, prompt back in the
                     // draft, staged files back in the chat's stash.

--- a/crates/ui/src/loaders.rs
+++ b/crates/ui/src/loaders.rs
@@ -9,7 +9,10 @@
 //! are paint-local and never move surrounding layout. Reduced motion snaps every
 //! cell to its rest state automatically (gpui `reduce_motion`).
 
-use gpui::{AnyElement, App, EntityId, IntoElement, ParentElement, SharedString, Styled, div, px};
+use gpui::{
+    AnyElement, App, EntityId, IntoElement, ParentElement, PathBuilder, SharedString, Styled,
+    canvas, div, point, px,
+};
 
 use crate::motion::{self, GRADIENT_SPIN, PULSE_STAGGER, SPLASH_OUT, ZERON_PULSE};
 use crate::theme::Theme;
@@ -182,6 +185,71 @@ pub fn mini_gradient_spinner(
                         .opacity(motion::gspin_opacity(delta + phase, GSPIN_DIM))
                 }))
         }))
+}
+
+/// Stroke width of [`upload_progress_ring`].
+const RING_STROKE: f32 = 2.5;
+/// Polyline segments for a full circle — plenty for a ≤40px ring.
+const RING_SEGMENTS: f32 = 64.0;
+
+/// Radial upload-progress ring with the percent centered — overlaid on a
+/// sending echo's attachment thumbnail while its bytes cross the relay
+/// (2026-08-18 "Sending… forever" report; the thumbnail is where the wait
+/// visibly belongs). A faint full track plus a bright arc growing clockwise
+/// from 12 o'clock; gpui paths have no arc primitive, so both are stroked
+/// polylines. Fixed white-on-wash palette: the caller dims the image behind
+/// it, which reads in both themes.
+pub fn upload_progress_ring(percent: u8, diameter: f32) -> AnyElement {
+    let frac = f32::from(percent.min(100)) / 100.0;
+    let ring = canvas(
+        |_, _, _| (),
+        move |bounds, _, window, _| {
+            let center = bounds.center();
+            let radius = diameter / 2.0 - RING_STROKE;
+            let mut paint_arc = |sweep: f32, color: gpui::Hsla| {
+                if sweep <= 0.0 {
+                    return;
+                }
+                let steps = ((RING_SEGMENTS * sweep).ceil() as usize).max(2);
+                let at = |i: usize| {
+                    // Clockwise from 12 o'clock.
+                    let theta = -std::f32::consts::FRAC_PI_2
+                        + std::f32::consts::TAU * sweep * (i as f32 / steps as f32);
+                    point(
+                        center.x + px(radius * theta.cos()),
+                        center.y + px(radius * theta.sin()),
+                    )
+                };
+                let mut builder = PathBuilder::stroke(px(RING_STROKE));
+                builder.move_to(at(0));
+                for i in 1..=steps {
+                    builder.line_to(at(i));
+                }
+                if let Ok(path) = builder.build() {
+                    window.paint_path(path, color);
+                }
+            };
+            paint_arc(1.0, gpui::hsla(0.0, 0.0, 1.0, 0.22));
+            paint_arc(frac, gpui::hsla(0.0, 0.0, 1.0, 0.95));
+        },
+    )
+    .absolute()
+    .inset_0();
+    div()
+        .relative()
+        .size(px(diameter))
+        .flex()
+        .items_center()
+        .justify_center()
+        .child(ring)
+        .child(
+            div()
+                .text_size(px(9.0))
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(gpui::hsla(0.0, 0.0, 1.0, 0.95))
+                .child(SharedString::from(format!("{percent}%"))),
+        )
+        .into_any_element()
 }
 
 /// Full-window boot splash (zeron App.tsx `Splash`): the animated zeron mark

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -5216,21 +5216,33 @@ impl Shell {
                 .text_color(theme.danger)
                 .child(SharedString::from("Run failed"))
                 .into_any_element(),
-            Indicator::None if sending => strip
-                .child(loaders::gradient_spinner(
-                    "sending-indicator",
-                    &theme,
-                    2.5,
-                    cx.entity_id(),
-                    cx,
-                ))
-                .child(
-                    div()
-                        .text_size(px(12.0))
-                        .text_color(theme.text_muted)
-                        .child(SharedString::from("Sending…")),
-                )
-                .into_any_element(),
+            Indicator::None if sending => {
+                // The attachment leg names itself with live progress — a slow
+                // upload must read as slow, never as a hang (2026-08-18). The
+                // spinner animates every frame, so the percent repaints
+                // without any notify plumbing.
+                let label = self
+                    .state
+                    .read(cx)
+                    .upload_progress_percent()
+                    .map(|pct| format!("Uploading… {pct}%"))
+                    .unwrap_or_else(|| "Sending…".to_string());
+                strip
+                    .child(loaders::gradient_spinner(
+                        "sending-indicator",
+                        &theme,
+                        2.5,
+                        cx.entity_id(),
+                        cx,
+                    ))
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .text_color(theme.text_muted)
+                            .child(SharedString::from(label)),
+                    )
+                    .into_any_element()
+            }
             Indicator::None => strip.into_any_element(),
         }
     }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -911,10 +911,11 @@ pub struct Shell {
     /// Last observed `window.is_window_active()` — rising edge fires a
     /// ProbeSync so a broadcast-deaf room heals as the user looks at the app.
     was_window_active: bool,
-    /// Dev/testing knobs (`ZERON_OPEN_DIALOG`, `ZERON_FORCE_GATE`) — see
-    /// [`Shell::new`].
+    /// Dev/testing knobs (`ZERON_OPEN_DIALOG`, `ZERON_FORCE_GATE`,
+    /// `ZERON_DEMO_UPLOAD`) — see [`Shell::new`].
     debug_dialog: Option<String>,
     debug_gate: Option<GatePhase>,
+    debug_upload: Option<String>,
     sidebar_tween: Option<WidthTween>,
     right_tween: Option<WidthTween>,
     /// Changes-panel takeover (the header's expand button): the panel fills
@@ -1045,6 +1046,10 @@ impl Shell {
         // `ZERON_FORCE_GATE=signin|org|failed` renders that gate regardless of
         // real auth state (display-only — for styling passes).
         let debug_dialog = std::env::var("ZERON_OPEN_DIALOG").ok();
+        // `ZERON_DEMO_UPLOAD=<pct>:<image path>` fabricates an in-flight image
+        // send on the selected chat (echo bubble + frozen thumbnail progress
+        // ring) — display-only; a real upload can't be paused for a capture.
+        let debug_upload = std::env::var("ZERON_DEMO_UPLOAD").ok();
         let debug_gate = match std::env::var("ZERON_FORCE_GATE").ok().as_deref() {
             Some("signin") => Some(GatePhase::SignIn),
             Some("org") => Some(GatePhase::OrgGate),
@@ -1128,6 +1133,7 @@ impl Shell {
             was_window_active: false,
             debug_dialog,
             debug_gate,
+            debug_upload,
             sidebar_tween: None,
             right_tween: None,
             right_pane_expanded: false,
@@ -1199,6 +1205,64 @@ impl Shell {
                     self.delete_confirm = Some(first);
                 }
                 _ => {}
+            }
+        }
+        // Capture knob: `ZERON_DEMO_UPLOAD=<pct>:<image path>` — once a chat
+        // is selected, push a fake sending echo carrying that image as a
+        // pending attachment and freeze upload progress at <pct>, so the
+        // thumbnail progress ring can be styled/screenshotted (a real upload
+        // is too fast to pause).
+        if let Some(spec) = self.debug_upload.clone()
+            && let Some(chat_id) = state.read(cx).selected_chat.clone()
+        {
+            self.debug_upload = None;
+            if let Some((pct, img_path)) = spec.split_once(':')
+                && let Ok(pct) = pct.parse::<u64>()
+                && let Ok(att) =
+                    crate::attachments::stage_file(std::path::Path::new(img_path))
+            {
+                let pending_path = format!("pending/{}/{}", att.id, att.name);
+                let device_ids: Vec<String> = {
+                    let s = state.read(cx);
+                    s.selected_chat_row()
+                        .map(|c| c.device_id.clone())
+                        .into_iter()
+                        .chain(s.local_device_id.clone())
+                        .chain(Some("local".to_string()))
+                        .collect()
+                };
+                for device_id in &device_ids {
+                    crate::attachments::seed_attachment(
+                        device_id,
+                        &pending_path,
+                        &att.name,
+                        att.image.clone(),
+                    );
+                }
+                let text = crate::attachments::with_attachments(
+                    "Here is the screenshot of the bug.",
+                    std::slice::from_ref(&pending_path),
+                );
+                let echo = zeron_doc::SessionMessageEntry {
+                    id: "demo-upload-echo".into(),
+                    role: zeron_doc::MessageRole::User,
+                    parts: vec![zeron_doc::MessagePart::Text {
+                        id: "t0".into(),
+                        text,
+                    }],
+                    created_at: chrono::Utc::now().timestamp_millis(),
+                    device_id: "local".into(),
+                    status: None,
+                    continuation_of: None,
+                };
+                state.update(cx, |s, cx| {
+                    s.push_echo(&chat_id, echo);
+                    s.begin_upload_progress(
+                        100,
+                        std::sync::Arc::new(std::sync::atomic::AtomicU64::new(pct)),
+                    );
+                    cx.notify();
+                });
             }
         }
         // Session chimes (herdr semantics, `sound::sound_for_transition`): a
@@ -5216,33 +5280,21 @@ impl Shell {
                 .text_color(theme.danger)
                 .child(SharedString::from("Run failed"))
                 .into_any_element(),
-            Indicator::None if sending => {
-                // The attachment leg names itself with live progress — a slow
-                // upload must read as slow, never as a hang (2026-08-18). The
-                // spinner animates every frame, so the percent repaints
-                // without any notify plumbing.
-                let label = self
-                    .state
-                    .read(cx)
-                    .upload_progress_percent()
-                    .map(|pct| format!("Uploading… {pct}%"))
-                    .unwrap_or_else(|| "Sending…".to_string());
-                strip
-                    .child(loaders::gradient_spinner(
-                        "sending-indicator",
-                        &theme,
-                        2.5,
-                        cx.entity_id(),
-                        cx,
-                    ))
-                    .child(
-                        div()
-                            .text_size(px(12.0))
-                            .text_color(theme.text_muted)
-                            .child(SharedString::from(label)),
-                    )
-                    .into_any_element()
-            }
+            Indicator::None if sending => strip
+                .child(loaders::gradient_spinner(
+                    "sending-indicator",
+                    &theme,
+                    2.5,
+                    cx.entity_id(),
+                    cx,
+                ))
+                .child(
+                    div()
+                        .text_size(px(12.0))
+                        .text_color(theme.text_muted)
+                        .child(SharedString::from("Sending…")),
+                )
+                .into_any_element(),
             Indicator::None => strip.into_any_element(),
         }
     }

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -562,6 +562,16 @@ struct PendingSend {
 /// truth after this.
 pub const PENDING_SEND_TTL_MS: i64 = 30_000;
 
+/// A send's attachment-upload leg in flight. `done` is bumped by the upload
+/// task per completed chunk (binary bytes); the working label reads it every
+/// paint (the spinner already animates each frame), so no notify plumbing is
+/// needed. A slow upload renders as "Uploading… N%" instead of a
+/// hang-indistinguishable "Sending…" (2026-08-18 user report).
+pub struct UploadProgress {
+    done: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    total: u64,
+}
+
 /// Root application state. Reducer methods (`apply_*`, [`Self::session_for`], …)
 /// are plain `&mut self` functions so tests construct the struct directly; gpui
 /// glue ([`Self::bootstrap`], [`Self::select_chat`]) layers subscriptions on top.
@@ -607,6 +617,8 @@ pub struct AppState {
     /// Send-in-flight overlay per chat id: a queued doc command the host
     /// hasn't executed yet (see [`Self::begin_pending_send`]).
     pending_sends: HashMap<String, PendingSend>,
+    /// The in-flight send's attachment upload, when it has one.
+    upload_progress: Option<UploadProgress>,
     /// Written by the changes pane, read by the composer.
     diff_comments: HashMap<String, Vec<DiffComment>>,
     /// This engine's device id (best-effort `LocalDevice` probe; `None` until
@@ -654,6 +666,7 @@ impl AppState {
             transcript: Vec::new(),
             echoes: HashMap::new(),
             pending_sends: HashMap::new(),
+            upload_progress: None,
             diff_comments: HashMap::new(),
             local_device_id: None,
             update: None,
@@ -922,6 +935,36 @@ impl AppState {
         }
     }
 
+    /// Attachment upload starting: expose its progress to the working label.
+    pub fn begin_upload_progress(
+        &mut self,
+        total: u64,
+        done: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    ) {
+        self.upload_progress = Some(UploadProgress { done, total });
+    }
+
+    /// Upload leg over (success or failure) — the label goes back to plain
+    /// send/working wording.
+    pub fn end_upload_progress(&mut self) {
+        self.upload_progress = None;
+    }
+
+    /// Percent of the in-flight attachment upload, clamped to 99 — the last
+    /// point belongs to the commit + queue, so "100% but still spinning"
+    /// never shows. `None` when no upload is in flight (or it's empty).
+    pub fn upload_progress_percent(&self) -> Option<u8> {
+        let progress = self.upload_progress.as_ref()?;
+        if progress.total == 0 {
+            return None;
+        }
+        let done = progress
+            .done
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .min(progress.total);
+        Some(((done * 100) / progress.total).min(99) as u8)
+    }
+
     /// Is a send still in flight for this chat (unacked, inside the TTL)?
     pub fn send_pending(&self, chat_id: &str, now: DateTime<Utc>) -> bool {
         self.pending_sends.get(chat_id).is_some_and(|p| {
@@ -1156,6 +1199,7 @@ impl AppState {
         self.transcript.clear();
         self.echoes.clear();
         self.pending_sends.clear();
+        self.upload_progress = None;
         self.local_device_id = None;
         self.update = None;
         cx.notify();
@@ -2270,6 +2314,33 @@ mod tests {
 
         state.apply_devices(vec![device("local", "José's MacBook Pro")]);
         assert_eq!(state.device_name("local"), Some("José's MacBook Pro"));
+    }
+
+    #[test]
+    fn upload_progress_percent_clamps_and_clears() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        let mut s = AppState::new();
+        assert_eq!(s.upload_progress_percent(), None);
+
+        let done = Arc::new(AtomicU64::new(0));
+        s.begin_upload_progress(1_000, done.clone());
+        assert_eq!(s.upload_progress_percent(), Some(0));
+        done.store(430, Ordering::Relaxed);
+        assert_eq!(s.upload_progress_percent(), Some(43));
+        // The last point belongs to commit+queue — never show a stuck 100%.
+        done.store(1_000, Ordering::Relaxed);
+        assert_eq!(s.upload_progress_percent(), Some(99));
+        // Overshoot (b64 padding rounding) stays clamped.
+        done.store(1_002, Ordering::Relaxed);
+        assert_eq!(s.upload_progress_percent(), Some(99));
+
+        s.end_upload_progress();
+        assert_eq!(s.upload_progress_percent(), None);
+
+        // A zero-byte total renders as plain "Sending…", not a percent.
+        s.begin_upload_progress(0, Arc::new(AtomicU64::new(0)));
+        assert_eq!(s.upload_progress_percent(), None);
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2743,6 +2743,15 @@ impl Transcript {
             .pt(px(4.0));
         for (aix, att) in atts.iter().enumerate() {
             let state = self.attachment_state(&device_ids, &att.path, cx);
+            // The in-flight send's upload progress belongs ON the thumbnail:
+            // only the un-refreshed echo carries synthetic `pending/` refs, so
+            // the pair (pending path, upload in flight) is exactly "this image
+            // is crossing the relay right now" (2026-08-18 user request).
+            let uploading = att
+                .path
+                .starts_with("pending/")
+                .then(|| self.state.read(cx).upload_progress_percent())
+                .flatten();
             let frame = div()
                 .flex_none()
                 .w(px(ATT_THUMB_W))
@@ -2757,6 +2766,7 @@ impl Transcript {
                     };
                     frame
                         .id(SharedString::from(format!("{row_id}#att{aix}")))
+                        .relative()
                         .border_1()
                         .border_color(crate::theme::hairline(0.11))
                         .bg(crate::theme::ink(0.035))
@@ -2776,6 +2786,27 @@ impl Transcript {
                                 .rounded(px(7.0))
                                 .object_fit(ObjectFit::Cover),
                         )
+                        .when_some(uploading, |el, pct| {
+                            // The pulse read registers this entity for frames,
+                            // so the percent stays live even once the trailer's
+                            // 30s pending-send bridge has lapsed.
+                            let pulse = motion::pulse_wave(motion::pulse_delta(
+                                &motion::ZERON_PULSE,
+                                cx.entity_id(),
+                                cx,
+                            ));
+                            el.child(
+                                div()
+                                    .absolute()
+                                    .inset_0()
+                                    .rounded(px(7.0))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .bg(gpui::hsla(0.0, 0.0, 0.0, 0.38 + 0.05 * pulse))
+                                    .child(crate::loaders::upload_progress_ring(pct, 34.0)),
+                            )
+                        })
                         .into_any_element()
                 }
                 // Errored/unavailable: the dashed "missing" thumb.
@@ -2820,7 +2851,7 @@ impl Transcript {
         }
         let chat_id = self.chat_id.clone()?;
         let now = chrono::Utc::now();
-        let (sending, elapsed_secs, upload_pct) = {
+        let (sending, elapsed_secs) = {
             let state = self.state.read(cx);
             if state.indicator_for(&chat_id, now) != crate::state::Indicator::Working {
                 return None;
@@ -2835,18 +2866,12 @@ impl Transcript {
             let elapsed = turn_started
                 .map(|t| now.signed_duration_since(t).num_seconds().max(0))
                 .unwrap_or(0);
-            (sending, elapsed, state.upload_progress_percent())
+            (sending, elapsed)
         };
-        // The attachment leg names itself with live progress — a slow upload
-        // must read as slow, never as a hang (2026-08-18 user report). The
-        // spinner repaints every frame, so the percent stays live.
         let word = if sending {
-            match upload_pct {
-                Some(pct) => format!("Uploading… {pct}%"),
-                None => "Sending…".to_string(),
-            }
+            "Sending"
         } else {
-            format!("{}…", flavour_word(flavour_seed(&chat_id), elapsed_secs))
+            flavour_word(flavour_seed(&chat_id), elapsed_secs)
         };
         let theme = Theme::of(cx).clone();
         Some(
@@ -2868,7 +2893,7 @@ impl Transcript {
                     div()
                         .text_size(px(12.0))
                         .text_color(theme.text_muted)
-                        .child(SharedString::from(word)),
+                        .child(SharedString::from(format!("{word}…"))),
                 )
                 .when(!sending, |el| {
                     el.child(

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2820,7 +2820,7 @@ impl Transcript {
         }
         let chat_id = self.chat_id.clone()?;
         let now = chrono::Utc::now();
-        let (sending, elapsed_secs) = {
+        let (sending, elapsed_secs, upload_pct) = {
             let state = self.state.read(cx);
             if state.indicator_for(&chat_id, now) != crate::state::Indicator::Working {
                 return None;
@@ -2835,12 +2835,18 @@ impl Transcript {
             let elapsed = turn_started
                 .map(|t| now.signed_duration_since(t).num_seconds().max(0))
                 .unwrap_or(0);
-            (sending, elapsed)
+            (sending, elapsed, state.upload_progress_percent())
         };
+        // The attachment leg names itself with live progress — a slow upload
+        // must read as slow, never as a hang (2026-08-18 user report). The
+        // spinner repaints every frame, so the percent stays live.
         let word = if sending {
-            "Sending"
+            match upload_pct {
+                Some(pct) => format!("Uploading… {pct}%"),
+                None => "Sending…".to_string(),
+            }
         } else {
-            flavour_word(flavour_seed(&chat_id), elapsed_secs)
+            format!("{}…", flavour_word(flavour_seed(&chat_id), elapsed_secs))
         };
         let theme = Theme::of(cx).clone();
         Some(
@@ -2862,7 +2868,7 @@ impl Transcript {
                     div()
                         .text_size(px(12.0))
                         .text_color(theme.text_muted)
-                        .child(SharedString::from(format!("{word}…"))),
+                        .child(SharedString::from(word)),
                 )
                 .when(!sending, |el| {
                     el.child(


### PR DESCRIPTION
## Problem

Image sends to a remote device could effectively never finish (observed on 0.2.10): the upload leg is bounded per-*call* but not per-*upload*. Each chunk races a 30s timer with 3 attempts, and the send only aborts after 3 **consecutive** failures on one chunk — on a flapping link most chunks succeed on attempt 2 or 3, so the abort never trips. With 45KB sequential chunks, a ~3MB screenshot is ~70 relay round trips; worst case that's hours of lawful crawling, rendered only as "Sending…". Text-only sends are all-local and instant, which is why only image sends looked hung.

## Fix

- **~510KB chunks** (`UPLOAD_CHUNK_B64_CHARS` 60 000 → 680 000): ~10x fewer round trips, ~35% headroom under Cloudflare's 1MB WebSocket message cap, still a multiple of 4 so b64 slices stay independently decodable. The engine's per-seq slot files are size-agnostic — no engine change.
- **3 chunks in flight** (`try_for_each_concurrent`): seq slots are idempotent so order doesn't matter; the first *window* (not just seq 0) gets the 90s cold-dial allowance.
- **Whole-attachment deadline** (120s + 15s/chunk, capped at 15 min): a crawling upload now fails with the existing composer banner (draft + files handed back) instead of spinning indefinitely.
- **Progress ring on the thumbnail**: while an image crosses the relay, its thumbnail in the echo bubble dims and shows a radial progress ring with the percent centered (stroked-polyline arcs — gpui has no arc primitive). The `pending/` attachment refs + upload-in-flight state identify exactly the images uploading, so nothing else in the UI changes; the "Sending…" label stays as-is. Percent clamps at 99 so the commit+queue tail never shows a stuck 100%.
- Capture knob `ZERON_DEMO_UPLOAD=<pct>:<image path>` (same family as `ZERON_OPEN_DIALOG`): fabricates a sending echo with a frozen ring for styling passes — a real upload is too fast to pause.

## Screenshots

_Coming shortly (captured separately)._

## Testing

- New unit tests: chunk-plan tiling (empty/exact/partial), frame-budget + alignment invariants, deadline scaling/cap, progress percent clamping/clearing (447 UI tests pass).
- Not covered by automation: a real flaky-relay upload — needs a live lossy link. Manual check after deploy: send a screenshot to personal-metal and watch the ring fill; on a dead link expect the red banner within ~2–4 minutes instead of an eternal spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)