### PR TITLE
Durable subagent steering: claude SendMessage re-key, engine settle/reopen gates, opencode resume fixes

### DIFF
--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -380,6 +380,10 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
                     zeron_proto::DoneStatus::Errored => SubagentStatus::Failed,
                     _ => SubagentStatus::Done,
                 }),
+                // A steer RESURRECTS a settled chip — it announces more work
+                // (claude: a queued SendMessage relaunches the agent), so
+                // this is the one event allowed past the no-regress guard.
+                AgentEvent::UserMessage { .. } => Some(SubagentStatus::Running),
                 _ => None,
             };
             for p in out.iter_mut() {

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -1353,6 +1353,13 @@ async fn drive_run(
             None => Some(std::time::Duration::from_secs(20)),
         };
     let mut self_continued_turn = false;
+    // Spawn chips that have SETTLED (tagged Done seen). Content events for a
+    // settled chip with no live sink are dropped — a straggler frame after
+    // the freeze must not mint a new doc entry or wedge the transcript back
+    // into Streaming. Only a steer (UserMessage) legitimately REOPENS a
+    // settled subagent: it announces more work is coming.
+    let mut settled_subagents: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
     // Live subagent sinks, parent tool-use id → transcript doc state.
     let mut subagents: std::collections::HashMap<String, SubagentSink> =
         std::collections::HashMap::new();
@@ -1519,6 +1526,16 @@ async fn drive_run(
         } = &event
         {
             inner.publish(&chat_id, &event);
+            let is_steer = matches!(sub_event.as_ref(), AgentEvent::UserMessage { .. });
+            if is_steer {
+                settled_subagents.remove(parent_tool_use_id);
+            } else if settled_subagents.contains(parent_tool_use_id)
+                && !subagents.contains_key(parent_tool_use_id)
+            {
+                // Straggler after the freeze: chip-only silence (the old
+                // pre-viz behavior), never a reopened doc.
+                continue;
+            }
             let sub_id = subagent_doc_id(&chat_id, parent_tool_use_id);
             let chip_streaming = folded
                 .iter()
@@ -1581,6 +1598,9 @@ async fn drive_run(
                 }
             }
             let done = matches!(sub_event.as_ref(), AgentEvent::Done { .. });
+            if done {
+                settled_subagents.insert(parent_tool_use_id.clone());
+            }
             if let Some(sink) = subagents.get_mut(parent_tool_use_id) {
                 if let AgentEvent::UserMessage { text } = sub_event.as_ref() {
                     // A steer splits ENTRIES, not parts — handled at the

--- a/crates/harness/src/acp/subagent_opencode.rs
+++ b/crates/harness/src/acp/subagent_opencode.rs
@@ -74,6 +74,9 @@ struct UnboundChild {
 /// What a bound child's bus traffic has produced so far.
 #[derive(Default)]
 struct ChildState {
+    /// Text parts whose message ROLE is not yet known (`message.part.updated`
+    /// raced ahead of `message.updated`): replayed when the role lands.
+    pending_parts: Vec<Value>,
     /// The spawn chip this child streams to.
     parent_tool_use_id: String,
     /// messageID → is-assistant (user prompt echoes must not render).
@@ -213,7 +216,12 @@ impl OpencodeTracker {
             Some(id) => {
                 state.unbound.remove(&id);
                 let entry = state.children.entry(id.clone()).or_default();
-                entry.parent_tool_use_id = tool_call_id.to_owned();
+                // First completion binds; a RESUME tool call's completion
+                // must not re-key an already-bound child — its transcript
+                // continues under the ORIGINAL spawn chip.
+                if entry.parent_tool_use_id.is_empty() {
+                    entry.parent_tool_use_id = tool_call_id.to_owned();
+                }
                 id
             }
             // No id on the completion (older wire?): settle whichever bound
@@ -547,6 +555,27 @@ fn handle_bus_event(state: &mut OcState, event: &Value) -> Vec<AgentEvent> {
                     .assistant_messages
                     .entry(message.to_owned())
                     .or_insert(role == "assistant");
+                // A NEW user message on a settled child is a steer resuming
+                // it (opencode re-prompts the same session): un-latch so the
+                // resumed traffic streams to the same chip again.
+                if role == "user" && child.done {
+                    child.done = false;
+                }
+                // Parts that raced ahead of this role fact replay now.
+                let held: Vec<Value> = std::mem::take(&mut child.pending_parts)
+                    .into_iter()
+                    .filter(|part| {
+                        part.get("messageID").and_then(Value::as_str) == Some(message)
+                    })
+                    .collect();
+                if !held.is_empty() {
+                    let parent = child.parent_tool_use_id.clone();
+                    return held
+                        .iter()
+                        .flat_map(|part| part_snapshot_events(child, part))
+                        .map(|ev| tag(&parent, ev))
+                        .collect();
+                }
             }
             Vec::new()
         }
@@ -610,6 +639,18 @@ fn part_snapshot_events(child: &mut ChildState, part: &Value) -> Vec<AgentEvent>
             // these, so we do too: one UserMessage per part (posted
             // atomically — there is no user delta channel), which the engine
             // writes as its own user entry.
+            if kind == "text" && child.assistant_messages.get(message_id).is_none() {
+                // Role unknown: hold the part instead of guessing (dedup by
+                // part id — snapshots re-deliver).
+                if !child
+                    .pending_parts
+                    .iter()
+                    .any(|p| p.get("id").and_then(Value::as_str) == Some(part_id))
+                {
+                    child.pending_parts.push(part.clone());
+                }
+                return Vec::new();
+            }
             if kind == "text" && child.assistant_messages.get(message_id) == Some(&false) {
                 let text = part.get("text").and_then(Value::as_str).unwrap_or_default();
                 if text.trim().is_empty() {

--- a/crates/harness/src/claude/normalize.rs
+++ b/crates/harness/src/claude/normalize.rs
@@ -165,6 +165,11 @@ fn tag(parent: &str, event: AgentEvent) -> AgentEvent {
 /// resume turns them into the done→Working→done wake.
 pub(crate) struct Normalizer {
     saw_init: bool,
+    /// Background-agent ids (`task_started.task_id`) → the spawning Agent
+    /// tool_use id. `SendMessage` steers address the AGENT id; this map
+    /// re-keys them onto the spawn chip's feed (the wire never echoes the
+    /// steer on the child feed — live-verified 2.1.228).
+    agent_tasks: std::collections::HashMap<String, String>,
     /// Rotates at each assistant-frame close and at each steer; SessionStarted
     /// carries the first value so folds can attribute deltas from the start.
     assistant_message_id: String,
@@ -176,6 +181,7 @@ impl Normalizer {
     pub fn new() -> Self {
         Self {
             saw_init: false,
+            agent_tasks: std::collections::HashMap::new(),
             assistant_message_id: new_message_id(),
             session_id: None,
         }
@@ -223,6 +229,19 @@ impl Normalizer {
                             session_id: None,
                         },
                     )];
+                }
+                // An AGENT task starting (subagent_type present — subagent-
+                // owned shell tasks carry the same subtype without it):
+                // record agentId → spawn id for SendMessage steer re-keying.
+                if f.subtype == "task_started"
+                    && f.subagent_type.is_some()
+                    && let (Some(task), Some(tool)) = (
+                        f.task_id.as_deref().filter(|t| !t.is_empty()),
+                        f.tool_use_id.as_deref().filter(|t| !t.is_empty()),
+                    )
+                {
+                    self.agent_tasks.insert(task.to_owned(), tool.to_owned());
+                    return Vec::new();
                 }
                 if f.subtype != "init" || self.saw_init {
                     return Vec::new();
@@ -351,7 +370,30 @@ impl Normalizer {
                                     text: prompt.to_owned(),
                                 },
                             ));
-                        std::iter::once(call).chain(opening)
+                        // A SendMessage steer never echoes on the child feed
+                        // (live-verified) — surface it from the parent's own
+                        // call, re-keyed onto the spawn it addresses.
+                        let steer = (b.name == "SendMessage")
+                            .then(|| {
+                                let to = ["to", "recipient"]
+                                    .iter()
+                                    .find_map(|k| b.input.get(*k))
+                                    .and_then(Value::as_str)?;
+                                let spawn = self.agent_tasks.get(to)?;
+                                let text = ["message", "content"]
+                                    .iter()
+                                    .find_map(|k| b.input.get(*k))
+                                    .and_then(Value::as_str)
+                                    .filter(|m| !m.trim().is_empty())?;
+                                Some(tag(
+                                    spawn,
+                                    AgentEvent::UserMessage {
+                                        text: text.to_owned(),
+                                    },
+                                ))
+                            })
+                            .flatten();
+                        std::iter::once(call).chain(opening).chain(steer)
                     })
                     .collect();
                 // A failed turn (usage limit, billing, auth, overloaded, …)
@@ -705,6 +747,51 @@ mod tests {
                 "{frame}: {ev:?}"
             );
         }
+    }
+
+    #[test]
+    fn send_message_steers_rekey_onto_the_spawn_feed() {
+        // Live 2.1.228: the steer NEVER echoes on the child feed; the only
+        // wire evidence is the parent's SendMessage call addressed to the
+        // agent id that task_started paired with the spawn tool id.
+        let mut norm = Normalizer::new();
+        let started = crate::claude::wire::parse_frame(
+            r#"{"type":"system","subtype":"task_started","task_id":"a20b2336","tool_use_id":"toolu_spawn","subagent_type":"general-purpose","prompt":"p","description":"d"}"#,
+        )
+        .expect("parses");
+        assert!(norm.normalize(started, false).is_empty());
+        let send = crate::claude::wire::parse_frame(
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_send","name":"SendMessage","input":{"to":"a20b2336","message":"Also read the rebuild.","summary":"s"}}]}}"#,
+        )
+        .expect("parses");
+        let ev = norm.normalize(send, false);
+        assert!(
+            ev.iter().any(|e| matches!(
+                e,
+                AgentEvent::Subagent { parent_tool_use_id, event }
+                    if parent_tool_use_id == "toolu_spawn"
+                        && matches!(event.as_ref(), AgentEvent::UserMessage { text } if text == "Also read the rebuild.")
+            )),
+            "{ev:?}"
+        );
+        // Unknown recipient (no task_started seen) or a subagent-owned shell
+        // task's task_started: no steer synthesized.
+        let mut norm = Normalizer::new();
+        let shell_task = crate::claude::wire::parse_frame(
+            r#"{"type":"system","subtype":"task_started","task_id":"bg1","tool_use_id":"toolu_bash","task_type":"local_bash"}"#,
+        )
+        .expect("parses");
+        assert!(norm.normalize(shell_task, false).is_empty());
+        let send = crate::claude::wire::parse_frame(
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"SendMessage","input":{"to":"bg1","message":"x"}}]}}"#,
+        )
+        .expect("parses");
+        assert!(
+            !norm
+                .normalize(send, false)
+                .iter()
+                .any(|e| matches!(e, AgentEvent::Subagent { .. }))
+        );
     }
 
     #[test]

--- a/crates/harness/src/claude/wire.rs
+++ b/crates/harness/src/claude/wire.rs
@@ -41,6 +41,14 @@ pub(crate) struct SystemFrame {
     /// `task_notification` terminal status (`completed`/`failed`/`killed`…).
     #[serde(default)]
     pub status: Option<String>,
+    /// `task_started`: the agent/task id (`SendMessage`'s `to:` address) —
+    /// with `tool_use_id`, the agentId→spawn mapping steers need.
+    #[serde(default, alias = "taskId")]
+    pub task_id: Option<String>,
+    /// `task_started`: present only for AGENT tasks (a subagent spawning),
+    /// absent on subagent-owned background shell tasks.
+    #[serde(default)]
+    pub subagent_type: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/harness/src/mock.rs
+++ b/crates/harness/src/mock.rs
@@ -339,6 +339,24 @@ impl Harness for MockHarness {
                     ),
                     resolve("mock-sub-1"),
                     tag("mock-sub-1", done.clone()),
+                    // A steer AFTER the subagent settled (claude's queued
+                    // SendMessage shape): resurrects the chip and reopens
+                    // the frozen transcript for the resumed segment.
+                    tag(
+                        "mock-sub-1",
+                        AgentEvent::UserMessage {
+                            text: "One more: confirm the rebuild path holds the byte cap too."
+                                .into(),
+                        },
+                    ),
+                    tag(
+                        "mock-sub-1",
+                        AgentEvent::TextDelta {
+                            text: "Rebuild path checked — same cap, applied before persisting."
+                                .into(),
+                        },
+                    ),
+                    tag("mock-sub-1", done.clone()),
                     tag(
                         "mock-sub-2",
                         AgentEvent::TextDelta {


### PR DESCRIPTION
Fixes the three live-testing findings on subagent steering (claude steers missing from the transcript + stuck-Working agents; opencode missing user messages + resumed tasks not continuing the transcript), and makes the steer lifecycle durable by construction across all harnesses.

## Ground truth (live capture, claude 2.1.228)

A fresh probe capture of a background spawn + SendMessage steer shows:

- The steer **never echoes on the child feed** — no tagged user frame exists. The only wire evidence is the parent's untagged `SendMessage` tool_use (`input.to` = agent id).
- `task_started` pairs that agent id (`task_id`) with the spawning Agent `tool_use_id` (agent tasks carry `subagent_type`; subagent-owned shell tasks don't).
- The steered child's resumed frames arrive under the **original** spawn id, and its completion `task_notification` reuses it.

## claude

The normalizer records the `task_started` agent-id → spawn-id mapping and re-keys every `SendMessage` into a tagged `UserMessage` on the spawn's feed. Steers now land in the subagent transcript as user entries, and (via the engine rules below) legitimately reopen an already-settled agent instead of wedging it.

## Engine — driver-agnostic lifecycle rules

- A tagged `Done` marks the chip **settled**. Content events for a settled chip with no live sink are dropped: a straggler frame after the freeze can never mint a new doc entry or wedge the transcript back into `Streaming` (the stuck-Working class).
- **Only a `UserMessage` reopens** a settled subagent — a steer announces more work. It is also the one event the fold's no-regress guard lets flip a terminal chip back to `Running`. The next `Done` settles and re-freezes the blob with the full transcript.

## opencode

- A resume completion no longer re-keys a bound child onto the resume call's id — the transcript continues under the original spawn chip (this was why steers "didn't continue the subagent transcript").
- A user `message.updated` on a settled child un-latches it (opencode resumes the same session).
- Text parts that race ahead of their message's role fact are **held and replayed** once `message.updated` lands instead of being dropped — the likely cause of the missing user messages on the live bus.

## Validation

- New unit test pins the SendMessage re-key (and that shell-task ids never synthesize steers); all prior steer/prompt tests still pass.
- The mock subagent script now steers sub-1 **after** its Done, exercising settle → resurrect → re-freeze end-to-end.
- Suites: harness 78 lib + claude/codex/acp integration, doc 73, engine 103, ui 462 — all green.
- Live-validated: the claude capture above. The opencode changes are defensive + unit-tested against the recorded 1.18 bus shapes; I could not re-run the live opencode rig in this pass — worth a check on your setup before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789715995&installation_model_id=425430&pr_number=167&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F167&signature=bdb2c709dd5d35d8b46e877a162b2d5d1ece3a1c053166fd4c9f97749e8f132f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->