### PR TITLE
Durable-by-design delivery on bad networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9218,6 +9218,7 @@ dependencies = [
 name = "zeron-sync"
 version = "0.2.10"
 dependencies = [
+ "block2 0.6.2",
  "chrono",
  "futures",
  "loro",

--- a/crates/engine/src/auth.rs
+++ b/crates/engine/src/auth.rs
@@ -382,6 +382,7 @@ impl Auth {
             }
             let mut state_rx = auth.watch_state();
             let mut wake = zeron_sync::wake::subscribe();
+            let mut online = zeron_sync::wake::subscribe_online();
             loop {
                 if !state_rx.borrow().is_signed_in() {
                     if state_rx.changed().await.is_err() {
@@ -416,7 +417,15 @@ impl Auth {
                 }
                 if let Err(err) = auth.refresh(None).await {
                     tracing::warn!(error = %err, "auth: background refresh failed");
-                    tokio::time::sleep(Duration::from_secs(30)).await;
+                    // A failed refresh is usually the network, not WorkOS —
+                    // retry the moment connectivity returns (online bus)
+                    // instead of always waiting out the full pause.
+                    while online.try_recv().is_ok() {}
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_secs(30)) => {}
+                        _ = wake.recv() => {}
+                        _ = online.recv() => {}
+                    }
                 }
             }
         })

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -88,6 +88,19 @@ enum TransferError {
     Permanent(String),
 }
 
+/// Peer-relay delivery fallback pacing (`spawn_command_delivery`): the grace
+/// the normal rows→edge path gets before the relay road opens, the poll while
+/// waiting, the relay retry curve, its per-call deadline, and the give-up cap
+/// (the command stays durably queued in the doc regardless).
+const ROWS_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+const ROWS_POLL: std::time::Duration = std::time::Duration::from_secs(1);
+const RELAY_BACKOFF_BASE: std::time::Duration = std::time::Duration::from_secs(5);
+const RELAY_BACKOFF_CAP: std::time::Duration = std::time::Duration::from_secs(30);
+const RELAY_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+const RELAY_GIVE_UP: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+/// Hosts below this stamped engine version don't serve `RelayCommand`.
+const RELAY_MIN_VERSION: (u64, u64, u64) = (0, 2, 12);
+
 /// Edge connection config. The bearer is a **provider**, never a snapshot:
 /// every room (re)connect and HTTP request re-reads it, so WorkOS access-token
 /// refreshes (~1h expiry) take effect without an engine restart. Dev bearers
@@ -1936,7 +1949,7 @@ impl DocHost {
             payload,
             SessionCommandPayload::Run { .. } | SessionCommandPayload::Steer { .. }
         );
-        handle.doc.queue_command(&SessionCommandEntry {
+        let entry = SessionCommandEntry {
             id: id.clone(),
             payload,
             issued_by: self.inner.config.device_id.clone(),
@@ -1945,7 +1958,8 @@ impl DocHost {
             expires_at: Some(now + COMMAND_DEFAULT_TTL_MS),
             status: SessionCommandStatus::Pending,
             resolution: None,
-        })?;
+        };
+        handle.doc.queue_command(&entry)?;
         // Sending a message revives an archived chat: the user is acting in it
         // again, so the LWW row flips back to active on every device. Best-
         // effort — the command itself is durable regardless.
@@ -1966,7 +1980,7 @@ impl DocHost {
         // the command is durable in the doc either way (a host that opens the chat
         // for any other reason still executes it).
         self.nudge_remote_host(chat_id);
-        self.spawn_attachment_transfers(chat_id, transfers);
+        self.spawn_command_delivery(chat_id, entry, transfers);
         Ok(id)
     }
 
@@ -2035,56 +2049,68 @@ impl DocHost {
         (host_device != self.inner.config.device_id).then_some(host_device)
     }
 
-    /// Push queued attachment bytes to the chat's host device, retrying on an
-    /// event-driven backoff (online bus / system wake) until they land or the
-    /// wait cap passes — the drain's own cap then rejects the command loudly
-    /// instead of running without its images. No-op for locally-hosted chats
-    /// (the bytes are already in this device's uploads dir).
-    fn spawn_attachment_transfers(
+    /// Durable-delivery escort for one queued command aimed at a REMOTE host:
+    ///
+    /// 1. push any queued attachment bytes over the peer link (retry until
+    ///    they land — the relayed command must never outrun its bytes);
+    /// 2. give the normal path (chat2 rows → edge → host's room) a short
+    ///    grace to ack;
+    /// 3. rows still not at the edge but the peer link alive → relay-forward
+    ///    the entry itself ([`zeron_rpc::methods::RELAY_COMMAND`]). The
+    ///    host's processed ledger claims the client-minted id, so the doc
+    ///    row arriving later dedupes to a no-op — exactly-once by
+    ///    construction (the 2026-08-18 03:45 incident shape: nudges flowed,
+    ///    rows didn't; there was no second road for the command).
+    ///
+    /// Stops the moment any path lands. No-op for locally-hosted chats.
+    fn spawn_command_delivery(
         &self,
         chat_id: &str,
+        entry: SessionCommandEntry,
         transfers: Vec<crate::uploads::AttachmentTransfer>,
     ) {
-        if transfers.is_empty() {
-            return;
-        }
         let Ok(runtime) = tokio::runtime::Handle::try_current() else {
             return; // bare sync callers (unit tests) skip rather than panic
         };
         let host = self.clone();
         let chat = chat_id.to_string();
         self.spawn_worker_on(&runtime, async move {
+            let Some(target) = host.remote_host_for(&chat) else {
+                return; // local host (or no row yet claimed remotely)
+            };
+            if !transfers.is_empty() && !host.deliver_attachments(&chat, &transfers).await {
+                return; // gave up; the drain's wait cap surfaces the failure
+            }
             let mut wake = zeron_sync::wake::subscribe();
             let mut online = zeron_sync::wake::subscribe_online();
-            let mut backoff = TRANSFER_BACKOFF_BASE;
-            let deadline = tokio::time::Instant::now() + ATTACHMENT_WAIT_MAX;
+            let give_up = tokio::time::Instant::now() + RELAY_GIVE_UP;
+            let grace_end = tokio::time::Instant::now() + ROWS_GRACE;
+            while tokio::time::Instant::now() < grace_end {
+                if host.rows_flushed(&chat) {
+                    return; // rows on the edge — the normal path has it
+                }
+                tokio::time::sleep(ROWS_POLL).await;
+            }
+            let mut backoff = RELAY_BACKOFF_BASE;
             loop {
-                let Some(target) = host.remote_host_for(&chat) else {
-                    return; // local host (or no row yet claimed remotely)
-                };
-                match host.push_attachments(&target, &transfers).await {
-                    Ok(()) => {
-                        tracing::info!(chat = %chat, device = %target,
-                            count = transfers.len(), "queued attachments delivered");
-                        // The bytes beat the drain's next look — kick it via
-                        // the durable nudge (the host's UploadCommit already
-                        // kicked its local drains too).
-                        host.nudge_remote_host(&chat);
+                if host.rows_flushed(&chat) {
+                    return; // the normal path won while we were retrying
+                }
+                match host.relay_command(&target, &chat, &entry).await {
+                    Ok(outcome) => {
+                        tracing::info!(chat = %chat, device = %target, command = %entry.id,
+                            outcome, "command delivered via peer relay");
                         return;
                     }
-                    Err(TransferError::Permanent(err)) => {
-                        tracing::warn!(chat = %chat, device = %target, error = %err,
-                            "queued attachment transfer failed permanently");
-                        return;
-                    }
-                    Err(TransferError::Transient(err)) => {
+                    Err(err) => {
                         tracing::warn!(chat = %chat, device = %target, error = %err,
                             backoff_ms = backoff.as_millis() as u64,
-                            "queued attachment transfer retrying");
+                            "peer-relay delivery retrying");
                     }
                 }
-                if tokio::time::Instant::now() >= deadline {
-                    tracing::warn!(chat = %chat, "queued attachment transfer gave up (wait cap)");
+                if tokio::time::Instant::now() >= give_up {
+                    tracing::warn!(chat = %chat, command = %entry.id,
+                        "peer-relay delivery gave up; command remains queued in the doc");
                     return;
                 }
                 while wake.try_recv().is_ok() {}
@@ -2094,9 +2120,177 @@ impl DocHost {
                     _ = wake.recv() => {}
                     _ = online.recv() => {}
                 }
-                backoff = (backoff * 2).min(TRANSFER_BACKOFF_CAP);
+                backoff = (backoff * 2).min(RELAY_BACKOFF_CAP);
             }
         });
+    }
+
+    /// Step 1 of the escort: push staged bytes until they land (event-driven
+    /// backoff), `true` on success. Re-resolves the host each attempt (a
+    /// claim can move the chat).
+    async fn deliver_attachments(
+        &self,
+        chat: &str,
+        transfers: &[crate::uploads::AttachmentTransfer],
+    ) -> bool {
+        let mut wake = zeron_sync::wake::subscribe();
+        let mut online = zeron_sync::wake::subscribe_online();
+        let mut backoff = TRANSFER_BACKOFF_BASE;
+        let deadline = tokio::time::Instant::now() + ATTACHMENT_WAIT_MAX;
+        loop {
+            let Some(target) = self.remote_host_for(chat) else {
+                return true; // became locally hosted: bytes already here
+            };
+            match self.push_attachments(&target, transfers).await {
+                Ok(()) => {
+                    tracing::info!(chat = %chat, device = %target,
+                        count = transfers.len(), "queued attachments delivered");
+                    // The bytes beat the drain's next look — kick it via the
+                    // durable nudge (the host's UploadCommit already kicked
+                    // its local drains too).
+                    self.nudge_remote_host(chat);
+                    return true;
+                }
+                Err(TransferError::Permanent(err)) => {
+                    tracing::warn!(chat = %chat, device = %target, error = %err,
+                        "queued attachment transfer failed permanently");
+                    return false;
+                }
+                Err(TransferError::Transient(err)) => {
+                    tracing::warn!(chat = %chat, device = %target, error = %err,
+                        backoff_ms = backoff.as_millis() as u64,
+                        "queued attachment transfer retrying");
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                tracing::warn!(chat = %chat, "queued attachment transfer gave up (wait cap)");
+                return false;
+            }
+            while wake.try_recv().is_ok() {}
+            while online.try_recv().is_ok() {}
+            tokio::select! {
+                _ = tokio::time::sleep(backoff) => {}
+                _ = wake.recv() => {}
+                _ = online.recv() => {}
+            }
+            backoff = (backoff * 2).min(TRANSFER_BACKOFF_CAP);
+        }
+    }
+
+    /// Every local chat2 batch acked while connected — our rows are ON the
+    /// edge, and the host's own room connection will deliver them. (A room
+    /// that hasn't joined keeps pre-join updates in a local buffer, so
+    /// `connected` is load-bearing here, not just the empty queue.)
+    fn rows_flushed(&self, chat_id: &str) -> bool {
+        let handle = lock(&self.inner.handles).get(chat_id).cloned();
+        handle
+            .and_then(|h| lock(&h.chat2).as_ref().map(|c| c.stats()))
+            .is_some_and(|s| s.connected && s.pending_pushes == 0)
+    }
+
+    /// One relay attempt: version-gate the host, then forward the entry over
+    /// the peer link. Timeouts mark the link suspect (drop + redial next
+    /// attempt); a host-side refusal is permanent for THIS attempt but the
+    /// escort keeps retrying until the give-up cap (the refusal may be
+    /// "attachments not landed yet").
+    async fn relay_command(
+        &self,
+        target: &str,
+        chat_id: &str,
+        entry: &SessionCommandEntry,
+    ) -> Result<&'static str, String> {
+        let supported = self
+            .workspace()
+            .and_then(|ws| ws.read_devices().ok())
+            .into_iter()
+            .flatten()
+            .find(|d| d.id == target)
+            .and_then(|d| d.version.as_deref().and_then(zeron_proto::version_triple))
+            .is_some_and(|v| v >= RELAY_MIN_VERSION);
+        if !supported {
+            return Err("host does not support relay delivery (version gate)".into());
+        }
+        let links = self
+            .inner
+            .links
+            .get()
+            .ok_or_else(|| "peer links not wired".to_string())?;
+        let client = links
+            .client(target)
+            .await
+            .map_err(|e| format!("peer link: {e}"))?;
+        let params = serde_json::json!({ "chatId": chat_id, "entry": entry });
+        let call = client.call(zeron_rpc::methods::RELAY_COMMAND, params);
+        match tokio::time::timeout(RELAY_CALL_TIMEOUT, call).await {
+            Err(_) => {
+                links.invalidate(target);
+                Err("relay call timed out; peer link suspect".into())
+            }
+            Ok(Err(zeron_rpc::RpcError::Failed(err))) => Err(format!("host refused: {err}")),
+            Ok(Err(err)) => {
+                links.invalidate(target);
+                Err(format!("relay call failed: {err}"))
+            }
+            Ok(Ok(reply)) => Ok(match reply.get("outcome").and_then(|v| v.as_str()) {
+                Some("executed") => "executed",
+                Some("duplicate") => "duplicate",
+                Some("expired") => "expired",
+                Some("superseded") => "superseded",
+                _ => "accepted",
+            }),
+        }
+    }
+
+    /// Host side of [`zeron_rpc::methods::RELAY_COMMAND`]: evaluate the
+    /// forwarded entry against OUR doc (dedupe/TTL/supersede rules apply
+    /// unchanged), claim its client-minted id in the processed ledger, then
+    /// execute. The claim is what makes the doc row arriving later — over
+    /// chat2 sync — a no-op in the drain: exactly-once across both roads.
+    pub async fn ingest_relayed_command(
+        &self,
+        chat_id: &str,
+        entry: SessionCommandEntry,
+    ) -> Result<&'static str, EngineError> {
+        let handle = self.open(chat_id)?;
+        // The sender sequences attachment transfers BEFORE the relay; refuse
+        // (retryably) rather than run without the images.
+        if !self.missing_attachments(&entry).is_empty() {
+            return Err(EngineError::Other("attachments not landed yet".into()));
+        }
+        let sessions = self
+            .sessions()
+            .ok_or_else(|| EngineError::Other("executor unavailable".into()))?;
+        let commands = handle.doc.read_commands()?;
+        let messages = handle.doc.read_entries().unwrap_or_default();
+        let current_turn_id = messages.last().map(|m| m.id.clone());
+        let turn_is_past = |turn_id: &str| messages.iter().any(|m| m.id == turn_id);
+        let is_processed = |id: &str| self.inner.store.is_processed(id).unwrap_or(false);
+        let disposition = evaluate_command(
+            &entry,
+            &EvaluationContext {
+                is_processed: &is_processed,
+                now_ms: now_ms(),
+                entries: &commands,
+                current_turn_id: current_turn_id.as_deref(),
+                turn_is_past: &turn_is_past,
+            },
+        );
+        if matches!(disposition, CommandDisposition::Skip) {
+            return Ok("duplicate");
+        }
+        // Claim BEFORE executing (the drain's own mark-before-execute rule).
+        if !self.inner.store.mark_processed(&entry.id)? {
+            return Ok("duplicate");
+        }
+        match disposition {
+            CommandDisposition::Skip => Ok("duplicate"),
+            CommandDisposition::Expired => Ok("expired"),
+            CommandDisposition::Superseded => Ok("superseded"),
+            CommandDisposition::Execute => {
+                self.execute(&sessions, &handle, &entry).await?;
+                Ok("executed")
+            }
+        }
     }
 
     /// One transfer attempt: chunked `UploadChunk` + `UploadCommit` straight

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -20,6 +20,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError, Weak};
 
+use base64::Engine as _;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
@@ -60,6 +61,32 @@ const DOC_RESIDENT_FLOOR_BYTES: usize = 512 * 1024;
 /// the doc is unwatched and unpinned — a concurrent eviction would orphan the
 /// watcher on a roomless doc that renders once and never updates again.
 const EVICT_MIN_IDLE_MS: i64 = 30_000;
+
+/// Queued-attachment transfer pacing: chunk pushes are bounded per call (a
+/// stalled-but-open relay link never fails on its own) and a timeout marks
+/// the link suspect; attempts retry on this backoff, cut short by the online
+/// bus / system wake.
+const TRANSFER_CHUNK_B64: usize = 60_000;
+const TRANSFER_CHUNK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const TRANSFER_COMMIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const TRANSFER_BACKOFF_BASE: std::time::Duration = std::time::Duration::from_secs(2);
+const TRANSFER_BACKOFF_CAP: std::time::Duration = std::time::Duration::from_secs(30);
+/// A command whose attachment bytes are still in transit waits at most this
+/// long before the drain rejects it loudly (and the transfer task gives up on
+/// the same clock) — a chat must never wedge behind bytes that aren't coming.
+const ATTACHMENT_WAIT_MAX: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+const ATTACHMENT_WAIT_MAX_MS: i64 = ATTACHMENT_WAIT_MAX.as_millis() as i64;
+/// Re-check cadence while a chat's queue is deferred on in-transit bytes
+/// (the happy path is event-driven — UploadCommit kicks the drain — this
+/// timer only covers the give-up transition and missed kicks).
+const ATTACHMENT_WAIT_RECHECK: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Transfer attempt outcome: transient failures retry (the link may heal),
+/// permanent ones stop (the host actively refused, or the bytes are gone).
+enum TransferError {
+    Transient(String),
+    Permanent(String),
+}
 
 /// Edge connection config. The bearer is a **provider**, never a snapshot:
 /// every room (re)connect and HTTP request re-reads it, so WorkOS access-token
@@ -189,6 +216,16 @@ struct DocHostInner {
     /// on every registry change, and a long run would stack a tick loop per
     /// change without this.
     seed_waiting: Mutex<HashSet<String>>,
+    /// Attachment-wait re-drain timers armed (one per chat): a command
+    /// deferred on in-transit attachment bytes re-checks on a cadence, and
+    /// each deferral must not stack another timer.
+    drain_waiting: Mutex<HashSet<String>>,
+    /// Uploads store (engine assembly) — resolves `pending://` attachment
+    /// refs and jails transfer reads to the uploads dir.
+    uploads: OnceLock<crate::uploads::Uploads>,
+    /// Peer links (engine assembly, edge runtimes only) — the transport that
+    /// pushes queued attachment bytes to a remote host.
+    links: OnceLock<Arc<zeron_rpc::LinkCache>>,
     /// Shared client for sidecar blob PUT/GET (30s timeout, uploads.rs
     /// discipline — diff_sync's untimed client hung on dead links).
     http: reqwest::Client,
@@ -395,6 +432,9 @@ impl DocHost {
                 handles: Mutex::new(HashMap::new()),
                 seeding: Mutex::new(HashSet::new()),
                 seed_waiting: Mutex::new(HashSet::new()),
+                drain_waiting: Mutex::new(HashSet::new()),
+                uploads: OnceLock::new(),
+                links: OnceLock::new(),
                 http: reqwest::Client::builder()
                     .timeout(std::time::Duration::from_secs(30))
                     .build()
@@ -489,6 +529,31 @@ impl DocHost {
     /// Run commands carrying a [`zeron_proto::WorktreeSpec`].
     pub fn set_repos(&self, repos: crate::repos::Repos) {
         let _ = self.inner.repos.set(repos);
+    }
+
+    /// Wire the uploads store (engine assembly) — `pending://` ref resolution
+    /// and the transfer-read jail.
+    pub fn set_uploads(&self, uploads: crate::uploads::Uploads) {
+        let _ = self.inner.uploads.set(uploads);
+    }
+
+    /// Wire the peer-link cache (engine assembly, edge runtimes only) — the
+    /// transport for queued attachment transfers to a remote host.
+    pub fn set_links(&self, links: Arc<zeron_rpc::LinkCache>) {
+        let _ = self.inner.links.set(links);
+    }
+
+    /// Re-evaluate every open chat's command queue NOW. Called after an
+    /// upload commit lands bytes on this device: a Run deferred on those
+    /// bytes (`pending://` refs not yet on disk) becomes executable the
+    /// moment its transfer completes — event-driven, not timer luck.
+    pub fn kick_drains(&self) {
+        let handles: Vec<Arc<ChatDocHandle>> =
+            lock(&self.inner.handles).values().cloned().collect();
+        for handle in handles {
+            let host = self.clone();
+            self.spawn_worker(async move { host.drain_commands(&handle).await });
+        }
     }
 
     /// Wire the workspace host (engine assembly) — the source of chat-ownership rows.
@@ -1751,6 +1816,21 @@ impl DocHost {
         chat_id: &str,
         payload: SessionCommandPayload,
     ) -> Result<String, EngineError> {
+        self.queue_command_with_transfers(chat_id, payload, Vec::new())
+    }
+
+    /// [`Self::queue_command`] plus queued-attachment transfers: the command's
+    /// `pending://` refs name bytes already committed to THIS device's uploads
+    /// dir; when another device hosts the chat, a background task pushes them
+    /// over the peer link (retry until they land) while the command is
+    /// already durably queued. The send is a local write — attachment bytes
+    /// chase it, never gate it (2026-08-19 incident).
+    pub fn queue_command_with_transfers(
+        &self,
+        chat_id: &str,
+        payload: SessionCommandPayload,
+        transfers: Vec<crate::uploads::AttachmentTransfer>,
+    ) -> Result<String, EngineError> {
         let handle = self.open(chat_id)?;
         let id = new_id();
         let now = now_ms();
@@ -1792,6 +1872,7 @@ impl DocHost {
         // the command is durable in the doc either way (a host that opens the chat
         // for any other reason still executes it).
         self.nudge_remote_host(chat_id);
+        self.spawn_attachment_transfers(chat_id, transfers);
         Ok(id)
     }
 
@@ -1847,6 +1928,160 @@ impl DocHost {
                 }
             }
         });
+    }
+
+    /// The chat's host device when it is NOT this engine (mirrors
+    /// `nudge_remote_host`'s ownership read).
+    fn remote_host_for(&self, chat_id: &str) -> Option<String> {
+        let workspace = self.workspace()?;
+        let host_device = match workspace.chat(chat_id) {
+            Ok(Some(chat)) => chat.device_id,
+            _ => return None,
+        };
+        (host_device != self.inner.config.device_id).then_some(host_device)
+    }
+
+    /// Push queued attachment bytes to the chat's host device, retrying on an
+    /// event-driven backoff (online bus / system wake) until they land or the
+    /// wait cap passes — the drain's own cap then rejects the command loudly
+    /// instead of running without its images. No-op for locally-hosted chats
+    /// (the bytes are already in this device's uploads dir).
+    fn spawn_attachment_transfers(
+        &self,
+        chat_id: &str,
+        transfers: Vec<crate::uploads::AttachmentTransfer>,
+    ) {
+        if transfers.is_empty() {
+            return;
+        }
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return; // bare sync callers (unit tests) skip rather than panic
+        };
+        let host = self.clone();
+        let chat = chat_id.to_string();
+        self.spawn_worker_on(&runtime, async move {
+            let mut wake = zeron_sync::wake::subscribe();
+            let mut online = zeron_sync::wake::subscribe_online();
+            let mut backoff = TRANSFER_BACKOFF_BASE;
+            let deadline = tokio::time::Instant::now() + ATTACHMENT_WAIT_MAX;
+            loop {
+                let Some(target) = host.remote_host_for(&chat) else {
+                    return; // local host (or no row yet claimed remotely)
+                };
+                match host.push_attachments(&target, &transfers).await {
+                    Ok(()) => {
+                        tracing::info!(chat = %chat, device = %target,
+                            count = transfers.len(), "queued attachments delivered");
+                        // The bytes beat the drain's next look — kick it via
+                        // the durable nudge (the host's UploadCommit already
+                        // kicked its local drains too).
+                        host.nudge_remote_host(&chat);
+                        return;
+                    }
+                    Err(TransferError::Permanent(err)) => {
+                        tracing::warn!(chat = %chat, device = %target, error = %err,
+                            "queued attachment transfer failed permanently");
+                        return;
+                    }
+                    Err(TransferError::Transient(err)) => {
+                        tracing::warn!(chat = %chat, device = %target, error = %err,
+                            backoff_ms = backoff.as_millis() as u64,
+                            "queued attachment transfer retrying");
+                    }
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    tracing::warn!(chat = %chat, "queued attachment transfer gave up (wait cap)");
+                    return;
+                }
+                while wake.try_recv().is_ok() {}
+                while online.try_recv().is_ok() {}
+                tokio::select! {
+                    _ = tokio::time::sleep(backoff) => {}
+                    _ = wake.recv() => {}
+                    _ = online.recv() => {}
+                }
+                backoff = (backoff * 2).min(TRANSFER_BACKOFF_CAP);
+            }
+        });
+    }
+
+    /// One transfer attempt: chunked `UploadChunk` + `UploadCommit` straight
+    /// over the peer link (same wire the UI's legacy path used, so old and
+    /// new engines interoperate). Timeouts mark the link suspect —
+    /// `invalidate` drops the cached socket so the retry dials fresh instead
+    /// of feeding a zombie pipe forever (2026-08-19 incident).
+    async fn push_attachments(
+        &self,
+        target: &str,
+        transfers: &[crate::uploads::AttachmentTransfer],
+    ) -> Result<(), TransferError> {
+        use TransferError::{Permanent, Transient};
+        let Some(links) = self.inner.links.get() else {
+            return Err(Permanent("peer links not wired".into()));
+        };
+        let Some(uploads) = self.inner.uploads.get() else {
+            return Err(Permanent("uploads not wired".into()));
+        };
+        let client = links
+            .client(target)
+            .await
+            .map_err(|e| Transient(format!("peer link: {e}")))?;
+        for transfer in transfers {
+            // Bytes come from the uploads jail only — a transfer names an
+            // upload identity, never an arbitrary path.
+            let source = uploads.pending_target(&transfer.upload_id, &transfer.file_name);
+            let bytes = tokio::fs::read(&source)
+                .await
+                .map_err(|e| Permanent(format!("staged attachment missing: {e}")))?;
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            let mut start = 0usize;
+            let mut seq = 0u64;
+            loop {
+                let end = (start + TRANSFER_CHUNK_B64).min(b64.len());
+                let params = serde_json::json!({
+                    "uploadId": transfer.upload_id, "seq": seq, "data": &b64[start..end],
+                });
+                let call = client.call(zeron_rpc::methods::UPLOAD_CHUNK, params);
+                match tokio::time::timeout(TRANSFER_CHUNK_TIMEOUT, call).await {
+                    Err(_) => {
+                        links.invalidate(target);
+                        return Err(Transient("chunk push timed out; peer link suspect".into()));
+                    }
+                    Ok(Err(zeron_rpc::RpcError::Failed(err))) => {
+                        return Err(Permanent(format!("host refused chunk: {err}")));
+                    }
+                    Ok(Err(err)) => {
+                        links.invalidate(target);
+                        return Err(Transient(format!("chunk push failed: {err}")));
+                    }
+                    Ok(Ok(_)) => {}
+                }
+                start = end;
+                seq += 1;
+                if start >= b64.len() {
+                    break;
+                }
+            }
+            let params = serde_json::json!({
+                "uploadId": transfer.upload_id, "fileName": transfer.file_name,
+            });
+            let call = client.call(zeron_rpc::methods::UPLOAD_COMMIT, params);
+            match tokio::time::timeout(TRANSFER_COMMIT_TIMEOUT, call).await {
+                Err(_) => {
+                    links.invalidate(target);
+                    return Err(Transient("commit timed out; peer link suspect".into()));
+                }
+                Ok(Err(zeron_rpc::RpcError::Failed(err))) => {
+                    return Err(Permanent(format!("host refused commit: {err}")));
+                }
+                Ok(Err(err)) => {
+                    links.invalidate(target);
+                    return Err(Transient(format!("commit failed: {err}")));
+                }
+                Ok(Ok(_)) => {}
+            }
+        }
+        Ok(())
     }
 
     /// Upload a tool result's full output/diff to the R2 sidecar
@@ -2031,6 +2266,36 @@ impl DocHost {
                     turn_is_past: &turn_is_past,
                 },
             );
+            // Queued-attachment gate (BEFORE the processed mark — a deferred
+            // command must stay eligible): a Run/Steer naming `pending://`
+            // refs whose bytes haven't landed on this device yet waits for
+            // the transfer instead of running without its images. The wait is
+            // bounded; past it the command fails loudly.
+            if matches!(disposition, CommandDisposition::Execute) {
+                let missing = self.missing_attachments(&entry);
+                if !missing.is_empty() {
+                    if now_ms().saturating_sub(entry.issued_at) < ATTACHMENT_WAIT_MAX_MS {
+                        tracing::info!(chat = %handle.chat_id, command = %entry.id,
+                            missing = missing.len(), "command deferred: attachment bytes in transit");
+                        self.arm_attachment_wait(handle);
+                        return; // preserve order; UploadCommit / the wait timer re-kick
+                    }
+                    if let Err(err) = self.inner.store.mark_processed(&entry.id) {
+                        tracing::error!(chat = %handle.chat_id, error = %err,
+                            "processed-ledger write failed; halting drain");
+                        return;
+                    }
+                    tracing::warn!(chat = %handle.chat_id, command = %entry.id,
+                        "command rejected: attachments never arrived");
+                    self.resolve_command(
+                        handle,
+                        &entry.id,
+                        SessionCommandStatus::Rejected,
+                        Some("attachments never arrived"),
+                    );
+                    continue;
+                }
+            }
             // Mark BEFORE executing: a crash mid-execution must never double-run a
             // command whose side effect may already have happened.
             if let Err(err) = self.inner.store.mark_processed(&entry.id) {
@@ -2056,6 +2321,100 @@ impl DocHost {
                 }
             }
         }
+    }
+
+    /// The command's `pending://` attachment refs whose bytes are NOT on this
+    /// device's disk yet. Empty when the command names none, when everything
+    /// has landed, or when no uploads store is wired (tests) — absence of the
+    /// subsystem must never wedge a queue.
+    fn missing_attachments(&self, entry: &SessionCommandEntry) -> Vec<String> {
+        let refs: Vec<String> = match &entry.payload {
+            SessionCommandPayload::Run { request, .. } => request
+                .attachments
+                .iter()
+                .filter(|p| crate::uploads::is_pending_ref(p))
+                .cloned()
+                .collect(),
+            SessionCommandPayload::Steer { prompt, .. } => crate::uploads::pending_refs_in(prompt),
+            _ => Vec::new(),
+        };
+        if refs.is_empty() {
+            return refs;
+        }
+        let Some(uploads) = self.inner.uploads.get() else {
+            return Vec::new();
+        };
+        refs.into_iter()
+            .filter(|r| uploads.resolve_pending(r).is_none())
+            .collect()
+    }
+
+    /// Arm (once per chat) the deferred-command re-check loop: while a
+    /// pending unprocessed command still waits on attachment bytes, re-drain
+    /// on a cadence so the bounded wait actually expires even if every
+    /// event-driven kick was missed.
+    fn arm_attachment_wait(&self, handle: &Arc<ChatDocHandle>) {
+        let chat = handle.chat_id.clone();
+        if !lock(&self.inner.drain_waiting).insert(chat.clone()) {
+            return;
+        }
+        let weak = Arc::downgrade(handle);
+        let host = self.clone();
+        self.spawn_worker(async move {
+            loop {
+                tokio::time::sleep(ATTACHMENT_WAIT_RECHECK).await;
+                let Some(handle) = weak.upgrade() else { break };
+                if !host.awaiting_attachments(&handle) {
+                    break;
+                }
+                host.drain_commands(&handle).await;
+                let Some(handle) = weak.upgrade() else { break };
+                if !host.awaiting_attachments(&handle) {
+                    break;
+                }
+            }
+            lock(&host.inner.drain_waiting).remove(&chat);
+        });
+    }
+
+    /// True while some pending, unprocessed command still waits on bytes.
+    fn awaiting_attachments(&self, handle: &Arc<ChatDocHandle>) -> bool {
+        let commands = handle.doc.read_commands().unwrap_or_default();
+        commands.iter().any(|c| {
+            c.status == SessionCommandStatus::Pending
+                && !self.inner.store.is_processed(&c.id).unwrap_or(false)
+                && !self.missing_attachments(c).is_empty()
+        })
+    }
+
+    /// Rewrite a request's landed `pending://` refs to this device's absolute
+    /// paths — in the attachments list AND the prompt text — so the harness
+    /// (and the persisted user entry) see ordinary local files, exactly like
+    /// the legacy pre-upload flow produced.
+    fn resolve_request_attachments(&self, request: &mut zeron_proto::RunRequest) {
+        let Some(uploads) = self.inner.uploads.get() else {
+            return;
+        };
+        for path in request.attachments.iter_mut() {
+            if let Some(abs) = uploads.resolve_pending(path) {
+                request.prompt = request.prompt.replace(path.as_str(), &abs);
+                *path = abs;
+            }
+        }
+    }
+
+    /// [`Self::resolve_request_attachments`] for a bare prompt (Steer).
+    fn resolve_prompt_attachments(&self, prompt: &str) -> String {
+        let Some(uploads) = self.inner.uploads.get() else {
+            return prompt.to_string();
+        };
+        let mut out = prompt.to_string();
+        for r in crate::uploads::pending_refs_in(prompt) {
+            if let Some(abs) = uploads.resolve_pending(&r) {
+                out = out.replace(&r, &abs);
+            }
+        }
+        out
     }
 
     /// Host-only outcome write (ledger rule 2).
@@ -2092,6 +2451,11 @@ impl DocHost {
                 message_id,
             } => {
                 let mut request = request.clone();
+                // Queued-attachment refs (`pending://`) resolve to this
+                // host's absolute paths before anything persists or
+                // dispatches — the drain already gated on the bytes being
+                // present, so every ref resolves here.
+                self.resolve_request_attachments(&mut request);
                 // Worktree directive (WorktreeSpec): materialize on THIS host at
                 // drain time — the durable command plane replaces the sender's
                 // old blocking CreateWorktree relay RPC, whose lost reply wedged
@@ -2150,6 +2514,8 @@ impl DocHost {
                 Ok((SessionCommandStatus::Applied, None))
             }
             SessionCommandPayload::Steer { prompt, message_id } => {
+                // Same `pending://` → absolute rewrite as the Run arm.
+                let prompt = &self.resolve_prompt_attachments(prompt);
                 match sessions.steer(chat_id, prompt, message_id.clone()).await? {
                     SteerOutcome::Accepted => Ok((SessionCommandStatus::Applied, None)),
                     SteerOutcome::NotSteerable => {

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -966,6 +966,7 @@ impl DocHost {
             ));
             let url = edge.room_url(format!("/chat2/{chat}/ws"));
             let mut wake = zeron_sync::wake::subscribe();
+            let mut online = zeron_sync::wake::subscribe_online();
             let mut backoff = crate::workspace_host::JOIN_RETRY_BASE;
             loop {
                 if weak.upgrade().is_none() {
@@ -1129,11 +1130,17 @@ impl DocHost {
                             "chat2 join timed out; retrying");
                     }
                 }
+                // Drain stale online events so only successes DURING this
+                // wait cut it short (our own failed dial doesn't count).
+                while online.try_recv().is_ok() {}
                 tokio::select! {
                     _ = tokio::time::sleep(backoff + crate::workspace_host::join_retry_jitter()) => {
                         backoff = (backoff * 2).min(crate::workspace_host::JOIN_RETRY_CAP);
                     }
                     _ = wake.recv() => {
+                        backoff = crate::workspace_host::JOIN_RETRY_BASE;
+                    }
+                    _ = online.recv() => {
                         backoff = crate::workspace_host::JOIN_RETRY_BASE;
                     }
                     _ = crate::workspace_host::token_changed(&mut token_changes) => {
@@ -1676,6 +1683,35 @@ impl DocHost {
                 chat2.probe();
             }
         }
+    }
+
+    /// Window-focus fast path: one cheap HTTP probe of the edge decides
+    /// whether to un-park every reconnect backoff NOW (success → online
+    /// event → immediate redials with fresh backoff) or to leave them
+    /// backing off (failure — a dial can't succeed either, so don't burn
+    /// the attempt). Recovery rides the "user looked at the app" event
+    /// instead of timer luck.
+    pub fn probe_edge_reachability(&self) {
+        let Some(edge) = self.inner.config.edge.clone() else {
+            return;
+        };
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let url = format!("{}/health", edge.url.trim_end_matches('/'));
+        let http = self.inner.http.clone();
+        self.spawn_worker_on(&runtime, async move {
+            let res = http
+                .get(&url)
+                .timeout(std::time::Duration::from_secs(3))
+                .send()
+                .await;
+            if let Ok(res) = res
+                && res.status().is_success()
+            {
+                zeron_sync::wake::notify_online();
+            }
+        });
     }
 
     /// Per-open-chat room introspection for SyncStatus / `zeron sync`.

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -2241,6 +2241,60 @@ impl DocHost {
         }
     }
 
+    /// User-driven retry (the failed-send affordance): re-kick every
+    /// delivery road for a chat whose queued sends haven't been adopted —
+    /// fresh chat2 socket (a zombie room is the usual suspect), host nudge,
+    /// a local drain pass, and a fresh delivery escort per still-pending
+    /// command with its attachment transfers re-derived from the entries'
+    /// `pending://` refs (idempotent: re-pushing landed bytes re-commits the
+    /// same file; the processed ledger keeps execution exactly-once).
+    pub fn retry_delivery(&self, chat_id: &str) -> Result<(), EngineError> {
+        let handle = self.open(chat_id)?;
+        if let Some(chat2) = lock(&handle.chat2).as_ref() {
+            chat2.redial();
+        }
+        self.nudge_remote_host(chat_id);
+        let commands = handle.doc.read_commands()?;
+        let pending: Vec<SessionCommandEntry> = commands
+            .into_iter()
+            .filter(|c| {
+                c.status == SessionCommandStatus::Pending
+                    && !self.inner.store.is_processed(&c.id).unwrap_or(false)
+            })
+            .collect();
+        for entry in pending {
+            let refs: Vec<String> = match &entry.payload {
+                SessionCommandPayload::Run { request, .. } => request
+                    .attachments
+                    .iter()
+                    .filter(|p| crate::uploads::is_pending_ref(p))
+                    .cloned()
+                    .collect(),
+                SessionCommandPayload::Steer { prompt, .. } => {
+                    crate::uploads::pending_refs_in(prompt)
+                }
+                _ => Vec::new(),
+            };
+            let transfers: Vec<crate::uploads::AttachmentTransfer> = refs
+                .iter()
+                .filter_map(|r| crate::uploads::parse_pending_ref(r))
+                .map(|(upload_id, file_name)| crate::uploads::AttachmentTransfer {
+                    upload_id: upload_id.to_string(),
+                    file_name: file_name.to_string(),
+                })
+                .collect();
+            self.spawn_command_delivery(chat_id, entry, transfers);
+        }
+        // Locally-hosted (or already-synced) commands: a drain pass is the
+        // whole retry.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            let host = self.clone();
+            let handle = handle.clone();
+            self.spawn_worker(async move { host.drain_commands(&handle).await });
+        }
+        Ok(())
+    }
+
     /// Host side of [`zeron_rpc::methods::RELAY_COMMAND`]: evaluate the
     /// forwarded entry against OUR doc (dedupe/TTL/supersede rules apply
     /// unchanged), claim its client-minted id in the processed ledger, then
@@ -2796,6 +2850,19 @@ impl DocHost {
                         tracing::warn!(chat = %chat_id, error = %err, "run-config backfill failed");
                     }
                 }
+                // Timestamp canonicalization: the user message lands in
+                // history at the moment the user SENT it (the entry's
+                // issued_at, clamped against clock skew) — not whenever this
+                // host got around to draining a queued command. Idempotent by
+                // id, so the dispatch path's own execution-time write dedupes
+                // to a no-op.
+                if let Err(err) = handle.write_user_message(
+                    message_id,
+                    &request.prompt,
+                    entry.issued_at.min(now_ms()),
+                ) {
+                    tracing::warn!(chat = %chat_id, error = %err, "canonical user-message write failed");
+                }
                 sessions
                     .dispatch(chat_id, harness, request, Some(message_id.clone()))
                     .await?;
@@ -2804,6 +2871,16 @@ impl DocHost {
             SessionCommandPayload::Steer { prompt, message_id } => {
                 // Same `pending://` → absolute rewrite as the Run arm.
                 let prompt = &self.resolve_prompt_attachments(prompt);
+                // Same send-time canonicalization as the Run arm.
+                if let Some(message_id) = message_id
+                    && let Err(err) = handle.write_user_message(
+                        message_id,
+                        prompt,
+                        entry.issued_at.min(now_ms()),
+                    )
+                {
+                    tracing::warn!(chat = %chat_id, error = %err, "canonical user-message write failed");
+                }
                 match sessions.steer(chat_id, prompt, message_id.clone()).await? {
                     SteerOutcome::Accepted => Ok((SessionCommandStatus::Applied, None)),
                     SteerOutcome::NotSteerable => {

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -223,6 +223,10 @@ struct DocHostInner {
     /// Uploads store (engine assembly) — resolves `pending://` attachment
     /// refs and jails transfer reads to the uploads dir.
     uploads: OnceLock<crate::uploads::Uploads>,
+    /// Connectivity watch (`WatchConnectivity`): lazily-started monitor
+    /// publishes the edge posture on change (see `watch_connectivity`).
+    connectivity: OnceLock<watch::Sender<zeron_proto::Connectivity>>,
+    connectivity_started: AtomicBool,
     /// Peer links (engine assembly, edge runtimes only) — the transport that
     /// pushes queued attachment bytes to a remote host.
     links: OnceLock<Arc<zeron_rpc::LinkCache>>,
@@ -434,6 +438,8 @@ impl DocHost {
                 seed_waiting: Mutex::new(HashSet::new()),
                 drain_waiting: Mutex::new(HashSet::new()),
                 uploads: OnceLock::new(),
+                connectivity: OnceLock::new(),
+                connectivity_started: AtomicBool::new(false),
                 links: OnceLock::new(),
                 http: reqwest::Client::builder()
                     .timeout(std::time::Duration::from_secs(30))
@@ -1777,6 +1783,94 @@ impl DocHost {
                 zeron_sync::wake::notify_online();
             }
         });
+    }
+
+    /// The connectivity stream: current posture first, then every change.
+    /// Lazily starts a monitor — a 1s recompute over in-memory stats
+    /// (atomics + small locks), published only when the value changes. The
+    /// retry countdown renders client-side from `retry_at_ms`, so quiet
+    /// periods emit nothing at all.
+    pub fn watch_connectivity(&self) -> watch::Receiver<zeron_proto::Connectivity> {
+        let tx = self
+            .inner
+            .connectivity
+            .get_or_init(|| watch::channel(self.compute_connectivity()).0);
+        let rx = tx.subscribe();
+        if !self.inner.connectivity_started.swap(true, Ordering::SeqCst)
+            && tokio::runtime::Handle::try_current().is_ok()
+        {
+            let host = self.clone();
+            self.spawn_worker(async move {
+                let mut tick = tokio::time::interval(std::time::Duration::from_secs(1));
+                tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                loop {
+                    tick.tick().await;
+                    let next = host.compute_connectivity();
+                    if let Some(tx) = host.inner.connectivity.get() {
+                        tx.send_if_modified(|cur| {
+                            if *cur == next {
+                                false
+                            } else {
+                                *cur = next;
+                                true
+                            }
+                        });
+                    }
+                }
+            });
+        }
+        rx
+    }
+
+    /// One snapshot of the edge posture: OS path status beats registry-room
+    /// state beats per-chat rooms. `Disabled` (the default) = local profile.
+    fn compute_connectivity(&self) -> zeron_proto::Connectivity {
+        use zeron_proto::{ChatConnectivity, Connectivity, ConnectivityState};
+        let workspace = self.workspace();
+        let edge_expected = self.inner.config.edge.is_some()
+            || workspace.as_ref().is_some_and(|w| w.edge_expected());
+        if !edge_expected {
+            return Connectivity::default();
+        }
+        let chats = self
+            .sync_statuses()
+            .into_iter()
+            .map(|(chat_id, stats)| {
+                let stats = stats.unwrap_or_default();
+                ChatConnectivity {
+                    chat_id,
+                    connected: stats.connected,
+                    pending_pushes: stats.pending_pushes,
+                }
+            })
+            .collect();
+        let reconnect = workspace.as_ref().and_then(|w| w.reconnect_state());
+        let registry_connected = workspace
+            .as_ref()
+            .and_then(|w| w.sync_status())
+            .is_some_and(|s| s.connected);
+        let (state, retry_at_ms, last_failure) = if zeron_sync::wake::path_is_offline() {
+            (
+                ConnectivityState::Offline,
+                0,
+                reconnect.and_then(|r| r.last_failure),
+            )
+        } else if registry_connected {
+            (ConnectivityState::Connected, 0, None)
+        } else {
+            let reconnect = reconnect.unwrap_or_default();
+            (
+                ConnectivityState::Reconnecting,
+                reconnect.retry_at_ms,
+                reconnect.last_failure,
+            )
+        };
+        Connectivity {
+            state,
+            retry_at_ms,
+            last_failure,
+            chats,
+        }
     }
 
     /// Per-open-chat room introspection for SyncStatus / `zeron sync`.

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -2278,10 +2278,12 @@ impl DocHost {
             let transfers: Vec<crate::uploads::AttachmentTransfer> = refs
                 .iter()
                 .filter_map(|r| crate::uploads::parse_pending_ref(r))
-                .map(|(upload_id, file_name)| crate::uploads::AttachmentTransfer {
-                    upload_id: upload_id.to_string(),
-                    file_name: file_name.to_string(),
-                })
+                .map(
+                    |(upload_id, file_name)| crate::uploads::AttachmentTransfer {
+                        upload_id: upload_id.to_string(),
+                        file_name: file_name.to_string(),
+                    },
+                )
                 .collect();
             self.spawn_command_delivery(chat_id, entry, transfers);
         }
@@ -2873,11 +2875,8 @@ impl DocHost {
                 let prompt = &self.resolve_prompt_attachments(prompt);
                 // Same send-time canonicalization as the Run arm.
                 if let Some(message_id) = message_id
-                    && let Err(err) = handle.write_user_message(
-                        message_id,
-                        prompt,
-                        entry.issued_at.min(now_ms()),
-                    )
+                    && let Err(err) =
+                        handle.write_user_message(message_id, prompt, entry.issued_at.min(now_ms()))
                 {
                     tracing::warn!(chat = %chat_id, error = %err, "canonical user-message write failed");
                 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -695,6 +695,13 @@ impl Engine {
                 .as_deref()
                 .is_some_and(|token| !token.trim().is_empty()),
         };
+        if edge_enabled {
+            // OS network-path events (macOS NWPathMonitor): the instant the
+            // path returns every parked reconnect backoff redials, and while
+            // the OS says there is no path the dial loops park instead of
+            // burning attempts. No-op on platforms without a monitor.
+            zeron_sync::net_path::spawn_path_monitor();
+        }
         let device_id = load_or_create_device_id(profile.device_root())?;
         let edge = edge_enabled.then(|| {
             EdgeConfig::new(config.edge_url.clone(), Arc::new(auth.clone())).with_device(device_id)

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -756,10 +756,16 @@ impl Engine {
         zeron_harness::acp::prewarm_managed_adapters();
 
         let host_relay = edge.as_ref().map(|edge| {
-            let links = zeron_rpc::LinkCache::new(zeron_rpc::LinkCacheConfig::new(
-                edge.url.clone(),
-                Arc::new(auth.clone()),
-            ));
+            let mut link_config =
+                zeron_rpc::LinkCacheConfig::new(edge.url.clone(), Arc::new(auth.clone()));
+            // Registry-dark dial gate: devices with no recent presence fail
+            // fast with zero dials; presence returning un-parks them (the
+            // peer-alive hook below clears any cooldown at the same moment).
+            let workspace_for_liveness = core.workspace.clone();
+            link_config.liveness = Some(Arc::new(move |device_id: &str| {
+                workspace_for_liveness.peer_liveness(device_id)
+            }));
+            let links = zeron_rpc::LinkCache::new(link_config);
             let links_for_presence = links.clone();
             core.workspace
                 .set_peer_alive_hook(Arc::new(move |device_id: &str| {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -244,6 +244,9 @@ impl EngineCore {
         {
             uploads.add_read_only_root(&root);
         }
+        // Queued-attachment support: the doc host resolves `pending://` refs
+        // against this store and pushes staged bytes to remote hosts.
+        doc_host.set_uploads(uploads.clone());
         let local_import = (profile.scope() == WorkspaceScope::Synced).then(|| {
             local_import::LocalImporter::new(
                 data_dir,
@@ -322,8 +325,10 @@ impl EngineCore {
         .clone()
     }
 
-    /// Attach the peer link cache — enables `targetDeviceId` routing and [`Self::dial_device`].
+    /// Attach the peer link cache — enables `targetDeviceId` routing,
+    /// [`Self::dial_device`], and the doc host's queued-attachment transfers.
     pub fn set_links(&self, links: Arc<zeron_rpc::LinkCache>) {
+        self.doc_host.set_links(links.clone());
         *self
             .links
             .lock()

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -107,6 +107,15 @@ struct QueueCommandParams {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct RelayCommandParams {
+    chat_id: String,
+    /// The full command entry, client-minted id included — the exactly-once
+    /// key the host claims in its processed ledger before executing.
+    entry: zeron_doc::SessionCommandEntry,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct RepoPathParams {
     /// `repoPath` per §3.5 (the §2.1 shorthand `repo` is accepted as an alias).
     #[serde(alias = "repo")]
@@ -1085,6 +1094,15 @@ impl RpcService for EngineRpc {
                     .queue_command_with_transfers(&p.chat_id, p.command, p.transfers)
                     .map_err(|e| RpcError::Failed(e.to_string()))?;
                 RpcReply::value(&serde_json::json!({ "commandId": command_id }))
+            }
+            methods::RELAY_COMMAND => {
+                let p: RelayCommandParams = parse_params(params)?;
+                let outcome = self
+                    .doc_host
+                    .ingest_relayed_command(&p.chat_id, p.entry)
+                    .await
+                    .map_err(|e| RpcError::Failed(e.to_string()))?;
+                RpcReply::value(&serde_json::json!({ "outcome": outcome }))
             }
             methods::WATCH_DOC_MESSAGES => {
                 let p: ChatParams = parse_params(params)?;

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -1094,6 +1094,7 @@ impl RpcService for EngineRpc {
             methods::PROBE_SYNC => {
                 self.workspace.probe();
                 self.doc_host.probe_open_chats();
+                self.doc_host.probe_edge_reachability();
                 RpcReply::value(&serde_json::json!({}))
             }
             methods::SYNC_STATUS => {

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -98,6 +98,11 @@ struct SetHarnessEnabledParams {
 struct QueueCommandParams {
     chat_id: String,
     command: SessionCommandPayload,
+    /// Queued attachments (bytes already committed locally as `pending://`
+    /// refs) the engine delivers to a remote host AFTER the command is
+    /// durably queued — never as a gate in front of it.
+    #[serde(default)]
+    transfers: Vec<crate::uploads::AttachmentTransfer>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1077,7 +1082,7 @@ impl RpcService for EngineRpc {
                 let p: QueueCommandParams = parse_params(params)?;
                 let command_id = self
                     .doc_host
-                    .queue_command(&p.chat_id, p.command)
+                    .queue_command_with_transfers(&p.chat_id, p.command, p.transfers)
                     .map_err(|e| RpcError::Failed(e.to_string()))?;
                 RpcReply::value(&serde_json::json!({ "commandId": command_id }))
             }
@@ -1733,6 +1738,9 @@ impl RpcService for EngineRpc {
                     .uploads
                     .commit(&p.upload_id, &p.file_name)
                     .map_err(|e| RpcError::Failed(e.to_string()))?;
+                // Bytes just landed on this device: any command deferred on
+                // them (queued-attachment refs) is executable NOW.
+                self.doc_host.kick_drains();
                 RpcReply::value(&serde_json::json!({ "path": path }))
             }
             methods::READ_ATTACHMENT_CHUNK => {

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -1151,6 +1151,9 @@ impl RpcService for EngineRpc {
                     "chats": chats,
                 }))
             }
+            methods::WATCH_CONNECTIVITY => Ok(RpcReply::Stream(watch_stream(
+                self.doc_host.watch_connectivity(),
+            ))),
             methods::WATCH_CHATS => {
                 Ok(RpcReply::Stream(watch_stream(self.workspace.watch_chats())))
             }

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -1095,6 +1095,13 @@ impl RpcService for EngineRpc {
                     .map_err(|e| RpcError::Failed(e.to_string()))?;
                 RpcReply::value(&serde_json::json!({ "commandId": command_id }))
             }
+            methods::RETRY_DELIVERY => {
+                let p: ChatParams = parse_params(params)?;
+                self.doc_host
+                    .retry_delivery(&p.chat_id)
+                    .map_err(|e| RpcError::Failed(e.to_string()))?;
+                RpcReply::value(&serde_json::json!({}))
+            }
             methods::RELAY_COMMAND => {
                 let p: RelayCommandParams = parse_params(params)?;
                 let outcome = self

--- a/crates/engine/src/uploads.rs
+++ b/crates/engine/src/uploads.rs
@@ -27,6 +27,56 @@ use crate::EngineError;
 
 /// A pending upload must finish within this window (covers slow mesh links).
 const STAGING_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// Queued-attachment ref scheme (2026-08-19 incident: attachment staging was
+/// a blocking pre-step in front of QueueCommand, so a send died with the peer
+/// link instead of queueing). A ref names bytes by identity instead of by a
+/// device-local absolute path: `pending://{uploadId}/{fileName}`. The sender
+/// commits the bytes to its OWN uploads dir first (fast, offline-safe), the
+/// command queues immediately carrying refs, and the bytes chase it over the
+/// peer link. Any device resolves a ref against its own uploads dir — the
+/// deterministic committed name `{id8}-{sanitize(fileName)}` makes sender and
+/// host land the same file at the same relative path.
+pub const PENDING_REF_PREFIX: &str = "pending://";
+
+pub fn is_pending_ref(path: &str) -> bool {
+    path.starts_with(PENDING_REF_PREFIX)
+}
+
+/// `pending://{uploadId}/{fileName}` (fileName is the ORIGINAL name; sanitize
+/// happens at resolution so both ends agree by construction).
+pub fn pending_ref(upload_id: &str, file_name: &str) -> String {
+    format!("{PENDING_REF_PREFIX}{upload_id}/{file_name}")
+}
+
+/// Split a pending ref into `(upload_id, file_name)`.
+pub fn parse_pending_ref(path: &str) -> Option<(&str, &str)> {
+    let rest = path.strip_prefix(PENDING_REF_PREFIX)?;
+    let (id, name) = rest.split_once('/')?;
+    (!id.is_empty() && !name.is_empty()).then_some((id, name))
+}
+
+/// One queued attachment a `QueueCommand` asks the engine to deliver: the
+/// bytes are already committed to THIS device's uploads dir under
+/// `{id8}-{sanitize(file_name)}`; the transfer pushes them to the chat's
+/// host device by upload identity (never by arbitrary path).
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachmentTransfer {
+    pub upload_id: String,
+    pub file_name: String,
+}
+
+/// Pending refs listed on a text's attachment-ref lines (`- pending://…`).
+/// Line-wise so file names with spaces survive intact.
+pub fn pending_refs_in(text: &str) -> Vec<String> {
+    text.lines()
+        .filter_map(|line| {
+            let path = line.trim_start().strip_prefix("- ")?.trim();
+            is_pending_ref(path).then(|| path.to_string())
+        })
+        .collect()
+}
 /// Hard cap on an assembled file.
 const MAX_BYTES: u64 = 32 * 1024 * 1024;
 /// Multiple of 3 so independent base64 chunks concatenate losslessly.
@@ -168,6 +218,26 @@ impl Uploads {
         Ok(path.to_string_lossy().to_string())
     }
 
+    /// The committed absolute path a pending ref resolves to on THIS device
+    /// (`{uploads_dir}/{id8}-{sanitize(name)}`), whether or not it exists yet.
+    pub fn pending_target(&self, upload_id: &str, file_name: &str) -> PathBuf {
+        let id8: String = upload_id.chars().take(8).collect();
+        // The id8 fragment becomes part of a file name — jail its charset the
+        // same way staging does (a hostile ref must not traverse).
+        let id8 = sanitize(&id8);
+        self.inner.dir.join(format!("{id8}-{}", sanitize(file_name)))
+    }
+
+    /// Resolve a `pending://` ref against this device's uploads dir.
+    /// `Some(absolute)` iff the bytes have landed here.
+    pub fn resolve_pending(&self, path: &str) -> Option<String> {
+        let (upload_id, file_name) = parse_pending_ref(path)?;
+        let target = self.pending_target(upload_id, file_name);
+        target
+            .is_file()
+            .then(|| target.to_string_lossy().to_string())
+    }
+
     /// Read one 45KB chunk of an attachment. `extra_roots` are the workspace's
     /// known chat cwds — together with the uploads dir they form the path jail.
     pub fn read_chunk(
@@ -244,6 +314,15 @@ impl Uploads {
 
     fn inspect(&self, path: &str, extra_roots: &[PathBuf]) -> Result<InspectedFile, EngineError> {
         let outside = || EngineError::Other("Attachment is outside the upload cache".into());
+        // Queued-attachment refs resolve against this device's uploads dir
+        // (present only once the transfer landed) — then jail as usual.
+        let resolved_ref;
+        let path = if is_pending_ref(path) {
+            resolved_ref = self.resolve_pending(path).ok_or_else(outside)?;
+            resolved_ref.as_str()
+        } else {
+            path
+        };
         // Canonicalize BOTH sides so `..` segments and symlinks can't escape.
         let resolved = std::fs::canonicalize(path).map_err(|_| outside())?;
         let read_roots = self
@@ -384,5 +463,55 @@ mod tests {
 
         assert_eq!(std::fs::read(&path).unwrap(), b"local");
         assert!(!dir.path().join("tmp").join("upload-1").exists());
+    }
+
+    #[test]
+    fn pending_refs_round_trip_and_resolve_after_commit() {
+        assert_eq!(
+            pending_ref("abcd1234-rest", "my photo (1).png"),
+            "pending://abcd1234-rest/my photo (1).png"
+        );
+        assert_eq!(
+            parse_pending_ref("pending://abcd1234-rest/my photo (1).png"),
+            Some(("abcd1234-rest", "my photo (1).png"))
+        );
+        assert_eq!(parse_pending_ref("pending://no-slash"), None);
+        assert_eq!(parse_pending_ref("/tmp/plain.png"), None);
+
+        let dir = tempfile::tempdir().unwrap();
+        let uploads = Uploads::from_root(dir.path());
+        let r = pending_ref("abcd1234-rest", "my photo (1).png");
+        // Not landed yet.
+        assert_eq!(uploads.resolve_pending(&r), None);
+        // Commit under the SAME identity → the ref resolves to the committed
+        // path (the invariant sender and host both rely on).
+        uploads
+            .append("abcd1234-rest", &BASE64.encode(b"img"), Some(0))
+            .unwrap();
+        let committed = uploads.commit("abcd1234-rest", "my photo (1).png").unwrap();
+        assert_eq!(uploads.resolve_pending(&r), Some(committed));
+    }
+
+    #[test]
+    fn pending_refs_in_scans_ref_lines_only() {
+        let text = "See the attached image(s).\n\nAttached images (local files — open them to view):\n- pending://u1/a b.png\n- /abs/other.png\n- pending://u2/c.png";
+        assert_eq!(
+            pending_refs_in(text),
+            vec![
+                "pending://u1/a b.png".to_string(),
+                "pending://u2/c.png".to_string()
+            ]
+        );
+        assert!(pending_refs_in("mentions pending://u1/x.png inline only").is_empty());
+    }
+
+    #[test]
+    fn pending_ref_traversal_cannot_escape_the_jail() {
+        let dir = tempfile::tempdir().unwrap();
+        let uploads = Uploads::from_root(dir.path());
+        // Hostile names sanitize into the jail rather than traversing out.
+        let target = uploads.pending_target("../../../etc", "../../passwd");
+        assert!(target.starts_with(dir.path()));
+        assert!(!target.to_string_lossy().contains(".."));
     }
 }

--- a/crates/engine/src/uploads.rs
+++ b/crates/engine/src/uploads.rs
@@ -225,7 +225,9 @@ impl Uploads {
         // The id8 fragment becomes part of a file name — jail its charset the
         // same way staging does (a hostile ref must not traverse).
         let id8 = sanitize(&id8);
-        self.inner.dir.join(format!("{id8}-{}", sanitize(file_name)))
+        self.inner
+            .dir
+            .join(format!("{id8}-{}", sanitize(file_name)))
     }
 
     /// Resolve a `pending://` ref against this device's uploads dir.

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -65,7 +65,10 @@ const SNAPSHOT_DEBOUNCE_MS: u64 = 1_000;
 /// it lands. Jittered so N devices restarting together don't resynchronize
 /// their retries into a thundering herd on the cold DO.
 pub(crate) const JOIN_RETRY_BASE: std::time::Duration = std::time::Duration::from_millis(500);
-pub(crate) const JOIN_RETRY_CAP: std::time::Duration = std::time::Duration::from_secs(30);
+/// 16s, matching the room clients' BACKOFF_CAP: the cap only bounds the dark
+/// window when every event wake (online bus, system wake, token change)
+/// missed, so it trades a few extra dials/minute for a tighter worst case.
+pub(crate) const JOIN_RETRY_CAP: std::time::Duration = std::time::Duration::from_secs(16);
 
 pub(crate) async fn token_changed(changes: &mut Option<tokio::sync::watch::Receiver<u64>>) {
     match changes {
@@ -320,6 +323,7 @@ impl WorkspaceHost {
         let weak = Arc::downgrade(&self.inner);
         tokio::spawn(async move {
             let mut wake = zeron_sync::wake::subscribe();
+            let mut online = zeron_sync::wake::subscribe_online();
             // `RegistryClient` only self-reconnects AFTER a first successful
             // join; an INITIAL failure (a 500 from an overloaded DO, a token
             // racing a refresh, an edge deploy) must not end this task and
@@ -405,11 +409,17 @@ impl WorkspaceHost {
                             "registry room join failed; retrying");
                     }
                 }
+                // Drain stale online events so only successes DURING this
+                // wait cut it short (our own failed dial doesn't count).
+                while online.try_recv().is_ok() {}
                 tokio::select! {
                     _ = tokio::time::sleep(backoff + join_retry_jitter()) => {
                         backoff = (backoff * 2).min(JOIN_RETRY_CAP);
                     }
                     _ = wake.recv() => {
+                        backoff = JOIN_RETRY_BASE;
+                    }
+                    _ = online.recv() => {
                         backoff = JOIN_RETRY_BASE;
                     }
                     _ = token_changed(&mut token_changes) => {

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -556,6 +556,20 @@ impl WorkspaceHost {
         lock(&self.inner.room).as_ref().map(|room| room.stats())
     }
 
+    /// The registry room's reconnect posture (next-dial deadline + sticky
+    /// last failure) for the connectivity stream. `None` = no room yet.
+    pub fn reconnect_state(&self) -> Option<zeron_sync::ReconnectState> {
+        lock(&self.inner.room)
+            .as_ref()
+            .map(|room| room.reconnect_state())
+    }
+
+    /// Whether this engine was configured with edge transports at all
+    /// (`false` = local profile: connectivity is `Disabled`, hide the pill).
+    pub fn edge_expected(&self) -> bool {
+        self.inner.config.edge.is_some()
+    }
+
     // ── registry access helpers ─────────────────────────────────────────────
 
     /// Run a mutation under the registry lock, then wake the publish/persist

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -43,6 +43,15 @@ pub const DEFAULT_ORG_ID: &str = "dev-org";
 pub const DEFAULT_USER_ID: &str = "dev-user";
 /// Presence beat cadence.
 const PRESENCE_INTERVAL_MS: u64 = 15_000;
+/// Dial-gate thresholds (`peer_liveness`): a device is judged `Dark` — dials
+/// parked with zero network traffic — only on POSITIVE evidence: our registry
+/// room joined and warm past the warm-up window, and the device's freshest
+/// known heartbeat (live map ∪ session cache ∪ durable row) older than the
+/// dark window. m1-laptop shape: offline 6 days, yet hot-dialed in 3-dial
+/// bursts every ~60s for the life of the app.
+const DIAL_GATE_WARMUP_MS: i64 = 60_000;
+const DIAL_GATE_DARK_MS: i64 = 5 * 60_000;
+
 /// A presence heartbeat younger than this marks the device alive (3 missed
 /// beats = offline). Also the "peer is reachable" signal that clears the
 /// peer-dial cooldown.
@@ -165,6 +174,10 @@ struct WorkspaceHostInner {
     peer_alive: Mutex<Option<PeerAliveHook>>,
     /// Deaf-socket tripwire state — see `check_presence_deafness`.
     presence_watch: Mutex<PresenceWatch>,
+    /// Epoch ms of the registry room's most recent (re)join — the dial gate's
+    /// warm-up clock (`peer_liveness`): a just-joined room hasn't heard
+    /// anyone's heartbeat yet, and that silence must not read as "offline".
+    room_joined_at: std::sync::atomic::AtomicI64,
 }
 
 /// "This peer is alive" callback (device id) — see `WorkspaceHost::set_peer_alive_hook`.
@@ -278,6 +291,7 @@ impl WorkspaceHost {
                 presence_seen: Mutex::new(std::collections::HashMap::new()),
                 peer_alive: Mutex::new(None),
                 presence_watch: Mutex::new(PresenceWatch::default()),
+                room_joined_at: std::sync::atomic::AtomicI64::new(0),
             }),
         };
         // Persist immediately: after this boot the migration source is never
@@ -365,6 +379,9 @@ impl WorkspaceHost {
                         }
                         let Some(inner) = weak.upgrade() else { return };
                         *lock(&inner.room) = Some(client.clone());
+                        inner
+                            .room_joined_at
+                            .store(now_ms(), std::sync::atomic::Ordering::Relaxed);
                         inner.bump_changed();
                         tracing::info!(org = %org_id, "registry room joined");
                         drop(inner);
@@ -377,8 +394,17 @@ impl WorkspaceHost {
                         loop {
                             tokio::select! {
                                 event = events.recv() => match event {
-                                    Ok(zeron_sync::RegistryEvent::Applied)
-                                    | Ok(zeron_sync::RegistryEvent::Connected) => {
+                                    Ok(zeron_sync::RegistryEvent::Connected) => {
+                                        let Some(inner) = weak.upgrade() else { return };
+                                        // Re-join: restart the dial gate's
+                                        // warm-up clock (presence map is empty
+                                        // again; silence isn't evidence yet).
+                                        inner
+                                            .room_joined_at
+                                            .store(now_ms(), std::sync::atomic::Ordering::Relaxed);
+                                        inner.bump_changed();
+                                    }
+                                    Ok(zeron_sync::RegistryEvent::Applied) => {
                                         let Some(inner) = weak.upgrade() else { return };
                                         inner.bump_changed();
                                     }
@@ -443,6 +469,65 @@ impl WorkspaceHost {
     /// the engine points this at `LinkCache::reset_cooldown`.
     pub fn set_peer_alive_hook(&self, hook: PeerAliveHook) {
         *lock(&self.inner.peer_alive) = Some(hook);
+    }
+
+    /// Dial-gate verdict for `LinkCache` (park dials to registry-dark peers).
+    /// `Dark` requires positive evidence; every ambiguous state — registry
+    /// room down or still in its warm-up window, unknown device, heartbeat in
+    /// the gray zone — stays `Unknown`, because a dead registry room (rows
+    /// down, relay fine: the 2026-08-18 03:45 incident shape) must never
+    /// park the relay. Un-park is presence-driven: heartbeats resume → the
+    /// verdict flips and the peer-alive hook clears any dial cooldown.
+    pub fn peer_liveness(&self, device_id: &str) -> zeron_rpc::PeerLiveness {
+        use zeron_rpc::PeerLiveness::{Dark, Live, Unknown};
+        if device_id == self.inner.config.device_id {
+            return Live;
+        }
+        let now = now_ms();
+        let (connected, live_beat) = {
+            let room = lock(&self.inner.room);
+            match room.as_ref() {
+                Some(room) => (
+                    room.stats().connected,
+                    room.presence().get(device_id).copied(),
+                ),
+                None => (false, None),
+            }
+        };
+        if !connected {
+            return Unknown;
+        }
+        let cached = lock(&self.inner.presence_seen).get(device_id).copied();
+        match live_beat.into_iter().chain(cached).max() {
+            Some(ms) if now.saturating_sub(ms) < PRESENCE_FRESH_MS => Live,
+            Some(ms) if now.saturating_sub(ms) >= DIAL_GATE_DARK_MS => Dark,
+            Some(_) => Unknown,
+            None => {
+                // Never heard this device beat. Silence is only evidence once
+                // OUR room has been joined long enough to have heard it.
+                let joined_at = self
+                    .inner
+                    .room_joined_at
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                if joined_at == 0 || now.saturating_sub(joined_at) < DIAL_GATE_WARMUP_MS {
+                    return Unknown;
+                }
+                // Fall back to the durable row: a device whose last stamped
+                // sighting is ancient AND which isn't beating now is dark.
+                let row_seen = self
+                    .read(|doc| doc.read_devices())
+                    .ok()
+                    .into_iter()
+                    .flatten()
+                    .find(|d| d.id == device_id)
+                    .and_then(|d| d.last_seen_at)
+                    .map(|at| at.timestamp_millis());
+                match row_seen {
+                    Some(ms) if now.saturating_sub(ms) >= DIAL_GATE_DARK_MS => Dark,
+                    _ => Unknown,
+                }
+            }
+        }
     }
 
     pub fn device_id(&self) -> &str {

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -471,6 +471,15 @@ impl WorkspaceHost {
         *lock(&self.inner.peer_alive) = Some(hook);
     }
 
+    /// Test seam: write a foreign device row (the relay version gate and the
+    /// dial gate read these; production rows arrive via registry sync).
+    #[doc(hidden)]
+    pub fn upsert_device_row(&self, device: &Device) {
+        if let Err(err) = self.mutate(|doc| doc.upsert_device(device)) {
+            tracing::warn!(error = %err, "device row upsert failed");
+        }
+    }
+
     /// Dial-gate verdict for `LinkCache` (park dials to registry-dark peers).
     /// `Dark` requires positive evidence; every ambiguous state — registry
     /// room down or still in its warm-up window, unknown device, heartbeat in

--- a/crates/engine/tests/queued_attachments.rs
+++ b/crates/engine/tests/queued_attachments.rs
@@ -208,7 +208,11 @@ async fn run_defers_until_attachment_bytes_land_then_executes_rewritten() {
         .await
         .expect("upload commit");
 
-    wait_for(|| complete_assistant_count(&core) == 1, "deferred run to execute").await;
+    wait_for(
+        || complete_assistant_count(&core) == 1,
+        "deferred run to execute",
+    )
+    .await;
 
     // The persisted user entry carries the rewritten ABSOLUTE path (legacy
     // transcript shape — old clients render it as always), not the ref.

--- a/crates/engine/tests/queued_attachments.rs
+++ b/crates/engine/tests/queued_attachments.rs
@@ -1,0 +1,235 @@
+//! Queued attachments (send-is-a-local-write): a Run command carrying
+//! `pending://` refs defers — Pending, unprocessed — until the bytes land in
+//! this device's uploads dir, then executes with the refs rewritten to
+//! absolute paths (2026-08-19 incident: attachment staging used to be a
+//! blocking pre-step in FRONT of QueueCommand, so a dead peer link killed the
+//! send instead of queueing it).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+
+use zeron_doc::{
+    MessageRole, MessageStatus, SessionCommandPayload, SessionCommandStatus, SessionMessageEntry,
+};
+use zeron_engine::{EngineCore, HarnessRegistry};
+use zeron_harness::{Harness, HarnessError, RunControls};
+use zeron_proto::{
+    AgentEvent, DoneStatus, HarnessId, Model, ReasoningLevel, RunRequest, SandboxLevel,
+    SteeringMode,
+};
+
+const CHAT: &str = "chat-queued-att";
+
+struct AckHarness;
+
+#[async_trait]
+impl Harness for AckHarness {
+    fn id(&self) -> HarnessId {
+        HarnessId::Mock
+    }
+    fn display_name(&self) -> &str {
+        "Ack"
+    }
+    fn supports_steering(&self) -> bool {
+        false
+    }
+    fn steering_mode(&self) -> SteeringMode {
+        SteeringMode::TurnBoundary
+    }
+    fn reasoning_levels(&self) -> &[ReasoningLevel] {
+        &[ReasoningLevel::Medium]
+    }
+    async fn models(&self) -> Result<Vec<Model>, HarnessError> {
+        Ok(vec![])
+    }
+    async fn run(
+        &self,
+        request: RunRequest,
+        _controls: RunControls,
+    ) -> Result<BoxStream<'static, Result<AgentEvent, HarnessError>>, HarnessError> {
+        // The harness must see ordinary local files, never pending refs.
+        assert!(
+            !request.prompt.contains("pending://"),
+            "prompt reached the harness with unresolved pending refs: {}",
+            request.prompt
+        );
+        for path in &request.attachments {
+            assert!(
+                std::path::Path::new(path).is_file(),
+                "attachment path not a real file: {path}"
+            );
+        }
+        let events: Vec<Result<AgentEvent, HarnessError>> = vec![
+            Ok(AgentEvent::SessionStarted {
+                harness: HarnessId::Mock,
+                model: "mock-1".into(),
+                tools: vec![],
+                cwd: request.cwd.clone(),
+                session_id: "sess-qa".into(),
+                assistant_message_id: "a-1".into(),
+            }),
+            Ok(AgentEvent::TextDelta { text: "ack".into() }),
+            Ok(AgentEvent::Done {
+                status: DoneStatus::Completed,
+                result: None,
+                error: None,
+                session_id: Some("sess-qa".into()),
+            }),
+        ];
+        Ok(futures::stream::iter(events).boxed())
+    }
+}
+
+async fn wait_for<F>(mut predicate: F, what: &str)
+where
+    F: FnMut() -> bool,
+{
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while !predicate() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for {what}"
+        );
+        tokio::time::sleep(Duration::from_millis(15)).await;
+    }
+}
+
+fn entries(core: &EngineCore) -> Vec<SessionMessageEntry> {
+    core.doc_host
+        .open(CHAT)
+        .ok()
+        .and_then(|h| h.doc().read_entries().ok())
+        .unwrap_or_default()
+}
+
+fn complete_assistant_count(core: &EngineCore) -> usize {
+    entries(core)
+        .iter()
+        .filter(|e| e.role == MessageRole::Assistant && e.status == Some(MessageStatus::Complete))
+        .count()
+}
+
+fn run_payload(message_id: &str, pending_ref: &str) -> SessionCommandPayload {
+    SessionCommandPayload::Run {
+        request: RunRequest {
+            prompt: format!(
+                "look at this\n\nAttached images (local files — open them to view):\n- {pending_ref}"
+            ),
+            harness: None,
+            model: None,
+            reasoning: None,
+            model_options: Default::default(),
+            cwd: "~".into(),
+            sandbox: SandboxLevel::WorkspaceWrite,
+            auto_approve: true,
+            attachments: vec![pending_ref.to_string()],
+            worktree: None,
+            resume: None,
+        },
+        message_id: message_id.into(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn run_defers_until_attachment_bytes_land_then_executes_rewritten() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = HarnessRegistry::new();
+    registry.register(Arc::new(AckHarness));
+    let core = EngineCore::assemble(
+        &tmp.path().join("data"),
+        Arc::new(registry),
+        HarnessId::Mock,
+        None,
+    )
+    .expect("engine core assembles");
+
+    let client = zeron_rpc::memory_client(core.rpc_service());
+    client
+        .call(
+            zeron_rpc::methods::MUTATE,
+            serde_json::json!({ "op": "createChat", "chatId": CHAT, "deviceId": core.device_id }),
+        )
+        .await
+        .expect("createChat");
+    core.workspace
+        .rename_chat(CHAT, "Pre-titled")
+        .expect("rename chat");
+
+    // Queue a Run whose attachment bytes have NOT landed yet: it must sit
+    // Pending — deferred, unprocessed, no turn — instead of running without
+    // its image (or worse, handing the harness a dangling ref).
+    let pending_ref = "pending://att-1/photo one.png";
+    core.doc_host
+        .queue_command(CHAT, run_payload("msg-qa-1", pending_ref))
+        .expect("queue run command");
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        complete_assistant_count(&core),
+        0,
+        "run must defer while attachment bytes are in transit"
+    );
+    let commands = core
+        .doc_host
+        .open(CHAT)
+        .unwrap()
+        .doc()
+        .read_commands()
+        .unwrap();
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0].status,
+        SessionCommandStatus::Pending,
+        "deferred command must stay Pending (not Rejected/Expired)"
+    );
+
+    // The bytes land (the engine-to-engine transfer ends in exactly these two
+    // RPCs on the host): UploadChunk + UploadCommit under the SAME identity.
+    // The commit handler kicks the drains — no timers involved.
+    client
+        .call(
+            zeron_rpc::methods::UPLOAD_CHUNK,
+            serde_json::json!({
+                "uploadId": "att-1", "seq": 0, "data": BASE64.encode(b"png-bytes"),
+            }),
+        )
+        .await
+        .expect("upload chunk");
+    client
+        .call(
+            zeron_rpc::methods::UPLOAD_COMMIT,
+            serde_json::json!({ "uploadId": "att-1", "fileName": "photo one.png" }),
+        )
+        .await
+        .expect("upload commit");
+
+    wait_for(|| complete_assistant_count(&core) == 1, "deferred run to execute").await;
+
+    // The persisted user entry carries the rewritten ABSOLUTE path (legacy
+    // transcript shape — old clients render it as always), not the ref.
+    let user_text = entries(&core)
+        .iter()
+        .find(|e| e.role == MessageRole::User)
+        .and_then(|e| {
+            e.parts.iter().find_map(|p| match p {
+                zeron_doc::MessagePart::Text { text, .. } => Some(text.clone()),
+                _ => None,
+            })
+        })
+        .expect("user entry persisted");
+    assert!(
+        !user_text.contains("pending://"),
+        "persisted text must not leak pending refs: {user_text}"
+    );
+    assert!(
+        user_text.contains("att-1-photo_one.png"),
+        "persisted text names the committed file: {user_text}"
+    );
+
+    core.shutdown().await;
+}

--- a/crates/engine/tests/relay_delivery.rs
+++ b/crates/engine/tests/relay_delivery.rs
@@ -1,0 +1,328 @@
+//! Peer-relay delivery fallback (durable-by-design §Phase 3): engine A queues
+//! a command for a chat hosted on engine B, A's chat2 rows can NEVER reach an
+//! edge (none is configured — the 03:45 incident shape, rows dark while the
+//! peer link lives), so after the rows grace A relay-forwards the entry over
+//! the device-room link. B claims the client-minted id in its processed
+//! ledger before executing — so when the doc row later "arrives" (simulated
+//! by writing the same entry into B's doc), the drain dedupes it to a no-op:
+//! exactly-once across both roads.
+
+// tungstenite's `accept_hdr_async` callback signature fixes the Err type as a
+// full `Response` — its size is not ours to shrink.
+#![allow(clippy::result_large_err)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use futures::{SinkExt, StreamExt};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use tokio_tungstenite::tungstenite::handshake::server::{
+    Request as WsRequest, Response as WsResponse,
+};
+
+use zeron_doc::{MessageRole, MessageStatus, SessionCommandPayload};
+use zeron_engine::{EngineCore, HarnessRegistry};
+use zeron_harness::{Harness, HarnessError, RunControls};
+use zeron_proto::{
+    AgentEvent, Device, DoneStatus, HarnessId, Model, ReasoningLevel, RunRequest, SandboxLevel,
+    SteeringMode,
+};
+use zeron_rpc::{
+    DeviceFrameHeader, LinkCache, LinkCacheConfig, StaticToken, decode_device_frame,
+    encode_device_frame, methods,
+};
+
+const CHAT: &str = "chat-relay-fallback";
+
+// Minimal in-memory device room (route-only subset of the DO semantics) —
+// same shape as device_routing.rs.
+#[derive(Default)]
+struct RelayState {
+    host: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    clients: HashMap<String, mpsc::UnboundedSender<Vec<u8>>>,
+}
+
+async fn fake_device_room() -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind relay");
+    let url = format!(
+        "http://127.0.0.1:{}",
+        listener.local_addr().expect("addr").port()
+    );
+    let state = Arc::new(Mutex::new(RelayState::default()));
+    let task = tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let state = state.clone();
+            tokio::spawn(async move {
+                let mut uri = String::new();
+                let Ok(ws) = tokio_tungstenite::accept_hdr_async(
+                    stream,
+                    |req: &WsRequest, res: WsResponse| {
+                        uri = req.uri().to_string();
+                        Ok(res)
+                    },
+                )
+                .await
+                else {
+                    return;
+                };
+                let query = uri.split_once('?').map(|(_, q)| q).unwrap_or("");
+                let is_host = query.contains("role=host");
+                let conn_id = query
+                    .split('&')
+                    .find_map(|kv| kv.strip_prefix("connId="))
+                    .unwrap_or("anon")
+                    .to_string();
+                let (mut sink, mut ws_stream) = ws.split();
+                let (tx, mut rx) = mpsc::unbounded_channel::<Vec<u8>>();
+                {
+                    let mut st = state.lock().expect("lock");
+                    if is_host {
+                        st.host = Some(tx);
+                    } else {
+                        st.clients.insert(conn_id.clone(), tx);
+                    }
+                }
+                let writer = tokio::spawn(async move {
+                    while let Some(bytes) = rx.recv().await {
+                        if sink.send(WsMessage::Binary(bytes)).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+                while let Some(Ok(message)) = ws_stream.next().await {
+                    let WsMessage::Binary(bytes) = message else {
+                        continue;
+                    };
+                    let Ok((header, payload)) = decode_device_frame(&bytes) else {
+                        break;
+                    };
+                    let st = state.lock().expect("lock");
+                    if is_host {
+                        let Some(to) = header.to else { continue };
+                        if let Some(client) = st.clients.get(&to) {
+                            let stripped = DeviceFrameHeader::new(header.s, header.k);
+                            let _ = client
+                                .send(encode_device_frame(&stripped, &payload).expect("encode"));
+                        }
+                    } else if let Some(host) = &st.host {
+                        let mut routed = DeviceFrameHeader::new(header.s, header.k);
+                        routed.from = Some(conn_id.clone());
+                        let _ = host.send(encode_device_frame(&routed, &payload).expect("encode"));
+                    }
+                }
+                writer.abort();
+            });
+        }
+    });
+    (url, task)
+}
+
+struct InstantHarness;
+
+#[async_trait]
+impl Harness for InstantHarness {
+    fn id(&self) -> HarnessId {
+        HarnessId::Mock
+    }
+    fn display_name(&self) -> &str {
+        "Instant"
+    }
+    fn supports_steering(&self) -> bool {
+        false
+    }
+    fn steering_mode(&self) -> SteeringMode {
+        SteeringMode::TurnBoundary
+    }
+    fn reasoning_levels(&self) -> &[ReasoningLevel] {
+        &[]
+    }
+    async fn models(&self) -> Result<Vec<Model>, HarnessError> {
+        Ok(vec![])
+    }
+    async fn run(
+        &self,
+        _request: RunRequest,
+        _controls: RunControls,
+    ) -> Result<BoxStream<'static, Result<AgentEvent, HarnessError>>, HarnessError> {
+        Ok(futures::stream::iter([
+            Ok(AgentEvent::SessionStarted {
+                harness: HarnessId::Mock,
+                model: "instant-1".into(),
+                tools: vec![],
+                cwd: "/tmp".into(),
+                session_id: "hs-relay".into(),
+                assistant_message_id: "a-1".into(),
+            }),
+            Ok(AgentEvent::TextDelta {
+                text: "relayed reply".into(),
+            }),
+            Ok(AgentEvent::Done {
+                status: DoneStatus::Completed,
+                result: None,
+                error: None,
+                session_id: Some("hs-relay".into()),
+            }),
+        ])
+        .boxed())
+    }
+}
+
+fn registry() -> Arc<HarnessRegistry> {
+    let registry = HarnessRegistry::new();
+    registry.register(Arc::new(InstantHarness));
+    Arc::new(registry)
+}
+
+fn assemble(dir: &std::path::Path, device_id: &str) -> EngineCore {
+    std::fs::create_dir_all(dir).expect("create data dir");
+    std::fs::write(dir.join("device-id"), device_id).expect("write device id");
+    EngineCore::assemble(dir, registry(), HarnessId::Mock, None).expect("engine assembles")
+}
+
+fn complete_assistant_count(core: &EngineCore) -> usize {
+    core.doc_host
+        .open(CHAT)
+        .ok()
+        .and_then(|h| h.doc().read_entries().ok())
+        .unwrap_or_default()
+        .iter()
+        .filter(|e| e.role == MessageRole::Assistant && e.status == Some(MessageStatus::Complete))
+        .count()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rows_dark_command_delivers_over_the_peer_relay_exactly_once() {
+    let (relay_url, _relay) = fake_device_room().await;
+    let dirs = tempfile::tempdir().expect("tempdir");
+
+    // Engine B hosts its device room on the fake relay.
+    let core_b = assemble(&dirs.path().join("b"), "device-b");
+    let _host = core_b.start_host_relay(&relay_url);
+
+    // Engine A dials peers through the same relay — and has NO edge, so its
+    // chat2 rows can never flush (the rows-dark half of the incident shape).
+    let core_a = assemble(&dirs.path().join("a"), "device-a");
+    let mut link_config =
+        LinkCacheConfig::new(relay_url.clone(), Arc::new(StaticToken("test-user".into())));
+    link_config.probe_timeout = Duration::from_secs(5);
+    core_a.set_links(LinkCache::new(link_config));
+
+    // A knows the chat is hosted on B (local registry writes), and knows B's
+    // stamped version passes the relay gate.
+    core_a.workspace.upsert_device_row(&Device {
+        id: "device-b".into(),
+        name: "b".into(),
+        platform: "linux".into(),
+        last_seen_at: Some(chrono::Utc::now()),
+        created_at: None,
+        version: Some("0.2.12".into()),
+    });
+    let client_a = zeron_rpc::memory_client(core_a.rpc_service());
+    client_a
+        .call(
+            methods::MUTATE,
+            serde_json::json!({ "op": "createChat", "chatId": CHAT, "deviceId": "device-b" }),
+        )
+        .await
+        .expect("createChat on A");
+    core_b
+        .workspace
+        .rename_chat(CHAT, "Pre-titled")
+        .expect("pre-title on B (no auto-title harness run)");
+
+    // The send: a durable local write on A. Rows go nowhere; the escort's
+    // grace elapses; the entry crosses the peer link instead.
+    let command = serde_json::to_value(SessionCommandPayload::Run {
+        request: RunRequest {
+            prompt: "over the relay".into(),
+            harness: None,
+            model: None,
+            reasoning: None,
+            model_options: Default::default(),
+            cwd: "~".into(),
+            sandbox: SandboxLevel::WorkspaceWrite,
+            auto_approve: true,
+            attachments: Vec::new(),
+            worktree: None,
+            resume: None,
+        },
+        message_id: "msg-relay-1".into(),
+    })
+    .expect("command json");
+    client_a
+        .call(
+            methods::QUEUE_COMMAND,
+            serde_json::json!({ "chatId": CHAT, "command": command }),
+        )
+        .await
+        .expect("queue on A");
+
+    // B executes it — allow the 10s rows grace plus relay dial time.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if complete_assistant_count(&core_b) == 1 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "relayed command never executed on B"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    let entries = core_b
+        .doc_host
+        .open(CHAT)
+        .expect("open on B")
+        .doc()
+        .read_entries()
+        .expect("read entries");
+    assert!(
+        entries
+            .iter()
+            .any(|e| e.id == "msg-relay-1" && e.role == MessageRole::User),
+        "B persisted the user message under the client-minted id"
+    );
+
+    // Exactly-once: the doc row "arrives" later over chat2 sync — simulate by
+    // writing A's exact entry into B's doc, which kicks B's drain. The
+    // processed ledger must dedupe it to a no-op.
+    let entry = core_a
+        .doc_host
+        .open(CHAT)
+        .expect("open on A")
+        .doc()
+        .read_commands()
+        .expect("read A's commands")
+        .into_iter()
+        .next()
+        .expect("A queued exactly one command");
+    let handle_b = core_b.doc_host.open(CHAT).expect("open on B");
+    handle_b
+        .doc()
+        .queue_command(&entry)
+        .expect("simulate the synced doc row");
+    // A second relay attempt (a retrying sender) must also dedupe.
+    let dup = core_b
+        .doc_host
+        .ingest_relayed_command(CHAT, entry)
+        .await
+        .expect("duplicate relay accepted");
+    assert_eq!(dup, "duplicate");
+    tokio::time::sleep(Duration::from_millis(800)).await;
+    assert_eq!(
+        complete_assistant_count(&core_b),
+        1,
+        "the doc row + a duplicate relay must not double-run the command"
+    );
+
+    core_a.shutdown().await;
+    core_b.shutdown().await;
+}

--- a/crates/proto/src/entities.rs
+++ b/crates/proto/src/entities.rs
@@ -528,6 +528,52 @@ pub enum TerminalEvent {
     },
 }
 
+/// Live edge-connectivity posture (the `WatchConnectivity` stream): the truth
+/// the connection pill, composer honesty, and queued-send badges render.
+/// Derived engine-side from the registry room's reconnect state, the OS
+/// network-path monitor, and each open chat room's stats.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Connectivity {
+    pub state: ConnectivityState,
+    /// Epoch ms of the next scheduled registry dial while reconnecting
+    /// (0 = none pending / dialing right now). The countdown renders
+    /// client-side from this.
+    #[serde(default)]
+    pub retry_at_ms: i64,
+    /// The failure that started the current outage — sticky through the next
+    /// attempt (no flicker back to a bare "connecting…"), cleared on rejoin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_failure: Option<String>,
+    /// Per-OPEN-chat room state; a chat absent here is unknown (consumers
+    /// fall back to the global state).
+    #[serde(default)]
+    pub chats: Vec<ChatConnectivity>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ConnectivityState {
+    /// No edge transports on this profile (local scope) — hide the pill.
+    #[default]
+    Disabled,
+    /// The OS reports no network path.
+    Offline,
+    /// Edge expected but the registry room is down (dialing/backing off).
+    Reconnecting,
+    Connected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatConnectivity {
+    pub chat_id: String,
+    pub connected: bool,
+    /// Local update batches not yet acked by the chat's edge room.
+    #[serde(default)]
+    pub pending_pushes: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -13,3 +13,21 @@ pub mod workspace;
 pub use agent::*;
 pub use entities::*;
 pub use workspace::*;
+
+/// Parse "0.2.12" (tolerating a `-suffix`/`+build` tail on the last part)
+/// into a comparable triple — the fleet feature-gate primitive (device rows
+/// stamp `Device::version` at boot). `None` for anything that doesn't lead
+/// with three dotted integers, and gates treat `None` as "too old".
+pub fn version_triple(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.trim().splitn(3, '.');
+    let major: u64 = parts.next()?.parse().ok()?;
+    let minor: u64 = parts.next()?.parse().ok()?;
+    let patch = parts.next()?;
+    let patch: u64 = patch
+        .split(['-', '+'])
+        .next()
+        .unwrap_or(patch)
+        .parse()
+        .ok()?;
+    Some((major, minor, patch))
+}

--- a/crates/rpc/src/device_room.rs
+++ b/crates/rpc/src/device_room.rs
@@ -49,19 +49,22 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 /// Text `"ping"` keepalive — answered by the DO's hibernation-safe auto-response
 /// pair (`edge/src/device-room.ts`) without waking it.
 ///
-/// 15s, not 30: a laptop's uplink (corporate proxy, VPN split-tunnel extension,
+/// 10s, not 30: a laptop's uplink (corporate proxy, VPN split-tunnel extension,
 /// consumer NAT) can reap an idle flow well inside a minute, and a keepalive
 /// that races the reaper loses. The frame is 4 bytes and never wakes the DO, so
-/// the only cost of halving the interval is that the host stays reachable.
-const PING_INTERVAL: Duration = Duration::from_secs(15);
+/// the only cost of shortening the interval is that the host stays reachable —
+/// and a tight interval is what lets the silence lease below stay short.
+const PING_INTERVAL: Duration = Duration::from_secs(10);
 /// Silence lease: every ping elicits an auto-pong, so a healthy socket sees
 /// inbound traffic at least once per `PING_INTERVAL`. No inbound frame for a
 /// couple of intervals plus grace = dead socket (half-open TCP after NAT
 /// timeout or sleep/wake) — drop it and reconnect instead of waiting on a TCP
-/// write error. Must stay well under the relay's own host-liveness window
-/// (`HOST_LIVENESS_MS`, edge/src/device-room.ts) so a host replaces its dead
-/// socket before the relay gives up on the device.
-const SILENCE_LEASE: Duration = Duration::from_secs(40);
+/// write error. 25s tolerates one lost pong (pings at +10/+20) before ruling
+/// the socket dead; the old 40s left sends wedged for most of a minute after
+/// an unnoticed drop. Must stay well under the relay's own host-liveness
+/// window (`HOST_LIVENESS_MS`, edge/src/device-room.ts) so a host replaces
+/// its dead socket before the relay gives up on the device.
+const SILENCE_LEASE: Duration = Duration::from_secs(25);
 
 // ---------------------------------------------------------------------------
 // Frame codec
@@ -707,12 +710,16 @@ impl LinkCache {
         });
         // Wake = every cached link is half-open and every cooldown is moot
         // (the failures belonged to the pre-suspend network). Drop them so the
-        // next call redials immediately with fresh credentials. Skipped
-        // outside a runtime (sync unit tests).
+        // next call redials immediately with fresh credentials. An online
+        // event (network path back / sibling dial success) likewise voids the
+        // cooldowns — those failures belonged to the dead network — but keeps
+        // live links, which a mere network *recovery* has not invalidated.
+        // Skipped outside a runtime (sync unit tests).
         if tokio::runtime::Handle::try_current().is_ok() {
             let weak = Arc::downgrade(&cache);
             tokio::spawn(async move {
                 let mut wake = zeron_sync::wake::subscribe();
+                let mut online = zeron_sync::wake::subscribe_online();
                 let mut token_changes = weak
                     .upgrade()
                     .and_then(|cache| cache.config.token.subscribe());
@@ -724,6 +731,11 @@ impl LinkCache {
                             lock(&cache.links).clear();
                             lock(&cache.dial_state).clear();
                             tracing::info!("peer: links + cooldowns cleared after wake");
+                        }
+                        result = online.recv() => {
+                            if result.is_err() { return; }
+                            let Some(cache) = weak.upgrade() else { return };
+                            lock(&cache.dial_state).clear();
                         }
                         _ = token_changed(&mut token_changes) => {
                             let Some(cache) = weak.upgrade() else { return };

--- a/crates/rpc/src/device_room.rs
+++ b/crates/rpc/src/device_room.rs
@@ -607,8 +607,9 @@ impl DeviceLink {
             // host has echoed at least once, so old hosts keep working.
             let mut last_echo = tokio::time::Instant::now();
             let mut echo_seen = false;
-            let echo_frame = encode_device_frame(&DeviceFrameHeader::new(ECHO_KIND, ECHO_KIND), &[])
-                .unwrap_or_default();
+            let echo_frame =
+                encode_device_frame(&DeviceFrameHeader::new(ECHO_KIND, ECHO_KIND), &[])
+                    .unwrap_or_default();
             // First echo right away: fast feature detection + instant proof
             // the host leg is alive (the dial's readiness probe proves it
             // too; this seeds the ongoing cadence).

--- a/crates/rpc/src/device_room.rs
+++ b/crates/rpc/src/device_room.rs
@@ -65,6 +65,44 @@ const PING_INTERVAL: Duration = Duration::from_secs(10);
 /// window (`HOST_LIVENESS_MS`, edge/src/device-room.ts) so a host replaces
 /// its dead socket before the relay gives up on the device.
 const SILENCE_LEASE: Duration = Duration::from_secs(25);
+/// App-level end-to-end liveness for the CLIENT link. The transport lease
+/// above proves only the client↔edge leg — the DO's auto-pong answers from
+/// the edge, so a link whose edge↔host leg is dead still looks healthy and
+/// retries frames into the void indefinitely (2026-08-19 incident: a peer
+/// link sat dead for 6 minutes until an unrelated token refresh cycled the
+/// host session). The client rides an `echo` frame on every keepalive; the
+/// HOST echoes it back. Silence past this deadline on a link that HAS echoed
+/// before = zombie relay path → drop and redial. Feature-detected: a link
+/// that never echoed (old host) keeps the transport-lease-only behavior, and
+/// inbound RPC frames count as echoes (end-to-end proof either way).
+const ECHO_KIND: &str = "echo";
+const ECHO_DEADLINE: Duration = Duration::from_secs(20);
+
+// Test seam: the consts above stay the production truth; integration tests
+// compress the client-link clocks so the zombie-path regression runs in
+// milliseconds instead of tens of seconds. Process-wide, test-only.
+static CLIENT_PING_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static CLIENT_ECHO_DEADLINE_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[doc(hidden)]
+pub fn set_client_liveness_for_tests(ping: Duration, echo_deadline: Duration) {
+    CLIENT_PING_MS.store(ping.as_millis() as u64, Ordering::Relaxed);
+    CLIENT_ECHO_DEADLINE_MS.store(echo_deadline.as_millis() as u64, Ordering::Relaxed);
+}
+
+fn client_ping_interval() -> Duration {
+    match CLIENT_PING_MS.load(Ordering::Relaxed) {
+        0 => PING_INTERVAL,
+        ms => Duration::from_millis(ms),
+    }
+}
+
+fn client_echo_deadline() -> Duration {
+    match CLIENT_ECHO_DEADLINE_MS.load(Ordering::Relaxed) {
+        0 => ECHO_DEADLINE,
+        ms => Duration::from_millis(ms),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Frame codec
@@ -491,6 +529,21 @@ async fn handle_host_frame(
         }
         return;
     }
+    if header.k == ECHO_KIND {
+        // App-level liveness: echo straight back to the sender — the
+        // client's proof the edge↔host leg is alive (auto-pongs only prove
+        // its client↔edge leg).
+        if let Some(from) = header.from {
+            let reply = DeviceFrameHeader::new(ECHO_KIND, ECHO_KIND).with_to(from);
+            match encode_device_frame(&reply, &payload) {
+                Ok(frame) => {
+                    let _ = out_tx.send(frame).await;
+                }
+                Err(err) => tracing::error!(error = %err, "device-room: echo encode failed"),
+            }
+        }
+        return;
+    }
     if header.k == NUDGE_KIND {
         // Durable command nudge (§7): open the chat doc so drain fires.
         #[derive(Deserialize)]
@@ -546,10 +599,22 @@ impl DeviceLink {
         let (closed_tx, closed_rx) = watch::channel::<Option<String>>(None);
 
         let pump = tokio::spawn(async move {
-            let mut ping = tokio::time::interval(PING_INTERVAL);
+            let mut ping = tokio::time::interval(client_ping_interval());
             ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             ping.tick().await; // consume the immediate first tick
             let mut last_rx = tokio::time::Instant::now();
+            // End-to-end liveness (see ECHO_DEADLINE): armed only once the
+            // host has echoed at least once, so old hosts keep working.
+            let mut last_echo = tokio::time::Instant::now();
+            let mut echo_seen = false;
+            let echo_frame = encode_device_frame(&DeviceFrameHeader::new(ECHO_KIND, ECHO_KIND), &[])
+                .unwrap_or_default();
+            // First echo right away: fast feature detection + instant proof
+            // the host leg is alive (the dial's readiness probe proves it
+            // too; this seeds the ongoing cadence).
+            if !echo_frame.is_empty() {
+                let _ = sink.send(WsMessage::Binary(echo_frame.clone())).await;
+            }
             let reason = loop {
                 tokio::select! {
                     frame = out_rx.recv() => match frame {
@@ -583,10 +648,17 @@ impl DeviceLink {
                                     break code;
                                 }
                                 Ok((header, payload)) if header.k == RPC_KIND => {
+                                    // An RPC frame from the host proves the
+                                    // whole path just as well as an echo.
+                                    last_echo = tokio::time::Instant::now();
                                     let text = String::from_utf8_lossy(&payload).into_owned();
                                     if in_tx.send(text).await.is_err() {
                                         break "client dropped".to_string();
                                     }
+                                }
+                                Ok((header, _)) if header.k == ECHO_KIND => {
+                                    last_echo = tokio::time::Instant::now();
+                                    echo_seen = true;
                                 }
                                 Ok(_) => {}
                                 Err(err) => {
@@ -604,9 +676,18 @@ impl DeviceLink {
                         if sink.send(WsMessage::Text("ping".into())).await.is_err() {
                             break "connection lost".to_string();
                         }
+                        if !echo_frame.is_empty()
+                            && sink.send(WsMessage::Binary(echo_frame.clone())).await.is_err()
+                        {
+                            break "connection lost".to_string();
+                        }
                     }
                     _ = tokio::time::sleep_until(last_rx + SILENCE_LEASE) => {
                         break "silent past lease".to_string();
+                    }
+                    _ = tokio::time::sleep_until(last_echo + client_echo_deadline()), if echo_seen => {
+                        tracing::warn!("device-room: host echo silent past deadline; link suspect");
+                        break "host echo silent".to_string();
                     }
                 }
             };
@@ -645,6 +726,19 @@ impl Drop for DeviceLink {
 // Link cache
 // ---------------------------------------------------------------------------
 
+/// A dial-gate verdict on a peer device from the workspace layer (registry
+/// presence). Only a definitive `Dark` parks dials; every ambiguous state
+/// stays `Unknown` so a dead registry room (rows down, relay fine — the
+/// 2026-08-18 03:45 incident shape) never blocks the relay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerLiveness {
+    Live,
+    Dark,
+    Unknown,
+}
+
+pub type PeerLivenessProbe = Arc<dyn Fn(&str) -> PeerLiveness + Send + Sync>;
+
 pub struct LinkCacheConfig {
     pub edge_url: String,
     pub token: Arc<dyn TokenSource>,
@@ -655,6 +749,12 @@ pub struct LinkCacheConfig {
     /// Readiness probe budget: the relay accepts client joins even when the host is
     /// offline, so a `ListHarnesses` round-trip proves the path before caching.
     pub probe_timeout: Duration,
+    /// Optional dial gate: a `Dark` verdict fails the call fast with NO dial.
+    /// Without it, retrying callers hot-dialed devices that had been offline
+    /// for days in 3-dial bursts every ~60s for the life of the app. Un-park
+    /// is presence-driven: the workspace's peer-alive hook fires the moment
+    /// heartbeats return, and the next call passes the gate.
+    pub liveness: Option<PeerLivenessProbe>,
 }
 
 impl LinkCacheConfig {
@@ -671,6 +771,7 @@ impl LinkCacheConfig {
             cooldown_base: Duration::from_secs(5),
             cooldown_max: Duration::from_secs(60),
             probe_timeout: Duration::from_secs(10),
+            liveness: None,
         }
     }
 }
@@ -776,6 +877,17 @@ impl LinkCache {
         // Fast path outside any lock.
         if let Some(link) = self.cached(device_id) {
             return Ok(link.client());
+        }
+        // Registry-dark gate: a device with no recent presence is not worth a
+        // dial (let alone the 3-attempt sequence) — fail fast with zero
+        // network traffic. A live cached link above always wins over the
+        // verdict; ambiguity (registry down, unknown device) never parks.
+        if let Some(probe) = &self.config.liveness
+            && probe(device_id) == PeerLiveness::Dark
+        {
+            return Err(RpcError::Transport(format!(
+                "peer {device_id}: device is offline (no recent presence)"
+            )));
         }
         let dial_lock = {
             let mut locks = lock(&self.dial_locks);
@@ -910,7 +1022,14 @@ impl LinkCache {
             &token,
         );
         tracing::info!(device = %device_id, "peer: dialing via device room");
-        let link = Arc::new(DeviceLink::connect(&url).await?);
+        // Bounded connect: `DeviceLink::connect` was the one unbounded await
+        // under `forward()` — a wedged edge socket hung callers indefinitely
+        // and only the UI's own per-call timers saved them (silently).
+        const DIAL_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+        let link = tokio::time::timeout(DIAL_CONNECT_TIMEOUT, DeviceLink::connect(&url))
+            .await
+            .map_err(|_| RpcError::Transport(format!("peer {device_id}: connect timed out")))?;
+        let link = Arc::new(link?);
         // Readiness probe: prove the host answers before caching (an offline host bounces
         // host_offline, which closes the link and fails this call fast).
         let client = link.client();

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -40,6 +40,13 @@ pub mod methods {
     pub const LIST_MODELS: &str = "ListModels";
     pub const LIST_COMMANDS: &str = "ListCommands";
     pub const QUEUE_COMMAND: &str = "QueueCommand";
+    /// Peer-to-peer delivery fallback: the SENDER's engine forwards a queued
+    /// command entry (client-minted id and all) straight over the device-room
+    /// link when its chat2 rows can't reach the edge but the host's peer link
+    /// is alive. The host claims the id in its processed ledger before
+    /// executing, so the doc row arriving later dedupes to a no-op —
+    /// exactly-once by construction. Params `{chatId, entry}`.
+    pub const RELAY_COMMAND: &str = "RelayCommand";
     pub const WATCH_DOC_MESSAGES: &str = "WatchDocMessages";
     /// Nudge every open room client to verify liveness NOW (window focus,
     /// app foregrounded). No params; IPC-only. Each room ignores the hint

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -50,6 +50,10 @@ pub mod methods {
     /// counters for the workspace room and every open chat doc. No params;
     /// IPC-only.
     pub const SYNC_STATUS: &str = "SyncStatus";
+    /// Pushed edge-connectivity posture (`zeron_proto::Connectivity`):
+    /// current value first, then every change — the connection pill /
+    /// composer-honesty / queued-badge feed. No params; IPC-only.
+    pub const WATCH_CONNECTIVITY: &str = "WatchConnectivity";
     pub const WATCH_CHATS: &str = "WatchChats";
     pub const WATCH_DEVICES: &str = "WatchDevices";
     pub const WATCH_SESSIONS: &str = "WatchSessions";

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -47,6 +47,10 @@ pub mod methods {
     /// executing, so the doc row arriving later dedupes to a no-op —
     /// exactly-once by construction. Params `{chatId, entry}`.
     pub const RELAY_COMMAND: &str = "RelayCommand";
+    /// User-driven delivery retry for a chat with unadopted queued sends:
+    /// fresh chat2 socket, host nudge, drain pass, and a new delivery escort
+    /// per pending command. Params `{chatId}`; IPC-only.
+    pub const RETRY_DELIVERY: &str = "RetryDelivery";
     pub const WATCH_DOC_MESSAGES: &str = "WatchDocMessages";
     /// Nudge every open room client to verify liveness NOW (window focus,
     /// app foregrounded). No params; IPC-only. Each room ignores the hint

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -25,8 +25,8 @@ mod server;
 pub use client::{RpcClient, connect_ws};
 pub use device_room::{
     DeviceFrameHeader, DeviceLink, HostRelay, HostRelayConfig, LinkCache, LinkCacheConfig,
-    NudgeHandler, StaticToken, TokenSource, decode_device_frame, device_room_ws_url,
-    encode_device_frame,
+    NudgeHandler, PeerLiveness, PeerLivenessProbe, StaticToken, TokenSource, decode_device_frame,
+    device_room_ws_url, encode_device_frame,
 };
 pub use server::{serve_connection, serve_ws_listener};
 

--- a/crates/rpc/tests/device_room.rs
+++ b/crates/rpc/tests/device_room.rs
@@ -47,6 +47,9 @@ enum Out {
 struct RelayState {
     host: Option<mpsc::UnboundedSender<Out>>,
     clients: HashMap<String, mpsc::UnboundedSender<Out>>,
+    /// Zombie-path simulation: the host stays "connected" (no bounce) but
+    /// client→host frames vanish — the 2026-08-19 dead edge↔host leg.
+    blackhole_host_bound: bool,
 }
 
 struct FakeRelay {
@@ -88,6 +91,12 @@ impl FakeRelay {
 
     async fn wait_host_connected(&self) {
         wait_until(|| self.host_connected()).await;
+    }
+
+    /// Swallow client→host frames while keeping the host registered — the
+    /// zombie relay path (client↔edge healthy, edge↔host dead).
+    fn set_blackhole_host_bound(&self, on: bool) {
+        self.state.lock().expect("lock").blackhole_host_bound = on;
     }
 
     /// Deliver a nudge frame to the connected host (the DO's /nudge live path).
@@ -179,6 +188,9 @@ async fn handle_socket(stream: tokio::net::TcpStream, state: Arc<Mutex<RelayStat
         };
         let st = state.lock().expect("lock");
         if !is_host {
+            if st.blackhole_host_bound {
+                continue; // zombie path: frame vanishes, no bounce
+            }
             match &st.host {
                 Some(host) => {
                     let mut routed = DeviceFrameHeader::new(header.s, header.k);
@@ -718,4 +730,37 @@ async fn live_edge_relay_round_trip() {
         .expect("echo");
     assert_eq!(echoed["host"], "live-host");
     assert_eq!(echoed["params"]["live"], true);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zombie_relay_path_trips_the_echo_deadline() {
+    // 2026-08-19 incident shape: the client↔edge leg stays healthy (pongs
+    // flow), the edge↔host leg is dead — the link used to sit "open" for
+    // minutes, retrying frames into the void, until an unrelated host-session
+    // cycle exposed it. The app-level echo must rule the link dead within its
+    // deadline instead.
+    zeron_rpc::device_room::set_client_liveness_for_tests(
+        Duration::from_millis(100),
+        Duration::from_millis(600),
+    );
+    let relay = FakeRelay::start().await;
+    let service = TestService::new("host-a");
+    let _host = HostRelay::spawn(relay_config(&relay.edge_url(), 100), service, noop_nudge());
+    relay.wait_host_connected().await;
+
+    let url = device_room_ws_url(&relay.edge_url(), "dev-a", "client", Some("c-echo"), "tok");
+    let link = DeviceLink::connect(&url).await.expect("client link dials");
+    // Healthy phase: echoes flow, the deadline never trips.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert!(!link.is_closed(), "echoing link must stay open");
+
+    relay.set_blackhole_host_bound(true);
+    wait_until(|| link.is_closed()).await;
+    assert_eq!(
+        link.closed().borrow().as_deref(),
+        Some("host echo silent"),
+        "the zombie path must be ruled dead by the echo deadline"
+    );
+    // Restore the production clocks for the rest of the process's tests.
+    zeron_rpc::device_room::set_client_liveness_for_tests(Duration::ZERO, Duration::ZERO);
 }

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -19,6 +19,10 @@ thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 
+# NWPathMonitor bridge (net_path.rs) — the update handler is an ObjC block.
+[target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6"
+
 [features]
 # In-process registry server speaking the DO's JSON WS protocol — test
 # infrastructure for this crate's tests and zeron-engine's integration tests.

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -36,7 +36,16 @@ const HELLO_DEADLINE: Duration = Duration::from_secs(15);
 const BACKFILL_DEADLINE: Duration = Duration::from_secs(120);
 const PROBE_DEADLINE: Duration = Duration::from_secs(10);
 const BACKOFF_BASE: Duration = Duration::from_millis(250);
-const BACKOFF_CAP: Duration = Duration::from_secs(30);
+/// Worst-case dark window after the network returns (event wakes usually
+/// beat this; the cap only matters when every event path missed).
+const BACKOFF_CAP: Duration = Duration::from_secs(16);
+/// A joined session must survive this long before a disconnect resets the
+/// backoff to base (see registry.rs STABLE_RESET — same connect-and-die
+/// hot-loop rationale).
+const STABLE_RESET: Duration = Duration::from_secs(30);
+/// Safety re-check cadence while parked on "OS says offline" — a stuck or
+/// wrong path monitor degrades to slow polling, never to silence.
+const OFFLINE_PARK_RECHECK: Duration = Duration::from_secs(30);
 /// Quiet-room probe cadence default (matches the registry's fleet math).
 const PROBE_QUIET_DEFAULT: Duration = Duration::from_secs(900);
 /// A checkpoint fetch that hasn't finished by now is treated as a dead link
@@ -337,6 +346,9 @@ struct Flags {
     disconnects: std::sync::atomic::AtomicU64,
     rejected: std::sync::atomic::AtomicU64,
     server_resets: std::sync::atomic::AtomicU64,
+    /// Monotonic dial-attempt counter; each attempt's number is its trace id
+    /// in logs, so an incident reads as one numbered sequence.
+    dial_seq: std::sync::atomic::AtomicU64,
 }
 
 impl ChatClient {
@@ -679,6 +691,11 @@ impl Actor {
             if *self.shutdown.borrow() {
                 return;
             }
+            let attempt = self
+                .flags
+                .dial_seq
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                + 1;
             let dial = tokio::time::timeout(CONNECT_TIMEOUT, self.connector.connect()).await;
             let pipe = match dial {
                 Ok(Ok(pipe)) => pipe,
@@ -687,7 +704,7 @@ impl Actor {
                         let _ = ready.send(Err(err));
                         return; // first join failed: caller owns the retry
                     }
-                    tracing::warn!(error = %err, "chat2 dial failed; backing off");
+                    tracing::warn!(error = %err, attempt, "chat2 dial failed; backing off");
                     self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
@@ -701,7 +718,7 @@ impl Actor {
                         let _ = ready.send(Err(SyncError::WebSocket("connect timeout".into())));
                         return;
                     }
-                    tracing::warn!("chat2 dial timed out; backing off");
+                    tracing::warn!(attempt, "chat2 dial timed out; backing off");
                     self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
@@ -712,13 +729,16 @@ impl Actor {
                 }
             };
 
+            let session_started = tokio::time::Instant::now();
             match self.run_session(pipe, &mut ready).await {
                 SessionEnd::Stop => return,
                 SessionEnd::Reconnect => {
                     use std::sync::atomic::Ordering::Relaxed;
-                    // A session that had joined resets the backoff — without
-                    // this, ~7 flaps pinned every future reconnect at the cap
-                    // for the life of the client.
+                    // Only a session that joined AND stayed healthy for a
+                    // while earns a fresh backoff. Reset-on-join alone let a
+                    // connect-and-die socket hot-loop at 250ms forever;
+                    // without any reset, ~7 flaps pinned every future
+                    // reconnect at the cap for the life of the client.
                     let joined = self.flags.connected.swap(false, Relaxed);
                     self.flags.disconnects.fetch_add(1, Relaxed);
                     let _ = self.events.send(ChatEvent::Disconnected);
@@ -729,7 +749,7 @@ impl Actor {
                         }
                         return;
                     }
-                    if joined {
+                    if joined && session_started.elapsed() >= STABLE_RESET {
                         backoff = BACKOFF_BASE;
                     }
                     self.spawn_offline_sync();
@@ -744,7 +764,9 @@ impl Actor {
     }
 
     /// Sleep out one backoff, cut short by system wake, a sibling dial
-    /// success, or shutdown.
+    /// success, or shutdown. While the OS reports no network path, the wait
+    /// parks on the event buses (with a coarse safety timer) instead of
+    /// burning dial attempts that cannot succeed.
     async fn wait_backoff(
         &mut self,
         wake: &mut tokio::sync::broadcast::Receiver<()>,
@@ -755,6 +777,11 @@ impl Actor {
         // or our own last dial would cut every wait to zero.
         while wake.try_recv().is_ok() {}
         while online.try_recv().is_ok() {}
+        let wait = if crate::wake::path_is_offline() {
+            wait.max(OFFLINE_PARK_RECHECK)
+        } else {
+            wait
+        };
         tokio::select! {
             _ = tokio::time::sleep(wait) => Waited::Elapsed,
             _ = wake.recv() => Waited::Woke,

--- a/crates/sync/src/chat_client/tests.rs
+++ b/crates/sync/src/chat_client/tests.rs
@@ -914,3 +914,271 @@ fn empty_frontier_with_real_checkpoint_is_not_contained() {
         "fresh reader must fetch a present checkpoint when the frontier is unreadable"
     );
 }
+
+// ── flaky-network suite (durable-by-design §Phase 3) ────────────────────────
+//
+// The deterministic drop harness: a scripted connector where each dial slot
+// is either a live pipe or a refusal, with connect times recorded on the
+// virtual clock. The contract under test: every send delivers exactly once
+// or surfaces a visible degraded state — silence is a failure.
+
+/// Tests that flip the process-global OS-path flag or assert precise dial
+/// timing serialize through this: a park triggered by one test inflates
+/// another's measured backoff gaps.
+static PATH_AND_TIMING: Mutex<()> = Mutex::new(());
+
+struct FlakyConnector {
+    /// One entry per dial: `Some(pipe)` connects, `None` refuses.
+    script: Mutex<VecDeque<Option<BinPipe>>>,
+    /// Virtual-clock instant of every dial attempt (gap assertions).
+    times: Mutex<Vec<tokio::time::Instant>>,
+}
+
+impl FlakyConnector {
+    fn new(script: Vec<Option<BinPipe>>) -> Arc<Self> {
+        Arc::new(Self {
+            script: Mutex::new(script.into_iter().collect()),
+            times: Mutex::new(Vec::new()),
+        })
+    }
+    fn dial_times(&self) -> Vec<tokio::time::Instant> {
+        lock(&self.times).clone()
+    }
+}
+
+impl BinConnector for FlakyConnector {
+    fn connect(&self) -> BoxFuture<'static, Result<BinPipe, SyncError>> {
+        lock(&self.times).push(tokio::time::Instant::now());
+        let slot = lock(&self.script).pop_front().flatten();
+        Box::pin(async move { slot.ok_or(SyncError::Closed) })
+    }
+}
+
+fn empty_state_json() -> serde_json::Value {
+    serde_json::json!({"headSeq": 0, "seqFloor": 0,
+        "checkpointSeq": 0, "checkpointSize": 0, "rowCount": 0, "rowBytes": 0})
+}
+
+/// A network that drops the socket mid-push and then refuses two dials must
+/// still deliver the batch EXACTLY once (same batch id, one ack, cursor 1)
+/// and must narrate the outage (Disconnected event + disconnect counters) —
+/// the UI-truth signal the pill and Queued badges ride on.
+#[tokio::test(start_paused = true)]
+async fn drops_and_refused_dials_deliver_the_push_exactly_once() {
+    let _serial = lock(&PATH_AND_TIMING);
+    let (pipe1, mut end1) = pipe_pair();
+    let (pipe2, mut end2) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, _) = fetcher(b"");
+    // Dial script: connect, then two refusals (the flap), then recover.
+    let flaky = FlakyConnector::new(vec![Some(pipe1), None, None, Some(pipe2)]);
+
+    let s1 = tokio::spawn({
+        let state = empty_state_json();
+        async move {
+            serve_join(&mut end1, state, &[], vec![], false).await;
+            let push = expect_kind(&mut end1, frame_type::PUSH).await;
+            let batch_id = push.header["batchId"].as_str().unwrap().to_string();
+            drop(end1); // mid-push socket death: no ack
+            batch_id
+        }
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        flaky.clone(),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("first join succeeds");
+    let mut events = client.events();
+
+    client.enqueue_update(vec![0xEE]);
+    let first_batch = s1.await.unwrap();
+
+    // The outage narrates: a Disconnected event reaches subscribers.
+    let mut saw_disconnect = false;
+    // Serve the recovery session concurrently so the actor can get there.
+    let s2 = tokio::spawn({
+        let state = empty_state_json();
+        async move {
+            serve_join(&mut end2, state, &[], vec![], true).await;
+            let push = expect_kind(&mut end2, frame_type::PUSH).await;
+            let batch_id = push.header["batchId"].as_str().unwrap().to_string();
+            send(
+                &end2,
+                frame_type::ACK,
+                serde_json::json!({"batchId": batch_id, "seq": 1, "dup": false}),
+                &[],
+            )
+            .await;
+            (batch_id, end2)
+        }
+    });
+    let (replayed, _keep_alive) = s2.await.unwrap();
+    assert_eq!(replayed, first_batch, "the SAME batch replays — no dupes, no loss");
+
+    while client.stats().pending_pushes > 0 {
+        if matches!(events.recv().await, Ok(ChatEvent::Disconnected)) {
+            saw_disconnect = true;
+        }
+    }
+    while let Ok(event) = events.try_recv() {
+        if matches!(event, ChatEvent::Disconnected) {
+            saw_disconnect = true;
+        }
+    }
+    assert!(saw_disconnect, "the outage must surface as a Disconnected event");
+    let stats = client.stats();
+    assert_eq!(stats.cursor, 1, "exactly one ack advanced the cursor");
+    assert_eq!(*lock(&sink.cursor_advances), vec![1]);
+    assert!(stats.disconnects >= 1, "disconnect counter recorded the drop");
+    assert_eq!(
+        flaky.dial_times().len(),
+        4,
+        "exactly the scripted dials: join, two refusals, recovery"
+    );
+    client.shutdown().await;
+}
+
+/// Stability-gated backoff reset: sessions that JOIN and then die immediately
+/// (captive portal / connect-and-die socket) must keep growing their backoff
+/// — reset-on-join alone hot-looped at 250ms forever. A session that stays
+/// healthy past STABLE_RESET earns the fresh 250ms base again.
+#[tokio::test(start_paused = true)]
+async fn connect_and_die_sessions_grow_backoff_until_a_stable_session_resets_it() {
+    let _serial = lock(&PATH_AND_TIMING);
+    let mut pipes = Vec::new();
+    let mut ends = VecDeque::new();
+    for _ in 0..5 {
+        let (pipe, end) = pipe_pair();
+        pipes.push(Some(pipe));
+        ends.push_back(end);
+    }
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, _) = fetcher(b"");
+    let flaky = FlakyConnector::new(pipes);
+
+    // Sessions 1-4: join then die instantly. Session 5: join, stay healthy
+    // past STABLE_RESET, then die.
+    let server = tokio::spawn(async move {
+        for i in 0..4 {
+            let mut end = ends.pop_front().unwrap();
+            serve_join(&mut end, empty_state_json(), &[], vec![], i > 0).await;
+            drop(end); // joined-and-died: an unstable session
+        }
+        let mut end = ends.pop_front().unwrap();
+        serve_join(&mut end, empty_state_json(), &[], vec![], true).await;
+        // Outlive the stability gate on the virtual clock, then die.
+        tokio::time::sleep(STABLE_RESET + Duration::from_secs(1)).await;
+        drop(end);
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        flaky.clone(),
+        sink,
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("first join succeeds");
+
+    // Wait until all five scripted sessions have been dialed (the 6th dial
+    // attempt hits the exhausted script and keeps failing — ignore it).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(600);
+    while flaky.dial_times().len() < 6 {
+        assert!(tokio::time::Instant::now() < deadline, "dials never happened");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    server.await.unwrap();
+    let times = flaky.dial_times();
+    // Gaps between redials after unstable sessions must GROW (each joined
+    // session died in ~0 virtual time, so the gap is ~the backoff).
+    let gap = |i: usize| times[i + 1].duration_since(times[i]);
+    assert!(gap(1) >= Duration::from_millis(400), "second redial backed off: {:?}", gap(1));
+    assert!(gap(2) > gap(1), "backoff grows across unstable sessions: {:?} vs {:?}", gap(2), gap(1));
+    assert!(gap(3) > gap(2), "…and keeps growing: {:?} vs {:?}", gap(3), gap(2));
+    // The stable session (index 4→5 gap includes its >30s healthy lifetime):
+    // after it died, the backoff was reset to base — the redial came within
+    // ~base of the death, i.e. the whole gap is dominated by the 31s life.
+    let stable_gap = gap(4);
+    assert!(
+        stable_gap < STABLE_RESET + Duration::from_secs(3),
+        "a stable session resets the backoff to base: {stable_gap:?}"
+    );
+    client.shutdown().await;
+}
+
+/// Park-while-offline: while the OS reports no network path, the backoff
+/// waiter parks on the event buses instead of burning dial attempts — and
+/// the online event un-parks it IMMEDIATELY (event-driven recovery, not
+/// timer luck).
+#[tokio::test(start_paused = true)]
+async fn os_offline_parks_dials_and_the_online_event_unparks_immediately() {
+    let _serial = lock(&PATH_AND_TIMING);
+    let (pipe1, mut end1) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, _) = fetcher(b"");
+    let flaky = FlakyConnector::new(vec![Some(pipe1)]);
+
+    let server = tokio::spawn(async move {
+        serve_join(&mut end1, empty_state_json(), &[], vec![], false).await;
+        // Hold the session; the path flag flips BEFORE this socket dies, so
+        // the redial wait is born parked.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        drop(end1); // the network goes away
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        flaky.clone(),
+        sink,
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+
+    // The OS says the path is gone while the session is still up.
+    crate::wake::set_path_online(false);
+    server.await.unwrap();
+    // Give the actor a beat to observe the death and enter the parked wait.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let dials_before = flaky.dial_times().len();
+
+    // 5 virtual seconds pass — far beyond the normal 250-500ms backoff. A
+    // parked waiter must NOT have dialed (the un-parked pre-fix behavior
+    // would have burned several attempts by now).
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    assert_eq!(
+        flaky.dial_times().len(),
+        dials_before,
+        "no dial attempts while the OS says there is no path"
+    );
+
+    // The path returns: the transition broadcasts the online event and the
+    // parked waiter redials NOW.
+    let restored_at = tokio::time::Instant::now();
+    crate::wake::set_path_online(true);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while flaky.dial_times().len() == dials_before {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "online event never un-parked the dialer"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let redial_at = *flaky.dial_times().last().unwrap();
+    assert!(
+        redial_at.duration_since(restored_at) < Duration::from_secs(2),
+        "redial rides the event, not a timer: {:?}",
+        redial_at.duration_since(restored_at)
+    );
+    client.shutdown().await;
+}

--- a/crates/sync/src/chat_client/tests.rs
+++ b/crates/sync/src/chat_client/tests.rs
@@ -1019,7 +1019,10 @@ async fn drops_and_refused_dials_deliver_the_push_exactly_once() {
         }
     });
     let (replayed, _keep_alive) = s2.await.unwrap();
-    assert_eq!(replayed, first_batch, "the SAME batch replays — no dupes, no loss");
+    assert_eq!(
+        replayed, first_batch,
+        "the SAME batch replays — no dupes, no loss"
+    );
 
     while client.stats().pending_pushes > 0 {
         if matches!(events.recv().await, Ok(ChatEvent::Disconnected)) {
@@ -1031,11 +1034,17 @@ async fn drops_and_refused_dials_deliver_the_push_exactly_once() {
             saw_disconnect = true;
         }
     }
-    assert!(saw_disconnect, "the outage must surface as a Disconnected event");
+    assert!(
+        saw_disconnect,
+        "the outage must surface as a Disconnected event"
+    );
     let stats = client.stats();
     assert_eq!(stats.cursor, 1, "exactly one ack advanced the cursor");
     assert_eq!(*lock(&sink.cursor_advances), vec![1]);
-    assert!(stats.disconnects >= 1, "disconnect counter recorded the drop");
+    assert!(
+        stats.disconnects >= 1,
+        "disconnect counter recorded the drop"
+    );
     assert_eq!(
         flaky.dial_times().len(),
         4,
@@ -1092,7 +1101,10 @@ async fn connect_and_die_sessions_grow_backoff_until_a_stable_session_resets_it(
     // attempt hits the exhausted script and keeps failing — ignore it).
     let deadline = tokio::time::Instant::now() + Duration::from_secs(600);
     while flaky.dial_times().len() < 6 {
-        assert!(tokio::time::Instant::now() < deadline, "dials never happened");
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "dials never happened"
+        );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
     server.await.unwrap();
@@ -1100,9 +1112,23 @@ async fn connect_and_die_sessions_grow_backoff_until_a_stable_session_resets_it(
     // Gaps between redials after unstable sessions must GROW (each joined
     // session died in ~0 virtual time, so the gap is ~the backoff).
     let gap = |i: usize| times[i + 1].duration_since(times[i]);
-    assert!(gap(1) >= Duration::from_millis(400), "second redial backed off: {:?}", gap(1));
-    assert!(gap(2) > gap(1), "backoff grows across unstable sessions: {:?} vs {:?}", gap(2), gap(1));
-    assert!(gap(3) > gap(2), "…and keeps growing: {:?} vs {:?}", gap(3), gap(2));
+    assert!(
+        gap(1) >= Duration::from_millis(400),
+        "second redial backed off: {:?}",
+        gap(1)
+    );
+    assert!(
+        gap(2) > gap(1),
+        "backoff grows across unstable sessions: {:?} vs {:?}",
+        gap(2),
+        gap(1)
+    );
+    assert!(
+        gap(3) > gap(2),
+        "…and keeps growing: {:?} vs {:?}",
+        gap(3),
+        gap(2)
+    );
     // The stable session (index 4→5 gap includes its >30s healthy lifetime):
     // after it died, the backoff was reset to base — the redial came within
     // ~base of the death, i.e. the whole gap is dominated by the 31s life.

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -22,6 +22,8 @@ pub mod wake;
 pub use chat_client::{
     ChatClient, ChatDocSink, ChatEvent, ChatStatsSnapshot, ChatTuning, CheckpointFetcher,
 };
-pub use registry::{ReconnectState, RegistryClient, RegistryEvent, RegistryTransport, RegistryTuning};
+pub use registry::{
+    ReconnectState, RegistryClient, RegistryEvent, RegistryTransport, RegistryTuning,
+};
 pub use store::{DocsStore, StoreError};
 pub use types::{RoomStatsSnapshot, StaticUrl, SyncError, UrlProvider};

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod chat_client;
 pub mod chat_frames;
 pub mod dial;
+pub mod net_path;
 pub mod registry;
 mod store;
 mod types;
@@ -21,6 +22,6 @@ pub mod wake;
 pub use chat_client::{
     ChatClient, ChatDocSink, ChatEvent, ChatStatsSnapshot, ChatTuning, CheckpointFetcher,
 };
-pub use registry::{RegistryClient, RegistryEvent, RegistryTransport, RegistryTuning};
+pub use registry::{ReconnectState, RegistryClient, RegistryEvent, RegistryTransport, RegistryTuning};
 pub use store::{DocsStore, StoreError};
 pub use types::{RoomStatsSnapshot, StaticUrl, SyncError, UrlProvider};

--- a/crates/sync/src/net_path.rs
+++ b/crates/sync/src/net_path.rs
@@ -1,0 +1,78 @@
+//! OS network-path monitoring → [`crate::wake::set_path_online`].
+//!
+//! macOS: `NWPathMonitor` (Network.framework, plain C surface + one ObjC
+//! block). The instant the OS says the path is back, every parked reconnect
+//! backoff redials; while the OS says there is no path, backoff waiters park
+//! on the event buses instead of burning dial attempts (see `wake.rs`).
+//!
+//! Other platforms: no-op — `path_is_offline()` stays false and the empirical
+//! signals (suspend detector, sibling-dial successes, focus probe) carry the
+//! recovery story unchanged, exactly as before this module existed.
+
+/// Start the process-wide path monitor. Idempotent; call from engine startup.
+pub fn spawn_path_monitor() {
+    static STARTED: std::sync::Once = std::sync::Once::new();
+    STARTED.call_once(|| {
+        #[cfg(target_os = "macos")]
+        imp::start();
+    });
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::ffi::{c_char, c_void};
+
+    use block2::{Block, RcBlock};
+
+    // nw_path_monitor_t / nw_path_t / dispatch_queue_t are ObjC objects;
+    // opaque pointers are all this bridge needs.
+    #[link(name = "Network", kind = "framework")]
+    unsafe extern "C" {
+        fn nw_path_monitor_create() -> *mut c_void;
+        fn nw_path_monitor_set_update_handler(
+            monitor: *mut c_void,
+            handler: &Block<dyn Fn(*mut c_void)>,
+        );
+        fn nw_path_monitor_set_queue(monitor: *mut c_void, queue: *mut c_void);
+        fn nw_path_monitor_start(monitor: *mut c_void);
+        fn nw_path_get_status(path: *mut c_void) -> i32;
+    }
+
+    unsafe extern "C" {
+        fn dispatch_queue_create(label: *const c_char, attr: *mut c_void) -> *mut c_void;
+    }
+
+    /// `nw_path_status_unsatisfied`. Only a definitive "no path" parks the
+    /// dialers — `invalid`/`satisfiable` stay optimistic, so a confused
+    /// monitor can only ever make us dial too much, never go silent.
+    const NW_PATH_STATUS_UNSATISFIED: i32 = 2;
+
+    pub(super) fn start() {
+        unsafe {
+            let monitor = nw_path_monitor_create();
+            if monitor.is_null() {
+                tracing::warn!("net_path: NWPathMonitor unavailable");
+                return;
+            }
+            let handler = RcBlock::new(|path: *mut c_void| {
+                let status = unsafe { nw_path_get_status(path) };
+                let online = status != NW_PATH_STATUS_UNSATISFIED;
+                crate::wake::set_path_online(online);
+                if online {
+                    // Interface handovers (wifi→hotspot, VPN up/down) arrive
+                    // as satisfied→satisfied updates. Old sockets are dead on
+                    // the new path either way, so kick parked dials on every
+                    // viable-path report — waiters drain stale events before
+                    // arming, so a redundant kick costs nothing.
+                    crate::wake::notify_online();
+                }
+            });
+            let queue = dispatch_queue_create(c"zeron.net-path".as_ptr(), std::ptr::null_mut());
+            nw_path_monitor_set_queue(monitor, queue);
+            nw_path_monitor_set_update_handler(monitor, &handler);
+            nw_path_monitor_start(monitor);
+            // The monitor (and its handler copy) lives for the process.
+            std::mem::forget(handler);
+        }
+    }
+}

--- a/crates/sync/src/registry.rs
+++ b/crates/sync/src/registry.rs
@@ -45,7 +45,16 @@ const PROBE_DEADLINE: Duration = Duration::from_secs(10);
 /// EphemeralStore's 30s TTL the old workspace room used).
 const PRESENCE_TTL: Duration = Duration::from_secs(30);
 const BACKOFF_BASE: Duration = Duration::from_millis(250);
-const BACKOFF_CAP: Duration = Duration::from_secs(30);
+/// Worst-case dark window after the network returns (event wakes usually
+/// beat this; the cap only matters when every event path missed).
+const BACKOFF_CAP: Duration = Duration::from_secs(16);
+/// A joined session must survive this long before a disconnect resets the
+/// backoff to base. Resetting on join alone lets a connect-and-die socket
+/// (captive portal, half-broken NAT) hot-loop at 250ms forever.
+const STABLE_RESET: Duration = Duration::from_secs(30);
+/// Safety re-check cadence while parked on "OS says offline" — a stuck or
+/// wrong path monitor degrades to slow polling, never to silence.
+const OFFLINE_PARK_RECHECK: Duration = Duration::from_secs(30);
 
 /// Quiet-room probe cadence default. The workspace registry is one room per
 /// engine, so a fixed 15min cadence costs ~100 DO wakes/day total.
@@ -241,6 +250,25 @@ struct Stats {
     full_resyncs: std::sync::atomic::AtomicU64,
     disconnects: std::sync::atomic::AtomicU64,
     rejected: std::sync::atomic::AtomicU64,
+    /// Epoch ms of the next scheduled dial attempt (0 = connected or dialing
+    /// right now). Drives the "Reconnecting — retrying in Ns" countdown.
+    retry_at_ms: std::sync::atomic::AtomicI64,
+    /// Monotonic dial-attempt counter; each attempt's number is its trace id
+    /// in logs, so an incident reads as one numbered sequence.
+    dial_seq: std::sync::atomic::AtomicU64,
+    /// The failure that started/extended the current outage. Sticky: cleared
+    /// only by a successful join, so the UI can keep the last failure visible
+    /// through the next attempt instead of flickering to "connecting…".
+    last_failure: Mutex<Option<String>>,
+}
+
+/// One room's reconnect posture, for connection-status UI.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconnectState {
+    /// Epoch ms of the next scheduled dial (0 = none pending).
+    pub retry_at_ms: i64,
+    /// Failure that started the current outage; `None` once rejoined.
+    pub last_failure: Option<String>,
 }
 
 impl Stats {
@@ -448,6 +476,18 @@ impl RegistryClient {
         self.stats.snapshot()
     }
 
+    /// Current reconnect posture (next-dial deadline + sticky last failure)
+    /// for connection-status UI.
+    pub fn reconnect_state(&self) -> ReconnectState {
+        ReconnectState {
+            retry_at_ms: self
+                .stats
+                .retry_at_ms
+                .load(std::sync::atomic::Ordering::Relaxed),
+            last_failure: lock(&self.stats.last_failure).clone(),
+        }
+    }
+
     /// Leave cleanly and stop the actor.
     pub async fn shutdown(mut self) {
         let _ = self.shutdown.send(true);
@@ -526,6 +566,11 @@ impl Actor {
             if *self.shutdown.borrow() {
                 return;
             }
+            let attempt = self
+                .stats
+                .dial_seq
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                + 1;
             let dial = tokio::time::timeout(CONNECT_TIMEOUT, self.connector.connect()).await;
             let pipe = match dial {
                 Ok(Ok(pipe)) => pipe,
@@ -534,7 +579,8 @@ impl Actor {
                         let _ = ready.send(Err(err));
                         return; // first join failed: caller owns the retry
                     }
-                    tracing::warn!(error = %err, "registry dial failed; backing off");
+                    tracing::warn!(error = %err, attempt, "registry dial failed; backing off");
+                    self.note_failure(format!("dial failed: {err}"));
                     self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
@@ -548,7 +594,8 @@ impl Actor {
                         let _ = ready.send(Err(SyncError::WebSocket("connect timeout".into())));
                         return;
                     }
-                    tracing::warn!("registry dial timed out; backing off");
+                    tracing::warn!(attempt, "registry dial timed out; backing off");
+                    self.note_failure("dial timed out".into());
                     self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
                         Waited::Shutdown => return,
@@ -559,13 +606,17 @@ impl Actor {
                 }
             };
 
+            let session_started = tokio::time::Instant::now();
             match self.run_session(pipe, &mut ready).await {
                 SessionEnd::Stop => return,
                 SessionEnd::Reconnect => {
                     lock(&self.doc).mark_disconnected();
-                    // A session that had joined resets the backoff — without
-                    // this, ~7 flaps pinned every future reconnect at the cap
-                    // for the life of the client.
+                    // Only a session that joined AND stayed healthy for a
+                    // while earns a fresh backoff. Reset-on-join alone let a
+                    // connect-and-die socket (captive portal, half-broken
+                    // NAT) hot-loop at 250ms forever; without any reset, ~7
+                    // flaps pinned every future reconnect at the cap for the
+                    // life of the client.
                     let joined = self
                         .stats
                         .connected
@@ -573,6 +624,7 @@ impl Actor {
                     self.stats
                         .disconnects
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    self.note_failure("connection dropped".into());
                     let _ = self.events.send(RegistryEvent::Disconnected);
                     if ready.is_some() {
                         // Handshake failed on the very first session.
@@ -582,12 +634,12 @@ impl Actor {
                         }
                         return;
                     }
-                    if joined {
+                    if joined && session_started.elapsed() >= STABLE_RESET {
                         backoff = BACKOFF_BASE;
                     }
                     // Socket down: sync over HTTPS while we wait — pending
                     // pushes flush and the doc stays fresh at backoff cadence
-                    // (≤30s), so a WS-hostile network degrades to polling
+                    // (≤16s), so a WS-hostile network degrades to polling
                     // instead of silence.
                     self.spawn_offline_sync();
                     match self.wait_backoff(&mut wake, &mut online, backoff).await {
@@ -600,8 +652,17 @@ impl Actor {
         }
     }
 
+    /// Record the failure that started/extended the current outage (sticky
+    /// until the next successful join — the UI keeps it visible through the
+    /// next attempt instead of flickering back to a bare "connecting").
+    fn note_failure(&self, msg: String) {
+        *lock(&self.stats.last_failure) = Some(msg);
+    }
+
     /// Sleep out one backoff, cut short by system wake, a sibling dial
-    /// success, or shutdown.
+    /// success, or shutdown. While the OS reports no network path, the wait
+    /// parks on the event buses (with a coarse safety timer) instead of
+    /// burning dial attempts that cannot succeed.
     async fn wait_backoff(
         &mut self,
         wake: &mut tokio::sync::broadcast::Receiver<()>,
@@ -612,7 +673,16 @@ impl Actor {
         // or our own last dial would cut every wait to zero.
         while wake.try_recv().is_ok() {}
         while online.try_recv().is_ok() {}
-        tokio::select! {
+        use std::sync::atomic::Ordering::Relaxed;
+        let wait = if crate::wake::path_is_offline() {
+            wait.max(OFFLINE_PARK_RECHECK)
+        } else {
+            wait
+        };
+        self.stats
+            .retry_at_ms
+            .store(epoch_ms() + wait.as_millis() as i64, Relaxed);
+        let waited = tokio::select! {
             _ = tokio::time::sleep(wait) => Waited::Elapsed,
             _ = wake.recv() => Waited::Woke,
             _ = online.recv() => Waited::Woke,
@@ -623,7 +693,9 @@ impl Actor {
                     Waited::Elapsed
                 }
             }
-        }
+        };
+        self.stats.retry_at_ms.store(0, Relaxed);
+        waited
     }
 
     async fn run_session(
@@ -697,6 +769,8 @@ impl Actor {
         }
         self.stats.connected.store(true, Relaxed);
         self.stats.last_pushed_ms.store(epoch_ms(), Relaxed);
+        self.stats.retry_at_ms.store(0, Relaxed);
+        *lock(&self.stats.last_failure) = None;
         if ready.is_none() {
             self.stats.rejoins.fetch_add(1, Relaxed);
         }

--- a/crates/sync/src/registry.rs
+++ b/crates/sync/src/registry.rs
@@ -884,7 +884,8 @@ impl Actor {
             let batches: Vec<PendingBatch> = lock(&doc).take_pushable();
             let mut push_failed = false;
             for batch in &batches {
-                let body = serde_json::json!({ "batch": batch.batch, "ops": batch.ops }).to_string();
+                let body =
+                    serde_json::json!({ "batch": batch.batch, "ops": batch.ops }).to_string();
                 match transport.push(body).await {
                     Ok(ack) => {
                         if let Ok(v) = serde_json::from_str::<serde_json::Value>(&ack) {

--- a/crates/sync/src/wake.rs
+++ b/crates/sync/src/wake.rs
@@ -16,6 +16,7 @@
 //! events — each subscriber treats ANY received event as "reconnect now",
 //! so a missed one is at worst covered by the next silence lease.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -28,6 +29,11 @@ const JUMP_THRESHOLD: Duration = Duration::from_secs(5);
 
 static CHANNEL: OnceLock<broadcast::Sender<()>> = OnceLock::new();
 static ONLINE: OnceLock<broadcast::Sender<()>> = OnceLock::new();
+/// OS-reported network path status. `false` (the default, and the permanent
+/// value on platforms without a path monitor) means "assume a path exists" —
+/// backoff loops behave exactly as before. Only an explicit
+/// [`set_path_online(false)`] from a platform monitor flips this true.
+static PATH_OFFLINE: AtomicBool = AtomicBool::new(false);
 
 /// Subscribe to system-wake events (the detector spawns on first call).
 pub fn subscribe() -> broadcast::Receiver<()> {
@@ -83,4 +89,28 @@ pub fn subscribe_online() -> broadcast::Receiver<()> {
 /// Broadcast that a dial just succeeded (see [`subscribe_online`]).
 pub fn notify_online() {
     let _ = online_channel().send(());
+}
+
+/// Report the OS network-path status (macOS `NWPathMonitor`; other platforms
+/// simply never call this). Two effects:
+///
+/// - offline → online broadcasts an online event, so every parked backoff
+///   redials the instant the path returns instead of waiting out its timer;
+/// - while offline, [`path_is_offline`] tells backoff waiters to park on the
+///   event buses rather than burn dial attempts the OS says cannot succeed.
+pub fn set_path_online(online: bool) {
+    let was_offline = PATH_OFFLINE.swap(!online, Ordering::Relaxed);
+    if online && was_offline {
+        tracing::info!("wake: network path restored");
+        notify_online();
+    } else if !online && !was_offline {
+        tracing::info!("wake: network path lost; parking reconnect backoffs");
+    }
+}
+
+/// True while the OS reports no viable network path. Waiters treat this as
+/// "park until an event", never as a hard guarantee — the monitor may be
+/// absent or wrong, so parked waits keep a coarse safety timer.
+pub fn path_is_offline() -> bool {
+    PATH_OFFLINE.load(Ordering::Relaxed)
 }

--- a/crates/sync/src/wake.rs
+++ b/crates/sync/src/wake.rs
@@ -16,8 +16,8 @@
 //! events — each subscriber treats ANY received event as "reconnect now",
 //! so a missed one is at worst covered by the next silence lease.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, SystemTime};
 
 use tokio::sync::broadcast;

--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -296,15 +296,17 @@ pub(crate) async fn call_with_timeout(
 /// Chunked upload: base64 the bytes, `UploadChunk{uploadId,seq,data}` per 60KB
 /// slice (positional `seq` makes the cheap retry idempotent), then
 /// `UploadCommit{uploadId,fileName}` → the durable absolute path on the target
-/// device. Errors return the raw cause (the composer shows friendly copy).
+/// device. The caller mints `upload_id` — the queued-attachment flow derives
+/// its `pending://` refs from the same identity before the bytes move.
+/// Errors return the raw cause (the composer shows friendly copy).
 pub async fn upload_attachment(
     engine: &EngineHandle,
     executor: &BackgroundExecutor,
     target_device_id: Option<&str>,
+    upload_id: &str,
     attachment: &StagedAttachment,
 ) -> Result<String, String> {
     let b64 = BASE64.encode(attachment.bytes());
-    let upload_id = uuid::Uuid::new_v4().to_string();
     let mut start = 0usize;
     let mut seq = 0u64;
     loop {
@@ -335,7 +337,10 @@ pub async fn upload_attachment(
                 Ok(_) => break,
                 Err(err) if attempt < 2 => {
                     attempt += 1;
-                    tracing::debug!(error = %err, seq, "upload chunk retry");
+                    // warn, not debug: the 2026-08-19 incident ground through
+                    // silent 30s timeout/retry cycles for minutes with a
+                    // literally empty log — degraded uploads must narrate.
+                    tracing::warn!(error = %err, seq, attempt, "upload chunk retry");
                 }
                 Err(err) => return Err(err),
             }

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -366,6 +366,12 @@ pub fn flip_morph_step(
     })
 }
 
+/// Engines at or above this version understand `pending://` attachment refs
+/// and QueueCommand `transfers` (send-is-a-local-write attachments). Gated on
+/// BOTH the local engine (an IPC daemon may be older than this UI) and, for
+/// remotely-hosted chats, the host device's stamped registry version.
+const QUEUED_ATTACHMENTS_MIN: (u64, u64, u64) = (0, 2, 12);
+
 /// What the send button is right now.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SendButtonMode {
@@ -3329,6 +3335,11 @@ pub struct Composer {
     current_key: String,
     sending: bool,
     failure: Option<SharedString>,
+    /// The chat key `failure` belongs to (`None` = global, e.g. "Engine not
+    /// connected"). Chat-scoped failures survive navigation and render only
+    /// under their own chat — a blanket clear-on-switch erased the one
+    /// visible trace of a failed send (2026-08-19).
+    failure_key: Option<String>,
     wizard: Option<Wizard>,
     wizard_focus: FocusHandle,
     /// Requests already answered locally (suppresses the panel until the doc
@@ -3336,6 +3347,11 @@ pub struct Composer {
     answered_requests: HashSet<String>,
     advance_task: Option<Task<()>>,
     send_task: Option<Task<()>>,
+    /// Interrupt/answer commands get their own slot: assigning `send_task`
+    /// DROPPED an in-flight send future mid-upload — no banner, no cleanup,
+    /// `sending` stuck true forever (2026-08-19 incident, "press Stop while
+    /// a send grinds" shape).
+    action_task: Option<Task<()>>,
     // -- compact/expanded flip state (hysteresis; see `composer_flip`) --
     /// Current layout mode (persisted across frames — never derived fresh).
     expanded_mode: bool,
@@ -3451,6 +3467,8 @@ impl Composer {
             wizard: None,
             wizard_focus: cx.focus_handle(),
             answered_requests: HashSet::new(),
+            failure_key: None,
+            action_task: None,
             advance_task: None,
             send_task: None,
             expanded_mode: false,
@@ -3550,6 +3568,7 @@ impl Composer {
                 Ok(att) => staged.push(att),
                 Err(message) => {
                     self.failure = Some(message.into());
+                    self.failure_key = Some(self.current_key.clone());
                     cx.notify();
                 }
             }
@@ -4329,7 +4348,10 @@ impl Composer {
             }
             let draft = self.drafts.get(&key).cloned().unwrap_or_default();
             self.current_key = key;
-            self.failure = None;
+            // `failure` deliberately survives navigation: chat-scoped
+            // failures render only under their own chat (see `failure_key`),
+            // so switching away and back must not erase the one visible
+            // trace of a failed send.
             self.wizard = None;
             // Attachments stay stashed under their chat key (the map swap IS
             // the navigation); only the transient chrome resets.
@@ -4449,6 +4471,7 @@ impl Composer {
     fn send(&mut self, text: String, steer: bool, cx: &mut Context<Self>) {
         let Some(engine) = self.state.read(cx).engine().cloned() else {
             self.failure = Some("Engine not connected".into());
+            self.failure_key = None; // global — meaningful on every chat
             cx.notify();
             return;
         };
@@ -4527,17 +4550,55 @@ impl Composer {
         let message_id = uuid::Uuid::new_v4().to_string();
         let created_at = chrono::Utc::now().timestamp_millis();
 
-        // The echo carries synthetic attachment refs from the first frame, so
-        // photos render while the send is still pending instead of waiting for
-        // the upload to finish (real paths replace them in the post-upload
-        // refresh). The refs resolve instantly: the staged bytes are seeded
-        // into the transcript cache under every device key the transcript
-        // consults, and the synthetic paths never persist — the queued command
-        // and the doc entry are built from `with_attachments` on real paths.
-        let echo_paths: Vec<String> = staged
+        // Queued-attachment flow (durable-by-design): stage the bytes on the
+        // LOCAL engine, queue the command immediately with `pending://` refs,
+        // and let the engine push the bytes to a remote host afterwards —
+        // staging must never gate the queue (2026-08-19 incident: a send
+        // died with a zombie peer link because the upload sat in front of
+        // QueueCommand). Requires every engine involved to understand the
+        // ref scheme — the local engine (an IPC daemon may be older than
+        // this UI) and, for remotely-hosted chats, the host; anything older
+        // keeps the legacy blocking upload.
+        let host_is_remote = host_device_id
+            .as_deref()
+            .is_some_and(|id| local_device_id.as_deref() != Some(id));
+        let queued_flow = !staged.is_empty() && {
+            let state = self.state.read(cx);
+            let local_ok = local_device_id
+                .as_deref()
+                .is_some_and(|id| state.device_version_at_least(id, QUEUED_ATTACHMENTS_MIN));
+            let host_ok = !host_is_remote
+                || host_device_id
+                    .as_deref()
+                    .is_some_and(|id| state.device_version_at_least(id, QUEUED_ATTACHMENTS_MIN));
+            local_ok && host_ok
+        };
+        // Upload identities minted NOW: in the queued flow the `pending://`
+        // ref IS the persisted transport until the host rewrites it, so the
+        // id must exist before any bytes move.
+        let upload_ids: Vec<String> = staged
             .iter()
-            .map(|att| format!("pending/{}/{}", att.id, att.name))
+            .map(|_| uuid::Uuid::new_v4().to_string())
             .collect();
+        // The echo carries attachment refs from the first frame, so photos
+        // render while the send is still pending. Queued flow: the refs are
+        // the real `pending://` identities (stable — no post-upload refresh).
+        // Legacy flow: synthetic `pending/…` paths that the post-upload
+        // refresh replaces with the host's absolute paths. Either way the
+        // staged bytes are seeded into the transcript cache under every
+        // device key the transcript consults.
+        let echo_paths: Vec<String> = if queued_flow {
+            staged
+                .iter()
+                .zip(&upload_ids)
+                .map(|(att, id)| format!("pending://{id}/{}", att.name))
+                .collect()
+        } else {
+            staged
+                .iter()
+                .map(|att| format!("pending/{}/{}", att.id, att.name))
+                .collect()
+        };
         let echo_text = attachments::with_attachments(&text, &echo_paths);
         for (path, att) in echo_paths.iter().zip(&staged) {
             attachments::seed_attachment(&device_id, path, &att.name, att.image.clone());
@@ -4688,27 +4749,85 @@ impl Composer {
                             object.insert("config".into(), config);
                         }
                     }
-                    if let Err(err) = engine.client().call(methods::MUTATE, mutate).await {
+                    if let Err(err) = attachments::call_with_timeout(
+                        &engine,
+                        cx.background_executor(),
+                        methods::MUTATE,
+                        mutate,
+                        std::time::Duration::from_secs(30),
+                    )
+                    .await
+                    {
                         tracing::warn!(error = %err, "CreateChat mutate unavailable; doc host will materialize the chat");
                     }
                 }
 
-                // Stage every attachment on the host device (sequential — the
-                // chunks share one channel), then thread the refs into the
-                // prompt text (`with_attachments`, the persisted transport)
-                // and the paths onto the Run request (inline image blocks).
+                // Attachments. Queued flow: commit the bytes to the LOCAL
+                // engine's uploads dir (fast, offline-safe) — the queued
+                // command carries the `pending://` refs and the engine
+                // delivers the bytes to a remote host afterwards, retrying
+                // until they land. Legacy flow (old engines): stage on the
+                // host device up front, bounded by a total budget so a
+                // degraded link fails the send loudly instead of grinding
+                // through silent per-chunk retries for minutes.
                 let mut content = text.clone();
                 let mut attachment_paths: Vec<String> = Vec::new();
-                if !staged.is_empty() {
-                    for att in &staged {
-                        match attachments::upload_attachment(
+                let mut transfers: Vec<serde_json::Value> = Vec::new();
+                if !staged.is_empty() && queued_flow {
+                    for (att, upload_id) in staged.iter().zip(&upload_ids) {
+                        if let Err(err) = attachments::upload_attachment(
                             &engine,
                             cx.background_executor(),
-                            host_device_id.as_deref(),
+                            None,
+                            upload_id,
                             att,
                         )
                         .await
                         {
+                            tracing::warn!(name = %att.name, error = %err, "local attachment stage failed");
+                            return Err("Couldn't stage the attachment locally.".to_string());
+                        }
+                        transfers.push(serde_json::json!({
+                            "uploadId": upload_id,
+                            "fileName": att.name,
+                        }));
+                    }
+                    // The echo refs ARE the persisted refs — no refresh pass.
+                    attachment_paths = echo_paths.clone();
+                    content = echo_text.clone();
+                } else if !staged.is_empty() {
+                    // Legacy: total wall-clock budget across all attachments —
+                    // per-chunk deadlines alone let a degraded relay grind
+                    // silently for the whole chunk count (2026-08-19).
+                    const LEGACY_UPLOAD_BUDGET: std::time::Duration =
+                        std::time::Duration::from_secs(300);
+                    let upload_started = std::time::Instant::now();
+                    for (att, upload_id) in staged.iter().zip(&upload_ids) {
+                        let Some(remaining) =
+                            LEGACY_UPLOAD_BUDGET.checked_sub(upload_started.elapsed())
+                        else {
+                            tracing::warn!(name = %att.name, "attachment upload budget exhausted");
+                            return Err(
+                                "Couldn't upload the attachment — the device may be offline."
+                                    .to_string(),
+                            );
+                        };
+                        let upload = attachments::upload_attachment(
+                            &engine,
+                            cx.background_executor(),
+                            host_device_id.as_deref(),
+                            upload_id,
+                            att,
+                        );
+                        let timer = cx.background_executor().timer(remaining);
+                        futures::pin_mut!(upload);
+                        let result = match futures::future::select(upload, timer).await {
+                            futures::future::Either::Left((result, _)) => result,
+                            futures::future::Either::Right(_) => {
+                                Err("upload budget exhausted".to_string())
+                            }
+                        };
+                        match result {
                             Ok(path) => attachment_paths.push(path),
                             Err(err) => {
                                 tracing::warn!(name = %att.name, error = %err, "attachment upload failed");
@@ -4781,12 +4900,22 @@ impl Composer {
                 };
                 let command = serde_json::to_value(&command)
                     .map_err(|e| format!("Send failed: {e}"))?;
-                let params = serde_json::json!({ "chatId": chat_id, "command": command });
-                engine
-                    .client()
-                    .call(methods::QUEUE_COMMAND, params)
-                    .await
-                    .map_err(|e| format!("Send failed: {e}"))?;
+                let mut params = serde_json::json!({ "chatId": chat_id, "command": command });
+                if !transfers.is_empty() {
+                    params["transfers"] = serde_json::Value::Array(transfers);
+                }
+                // Deadline-bounded: QueueCommand is a local write (in-process
+                // or IPC), but a deferred engine handle can park forever —
+                // the send task must never grind silently (2026-08-19).
+                attachments::call_with_timeout(
+                    &engine,
+                    cx.background_executor(),
+                    methods::QUEUE_COMMAND,
+                    params,
+                    std::time::Duration::from_secs(30),
+                )
+                .await
+                .map_err(|e| format!("Send failed: {e}"))?;
                 Ok(())
             }
             .await;
@@ -4796,6 +4925,7 @@ impl Composer {
                     // Failure: red banner, echo removed, prompt back in the
                     // draft, staged files back in the chat's stash.
                     composer.failure = Some(message.into());
+                    composer.failure_key = Some(err_chat_id.clone());
                     composer.state.update(cx, |s, cx| {
                         s.remove_echo(&err_chat_id, &err_message_id);
                         s.end_pending_send(&err_chat_id, &err_message_id);
@@ -4833,15 +4963,19 @@ impl Composer {
         let Some(chat_id) = self.state.read(cx).selected_chat.clone() else {
             return;
         };
+        let failure_chat = chat_id.clone();
         let params = serde_json::json!({
             "chatId": chat_id,
             "command": { "kind": "interrupt" },
         });
-        self.send_task = Some(cx.spawn(async move |this, cx| {
+        // `action_task`, NOT `send_task`: a Stop pressed while a send is in
+        // flight must not drop the send future on the floor.
+        self.action_task = Some(cx.spawn(async move |this, cx| {
             let result = engine.client().call(methods::QUEUE_COMMAND, params).await;
             if let Err(err) = result {
                 this.update(cx, |composer, cx| {
                     composer.failure = Some(format!("Stop failed: {err}").into());
+                    composer.failure_key = Some(failure_chat);
                     cx.notify();
                 })
                 .ok();
@@ -4929,15 +5063,18 @@ impl Composer {
             request_id: request_id.clone(),
             answers,
         };
+        let failure_chat = chat_id.clone();
         let params = match serde_json::to_value(&command) {
             Ok(value) => serde_json::json!({ "chatId": chat_id, "command": value }),
             Err(_) => return,
         };
-        self.send_task = Some(cx.spawn(async move |this, cx| {
+        // `action_task`, NOT `send_task` — see `interrupt`.
+        self.action_task = Some(cx.spawn(async move |this, cx| {
             let result = engine.client().call(methods::QUEUE_COMMAND, params).await;
             if let Err(err) = result {
                 this.update(cx, |composer, cx| {
                     composer.failure = Some(format!("Answer failed: {err}").into());
+                    composer.failure_key = Some(failure_chat);
                     // The answer never left this device — put the panel back.
                     composer.answered_requests.remove(&request_id);
                     cx.notify();
@@ -5378,7 +5515,13 @@ impl Render for Composer {
         );
         let expanded = self.expanded_mode;
 
-        let failure = self.failure.clone();
+        // Chat-scoped failures render only under their own chat; a global
+        // failure (no key) renders everywhere.
+        let failure = self.failure.clone().filter(|_| {
+            self.failure_key
+                .as_ref()
+                .is_none_or(|key| *key == self.current_key)
+        });
         // Centered composer column (zeron `mx-auto w-full max-w-3xl`).
         let container = div()
             .w_full()
@@ -5434,6 +5577,7 @@ impl Render for Composer {
                         .cursor_pointer()
                         .on_click(cx.listener(|this, _, _, cx| {
                             this.failure = None;
+                            this.failure_key = None;
                             cx.notify();
                         }))
                         .child(

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -5532,9 +5532,9 @@ impl Render for Composer {
                 Some(id) => state.chat_delivery_degraded(id),
                 None => {
                     // New-chat canvas: judge by the picked target device.
-                    let remote_target = state.effective_device_id().is_some_and(|id| {
-                        state.local_device_id.as_deref() != Some(id.as_str())
-                    });
+                    let remote_target = state
+                        .effective_device_id()
+                        .is_some_and(|id| state.local_device_id.as_deref() != Some(id.as_str()));
                     remote_target
                         && (matches!(state.connectivity.state, S::Offline | S::Reconnecting)
                             || state

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -5522,6 +5522,34 @@ impl Render for Composer {
                 .as_ref()
                 .is_none_or(|key| *key == self.current_key)
         });
+        // Composer honesty: when the target's delivery path is degraded, say
+        // UP FRONT that a send will queue (a durable local write delivered on
+        // reconnect) instead of letting the button imply instant delivery.
+        let queue_notice: Option<SharedString> = {
+            use zeron_proto::ConnectivityState as S;
+            let state = self.state.read(cx);
+            let degraded = match state.selected_chat.as_deref() {
+                Some(id) => state.chat_delivery_degraded(id),
+                None => {
+                    // New-chat canvas: judge by the picked target device.
+                    let remote_target = state.effective_device_id().is_some_and(|id| {
+                        state.local_device_id.as_deref() != Some(id.as_str())
+                    });
+                    remote_target
+                        && (matches!(state.connectivity.state, S::Offline | S::Reconnecting)
+                            || state
+                                .effective_device_id()
+                                .is_some_and(|id| !state.device_online(&id, chrono::Utc::now())))
+                }
+            };
+            degraded.then(|| {
+                if state.connectivity.state == S::Offline {
+                    "Offline — messages will queue and send automatically.".into()
+                } else {
+                    "Connection degraded — messages will queue and send automatically.".into()
+                }
+            })
+        };
         // Centered composer column (zeron `mx-auto w-full max-w-3xl`).
         let container = div()
             .w_full()
@@ -5587,6 +5615,31 @@ impl Render for Composer {
                                 .text_color(text_c),
                         )
                         .child(div().min_w_0().child(message)),
+                )
+            })
+            .when_some(queue_notice, |el, notice| {
+                // Same Notice shape as above, amber, not dismissable — it
+                // clears itself the moment the path heals.
+                let amber = theme.warning;
+                let amber_200 = theme.warning_muted;
+                el.child(
+                    div()
+                        .id("composer-queue-notice")
+                        .mx(px(4.0))
+                        .mt(px(6.0))
+                        .flex()
+                        .items_start()
+                        .gap(px(8.0))
+                        .rounded(px(12.0))
+                        .border_1()
+                        .border_color(amber.opacity(0.16))
+                        .bg(amber.opacity(0.05))
+                        .px(px(12.0))
+                        .py(px(8.0))
+                        .text_size(px(12.0))
+                        .line_height(px(16.0))
+                        .text_color(amber_200.opacity(0.9))
+                        .child(div().min_w_0().child(notice)),
                 )
             });
 

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -1671,7 +1671,13 @@ impl Shell {
                 title,
                 frozen,
             } => {
-                self.add_subagent_surface(chat_id.clone(), doc_id.clone(), title.clone(), *frozen, cx);
+                self.add_subagent_surface(
+                    chat_id.clone(),
+                    doc_id.clone(),
+                    title.clone(),
+                    *frozen,
+                    cx,
+                );
             }
         }
     }
@@ -3625,14 +3631,15 @@ impl Shell {
                     .when(
                         status == zeron_proto::ChatIndicator::Working && !queued && !undelivered,
                         |el| {
-                        el.child(div().flex_1())
-                            .child(loaders::mini_gradient_spinner(
-                                format!("chat-working-{id}"),
-                                2.0,
-                                cx.entity_id(),
-                                cx,
-                            ))
-                    }),
+                            el.child(div().flex_1())
+                                .child(loaders::mini_gradient_spinner(
+                                    format!("chat-working-{id}"),
+                                    2.0,
+                                    cx.entity_id(),
+                                    cx,
+                                ))
+                        },
+                    ),
             )
             .into_any_element()
     }
@@ -5104,12 +5111,7 @@ impl Shell {
                 .right(px(10.0))
                 .flex()
                 .justify_center()
-                .child(self.jump_pill(
-                    "jump-to-bottom",
-                    "jump-pill",
-                    self.transcript.clone(),
-                    cx,
-                ))
+                .child(self.jump_pill("jump-to-bottom", "jump-pill", self.transcript.clone(), cx))
                 .into_any_element(),
         )
     }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3347,15 +3347,28 @@ impl Shell {
         // ARCHIVE button (UNARCHIVE on rows in the sidebar's archived
         // accordion), t3code's settle-on-hover.
         let corner_hovered = self.chat_status_hover.as_deref() == Some(id.as_str());
-        // A send whose delivery path is degraded is QUEUED, not Working —
-        // the pending pill tells the truth instead of faking a spinner.
-        let queued = self.state.read(cx).send_queued(&id, Utc::now());
-        let status_color = if queued {
+        // Send-truth overrides: a send unadopted past the grace window is
+        // FAILED (explicit, with the transcript's retry affordance); a send
+        // whose delivery path is degraded is QUEUED, not Working — the
+        // pending pill tells the truth instead of faking a spinner.
+        let (queued, undelivered) = {
+            let now = Utc::now();
+            let state = self.state.read(cx);
+            (
+                state.send_queued(&id, now),
+                state.send_undelivered(&id, now),
+            )
+        };
+        let status_color = if undelivered {
+            theme.danger
+        } else if queued {
             theme.warning
         } else {
             spaces::status_dot_color(status, theme)
         };
-        let status_label: Option<&'static str> = if queued {
+        let status_label: Option<&'static str> = if undelivered {
+            Some("Failed")
+        } else if queued {
             Some("Queued")
         } else {
             match status {
@@ -3366,6 +3379,7 @@ impl Shell {
                 zeron_proto::ChatIndicator::Idle => None,
             }
         };
+        let queued = queued && !undelivered;
         let corner_body: AnyElement = if corner_hovered {
             div()
                 .flex()
@@ -3607,8 +3621,10 @@ impl Shell {
                     })
                     // Working rows animate the spinner at the row's
                     // bottom-right (the status word keeps its dot up top).
-                    // Queued rows don't: a spinner would fake progress.
-                    .when(status == zeron_proto::ChatIndicator::Working && !queued, |el| {
+                    // Queued/Failed rows don't: a spinner would fake progress.
+                    .when(
+                        status == zeron_proto::ChatIndicator::Working && !queued && !undelivered,
+                        |el| {
                         el.child(div().flex_1())
                             .child(loaders::mini_gradient_spinner(
                                 format!("chat-working-{id}"),

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -1005,6 +1005,13 @@ impl Shell {
                         s.selected_chat
                             .as_deref()
                             .is_some_and(|id| s.indicator_for(id, Utc::now()) != Indicator::None)
+                            // The connection pill's retry countdown needs the
+                            // same per-second refresh while degraded.
+                            || matches!(
+                                s.connectivity.state,
+                                zeron_proto::ConnectivityState::Offline
+                                    | zeron_proto::ConnectivityState::Reconnecting
+                            )
                     };
                     if live {
                         cx.notify();
@@ -3340,13 +3347,24 @@ impl Shell {
         // ARCHIVE button (UNARCHIVE on rows in the sidebar's archived
         // accordion), t3code's settle-on-hover.
         let corner_hovered = self.chat_status_hover.as_deref() == Some(id.as_str());
-        let status_color = spaces::status_dot_color(status, theme);
-        let status_label: Option<&'static str> = match status {
-            zeron_proto::ChatIndicator::Working => Some("Working"),
-            zeron_proto::ChatIndicator::AwaitingInput => Some("Input"),
-            zeron_proto::ChatIndicator::Errored => Some("Failed"),
-            zeron_proto::ChatIndicator::Completed => Some("Done"),
-            zeron_proto::ChatIndicator::Idle => None,
+        // A send whose delivery path is degraded is QUEUED, not Working —
+        // the pending pill tells the truth instead of faking a spinner.
+        let queued = self.state.read(cx).send_queued(&id, Utc::now());
+        let status_color = if queued {
+            theme.warning
+        } else {
+            spaces::status_dot_color(status, theme)
+        };
+        let status_label: Option<&'static str> = if queued {
+            Some("Queued")
+        } else {
+            match status {
+                zeron_proto::ChatIndicator::Working => Some("Working"),
+                zeron_proto::ChatIndicator::AwaitingInput => Some("Input"),
+                zeron_proto::ChatIndicator::Errored => Some("Failed"),
+                zeron_proto::ChatIndicator::Completed => Some("Done"),
+                zeron_proto::ChatIndicator::Idle => None,
+            }
         };
         let corner_body: AnyElement = if corner_hovered {
             div()
@@ -3589,7 +3607,8 @@ impl Shell {
                     })
                     // Working rows animate the spinner at the row's
                     // bottom-right (the status word keeps its dot up top).
-                    .when(status == zeron_proto::ChatIndicator::Working, |el| {
+                    // Queued rows don't: a spinner would fake progress.
+                    .when(status == zeron_proto::ChatIndicator::Working && !queued, |el| {
                         el.child(div().flex_1())
                             .child(loaders::mini_gradient_spinner(
                                 format!("chat-working-{id}"),
@@ -3605,6 +3624,70 @@ impl Shell {
     /// Chat-mode sidebar (spaces overhaul): window-control strip, the Spaces
     /// section (folder + device rows, add-space), the global Active sessions
     /// list, the notice strip, and the UserMenu (§1.6).
+    /// The global connection pill. `None` while healthy (`Connected`) or on
+    /// local profiles (`Disabled`). Degraded states render an amber strip:
+    /// Offline (OS says no path) or Reconnecting with a live retry countdown,
+    /// keeping the last failure visible through the next attempt — the pill
+    /// never flickers back to a bare "connecting…" mid-outage.
+    fn render_connection_pill(&self, theme: &Theme, cx: &Context<Self>) -> Option<AnyElement> {
+        use zeron_proto::ConnectivityState as S;
+        let conn = self.state.read(cx).connectivity.clone();
+        let (label, detail): (SharedString, Option<SharedString>) = match conn.state {
+            S::Disabled | S::Connected => return None,
+            S::Offline => (
+                "Offline — sends will queue".into(),
+                conn.last_failure.clone().map(SharedString::from),
+            ),
+            S::Reconnecting => {
+                let now_ms = Utc::now().timestamp_millis();
+                let label: SharedString = if conn.retry_at_ms > now_ms {
+                    let secs = (conn.retry_at_ms - now_ms + 999) / 1000;
+                    format!("Reconnecting — retrying in {secs}s").into()
+                } else {
+                    "Reconnecting…".into()
+                };
+                (label, conn.last_failure.clone().map(SharedString::from))
+            }
+        };
+        Some(
+            div()
+                .id("connection-pill")
+                .mx(px(Theme::SPACE_SM))
+                .mb(px(Theme::SPACE_SM))
+                .px(px(Theme::SPACE_SM))
+                .py(px(4.0))
+                .rounded(px(Theme::CONTROL_RADIUS))
+                .border_1()
+                .border_color(theme.warning)
+                .flex()
+                .items_center()
+                .gap(px(6.0))
+                .child(div().size(px(6.0)).rounded_full().bg(theme.warning))
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .min_w_0()
+                        .child(
+                            div()
+                                .text_size(px(11.0))
+                                .text_color(theme.warning)
+                                .child(label),
+                        )
+                        .when_some(detail, |el, detail| {
+                            el.child(
+                                div()
+                                    .text_size(px(10.0))
+                                    .text_color(theme.text_faint)
+                                    .truncate()
+                                    .child(detail),
+                            )
+                        }),
+                )
+                .into_any_element(),
+        )
+    }
+
     fn render_chat_sidebar(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
         let (user, workspace_scope) = {
             let state = self.state.read(cx);
@@ -3762,6 +3845,12 @@ impl Shell {
                 )
                 .fade_overflow_y(&self.sidebar_scroll),
             )
+            // Global connection pill (durable-by-design UI truth): appears
+            // whenever the edge posture is degraded; hidden while healthy —
+            // appearing IS the signal.
+            .when_some(self.render_connection_pill(theme, cx), |el, pill| {
+                el.child(pill)
+            })
             // Update strip (above the user menu; below the lists).
             .when_some(self.render_update_strip(theme, cx), |el, strip| {
                 el.child(strip)

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -773,6 +773,19 @@ impl AppState {
         self.devices = devices;
     }
 
+    /// True when `device_id`'s engine (per its registry device row) is at
+    /// least `min`. Unknown devices and unstamped versions are conservatively
+    /// false — feature gates fall back to the legacy path rather than speak a
+    /// protocol the peer may not understand.
+    pub fn device_version_at_least(&self, device_id: &str, min: (u64, u64, u64)) -> bool {
+        self.devices
+            .iter()
+            .find(|d| d.id == device_id)
+            .and_then(|d| d.version.as_deref())
+            .and_then(version_triple)
+            .is_some_and(|v| v >= min)
+    }
+
     /// First project on the composer's picked device (falling back through
     /// the local device, then any project at all — better a cross-device
     /// project than a surprise project-less canvas). Display order.
@@ -1433,6 +1446,23 @@ fn spawn_chats_watch(cx: &mut Context<AppState>, handle: EngineHandle) -> Task<(
             cx.background_executor().timer(RETRY_DELAY).await;
         }
     })
+}
+
+/// Parse "0.2.12" (tolerating a `-suffix`/`+build` tail on the last part)
+/// into a comparable triple. `None` for anything that doesn't lead with
+/// three dotted integers.
+pub fn version_triple(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.trim().splitn(3, '.');
+    let major: u64 = parts.next()?.parse().ok()?;
+    let minor: u64 = parts.next()?.parse().ok()?;
+    let patch = parts.next()?;
+    let patch: u64 = patch
+        .split(['-', '+'])
+        .next()
+        .unwrap_or(patch)
+        .parse()
+        .ok()?;
+    Some((major, minor, patch))
 }
 
 fn spawn_watch<T: DeserializeOwned + 'static>(

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -556,11 +556,12 @@ struct PendingSend {
     started: DateTime<Utc>,
 }
 
-/// How long the send-in-flight overlay may hold before the synced status
-/// shows through again. Covers the queue → nudge → drain → sync round-trip
-/// to a remote host; when the host is offline the dot falls back to the
-/// truth after this.
-pub const PENDING_SEND_TTL_MS: i64 = 30_000;
+/// How long an unadopted send reads as Working/Sending (or Queued when the
+/// path is degraded) before flipping to the EXPLICIT failed state with a
+/// retry affordance. The old 30s overlay silently expired back to Idle with
+/// no visible trace of the send at all — the exact hole the 2026-08-19
+/// incident fell into.
+pub const UNDELIVERED_GRACE_MS: i64 = 120_000;
 
 /// Root application state. Reducer methods (`apply_*`, [`Self::session_for`], …)
 /// are plain `&mut self` functions so tests construct the struct directly; gpui
@@ -982,16 +983,33 @@ impl AppState {
         }
     }
 
-    /// Is a send still in flight for this chat (unacked)? Inside the TTL
-    /// normally; while the chat's delivery path is degraded the overlay
-    /// holds — the truth IS "Queued", and silently expiring back to Idle
-    /// left a queued send with no visible trace at all (the 30s→silence
-    /// hole, 2026-08-19).
+    /// Is a send still in flight for this chat (unacked)? Inside the grace
+    /// window normally; while the chat's delivery path is degraded the
+    /// overlay holds indefinitely — the truth IS "Queued", and silently
+    /// expiring back to Idle left a queued send with no visible trace at
+    /// all (the 30s→silence hole, 2026-08-19).
     pub fn send_pending(&self, chat_id: &str, now: DateTime<Utc>) -> bool {
         self.pending_sends.get(chat_id).is_some_and(|p| {
-            now.signed_duration_since(p.started).num_milliseconds() <= PENDING_SEND_TTL_MS
+            now.signed_duration_since(p.started).num_milliseconds() <= UNDELIVERED_GRACE_MS
                 || self.chat_delivery_degraded(chat_id)
         })
+    }
+
+    /// The send has sat unadopted past the grace window: surface the
+    /// EXPLICIT failed state ("Not delivered — retry") instead of either
+    /// faking progress or silently forgetting the send ever happened.
+    pub fn send_undelivered(&self, chat_id: &str, now: DateTime<Utc>) -> bool {
+        self.pending_sends.get(chat_id).is_some_and(|p| {
+            now.signed_duration_since(p.started).num_milliseconds() > UNDELIVERED_GRACE_MS
+        })
+    }
+
+    /// Retry pressed: restart the grace clock so the overlay returns to its
+    /// Sending/Queued phase while the re-kicked delivery runs.
+    pub fn retry_pending_send(&mut self, chat_id: &str, now: DateTime<Utc>) {
+        if let Some(p) = self.pending_sends.get_mut(chat_id) {
+            p.started = now;
+        }
     }
 
     /// When the in-flight send (if any, inside the TTL) was fired — the
@@ -1003,7 +1021,7 @@ impl AppState {
         self.pending_sends
             .get(chat_id)
             .filter(|p| {
-                now.signed_duration_since(p.started).num_milliseconds() <= PENDING_SEND_TTL_MS
+                now.signed_duration_since(p.started).num_milliseconds() <= UNDELIVERED_GRACE_MS
                     || self.chat_delivery_degraded(chat_id)
             })
             .map(|p| p.started)
@@ -2347,7 +2365,7 @@ mod tests {
     }
 
     #[test]
-    fn send_pending_overlays_working_until_ttl() {
+    fn send_pending_overlays_working_until_the_grace_window() {
         let now = Utc::now();
         let s_chat = chat("c", 0, Some(10)); // unseen, no session row
         let mut s = AppState::new();
@@ -2356,13 +2374,16 @@ mod tests {
         s.begin_pending_send("c", "m1", now);
         assert_eq!(s.display_status_for(&s_chat, now), ChatIndicator::Working);
         assert_eq!(s.indicator_for("c", now), Indicator::Working);
-        // Time-bounded: an offline host must not leave an eternal spinner.
-        let later = now + TimeDelta::milliseconds(PENDING_SEND_TTL_MS + 1);
+        // Time-bounded: an offline host must not leave an eternal spinner —
+        // past the grace the overlay yields (and `send_undelivered` takes
+        // over with the explicit failed state).
+        let later = now + TimeDelta::milliseconds(UNDELIVERED_GRACE_MS + 1);
         assert_eq!(
             s.display_status_for(&s_chat, later),
             ChatIndicator::Completed
         );
         assert_eq!(s.indicator_for("c", later), Indicator::None);
+        assert!(s.send_undelivered("c", later));
     }
 
     #[test]
@@ -2995,15 +3016,25 @@ mod tests {
         assert!(!s.chat_delivery_degraded("c-remote"));
 
         // Queued = pending send + degraded path — and degradation HOLDS the
-        // overlay past the 30s TTL instead of silently expiring (the
+        // overlay past the grace window instead of silently expiring (the
         // no-trace hole).
         s.connectivity.state = ConnectivityState::Offline;
-        s.begin_pending_send("c-remote", "m1", now - TimeDelta::seconds(60));
+        s.begin_pending_send("c-remote", "m1", now - TimeDelta::seconds(200));
         assert!(s.send_pending("c-remote", now));
         assert!(s.send_queued("c-remote", now));
-        // Path healed: the TTL applies again and the stale overlay expires.
+        // Past the grace: the explicit failed state surfaces alongside.
+        assert!(s.send_undelivered("c-remote", now));
+        // Retry restarts the clock: back to Queued, no longer failed.
+        s.retry_pending_send("c-remote", now);
+        assert!(!s.send_undelivered("c-remote", now));
+        assert!(s.send_queued("c-remote", now));
+        // Path healed with a stale unacked send: the overlay expires after
+        // the grace rather than holding forever.
+        s.retry_pending_send("c-remote", now - TimeDelta::seconds(200));
         s.connectivity.state = ConnectivityState::Connected;
         assert!(!s.send_pending("c-remote", now));
         assert!(!s.send_queued("c-remote", now));
+        // …but the explicit undelivered flag still tells the truth.
+        assert!(s.send_undelivered("c-remote", now));
     }
 }

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -573,6 +573,9 @@ pub struct AppState {
     /// Auth stream value; `None` until the engine reports one (M4).
     pub auth: Option<AuthState>,
     pub devices: Vec<Device>,
+    /// Live edge posture (WatchConnectivity): drives the connection pill,
+    /// composer honesty ("will queue"), and the Queued send badges.
+    pub connectivity: zeron_proto::Connectivity,
     /// Sorted (see [`sort_spaces`]).
     pub spaces: Vec<Space>,
     /// Sorted (see [`sort_chats`]); includes archived rows — views filter.
@@ -644,6 +647,7 @@ impl AppState {
             workspace_scope: None,
             auth: None,
             devices: Vec::new(),
+            connectivity: zeron_proto::Connectivity::default(),
             spaces: Vec::new(),
             chats: Vec::new(),
             sessions: Vec::new(),
@@ -757,6 +761,49 @@ impl AppState {
         if let Some(chat) = self.chats.iter_mut().find(|c| c.id == chat_id) {
             chat.config = Some(config);
         }
+    }
+
+    pub fn apply_connectivity(&mut self, connectivity: zeron_proto::Connectivity) {
+        self.connectivity = connectivity;
+    }
+
+    /// Is this chat's delivery path degraded — will a send QUEUE rather than
+    /// reach its executor promptly? Locally-hosted chats are never degraded
+    /// (a queued command executes on this device even fully offline). Remote
+    /// chats degrade when the OS says offline, when the chat's own edge room
+    /// is down, or when the host device has gone presence-dark.
+    pub fn chat_delivery_degraded(&self, chat_id: &str) -> bool {
+        use zeron_proto::ConnectivityState as S;
+        if self.connectivity.state == S::Disabled {
+            return false;
+        }
+        let Some(chat) = self.chats.iter().find(|c| c.id == chat_id) else {
+            // Unknown chat (a just-minted canvas send): only the global
+            // state can speak.
+            return self.connectivity.state == S::Offline;
+        };
+        if Some(chat.device_id.as_str()) == self.local_device_id.as_deref() {
+            return false;
+        }
+        if self.connectivity.state == S::Offline {
+            return true;
+        }
+        let room_down = match self
+            .connectivity
+            .chats
+            .iter()
+            .find(|c| c.chat_id == chat_id)
+        {
+            Some(net) => !net.connected,
+            None => self.connectivity.state != S::Connected,
+        };
+        room_down || !self.device_online(&chat.device_id, Utc::now())
+    }
+
+    /// A send is queued: in flight AND its delivery path is degraded — the
+    /// honest badge is "Queued", not a Working spinner.
+    pub fn send_queued(&self, chat_id: &str, now: DateTime<Utc>) -> bool {
+        self.send_pending(chat_id, now) && self.chat_delivery_degraded(chat_id)
     }
 
     pub fn apply_devices(&mut self, mut devices: Vec<Device>) {
@@ -935,10 +982,15 @@ impl AppState {
         }
     }
 
-    /// Is a send still in flight for this chat (unacked, inside the TTL)?
+    /// Is a send still in flight for this chat (unacked)? Inside the TTL
+    /// normally; while the chat's delivery path is degraded the overlay
+    /// holds — the truth IS "Queued", and silently expiring back to Idle
+    /// left a queued send with no visible trace at all (the 30s→silence
+    /// hole, 2026-08-19).
     pub fn send_pending(&self, chat_id: &str, now: DateTime<Utc>) -> bool {
         self.pending_sends.get(chat_id).is_some_and(|p| {
             now.signed_duration_since(p.started).num_milliseconds() <= PENDING_SEND_TTL_MS
+                || self.chat_delivery_degraded(chat_id)
         })
     }
 
@@ -952,6 +1004,7 @@ impl AppState {
             .get(chat_id)
             .filter(|p| {
                 now.signed_duration_since(p.started).num_milliseconds() <= PENDING_SEND_TTL_MS
+                    || self.chat_delivery_degraded(chat_id)
             })
             .map(|p| p.started)
     }
@@ -1234,6 +1287,12 @@ impl AppState {
                 handle.clone(),
                 methods::WATCH_DEVICES,
                 AppState::apply_devices,
+            ),
+            spawn_watch(
+                cx,
+                handle.clone(),
+                methods::WATCH_CONNECTIVITY,
+                AppState::apply_connectivity,
             ),
             spawn_watch(
                 cx,
@@ -2868,5 +2927,98 @@ mod tests {
             1
         );
         assert!(parse_orgs(&serde_json::json!("nope")).is_empty());
+    }
+
+    #[test]
+    fn version_triple_parses_and_gates_device_features() {
+        assert_eq!(version_triple("0.2.12"), Some((0, 2, 12)));
+        assert_eq!(version_triple("0.2.12-beta.1"), Some((0, 2, 12)));
+        assert_eq!(version_triple("1.0.0+build7"), Some((1, 0, 0)));
+        assert_eq!(version_triple("0.2"), None);
+        assert_eq!(version_triple("garbage"), None);
+
+        let mut s = AppState::default();
+        assert!(
+            !s.device_version_at_least("d1", (0, 2, 12)),
+            "unknown device conservatively fails the gate"
+        );
+        s.devices = vec![Device {
+            id: "d1".into(),
+            name: "laptop".into(),
+            platform: "macos".into(),
+            last_seen_at: None,
+            created_at: None,
+            version: Some("0.2.12".into()),
+        }];
+        assert!(s.device_version_at_least("d1", (0, 2, 12)));
+        assert!(!s.device_version_at_least("d1", (0, 2, 13)));
+        s.devices[0].version = None;
+        assert!(
+            !s.device_version_at_least("d1", (0, 2, 12)),
+            "unstamped version conservatively fails the gate"
+        );
+    }
+
+    #[test]
+    fn delivery_degradation_and_queued_sends_tell_the_truth() {
+        use zeron_proto::{ChatConnectivity, ConnectivityState};
+        let now = Utc::now();
+        let mut s = AppState::default();
+        s.local_device_id = Some("local".into());
+        let mut remote = chat("c-remote", 0, None);
+        remote.device_id = "remote".into();
+        let mut local = chat("c-local", 0, None);
+        local.device_id = "local".into();
+        s.chats = vec![remote, local];
+        s.devices = vec![Device {
+            id: "remote".into(),
+            name: "vps".into(),
+            platform: "linux".into(),
+            last_seen_at: Some(now),
+            created_at: None,
+            version: None,
+        }];
+        s.connectivity.state = ConnectivityState::Connected;
+        s.connectivity.chats = vec![ChatConnectivity {
+            chat_id: "c-remote".into(),
+            connected: true,
+            pending_pushes: 0,
+        }];
+
+        // Healthy: nothing degraded.
+        assert!(!s.chat_delivery_degraded("c-remote"));
+        assert!(!s.chat_delivery_degraded("c-local"));
+
+        // The chat's own room down → degraded even while globally Connected.
+        s.connectivity.chats[0].connected = false;
+        assert!(s.chat_delivery_degraded("c-remote"));
+        s.connectivity.chats[0].connected = true;
+
+        // Host gone presence-dark → degraded (a send would queue at best).
+        s.devices[0].last_seen_at = Some(now - TimeDelta::minutes(10));
+        assert!(s.chat_delivery_degraded("c-remote"));
+        s.devices[0].last_seen_at = Some(now);
+
+        // OS offline: remote degrades; a locally-hosted chat NEVER does (the
+        // queued command executes on this device even fully offline).
+        s.connectivity.state = ConnectivityState::Offline;
+        assert!(s.chat_delivery_degraded("c-remote"));
+        assert!(!s.chat_delivery_degraded("c-local"));
+
+        // Local profile (Disabled): nothing degrades.
+        s.connectivity.state = ConnectivityState::Disabled;
+        assert!(!s.chat_delivery_degraded("c-remote"));
+
+        // Queued = pending send + degraded path — and degradation HOLDS the
+        // overlay past the 30s TTL instead of silently expiring (the
+        // no-trace hole).
+        s.connectivity.state = ConnectivityState::Offline;
+        s.begin_pending_send("c-remote", "m1", now - TimeDelta::seconds(60));
+        assert!(s.send_pending("c-remote", now));
+        assert!(s.send_queued("c-remote", now));
+        // Path healed: the TTL applies again and the stale overlay expires.
+        s.connectivity.state = ConnectivityState::Connected;
+        assert!(!s.send_pending("c-remote", now));
+        assert!(!s.send_queued("c-remote", now));
     }
 }

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -1507,22 +1507,7 @@ fn spawn_chats_watch(cx: &mut Context<AppState>, handle: EngineHandle) -> Task<(
     })
 }
 
-/// Parse "0.2.12" (tolerating a `-suffix`/`+build` tail on the last part)
-/// into a comparable triple. `None` for anything that doesn't lead with
-/// three dotted integers.
-pub fn version_triple(version: &str) -> Option<(u64, u64, u64)> {
-    let mut parts = version.trim().splitn(3, '.');
-    let major: u64 = parts.next()?.parse().ok()?;
-    let minor: u64 = parts.next()?.parse().ok()?;
-    let patch = parts.next()?;
-    let patch: u64 = patch
-        .split(['-', '+'])
-        .next()
-        .unwrap_or(patch)
-        .parse()
-        .ok()?;
-    Some((major, minor, patch))
-}
+pub use zeron_proto::version_triple;
 
 fn spawn_watch<T: DeserializeOwned + 'static>(
     cx: &mut Context<AppState>,

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -4162,15 +4162,17 @@ fn chip_header_row(
             // The sidebar working-row spinner, in the chip's trailing slot —
             // paint-local (fixed footprint), so it never moves the layout.
             row.child(
-                div().flex_none().child(crate::loaders::mini_gradient_spinner(
-                    format!(
-                        "subagent-chip-{}",
-                        tool.subagent_ref.as_deref().unwrap_or_default()
-                    ),
-                    2.0,
-                    view,
-                    cx,
-                )),
+                div()
+                    .flex_none()
+                    .child(crate::loaders::mini_gradient_spinner(
+                        format!(
+                            "subagent-chip-{}",
+                            tool.subagent_ref.as_deref().unwrap_or_default()
+                        ),
+                        2.0,
+                        view,
+                        cx,
+                    )),
             )
         })
         .when_some(chevron, |row, open| {

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2812,6 +2812,34 @@ impl Transcript {
     /// — user request), so it reads as part of the streaming reply and
     /// scrolls away with it. The spinner drives this entity's frames, which
     /// keeps the elapsed timer ticking through delta-quiet tool runs.
+    /// The failed-send retry (trailer affordance): re-kick every delivery
+    /// road engine-side (fresh chat2 socket, host nudge, delivery escorts)
+    /// and restart the grace clock so the trailer returns to Sending/Queued
+    /// while the retry runs.
+    fn retry_send(&mut self, cx: &mut Context<Self>) {
+        let Some(chat_id) = self.chat_id.clone() else {
+            return;
+        };
+        let engine = self.state.read(cx).engine().cloned();
+        self.state.update(cx, |s, cx| {
+            s.retry_pending_send(&chat_id, chrono::Utc::now());
+            cx.notify();
+        });
+        if let Some(engine) = engine {
+            cx.spawn(async move |_, _| {
+                let params = serde_json::json!({ "chatId": chat_id });
+                if let Err(err) = engine
+                    .client()
+                    .call(zeron_rpc::methods::RETRY_DELIVERY, params)
+                    .await
+                {
+                    tracing::warn!(error = %err, "delivery retry RPC failed");
+                }
+            })
+            .detach();
+        }
+    }
+
     fn render_working_trailer(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
         // A subagent doc has no Session row — `indicator_for` would read the
         // PARENT chat's live state into a frozen tab.
@@ -2820,6 +2848,26 @@ impl Transcript {
         }
         let chat_id = self.chat_id.clone()?;
         let now = chrono::Utc::now();
+        // Failed-send state first: past the grace window the trailer IS the
+        // retry affordance, whatever the indicator fell back to.
+        if self.state.read(cx).send_undelivered(&chat_id, now) {
+            let theme = Theme::of(cx).clone();
+            return Some(
+                div()
+                    .id("undelivered-retry")
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap(px(Theme::SPACE_SM))
+                    .pt(px(10.0))
+                    .text_size(px(12.0))
+                    .text_color(theme.danger)
+                    .cursor_pointer()
+                    .on_click(cx.listener(|this, _, _, cx| this.retry_send(cx)))
+                    .child(SharedString::from("Not delivered — click to retry"))
+                    .into_any_element(),
+            );
+        }
         let (sending, queued, elapsed_secs) = {
             let state = self.state.read(cx);
             if state.indicator_for(&chat_id, now) != crate::state::Indicator::Working {

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2820,7 +2820,7 @@ impl Transcript {
         }
         let chat_id = self.chat_id.clone()?;
         let now = chrono::Utc::now();
-        let (sending, elapsed_secs) = {
+        let (sending, queued, elapsed_secs) = {
             let state = self.state.read(cx);
             if state.indicator_for(&chat_id, now) != crate::state::Indicator::Working {
                 return None;
@@ -2832,12 +2832,17 @@ impl Transcript {
             // timer instead; the word + timer start with the turn.
             let turn_started = state.session_for(&chat_id).and_then(|s| s.started_at);
             let sending = sending_bridge(state.pending_send_started(&chat_id, now), turn_started);
+            // Degraded delivery path: the send is a durable local write
+            // waiting on connectivity — say so instead of faking progress.
+            let queued = sending && state.chat_delivery_degraded(&chat_id);
             let elapsed = turn_started
                 .map(|t| now.signed_duration_since(t).num_seconds().max(0))
                 .unwrap_or(0);
-            (sending, elapsed)
+            (sending, queued, elapsed)
         };
-        let word = if sending {
+        let word = if queued {
+            "Queued — will send automatically"
+        } else if sending {
             "Sending"
         } else {
             flavour_word(flavour_seed(&chat_id), elapsed_secs)
@@ -2861,8 +2866,16 @@ impl Transcript {
                 .child(
                     div()
                         .text_size(px(12.0))
-                        .text_color(theme.text_muted)
-                        .child(SharedString::from(format!("{word}…"))),
+                        .text_color(if queued {
+                            theme.warning
+                        } else {
+                            theme.text_muted
+                        })
+                        .child(SharedString::from(if queued {
+                            word.to_string()
+                        } else {
+                            format!("{word}…")
+                        })),
                 )
                 .when(!sending, |el| {
                     el.child(


### PR DESCRIPTION
Implements the full durable-by-design plan — a send is a local write that always either delivers exactly once or visibly says why not, and recovery is event-driven, never timer luck — plus the three priority asks from the Aug 19 zombie-peer-link incident.

## Phase 2 — event-driven recovery (`ed8cd60`)
- Online-bus subscriptions for the previously wake-only supervisors (registry/chat2 initial joins, LinkCache cooldowns, auth refresh retry) — a room stuck in its FIRST join now un-parks on any sibling dial success.
- macOS `NWPathMonitor` (`crates/sync/src/net_path.rs`) → `wake::set_path_online`: offline→online broadcasts the online event; while offline, backoff waits park on the event buses (30s safety recheck) instead of burning dials.
- Window-focus fast path: `ProbeSync` also probes `{edge}/health` (3s); success fires the online event so a focus lands a redial in ~1 RTT, while a failed probe leaves backoffs parked.
- Stability-gated backoff reset (a join must survive 30s — reset-on-join let connect-and-die sockets hot-loop at 250ms forever); caps 30s→16s; device-room silence lease 40s→25s with 10s pings.
- Reconnect posture is observable: `retry_at_ms` + sticky `last_failure` + numbered dial attempts in logs.

## Incident asks (Aug 19, done first)
**Attachments ride the durable queue (`8f3bce8`)** — staging was a blocking pre-step in front of QueueCommand, so a send with an image died with the dead link. Now: bytes commit to the LOCAL uploads dir, the command queues immediately with `pending://{uploadId}/{name}` refs, and the engine pushes bytes to the host afterwards (retry-forever on the online bus; chunk/commit timeouts invalidate the link). The host drain defers a command whose refs aren't on disk — BEFORE the processed mark — and `UploadCommit` kicks drains; at dispatch the refs rewrite to absolute paths so the persisted transcript keeps the legacy shape. Version-gated on both the local engine and the host (>= 0.2.12); old peers keep the legacy upload, now bounded by a 300s total budget. Also fixes the incident's silent-wedge mechanics: interrupt/answer get their own task slot (assigning `send_task` dropped an in-flight send with no banner and a permanently stuck "Sending…"), failure banners are chat-scoped and survive navigation, chunk retries log at warn, MUTATE/QUEUE_COMMAND are deadline-bounded.

**Peer-link end-to-end liveness (`449a1db`)** — the transport lease counts the DO's auto-pong, which answers from the EDGE, so a healthy client↔edge leg masked a dead edge↔host leg for 6 minutes. The client now rides an `echo` frame on every keepalive and the HOST echoes it back; 20s of echo silence = zombie path → drop and redial. Feature-detected (old hosts keep transport-lease behavior; inbound RPC frames count as proof too), no edge changes (the DO relays kinds untouched). `DeviceLink::connect` bounded at 15s — the one unbounded await under `forward()`.

**Registry-dark dial parking (`449a1db`)** — `LinkCacheConfig.liveness`: a `Dark` verdict fails peer calls fast with ZERO dials (was: 3-dial bursts every ~60s to a device offline for days). Dark requires positive evidence (registry room joined + past a 60s warm-up, freshest heartbeat older than 5min); registry-down and every ambiguity stay `Unknown`, so the rows-down/relay-up incident shape can never park the relay. Presence returning un-parks and clears the cooldown in the same beat.

## Phase 1 — UI truth (`b98d698`)
`WatchConnectivity` stream (engine pushes Disabled/Offline/Reconnecting{retryAtMs,lastFailure}/Connected + per-open-chat room state, emitted only on change) → sidebar connection pill (visible only while degraded; live retry countdown; last failure stays visible through the next attempt), composer "messages will queue and send automatically" notice, amber **Queued** row pill + trailer instead of a fake Working spinner, and the pending overlay HOLDS while degraded instead of silently expiring at 30s with no trace. Locally-hosted chats never read as degraded — a queued command executes offline.

## Phase 3 — second road + chaos suite (`9055e01`)
- **RelayCommand**: when rows can't reach the edge (10s grace) but the peer link is alive, the sender's engine forwards the queued entry itself over the device-room link. The host evaluates it against its own doc, claims the client-minted id in the processed ledger BEFORE executing — so the doc row arriving later over chat2 sync dedupes to a no-op. Exactly-once across both roads by construction, proven in `relay_delivery.rs` (execute via relay, then simulated row arrival + duplicate relay → still one turn). Version-gated; relay timeouts mark the link suspect.
- Deterministic flaky-network suite (`chat_client/tests.rs`, virtual clock): scripted drop/refuse connector asserting the durable contract — a mid-push socket death + refused dials deliver the batch exactly once AND surface `Disconnected` (silence is a test failure); connect-and-die sessions grow backoff until a stable session resets it; OS-offline parks dials entirely and the online event un-parks within a beat. Plus the zombie-relay echo regression (`device_room.rs` tests) and the queued-attachment defer/execute cycle (`queued_attachments.rs`).

## Phase 4 — failed state + canonical timestamps (`d4d4045`)
Two-minute grace on unadopted sends → explicit **Failed** row pill and a transcript "Not delivered — click to retry" affordance wired to `RetryDelivery` (fresh chat2 socket, host nudge, drain pass, fresh delivery escorts with transfers re-derived from the pending refs). Timestamp canonicalization: the executor pre-writes the user message at the entry's `issued_at` (clamped, idempotent by id), so a send queued for minutes lands in history where the user sent it.

## Notes for review
- Version gates assume this releases as **0.2.12** (`QUEUED_ATTACHMENTS_MIN`, `RELAY_MIN_VERSION`) — adjust if the release number differs.
- `net_path.rs` is `cfg(target_os = "macos")` FFI written on a Linux box — needs one mac build check.
- 685 tests green across sync/rpc/engine/ui (`--features mock-server` for the sync integration tier). The live half of the acceptance matrix (airplane wifi 20% loss, captive portal, flap-every-5s) still wants a real-network pass; the deterministic analogues are in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789716092&installation_model_id=425430&pr_number=168&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F168&signature=29497d0cf96a48e8dab29d4ed7a5c0613adaf081621c177a701560375408a8a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->