### PR TITLE
ui: contain wheel overscroll inside scrollable composer input

### DIFF
--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -2390,14 +2390,22 @@ impl ComposerInput {
         let Some(bounds) = self.last_bounds else {
             return;
         };
+        let viewport_height = f32::from(bounds.size.height);
         let delta_y = f32::from(event.delta.pixel_delta(self.line_height).y);
         let next = input_scroll_offset(
             self.scroll_top,
             delta_y,
             self.content_height,
-            f32::from(bounds.size.height),
+            viewport_height,
         );
         if next == self.scroll_top {
+            // Overscroll guard: when the input itself is scrollable (content
+            // taller than the viewport), swallow the wheel event even at the
+            // scroll boundary so it never chains into the outer transcript
+            // list (the native equivalent of `overscroll-behavior: contain`).
+            if delta_y != 0.0 && input_max_scroll(self.content_height, viewport_height) > 0.0 {
+                cx.stop_propagation();
+            }
             return;
         }
         self.invalidate_mention_tooltip();


### PR DESCRIPTION
## Problem                                                                                                           
                                                                                                                        
   The composer input (below each session transcript) is its own scroll                                                 
   container once the draft grows taller than its max height. When the                                                  
   input's own scroll hits the top or bottom boundary, continued wheel                                                  
   input **chains into the outer transcript list**, scrolling the session                                               
   behind it — even though the pointer never left the input.                                                            
                                                                                                                        
   This is the native equivalent of a missing                                                                           
   `overscroll-behavior: contain` on a web scroll container.                                                            
                                                                                                                        
   ### Before (bug)
<img width="1800" height="1200" alt="修复前" src="https://github.com/user-attachments/assets/df0cbc08-6582-4698-ab82-3eb690eaf738" />                                                                                       
                                                                                                                        
   ### After (fix) 
<img width="1800" height="1200" alt="修复后" src="https://github.com/user-attachments/assets/05754493-6f33-4214-8293-04fac14e43e4" />                                                                                  
                                                                                                                        
   ## Root cause                                                                                                        
                                                                                                                        
   `ComposerInput::on_scroll_wheel` (crates/ui/src/composer.rs) only calls                                              
   `cx.stop_propagation()` when the input *actually scrolls*. At a scroll                                               
   boundary, `input_scroll_offset` clamps the offset so                                                                 
   `next == scroll_top`, the handler returns early, and the wheel event                                                 
   keeps bubbling to the transcript's `ListState`, which scrolls instead.                                               
                                                                                                                        
   ## Fix                                                                                                               
                                                                                                                        
   Swallow the wheel event whenever the input itself is scrollable —                                                    
   i.e. `input_max_scroll(...) > 0` — even when the wheel delta would not                                               
   move the offset. Behavior now matches `overscroll-behavior: contain`:                                                
                                                                                                                        
   - Input content overflows → wheel events are fully consumed by the                                                   
     input; overscroll at the boundary does nothing.                                                                    
   - Input content fits the viewport → the input is not a scroll                                                        
     container, so wheel events still chain to the outer list (intended,                                                
     matching web default behavior).                                                                                    
                                                                                                                        
   ## Test plan                                                                                                         
                                                                                                                        
   1. Paste a large draft into the composer so it becomes scrollable.                                                   
   2. Scroll inside the input to the bottom, keep scrolling → the outer                                                 
      transcript no longer moves (was scrolling before the fix).                                                        
   3. Clear the draft (content fits) → wheel over the input still scrolls                                               
      the outer transcript as before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789706137&installation_model_id=425430&pr_number=166&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F166&signature=b06e4ded84759d24955719b4beb7d1b3bd2255c1d414277c2713f13d53faf692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->