### PR TITLE
opencode: surface provider failures instead of silent forever-Working

### DIFF
--- a/crates/engine/src/registry.rs
+++ b/crates/engine/src/registry.rs
@@ -464,7 +464,13 @@ pub fn default_registry() -> HarnessRegistry {
             name: "OpenCode".into(),
             supports_steering: true,
             steering_mode: SteeringMode::TurnBoundary,
-            reasoning_levels: Vec::new(),
+            reasoning_levels: vec![
+                ReasoningLevel::Low,
+                ReasoningLevel::Medium,
+                ReasoningLevel::High,
+                ReasoningLevel::XHigh,
+                ReasoningLevel::Max,
+            ],
             installed: true,
             enabled: None,
         },
@@ -566,7 +572,16 @@ mod tests {
         assert_eq!(opencode.id(), HarnessId::Opencode);
         assert_eq!(opencode.display_name(), "OpenCode");
         assert_eq!(opencode.steering_mode(), SteeringMode::TurnBoundary);
-        assert!(opencode.reasoning_levels().is_empty());
+        assert_eq!(
+            opencode.reasoning_levels(),
+            &[
+                ReasoningLevel::Low,
+                ReasoningLevel::Medium,
+                ReasoningLevel::High,
+                ReasoningLevel::XHigh,
+                ReasoningLevel::Max,
+            ]
+        );
         let pi = registry.resolve(HarnessId::Pi).unwrap();
         assert_eq!(pi.id(), HarnessId::Pi);
         assert_eq!(pi.display_name(), "Pi");

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -453,9 +453,24 @@ fn opencode_spec() -> AcpAgentSpec {
         },
         // No `_session/steering` extension (1.18.18): turn boundaries.
         steering_mode: SteeringMode::TurnBoundary,
-        // No `thought_level` config option over ACP today — effort stays
-        // with opencode's own per-model config; revisit when advertised.
-        reasoning_levels: &[],
+        // Effort rides opencode's model VARIANTS: when the session's current
+        // model has variants (models.dev metadata, or `variants` in
+        // opencode.json), the session advertises an `effort` config option
+        // (category thought_level) whose values mirror them — verified live
+        // (1.18.18) end to end: set_config_option effort=high applies the
+        // variant's options to the provider request. Variant-less models
+        // (the Zen frees today) advertise no option and the run-start set
+        // skips, falling to the agent default — so the blanket ladder here
+        // is safe (pi precedent). The option is per-model and reactive;
+        // exact per-model ladders would need the sidecar's provider.list
+        // (model.variants) — follow-up.
+        reasoning_levels: &[
+            ReasoningLevel::Low,
+            ReasoningLevel::Medium,
+            ReasoningLevel::High,
+            ReasoningLevel::XHigh,
+            ReasoningLevel::Max,
+        ],
         prompt_transform: identity_transform,
         effort_values: default_effort_values,
         ladder_extras: &[],

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -111,6 +111,9 @@ struct AcpAgentSpec {
     /// a dead update check) — surface a visible error chip instead of
     /// indefinite Working.
     prompt_stall: Option<Duration>,
+    /// Agent-specific advice appended to the stall error chip: what a wedge
+    /// usually means for THIS agent and what the user can check.
+    stall_hint: &'static str,
     /// The agent's ACP process doubles as its own HTTP server (opencode):
     /// runs pass `--port <free>` and tail the `/event` SSE bus for subagent
     /// transcripts, which never ride the ACP wire. A failed port pick (or a
@@ -262,6 +265,9 @@ fn grok_spec() -> AcpAgentSpec {
         // `_meta.promptId`, just ahead of the RPC response.
         prompt_complete_extension: true,
         prompt_stall: Some(Duration::from_secs(30)),
+        stall_hint: "The agent process is likely wedged — a stale shared leader \
+             process or a hung startup check; zeron launches it with --no-leader \
+             and --no-auto-update to avoid both.",
         http_sidecar: false,
     }
 }
@@ -327,6 +333,7 @@ fn hermes_spec() -> AcpAgentSpec {
         ladder_extras: &[],
         prompt_complete_extension: false,
         prompt_stall: None,
+        stall_hint: "The agent process is likely wedged.",
         http_sidecar: false,
     }
 }
@@ -383,6 +390,7 @@ fn pi_spec() -> AcpAgentSpec {
         ladder_extras: &[],
         prompt_complete_extension: false,
         prompt_stall: None,
+        stall_hint: "The agent process is likely wedged.",
         http_sidecar: false,
     }
 }
@@ -452,7 +460,21 @@ fn opencode_spec() -> AcpAgentSpec {
         effort_values: default_effort_values,
         ladder_extras: &[],
         prompt_complete_extension: false,
-        prompt_stall: None,
+        // A failing model provider is INVISIBLE on this wire: opencode
+        // retries the provider stream forever without failing the
+        // session/prompt RPC, and neither session/update nor the /event bus
+        // carries the error (verified live, 1.18.18, unreachable provider —
+        // only ~/.local/share/opencode/log records the AI_APICallError
+        // retry loop). Fast provider rejections (e.g. a Zen model without a
+        // subscription) DO fail the RPC and surface as an error chip; total
+        // silence past the bound means the retry loop, so the watchdog is
+        // the only way the user ever learns.
+        prompt_stall: Some(Duration::from_secs(60)),
+        stall_hint: "The model provider is likely unreachable or rejecting \
+             requests — opencode retries these silently and never reports the \
+             failure. Check the model/provider setup (`opencode auth list`, \
+             opencode.json) or the opencode log \
+             (~/.local/share/opencode/log).",
         http_sidecar: true,
     }
 }
@@ -1185,6 +1207,7 @@ impl Harness for AcpHarness {
             effort_values: self.spec.effort_values,
             prompt_complete_extension: self.spec.prompt_complete_extension,
             prompt_stall: self.spec.prompt_stall,
+            stall_hint: self.spec.stall_hint,
             sessions_root: self.sessions_root.clone(),
             sidecar_port,
             interrupt_grace: self.interrupt_grace,
@@ -1215,6 +1238,7 @@ struct Session {
     agent_name: &'static str,
     prompt_complete_extension: bool,
     prompt_stall: Option<Duration>,
+    stall_hint: &'static str,
     /// Sessions-root override for the subagent transcript tail (tests).
     sessions_root: Option<PathBuf>,
     /// The http_sidecar port this run's agent was told to bind (opencode).
@@ -1807,6 +1831,7 @@ async fn run_session(session: Session) {
         agent_name,
         prompt_complete_extension,
         prompt_stall,
+        stall_hint,
         sessions_root,
         sidecar_port,
         prompt_transform,
@@ -2314,9 +2339,27 @@ async fn run_session(session: Session) {
             inc = incoming.recv() => match inc {
                 Some(Incoming::Notification { method, params }) => {
                     last_update_at = tokio::time::Instant::now();
-                    // Any wire traffic is a sign of life: the prompt-stall
-                    // watchdog only guards TOTAL silence after a prompt.
-                    prompt_stall_deadline = None;
+                    // Wire traffic is a sign of life for the prompt-stall
+                    // watchdog — EXCEPT session boilerplate: opencode emits
+                    // available_commands_update right after session/new on
+                    // every session, including ones whose provider is down
+                    // (where it then retries the provider stream forever
+                    // with nothing further on the wire — verified live,
+                    // 1.18.18). One such frame must not disarm the watchdog
+                    // for the whole turn; only turn progress counts.
+                    let boilerplate = method == "session/update"
+                        && matches!(
+                            params
+                                .get("update")
+                                .and_then(|u| u.get("sessionUpdate"))
+                                .and_then(Value::as_str),
+                            Some("available_commands_update")
+                                | Some("config_option_update")
+                                | Some("current_mode_update")
+                        );
+                    if !boilerplate {
+                        prompt_stall_deadline = None;
+                    }
                     // `_x.ai/session/prompt_complete` — the AUTHORITATIVE
                     // turn end for agents advertising it (grok): the
                     // `session/prompt` RPC can hang after the turn really
@@ -2862,8 +2905,10 @@ async fn run_session(session: Session) {
                     &event_tx,
                     AgentEvent::Error {
                         message: format!(
-                            "{agent_name} did not respond to the prompt at all                              (no wire activity for {}s). The agent process is                              likely wedged — a stale shared leader process or a                              hung startup check; zeron launches it with                              --no-leader and --no-auto-update to avoid both.",
-                            prompt_stall.map(|d| d.as_secs()).unwrap_or(0)
+                            "{agent_name} did not respond to the prompt at all \
+                             (no wire activity for {}s). {}",
+                            prompt_stall.map(|d| d.as_secs()).unwrap_or(0),
+                            stall_hint,
                         ),
                     },
                 )

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -579,7 +579,18 @@ fn hermes_and_pi_descriptor_surfaces_match_registry_expectations() {
     assert_eq!(opencode.display_name(), "OpenCode");
     assert!(opencode.supports_steering());
     assert_eq!(opencode.steering_mode(), SteeringMode::TurnBoundary);
-    assert!(opencode.reasoning_levels().is_empty());
+    // Effort rides opencode's model variants (the session's `effort` config
+    // option, category thought_level); variant-less models skip the set.
+    assert_eq!(
+        opencode.reasoning_levels(),
+        &[
+            zeron_proto::ReasoningLevel::Low,
+            zeron_proto::ReasoningLevel::Medium,
+            zeron_proto::ReasoningLevel::High,
+            zeron_proto::ReasoningLevel::XHigh,
+            zeron_proto::ReasoningLevel::Max,
+        ]
+    );
 
     let pi = AcpHarness::pi();
     assert_eq!(pi.id(), HarnessId::Pi);

--- a/crates/harness/tests/acp_stall.rs
+++ b/crates/harness/tests/acp_stall.rs
@@ -85,3 +85,67 @@ async fn silent_agent_errors_via_the_prompt_stall_watchdog() {
         })
     ));
 }
+
+/// Same watchdog, opencode spec: a failing model provider is INVISIBLE on
+/// opencode's wire (the CLI retries the provider stream forever without
+/// failing `session/prompt` — verified live, 1.18.18), so the stall chip is
+/// the only feedback a user with a broken/unauthorized provider ever gets.
+/// The hint must point at the provider, not at a wedged process.
+#[tokio::test]
+async fn opencode_stall_hint_names_the_provider() {
+    unsafe {
+        std::env::set_var("ZERON_ACP_PROMPT_STALL_MS", "700");
+    }
+    let (_steer_tx, steer_rx) = mpsc::channel(8);
+    let token = CancellationToken::new();
+    let controls = RunControls {
+        request_input: Box::new(move |_| {
+            let (tx, rx) = oneshot::channel();
+            let _ = tx.send(Vec::new());
+            rx
+        }),
+        steering: steer_rx,
+        interrupt: token.clone(),
+    };
+    let request = RunRequest {
+        prompt: "scenario:prompt-stall".into(),
+        harness: None,
+        model: None,
+        reasoning: None,
+        model_options: serde_json::Map::new(),
+        cwd: String::new(),
+        sandbox: SandboxLevel::DangerFullAccess,
+        auto_approve: true,
+        attachments: Vec::new(),
+        worktree: None,
+        resume: None,
+    };
+    let harness = AcpHarness::opencode().with_executable(fixture_path());
+    let stream = harness.run(request, controls).await.expect("run starts");
+    let events = tokio::time::timeout(
+        Duration::from_secs(10),
+        stream.map(|r| r.expect("stream event")).collect::<Vec<_>>(),
+    )
+    .await
+    .expect("watchdog closed the run in time");
+
+    let error = events
+        .iter()
+        .find_map(|e| match e {
+            AgentEvent::Error { message } => Some(message.clone()),
+            _ => None,
+        })
+        .expect("visible error chip");
+    assert!(
+        error.contains("provider") && error.contains("opencode auth"),
+        "hint points at the provider setup: {error}"
+    );
+    assert!(matches!(
+        events.last(),
+        Some(AgentEvent::Done {
+            status: DoneStatus::Errored,
+            error: Some(_),
+            ..
+        })
+    ));
+}

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -123,8 +123,11 @@ case "$promptline" in
   ;;
 
 *scenario:prompt-stall*)
-  # TOTAL silence after the prompt — the leader-wedge signature. Nothing is
-  # ever emitted; the harness's prompt-stall watchdog must error the run.
+  # Session boilerplate, then silence — the REAL wedge signature. opencode
+  # emits available_commands_update on every session (provider dead or not),
+  # so the watchdog must not count it as turn progress: exactly this frame
+  # used to disarm the watchdog for the whole turn (found live, 1.18.18).
+  emit "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"sessionId\":\"$SID\",\"update\":{\"sessionUpdate\":\"available_commands_update\",\"availableCommands\":[{\"name\":\"init\",\"description\":\"guided AGENTS.md setup\"}]}}}"
   exec sleep 60
   ;;
 


### PR DESCRIPTION
Fixes the report that opencode runs "say Working for a few moments then go blank" with Zen models.

## What the wire actually does on provider failure (probed live, 1.18.18)

| failure | opencode's behavior | user experience before this PR |
|---|---|---|
| fast rejection (e.g. Zen model without subscription, HTTP 401) | `session/prompt` fails with a JSON-RPC error carrying the human-readable reason | already works: error chip renders ("This model requires an active OpenCode Zen subscription") |
| unreachable / erroring provider stream | **retries forever, never fails the RPC, emits nothing** on session/update or the `/event` sidecar bus; only `~/.local/share/opencode/log` records the `AI_APICallError` loop | Working forever; interrupt then leaves a blank transcript — nothing ever told the user |

## The fix

1. **opencode gets the prompt-stall watchdog** (60s default, `ZERON_ACP_PROMPT_STALL_MS` override), with a new per-spec `stall_hint`: the error chip now points at the provider setup (`opencode auth list`, opencode.json, the opencode log) instead of grok's stale-leader story.

2. **Boilerplate no longer disarms the watchdog.** The interesting bug: the watchdog cleared its deadline on *any* incoming notification, and opencode emits `available_commands_update` right after `session/new` on every session — provider dead or not. That single frame disarmed the watchdog for the whole turn, which is why the stall guard shipped in #157 never fired in the field. The fake agent in `acp_stall` was fully silent, so the test passed while the field failed; it now emits the boilerplate frame first, making the test honest.

## Validation

- `acp_stall` suite green, now covering both specs; the opencode test asserts the hint names the provider.
- Full harness suite: 131 passed, 0 failed.
- End-to-end against a real daemon + real opencode 1.18.18 + unreachable provider — the doc now carries:
  > `Error: OpenCode did not respond to the prompt at all (no wire activity for 8s). The model provider is likely unreachable or rejecting requests — opencode retries these silently and never reports the failure. Check the model/provider setup (opencode auth list, opencode.json) or the opencode log.`

## Effort selector: fixed (second commit — corrects this PR's own earlier claim)

Wing was right that opencode exposes effort — the t3code screenshot led straight to it. opencode's effort rides **model variants**: when the session's current model has variants (models.dev metadata, or `variants` in opencode.json), the ACP session advertises an `effort` config option (category `thought_level`, values mirroring the variants), reactive to model switches. The original probe ran against a variant-less model and truncated the one response that showed the option — bad probe, wrong conclusion.

Verified end to end against a real daemon: a run with reasoning **High** → the harness's existing run-start config set applies `effort=high` → opencode applies the high variant → the provider request carries its options (`reasoningEffort: high`, proven via a mock provider logging request bodies).

The existing thought_level machinery needed zero changes — the only gate was the spec's empty `reasoning_levels` keeping the picker from offering effort at all. The ladder is now Low→Max (registry descriptor mirrored). Variant-less models (the Zen frees today) advertise no option, so the set skips and the agent default applies — same blanket-ladder precedent as pi. Exact per-model ladders would need the sidecar's `provider.list` (`model.variants`); noted as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
