### PR TITLE
send: New-worktree never silently degrades; undelivered sends say "Queued"

### DIFF
--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -966,6 +966,14 @@ impl DocHost {
             ));
             let url = edge.room_url(format!("/chat2/{chat}/ws"));
             let mut wake = zeron_sync::wake::subscribe();
+            // Sibling-dial successes end a backoff wait immediately, exactly
+            // like the joined clients' own reconnect loops (chat_client.rs).
+            // Without this, a NEW chat whose first joins hit a network blip
+            // waited out the full accumulated backoff (→30s) while every
+            // established room redialed instantly on recovery — fresh sends
+            // to new sessions stalled while other chats hummed (2026-08-19
+            // user report, reproduced on two networks).
+            let mut online = zeron_sync::wake::subscribe_online();
             let mut backoff = crate::workspace_host::JOIN_RETRY_BASE;
             loop {
                 if weak.upgrade().is_none() {
@@ -1129,11 +1137,18 @@ impl DocHost {
                             "chat2 join timed out; retrying");
                     }
                 }
+                // Drain stale online events first: only successes DURING this
+                // wait count, or our own last dial would cut every wait to
+                // zero (same discipline as chat_client's wait_backoff).
+                while online.try_recv().is_ok() {}
                 tokio::select! {
                     _ = tokio::time::sleep(backoff + crate::workspace_host::join_retry_jitter()) => {
                         backoff = (backoff * 2).min(crate::workspace_host::JOIN_RETRY_CAP);
                     }
                     _ = wake.recv() => {
+                        backoff = crate::workspace_host::JOIN_RETRY_BASE;
+                    }
+                    _ = online.recv() => {
                         backoff = crate::workspace_host::JOIN_RETRY_BASE;
                     }
                     _ = crate::workspace_host::token_changed(&mut token_changes) => {

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -4633,10 +4633,20 @@ impl Composer {
                             // know the spec degrades to the main checkout
                             // instead of failing the run.
                             chat_branch = base.clone();
-                            if let (Some(repo_path), Some(base)) = (&space_path, base) {
+                            if let Some(repo_path) = &space_path {
+                                // A remote repo's branch list loads over the
+                                // relay — on a bad link it may never arrive
+                                // and the picker has no base. That must NOT
+                                // silently drop the isolation the user picked
+                                // (2026-08-19: "New worktree" ran in the main
+                                // checkout): default to HEAD, which git — any
+                                // host version — resolves as the repo's
+                                // current checkout state.
+                                let base =
+                                    base.clone().unwrap_or_else(|| "HEAD".to_string());
                                 run_worktree = Some(zeron_proto::WorktreeSpec {
                                     repo_path: repo_path.clone(),
-                                    base: base.clone(),
+                                    base,
                                 });
                             }
                         }

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -965,6 +965,19 @@ impl AppState {
         Some(((done * 100) / progress.total).min(99) as u8)
     }
 
+    /// A send whose queued command is PAST the Working-overlay TTL and still
+    /// unacked — almost always undelivered (the edge link is down; the queue
+    /// write itself is local and instant). The overlay must stop faking
+    /// Working after the TTL (its contract), but the total silence that
+    /// followed read as a hang during a network flap (2026-08-19 user
+    /// report) — the trailer shows an honest "Queued" line instead. Cleared
+    /// the moment the host writes the message into the transcript.
+    pub fn send_queued_unacked(&self, chat_id: &str, now: DateTime<Utc>) -> bool {
+        self.pending_sends.get(chat_id).is_some_and(|p| {
+            now.signed_duration_since(p.started).num_milliseconds() > PENDING_SEND_TTL_MS
+        })
+    }
+
     /// Is a send still in flight for this chat (unacked, inside the TTL)?
     pub fn send_pending(&self, chat_id: &str, now: DateTime<Utc>) -> bool {
         self.pending_sends.get(chat_id).is_some_and(|p| {
@@ -2314,6 +2327,24 @@ mod tests {
 
         state.apply_devices(vec![device("local", "José's MacBook Pro")]);
         assert_eq!(state.device_name("local"), Some("José's MacBook Pro"));
+    }
+
+    #[test]
+    fn queued_unacked_takes_over_after_the_ttl() {
+        let now = Utc::now();
+        let mut s = AppState::new();
+        assert!(!s.send_queued_unacked("c", now), "no send, no queued line");
+        s.begin_pending_send("c", "m1", now);
+        // Inside the TTL the Working overlay owns the surface.
+        assert!(s.send_pending("c", now));
+        assert!(!s.send_queued_unacked("c", now));
+        // Past it, the overlay lapses and the queued line takes over.
+        let later = now + TimeDelta::milliseconds(PENDING_SEND_TTL_MS + 1);
+        assert!(!s.send_pending("c", later));
+        assert!(s.send_queued_unacked("c", later));
+        // The host ack (or failure cleanup) clears it.
+        s.end_pending_send("c", "m1");
+        assert!(!s.send_queued_unacked("c", later));
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2854,6 +2854,27 @@ impl Transcript {
         let (sending, elapsed_secs) = {
             let state = self.state.read(cx);
             if state.indicator_for(&chat_id, now) != crate::state::Indicator::Working {
+                // Past the pending-send TTL with no ack, the Working overlay
+                // has lapsed but the queued command is still undelivered
+                // (edge link down). Silence here read as a hang (2026-08-19)
+                // — say what's actually happening. Static line, no spinner:
+                // nothing is progressing; the ack notify clears it.
+                if state.send_queued_unacked(&chat_id, now) {
+                    let theme = Theme::of(cx).clone();
+                    return Some(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .pt(px(10.0))
+                            .text_size(px(12.0))
+                            .text_color(theme.text_faint)
+                            .child(SharedString::from(
+                                "Queued — waiting for connection…",
+                            ))
+                            .into_any_element(),
+                    );
+                }
                 return None;
             }
             // During the send→turn window the session row's `started_at`


### PR DESCRIPTION
## What happened (2026-08-19 03:46 incident + follow-up reports)

A "New worktree" text-only send appeared stuck on "Sending…" and its session ran **without** a worktree — and per user reports, new-session sends stalled **while existing chats kept sending fine, on two different networks** (home + hotspot). Forensics (local doc store + host journal + client logs) found three separate defects:

1. **New-chat room joins didn't hear "the network is back".** A new chat's chat2 join loop reset its backoff on system wake and token change only — the "sibling dial succeeded" broadcast that every *joined* room's reconnect loop listens for was missing. After a blip at join time, the fresh room waited out up to 30s of accumulated backoff while established rooms redialed instantly. That's exactly "new sessions stall, other chats work", independent of which network you're on.
2. **"New worktree" silently degraded.** The remote repo's branch list loads over the relay; when it hasn't arrived the picker has no base ref, and the composer dropped the WorktreeSpec — the session ran in the repo's main checkout.
3. **Undelivered sends looked like hangs.** Past the 30s pending-send TTL the Working overlay lapses by contract, and the silence that followed was indistinguishable from a wedge.

## Fix

- **Sibling-online wake for new-chat joins**: `spawn_chat2_join` now subscribes to the same `wake::subscribe_online()` signal as `chat_client`'s reconnect loop (with the same drain-stale-events discipline), so a recovered network un-parks a new session's room immediately.
- **Base defaults to `HEAD`**: the WorktreeSpec is attached whenever the plan is New worktree and the space has a repo path, ref list or not. `git worktree add -b zeron/<name> <path> HEAD` resolves as the repo's current checkout state on any host version — no proto change, no skew risk.
- **Honest queued state**: past the pending-send TTL with no transcript ack, the trailer shows a static "Queued — waiting for connection…" line instead of silence; the host's ack clears it.

## Testing

- New unit test: queued-unacked takes over exactly at TTL expiry and clears on ack (449 UI tests pass); engine worktree/drain suites pass.
- Manual after deploy: new session with "New worktree" while the branch picker is empty → worktree still created off HEAD; yank the network mid-send to a new session → "Queued — waiting for connection…" after 30s, delivery resumes within ~a second of any other room reconnecting (previously up to 30s later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)