### PR TITLE
Calm connectivity: degrade hysteresis, staging sweep race fix, quiet reconnect UI

### DIFF
--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -240,6 +240,7 @@ struct DocHostInner {
     /// publishes the edge posture on change (see `watch_connectivity`).
     connectivity: OnceLock<watch::Sender<zeron_proto::Connectivity>>,
     connectivity_started: AtomicBool,
+    connectivity_grace: Mutex<DegradeGrace>,
     /// Peer links (engine assembly, edge runtimes only) — the transport that
     /// pushes queued attachment bytes to a remote host.
     links: OnceLock<Arc<zeron_rpc::LinkCache>>,
@@ -250,6 +251,64 @@ struct DocHostInner {
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// How long raw degradation must persist before connectivity reports it.
+/// Room joins, idle-link wakes, and navigation dials resolve well under a
+/// second on healthy networks; real outages outlive this comfortably. Recovery
+/// is never delayed.
+const DEGRADE_GRACE: std::time::Duration = std::time::Duration::from_secs(4);
+
+/// One tracked degradation source in [`DegradeGrace`].
+enum GraceKey<'a> {
+    OsPath,
+    Registry,
+    Chat(&'a str),
+}
+
+/// Show-slow / hide-fast hysteresis over raw connectivity signals. Pure over
+/// injected `Instant`s so the grace window is unit-testable.
+#[derive(Default)]
+struct DegradeGrace {
+    os_path: Option<std::time::Instant>,
+    registry: Option<std::time::Instant>,
+    chats: HashMap<String, std::time::Instant>,
+}
+
+impl DegradeGrace {
+    /// Feed one raw sample; returns whether to REPORT the source as degraded.
+    /// Healthy clears the timer instantly; degraded reports only once it has
+    /// persisted for [`DEGRADE_GRACE`].
+    fn degraded(&mut self, key: GraceKey, raw: bool, now: std::time::Instant) -> bool {
+        let slot: &mut Option<std::time::Instant> = match key {
+            GraceKey::OsPath => &mut self.os_path,
+            GraceKey::Registry => &mut self.registry,
+            GraceKey::Chat(id) => {
+                if raw && !self.chats.contains_key(id) {
+                    self.chats.insert(id.to_string(), now);
+                }
+                match self.chats.get_mut(id) {
+                    Some(_) if !raw => {
+                        self.chats.remove(id);
+                        return false;
+                    }
+                    Some(since) => return now.duration_since(*since) >= DEGRADE_GRACE,
+                    None => return false,
+                }
+            }
+        };
+        if !raw {
+            *slot = None;
+            return false;
+        }
+        let since = *slot.get_or_insert(now);
+        now.duration_since(since) >= DEGRADE_GRACE
+    }
+
+    /// Drop timers for chats that no longer have open docs.
+    fn retain_chats(&mut self, keep: impl Fn(&str) -> bool) {
+        self.chats.retain(|id, _| keep(id));
+    }
 }
 
 #[derive(Clone)]
@@ -453,6 +512,7 @@ impl DocHost {
                 uploads: OnceLock::new(),
                 connectivity: OnceLock::new(),
                 connectivity_started: AtomicBool::new(false),
+                connectivity_grace: Mutex::new(DegradeGrace::default()),
                 links: OnceLock::new(),
                 http: reqwest::Client::builder()
                     .timeout(std::time::Duration::from_secs(30))
@@ -1845,6 +1905,13 @@ impl DocHost {
 
     /// One snapshot of the edge posture: OS path status beats registry-room
     /// state beats per-chat rooms. `Disabled` (the default) = local profile.
+    ///
+    /// Degradation is HYSTERETIC (v0.2.12 feedback): a room mid-join, an
+    /// idle link waking for a send, or a navigation-triggered dial all read
+    /// "disconnected" for a few hundred ms on a healthy network — surfacing
+    /// those flashed amber warnings and "Queued" badges at every chat
+    /// switch. Raw degradation must persist [`DEGRADE_GRACE`] before it is
+    /// reported; recovery reports instantly.
     fn compute_connectivity(&self) -> zeron_proto::Connectivity {
         use zeron_proto::{ChatConnectivity, Connectivity, ConnectivityState};
         let workspace = self.workspace();
@@ -1853,14 +1920,18 @@ impl DocHost {
         if !edge_expected {
             return Connectivity::default();
         }
-        let chats = self
-            .sync_statuses()
+        let now = std::time::Instant::now();
+        let mut grace = lock(&self.inner.connectivity_grace);
+        let statuses = self.sync_statuses();
+        grace.retain_chats(|id| statuses.iter().any(|(chat_id, _)| chat_id == id));
+        let chats = statuses
             .into_iter()
             .map(|(chat_id, stats)| {
                 let stats = stats.unwrap_or_default();
+                let connected = !grace.degraded(GraceKey::Chat(&chat_id), !stats.connected, now);
                 ChatConnectivity {
                     chat_id,
-                    connected: stats.connected,
+                    connected,
                     pending_pushes: stats.pending_pushes,
                 }
             })
@@ -1870,13 +1941,19 @@ impl DocHost {
             .as_ref()
             .and_then(|w| w.sync_status())
             .is_some_and(|s| s.connected);
-        let (state, retry_at_ms, last_failure) = if zeron_sync::wake::path_is_offline() {
+        let path_offline = grace.degraded(
+            GraceKey::OsPath,
+            zeron_sync::wake::path_is_offline(),
+            now,
+        );
+        let registry_down = grace.degraded(GraceKey::Registry, !registry_connected, now);
+        let (state, retry_at_ms, last_failure) = if path_offline {
             (
                 ConnectivityState::Offline,
                 0,
                 reconnect.and_then(|r| r.last_failure),
             )
-        } else if registry_connected {
+        } else if !registry_down {
             (ConnectivityState::Connected, 0, None)
         } else {
             let reconnect = reconnect.unwrap_or_default();
@@ -3160,6 +3237,49 @@ fn encode_part_segment(part_id: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod degrade_grace_tests {
+    use super::{DEGRADE_GRACE, DegradeGrace, GraceKey};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn blips_shorter_than_the_grace_never_report() {
+        let mut g = DegradeGrace::default();
+        let t0 = Instant::now();
+        // A 300ms room join: degraded at t0, healthy again shortly after.
+        assert!(!g.degraded(GraceKey::Chat("c1"), true, t0));
+        assert!(!g.degraded(GraceKey::Chat("c1"), true, t0 + Duration::from_millis(300)));
+        assert!(!g.degraded(GraceKey::Chat("c1"), false, t0 + Duration::from_millis(600)));
+        // The recovery cleared the timer — a fresh blip starts from zero.
+        assert!(!g.degraded(GraceKey::Chat("c1"), true, t0 + Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn persistent_degradation_reports_after_the_grace_and_clears_instantly() {
+        let mut g = DegradeGrace::default();
+        let t0 = Instant::now();
+        assert!(!g.degraded(GraceKey::Registry, true, t0));
+        assert!(!g.degraded(GraceKey::Registry, true, t0 + DEGRADE_GRACE / 2));
+        assert!(g.degraded(GraceKey::Registry, true, t0 + DEGRADE_GRACE));
+        assert!(g.degraded(GraceKey::Registry, true, t0 + DEGRADE_GRACE * 3));
+        // Hide-fast: one healthy sample reports Connected immediately.
+        assert!(!g.degraded(GraceKey::Registry, false, t0 + DEGRADE_GRACE * 4));
+    }
+
+    #[test]
+    fn sources_are_independent_and_closed_chats_are_dropped() {
+        let mut g = DegradeGrace::default();
+        let t0 = Instant::now();
+        assert!(!g.degraded(GraceKey::Chat("gone"), true, t0));
+        assert!(!g.degraded(GraceKey::OsPath, true, t0));
+        // The chat's doc closes; its timer must not leak.
+        g.retain_chats(|id| id != "gone");
+        assert!(g.chats.is_empty());
+        // OsPath kept its own timer through the retain.
+        assert!(g.degraded(GraceKey::OsPath, true, t0 + DEGRADE_GRACE));
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/uploads.rs
+++ b/crates/engine/src/uploads.rs
@@ -304,9 +304,15 @@ impl Uploads {
                 .flatten()
                 .filter_map(|f| f.metadata().ok()?.modified().ok())
                 .max();
+            // An empty dir is NOT free to reclaim: `append` creates the dir
+            // before writing the first chunk, and parallel chunk uploads run
+            // 3-wide — a sibling's sweep landing in that window deleted the
+            // dir out from under the first write (v0.2.12 "Couldn't stage the
+            // attachment locally"). Judge an empty dir by its own age.
+            let newest = newest.or_else(|| entry.metadata().ok()?.modified().ok());
             let expired = match newest {
                 Some(at) => at.elapsed().map(|age| age > STAGING_TTL).unwrap_or(false),
-                None => true, // empty dir — reclaim
+                None => false,
             };
             if expired {
                 let _ = std::fs::remove_dir_all(entry.path());
@@ -451,6 +457,28 @@ mod tests {
         assert_eq!(sanitize("../../etc/passwd"), "passwd");
         assert_eq!(sanitize("my photo (1).png"), "my_photo__1_.png");
         assert_eq!(sanitize(""), "upload");
+    }
+
+    #[test]
+    fn sweep_spares_a_fresh_empty_staging_dir() {
+        // The parallel-chunk race: uploader A has created its staging dir but
+        // not yet written chunk 0 when uploader B's sweep runs. The empty dir
+        // must survive; only an ABANDONED empty dir (older than the TTL) goes.
+        let dir = tempfile::tempdir().unwrap();
+        let uploads = Uploads::from_root(dir.path());
+        let racing = dir.path().join("tmp").join("upload-racing");
+        std::fs::create_dir_all(&racing).unwrap();
+
+        uploads.append("upload-other", "aGk=", Some(0)).unwrap();
+        assert!(racing.exists(), "fresh empty staging dir was reclaimed");
+
+        let stale = std::time::SystemTime::now() - (STAGING_TTL + Duration::from_secs(60));
+        std::fs::File::open(&racing)
+            .unwrap()
+            .set_modified(stale)
+            .unwrap();
+        uploads.append("upload-other", "aGk=", Some(0)).unwrap();
+        assert!(!racing.exists(), "abandoned empty staging dir must be swept");
     }
 
     #[test]

--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -395,6 +395,11 @@ pub async fn upload_attachment(
                                 // for minutes with a literally empty log —
                                 // degraded uploads must narrate.
                                 tracing::warn!(error = %err, seq, attempt, "upload chunk retry");
+                                // Stagger by seq so parallel chunks that failed
+                                // together don't re-collide in lockstep.
+                                executor
+                                    .timer(Duration::from_millis(50 * (attempt as u64) * (seq + 1)))
+                                    .await;
                             }
                             Err(err) => return Err(err),
                         }

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -4651,6 +4651,132 @@ impl Composer {
         let err_message_id = message_id.clone();
         self.send_task = Some(cx.spawn(async move |this, cx| {
             let result: Result<(), String> = async {
+                // Attachments stage FIRST — before the chat row or anything
+                // else exists. Staging is chat-independent (keyed by
+                // uploadId), and ordering it first makes a new-chat send
+                // atomic: a staging failure aborts with NOTHING created,
+                // instead of stranding a just-minted empty chat (v0.2.12
+                // "failed to stage → empty transcript" report).
+                //
+                // Queued flow: commit the bytes to the LOCAL engine's uploads
+                // dir (fast, offline-safe) — the queued command carries the
+                // `pending://` refs and the engine delivers the bytes to a
+                // remote host afterwards, retrying until they land. Legacy
+                // flow (old engines): stage on the host device up front,
+                // bounded by a total budget so a degraded link fails the send
+                // loudly instead of grinding through silent per-chunk retries
+                // for minutes.
+                let mut content = text.clone();
+                let mut attachment_paths: Vec<String> = Vec::new();
+                let mut transfers: Vec<serde_json::Value> = Vec::new();
+                if !staged.is_empty() && queued_flow {
+                    // Local staging is disk-speed; publish progress anyway so
+                    // huge files still narrate.
+                    let progress = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+                    let total: u64 = staged.iter().map(|a| a.bytes().len() as u64).sum();
+                    {
+                        let progress = progress.clone();
+                        this.update(cx, |composer, cx| {
+                            composer.state.update(cx, |s, cx| {
+                                s.begin_upload_progress(total, progress);
+                                cx.notify();
+                            });
+                        })
+                        .ok();
+                    }
+                    for (att, upload_id) in staged.iter().zip(&upload_ids) {
+                        if let Err(err) = attachments::upload_attachment(
+                            &engine,
+                            cx.background_executor(),
+                            None,
+                            upload_id,
+                            att,
+                            Some(progress.clone()),
+                        )
+                        .await
+                        {
+                            tracing::warn!(name = %att.name, error = %err, "local attachment stage failed");
+                            return Err("Couldn't stage the attachment locally.".to_string());
+                        }
+                        transfers.push(serde_json::json!({
+                            "uploadId": upload_id,
+                            "fileName": att.name,
+                        }));
+                    }
+                    // The echo refs ARE the persisted refs — no refresh pass.
+                    attachment_paths = echo_paths.clone();
+                    content = echo_text.clone();
+                } else if !staged.is_empty() {
+                    let progress = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+                    let total: u64 = staged.iter().map(|a| a.bytes().len() as u64).sum();
+                    {
+                        let progress = progress.clone();
+                        this.update(cx, |composer, cx| {
+                            composer.state.update(cx, |s, cx| {
+                                s.begin_upload_progress(total, progress);
+                                cx.notify();
+                            });
+                        })
+                        .ok();
+                    }
+                    for (att, upload_id) in staged.iter().zip(&upload_ids) {
+                        match attachments::upload_attachment(
+                            &engine,
+                            cx.background_executor(),
+                            host_device_id.as_deref(),
+                            upload_id,
+                            att,
+                            Some(progress.clone()),
+                        )
+                        .await
+                        {
+                            Ok(path) => attachment_paths.push(path),
+                            Err(err) => {
+                                tracing::warn!(name = %att.name, error = %err, "attachment upload failed");
+                                return Err(
+                                    "Couldn't upload the attachment — the device may be offline."
+                                        .to_string(),
+                                );
+                            }
+                        }
+                    }
+                    // Seed the transcript cache from local bytes so the sent
+                    // bubble's thumbnails never round-trip (seedTranscript-
+                    // Attachment in the original send path).
+                    let seed_device = host_device_id.clone().unwrap_or_else(|| device_id.clone());
+                    for (path, att) in attachment_paths.iter().zip(&staged) {
+                        attachments::seed_attachment(&seed_device, path, &att.name, att.image.clone());
+                        if seed_device != device_id {
+                            attachments::seed_attachment(&device_id, path, &att.name, att.image.clone());
+                        }
+                    }
+                    content = attachments::with_attachments(&text, &attachment_paths);
+                    // Refresh the echo in place with the attachment refs
+                    // (same id, same clock — the bubble grows its thumbnails
+                    // without flickering).
+                    let refreshed = SessionMessageEntry {
+                        id: message_id.clone(),
+                        role: zeron_doc::MessageRole::User,
+                        parts: vec![MessagePart::Text {
+                            id: "t0".into(),
+                            text: content.clone(),
+                        }],
+                        created_at,
+                        device_id: "local".into(),
+                        status: None,
+                        continuation_of: None,
+                    };
+                    let echo_chat_id = chat_id.clone();
+                    this.update(cx, |composer, cx| {
+                        composer.state.update(cx, |s, cx| {
+                            s.remove_echo(&echo_chat_id, &message_id);
+                            s.push_echo(&echo_chat_id, refreshed);
+                            cx.notify();
+                        });
+                    })
+                    .ok();
+                }
+
                 // Resolve the working directory: existing chats keep theirs;
                 // new chats run per the checkout plan (t3code env-mode): the
                 // space's folder as-is, an EXISTING worktree of the picked ref
@@ -4772,132 +4898,6 @@ impl Composer {
                     }
                 }
 
-                // Attachments. Queued flow: commit the bytes to the LOCAL
-                // engine's uploads dir (fast, offline-safe) — the queued
-                // command carries the `pending://` refs and the engine
-                // delivers the bytes to a remote host afterwards, retrying
-                // until they land. Legacy flow (old engines): stage on the
-                // host device up front, bounded by a total budget so a
-                // degraded link fails the send loudly instead of grinding
-                // through silent per-chunk retries for minutes.
-                let mut content = text.clone();
-                let mut attachment_paths: Vec<String> = Vec::new();
-                let mut transfers: Vec<serde_json::Value> = Vec::new();
-                if !staged.is_empty() && queued_flow {
-                    // Local staging is disk-speed; publish progress anyway so
-                    // huge files still narrate.
-                    let progress = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-                    let total: u64 = staged.iter().map(|a| a.bytes().len() as u64).sum();
-                    {
-                        let progress = progress.clone();
-                        this.update(cx, |composer, cx| {
-                            composer.state.update(cx, |s, cx| {
-                                s.begin_upload_progress(total, progress);
-                                cx.notify();
-                            });
-                        })
-                        .ok();
-                    }
-                    for (att, upload_id) in staged.iter().zip(&upload_ids) {
-                        if let Err(err) = attachments::upload_attachment(
-                            &engine,
-                            cx.background_executor(),
-                            None,
-                            upload_id,
-                            att,
-                            Some(progress.clone()),
-                        )
-                        .await
-                        {
-                            tracing::warn!(name = %att.name, error = %err, "local attachment stage failed");
-                            return Err("Couldn't stage the attachment locally.".to_string());
-                        }
-                        transfers.push(serde_json::json!({
-                            "uploadId": upload_id,
-                            "fileName": att.name,
-                        }));
-                    }
-                    // The echo refs ARE the persisted refs — no refresh pass.
-                    attachment_paths = echo_paths.clone();
-                    content = echo_text.clone();
-                } else if !staged.is_empty() {
-                    // Legacy flow (old engines): stage on the host device up
-                    // front. Publish upload progress so the working label can
-                    // read "Uploading… N%" instead of an opaque "Sending…"
-                    // while the chunks cross the relay; the per-attachment
-                    // deadline inside `upload_attachment` bounds the whole
-                    // crawl (2026-08-19: silent per-chunk retries ground for
-                    // minutes with no total budget).
-                    let progress = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-                    let total: u64 = staged.iter().map(|a| a.bytes().len() as u64).sum();
-                    {
-                        let progress = progress.clone();
-                        this.update(cx, |composer, cx| {
-                            composer.state.update(cx, |s, cx| {
-                                s.begin_upload_progress(total, progress);
-                                cx.notify();
-                            });
-                        })
-                        .ok();
-                    }
-                    for (att, upload_id) in staged.iter().zip(&upload_ids) {
-                        match attachments::upload_attachment(
-                            &engine,
-                            cx.background_executor(),
-                            host_device_id.as_deref(),
-                            upload_id,
-                            att,
-                            Some(progress.clone()),
-                        )
-                        .await
-                        {
-                            Ok(path) => attachment_paths.push(path),
-                            Err(err) => {
-                                tracing::warn!(name = %att.name, error = %err, "attachment upload failed");
-                                return Err(
-                                    "Couldn't upload the attachment — the device may be offline."
-                                        .to_string(),
-                                );
-                            }
-                        }
-                    }
-                    // Seed the transcript cache from local bytes so the sent
-                    // bubble's thumbnails never round-trip (seedTranscript-
-                    // Attachment in the original send path).
-                    let seed_device = host_device_id.clone().unwrap_or_else(|| device_id.clone());
-                    for (path, att) in attachment_paths.iter().zip(&staged) {
-                        attachments::seed_attachment(&seed_device, path, &att.name, att.image.clone());
-                        if seed_device != device_id {
-                            attachments::seed_attachment(&device_id, path, &att.name, att.image.clone());
-                        }
-                    }
-                    content = attachments::with_attachments(&text, &attachment_paths);
-                    // Refresh the echo in place with the attachment refs
-                    // (same id, same clock — the bubble grows its thumbnails
-                    // without flickering).
-                    let refreshed = SessionMessageEntry {
-                        id: message_id.clone(),
-                        role: zeron_doc::MessageRole::User,
-                        parts: vec![MessagePart::Text {
-                            id: "t0".into(),
-                            text: content.clone(),
-                        }],
-                        created_at,
-                        device_id: "local".into(),
-                        status: None,
-                        continuation_of: None,
-                    };
-                    let echo_chat_id = chat_id.clone();
-                    this.update(cx, |composer, cx| {
-                        composer.state.update(cx, |s, cx| {
-                            s.remove_echo(&echo_chat_id, &message_id);
-                            s.push_echo(&echo_chat_id, refreshed);
-                            cx.notify();
-                        });
-                    })
-                    .ok();
-                }
-
                 let command = if steer_cmd {
                     SessionCommandPayload::Steer {
                         prompt: content.clone(),
@@ -4942,6 +4942,22 @@ impl Composer {
                 Ok(())
             }
             .await;
+            if result.is_err() && is_new {
+                // A failed new-chat send must not strand a just-minted empty
+                // chat in the sidebar (v0.2.12 "empty transcript" report).
+                // Staging now runs before CreateChat, so usually nothing was
+                // created — but a post-mutate failure (QueueCommand) still
+                // leaves a row. Best-effort delete; a no-op if the chat was
+                // never materialized.
+                let _ = attachments::call_with_timeout(
+                    &engine,
+                    cx.background_executor(),
+                    methods::MUTATE,
+                    serde_json::json!({ "op": "deleteChat", "chatId": err_chat_id }),
+                    std::time::Duration::from_secs(5),
+                )
+                .await;
+            }
             this.update(cx, |composer, cx| {
                 composer.sending = false;
                 composer
@@ -4949,31 +4965,59 @@ impl Composer {
                     .update(cx, |s, _| s.end_upload_progress());
                 if let Err(message) = result {
                     // Failure: red banner, echo removed, prompt back in the
-                    // draft, staged files back in the chat's stash.
+                    // draft, staged files back in the stash. A failed NEW
+                    // chat restores to the CANVAS (key "") and navigates back
+                    // there — the minted chat is gone (deleted above), so
+                    // nothing may restore under its key.
+                    let restore_key = if is_new {
+                        String::new()
+                    } else {
+                        err_chat_id.clone()
+                    };
                     composer.failure = Some(message.into());
-                    composer.failure_key = Some(err_chat_id.clone());
+                    composer.failure_key = Some(restore_key.clone());
                     composer.state.update(cx, |s, cx| {
                         s.remove_echo(&err_chat_id, &err_message_id);
                         s.end_pending_send(&err_chat_id, &err_message_id);
-                        // Re-staged under the chat's key: a new chat's send has
-                        // already re-keyed the composer to the minted id by
-                        // now, exactly like the staged files below.
+                        if is_new && s.selected_chat.as_deref() == Some(err_chat_id.as_str()) {
+                            // Back to the canvas; the navigation draft-swap
+                            // loads the restored draft below.
+                            s.select_chat(None, cx);
+                        }
                         for comment in &comments {
-                            s.add_diff_comment(&err_chat_id, comment.clone());
+                            s.add_diff_comment(&restore_key, comment.clone());
                         }
                         cx.notify();
                     });
-                    composer.input.update(cx, |input, cx| input.set_text(restore_text, cx));
+                    if is_new && composer.current_key != restore_key {
+                        // A re-key swap to the canvas is pending (the
+                        // select_chat(None) above); it loads this draft into
+                        // the input on flush — setting the input directly
+                        // here would be clobbered by that same swap.
+                        composer.drafts.insert(restore_key.clone(), restore_text.clone());
+                    } else {
+                        // Already keyed to the restore target (either an
+                        // existing chat, or the deleted row's watch event
+                        // re-keyed to the canvas before this handler ran —
+                        // no further swap will fire). Set the input directly.
+                        composer.input.update(cx, |input, cx| input.set_text(restore_text, cx));
+                    }
                     if !staged.is_empty() {
                         // Merge by id (stashAttachments): files the user staged
-                        // while the send was in flight survive the hand-back.
-                        let slot = composer.attachments.entry(err_chat_id.clone()).or_default();
+                        // while the send was in flight survive the hand-back —
+                        // draining the minted chat's slot too when the restore
+                        // target is the canvas.
                         let mut merged = staged.clone();
-                        merged.extend(
-                            slot.drain(..)
-                                .filter(|e| !staged.iter().any(|f| f.id == e.id)),
-                        );
-                        *slot = merged;
+                        for key in [err_chat_id.clone(), restore_key.clone()] {
+                            if let Some(slot) = composer.attachments.get_mut(&key) {
+                                let fresh: Vec<_> = slot
+                                    .drain(..)
+                                    .filter(|e| !merged.iter().any(|f| f.id == e.id))
+                                    .collect();
+                                merged.extend(fresh);
+                            }
+                        }
+                        composer.attachments.insert(restore_key, merged);
                     }
                 }
                 cx.notify();

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -5551,7 +5551,7 @@ impl Render for Composer {
         // Composer honesty: when the target's delivery path is degraded, say
         // UP FRONT that a send will queue (a durable local write delivered on
         // reconnect) instead of letting the button imply instant delivery.
-        let queue_notice: Option<SharedString> = {
+        let queue_notice: Option<(SharedString, bool)> = {
             use zeron_proto::ConnectivityState as S;
             let state = self.state.read(cx);
             let degraded = match state.selected_chat.as_deref() {
@@ -5568,12 +5568,14 @@ impl Render for Composer {
                                 .is_some_and(|id| !state.device_online(&id, chrono::Utc::now())))
                 }
             };
+            let offline = state.connectivity.state == S::Offline;
             degraded.then(|| {
-                if state.connectivity.state == S::Offline {
-                    "Offline — messages will queue and send automatically.".into()
+                let text: SharedString = if offline {
+                    "Offline — messages will send when you're back online.".into()
                 } else {
-                    "Connection degraded — messages will queue and send automatically.".into()
-                }
+                    "Messages will send once the connection recovers.".into()
+                };
+                (text, offline)
             })
         };
         // Centered composer column (zeron `mx-auto w-full max-w-3xl`).
@@ -5643,30 +5645,31 @@ impl Render for Composer {
                         .child(div().min_w_0().child(message)),
                 )
             })
-            .when_some(queue_notice, |el, notice| {
-                // Same Notice shape as above, amber, not dismissable — it
+            .when_some(queue_notice, |el, (notice, offline)| {
+                // Not a warning box (v0.2.12 feedback: the amber Notice read
+                // as an error and flashed on every blip — pre-grace). One
+                // quiet caption line, amber dot only for hard offline; it
                 // clears itself the moment the path heals.
-                let amber = theme.warning;
-                let amber_200 = theme.warning_muted;
-                el.child(
+                let dot = if offline {
+                    theme.warning
+                } else {
+                    theme.text_faint
+                };
+                el.child(crate::motion::fade_in(
+                    "composer-queue-notice",
                     div()
                         .id("composer-queue-notice")
-                        .mx(px(4.0))
+                        .mx(px(8.0))
                         .mt(px(6.0))
                         .flex()
-                        .items_start()
-                        .gap(px(8.0))
-                        .rounded(px(12.0))
-                        .border_1()
-                        .border_color(amber.opacity(0.16))
-                        .bg(amber.opacity(0.05))
-                        .px(px(12.0))
-                        .py(px(8.0))
-                        .text_size(px(12.0))
-                        .line_height(px(16.0))
-                        .text_color(amber_200.opacity(0.9))
-                        .child(div().min_w_0().child(notice)),
-                )
+                        .items_center()
+                        .gap(px(6.0))
+                        .text_size(px(11.0))
+                        .line_height(px(14.0))
+                        .text_color(theme.text_faint)
+                        .child(div().size(px(5.0)).rounded_full().bg(dot))
+                        .child(div().min_w_0().truncate().child(notice)),
+                ))
             });
 
         // Turn-boundary steering notice: for agents without mid-turn

--- a/crates/ui/src/loaders.rs
+++ b/crates/ui/src/loaders.rs
@@ -158,6 +158,30 @@ pub fn mini_gradient_spinner(
     view: EntityId,
     cx: &mut App,
 ) -> impl IntoElement {
+    let tints = GSPIN_ROW_TINTS.map(|t| gpui::rgb(t).into());
+    mini_spinner_tinted(key, cell_px, tints, view, cx)
+}
+
+/// [`mini_gradient_spinner`] in a single flat tint — the grayscale take for
+/// surfaces where the brand gradient would pull focus (the sidebar
+/// connection line): same grid, snake, and timing, color left to the caller.
+pub fn mini_mono_spinner(
+    key: impl Into<SharedString>,
+    cell_px: f32,
+    tint: gpui::Hsla,
+    view: EntityId,
+    cx: &mut App,
+) -> impl IntoElement {
+    mini_spinner_tinted(key, cell_px, [tint; 3], view, cx)
+}
+
+fn mini_spinner_tinted(
+    key: impl Into<SharedString>,
+    cell_px: f32,
+    row_tints: [gpui::Hsla; 3],
+    view: EntityId,
+    cx: &mut App,
+) -> impl IntoElement {
     const COLS: usize = 2;
     const ROWS: usize = 3;
     /// Clockwise ring position of each `(row, col)` cell, top-left first:
@@ -171,7 +195,7 @@ pub fn mini_gradient_spinner(
         .flex_col()
         .gap(px(cell_px / 2.0))
         .children((0..ROWS).map(move |row| {
-            let tint: gpui::Hsla = gpui::rgb(GSPIN_ROW_TINTS[row]).into();
+            let tint = row_tints[row];
             div()
                 .flex()
                 .flex_row()

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3723,66 +3723,46 @@ impl Shell {
     /// section (folder + device rows, add-space), the global Active sessions
     /// list, the notice strip, and the UserMenu (§1.6).
     /// The global connection pill. `None` while healthy (`Connected`) or on
-    /// local profiles (`Disabled`). Degraded states render an amber strip:
-    /// Offline (OS says no path) or Reconnecting with a live retry countdown,
-    /// keeping the last failure visible through the next attempt — the pill
-    /// never flickers back to a bare "connecting…" mid-outage.
+    /// local profiles (`Disabled`) — and the engine's degrade grace means it
+    /// only exists during REAL outages, never join/wake blips. Quiet by
+    /// design (v0.2.12 feedback): one soft-frost line, a status dot (amber
+    /// only when the OS says offline), no failure dump — the transport error
+    /// belongs in logs, not the sidebar.
     fn render_connection_pill(&self, theme: &Theme, cx: &Context<Self>) -> Option<AnyElement> {
         use zeron_proto::ConnectivityState as S;
         let conn = self.state.read(cx).connectivity.clone();
-        let (label, detail): (SharedString, Option<SharedString>) = match conn.state {
+        let (label, dot): (SharedString, gpui::Hsla) = match conn.state {
             S::Disabled | S::Connected => return None,
-            S::Offline => (
-                "Offline — sends will queue".into(),
-                conn.last_failure.clone().map(SharedString::from),
-            ),
-            S::Reconnecting => {
-                let now_ms = Utc::now().timestamp_millis();
-                let label: SharedString = if conn.retry_at_ms > now_ms {
-                    let secs = (conn.retry_at_ms - now_ms + 999) / 1000;
-                    format!("Reconnecting — retrying in {secs}s").into()
-                } else {
-                    "Reconnecting…".into()
-                };
-                (label, conn.last_failure.clone().map(SharedString::from))
-            }
+            S::Offline => ("Offline — sends are saved".into(), theme.warning),
+            S::Reconnecting => ("Reconnecting…".into(), theme.text_faint),
         };
         Some(
-            div()
-                .id("connection-pill")
-                .mx(px(Theme::SPACE_SM))
-                .mb(px(Theme::SPACE_SM))
-                .px(px(Theme::SPACE_SM))
-                .py(px(4.0))
-                .rounded(px(Theme::CONTROL_RADIUS))
-                .border_1()
-                .border_color(theme.warning)
-                .flex()
-                .items_center()
-                .gap(px(6.0))
-                .child(div().size(px(6.0)).rounded_full().bg(theme.warning))
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .min_w_0()
-                        .child(
-                            div()
-                                .text_size(px(11.0))
-                                .text_color(theme.warning)
-                                .child(label),
-                        )
-                        .when_some(detail, |el, detail| {
-                            el.child(
-                                div()
-                                    .text_size(px(10.0))
-                                    .text_color(theme.text_faint)
-                                    .truncate()
-                                    .child(detail),
-                            )
-                        }),
-                )
-                .into_any_element(),
+            crate::motion::fade_in(
+                "connection-pill",
+                div()
+                    .id("connection-pill")
+                    .mx(px(Theme::SPACE_SM))
+                    .mb(px(Theme::SPACE_SM))
+                    .px(px(Theme::SPACE_SM))
+                    .py(px(4.0))
+                    .rounded_full()
+                    .bg(theme.surface_raised)
+                    .border_1()
+                    .border_color(theme.border)
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .child(div().size(px(5.0)).rounded_full().bg(dot))
+                    .child(
+                        div()
+                            .min_w_0()
+                            .truncate()
+                            .text_size(px(11.0))
+                            .text_color(theme.text_muted)
+                            .child(label),
+                    ),
+            )
+            .into_any_element(),
         )
     }
 

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3722,43 +3722,53 @@ impl Shell {
     /// Chat-mode sidebar (spaces overhaul): window-control strip, the Spaces
     /// section (folder + device rows, add-space), the global Active sessions
     /// list, the notice strip, and the UserMenu (§1.6).
-    /// The global connection pill. `None` while healthy (`Connected`) or on
+    /// The global connection line. `None` while healthy (`Connected`) or on
     /// local profiles (`Disabled`) — and the engine's degrade grace means it
-    /// only exists during REAL outages, never join/wake blips. Quiet by
-    /// design (v0.2.12 feedback): one soft-frost line, a status dot (amber
-    /// only when the OS says offline), no failure dump — the transport error
-    /// belongs in logs, not the sidebar.
-    fn render_connection_pill(&self, theme: &Theme, cx: &Context<Self>) -> Option<AnyElement> {
+    /// only exists during REAL outages, never join/wake blips. No surface,
+    /// no border (v0.2.12 feedback): a bare spinner + faint caption while
+    /// reconnecting; an amber dot only when the OS says offline. The
+    /// transport error belongs in logs, not the sidebar.
+    fn render_connection_pill(&self, theme: &Theme, cx: &mut Context<Self>) -> Option<AnyElement> {
         use zeron_proto::ConnectivityState as S;
         let conn = self.state.read(cx).connectivity.clone();
-        let (label, dot): (SharedString, gpui::Hsla) = match conn.state {
+        let (label, glyph): (SharedString, AnyElement) = match conn.state {
             S::Disabled | S::Connected => return None,
-            S::Offline => ("Offline — sends are saved".into(), theme.warning),
-            S::Reconnecting => ("Reconnecting…".into(), theme.text_faint),
+            S::Offline => (
+                "Offline — sends are saved".into(),
+                div()
+                    .size(px(5.0))
+                    .rounded_full()
+                    .bg(theme.warning)
+                    .into_any_element(),
+            ),
+            S::Reconnecting => (
+                "Reconnecting…".into(),
+                loaders::mini_gradient_spinner(
+                    "connection-spinner",
+                    2.0,
+                    cx.entity_id(),
+                    cx,
+                )
+                .into_any_element(),
+            ),
         };
         Some(
             crate::motion::fade_in(
                 "connection-pill",
                 div()
                     .id("connection-pill")
-                    .mx(px(Theme::SPACE_SM))
+                    .mx(px(Theme::SPACE_SM + 4.0))
                     .mb(px(Theme::SPACE_SM))
-                    .px(px(Theme::SPACE_SM))
-                    .py(px(4.0))
-                    .rounded_full()
-                    .bg(theme.surface_raised)
-                    .border_1()
-                    .border_color(theme.border)
                     .flex()
                     .items_center()
                     .gap(px(6.0))
-                    .child(div().size(px(5.0)).rounded_full().bg(dot))
+                    .child(glyph)
                     .child(
                         div()
                             .min_w_0()
                             .truncate()
                             .text_size(px(11.0))
-                            .text_color(theme.text_muted)
+                            .text_color(theme.text_faint)
                             .child(label),
                     ),
             )

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3743,9 +3743,10 @@ impl Shell {
             ),
             S::Reconnecting => (
                 "Reconnecting…".into(),
-                loaders::mini_gradient_spinner(
+                loaders::mini_mono_spinner(
                     "connection-spinner",
                     2.0,
+                    theme.text_muted,
                     cx.entity_id(),
                     cx,
                 )


### PR DESCRIPTION
Fixes the four v0.2.12 field reports on healthy networks:

## 1. Flashing warnings / phantom "Queued" / "Reconnecting" before sends
`compute_connectivity` reported **raw** socket state, so a chat room mid-join (every navigation), an idle link waking for a send, or any sub-second dial read as degraded — flashing the amber notice for ~300ms and stamping sends "Queued" on enterprise-grade connections.

Degradation is now **hysteretic** (`DegradeGrace`, engine-side): a source (OS path / registry room / per-chat room) must be raw-degraded for **4s continuously** before it's reported; recovery reports instantly. All consumers (pill, composer notice, row Queued/Failed, send_queued) inherit the calm from the one stream. Unit-tested over injected instants.

## 2. "Couldn't stage the attachment locally"
A real race shipped in the parallel-chunk upload path: `Uploads::append` runs `sweep()` before writing, and sweep reclaimed **empty** staging dirs unconditionally — deleting a sibling chunk's just-created dir between its `create_dir_all` and first write. 3-wide chunk concurrency made the window live, and the no-delay lockstep retries re-collided. Empty dirs are now judged by their own mtime against the 10-min TTL (regression test included), and chunk retries stagger by `seq`.

## 3. Reconnect UI restyle
The amber-bordered strip with the raw transport-error line is gone. Degraded states render as one quiet frost pill — neutral dot + muted 11px label, fade-in entrance — with amber reserved for hard OS-offline. The composer notice drops its warning box for a single caption line ("Messages will send once the connection recovers."). Retry-countdown and last-failure text removed from the sidebar (they read as debug output; the detail still lands in logs).

## 4. Atomic new-chat sends (the "empty transcript" report)

The staging failure had a worse half on new-chat sends: the pipeline created state before it was entitled to (CreateChat mutate ran before staging; the composer had already selected the minted chat and cleared the input), so a staging failure stranded the user inside a just-created **empty chat** with their message gone.

- Attachments now stage **first** — before the chat row or worktree spec exist anywhere. Staging is chat-independent (uploadId-keyed), so a failure aborts with *nothing created*. Both the queued local-stage and legacy host-stage flows move together.
- A post-mutate failure (QueueCommand) best-effort deletes the minted row — no orphan either way.
- Failure restore targets the **canvas** for new chats: back to the new-session canvas with prompt text, attachment stash, and the error banner — handling both re-key orderings (the deleted row's watch event can re-key the composer before the failure handler runs; caught live in the rig).

Verified E2E on the headless rig — read-only uploads dir + new-chat image send: canvas retained, **no stranded sidebar row**, banner + prompt text + attachment chip all restored:

<img src="https://github.com/user-attachments/assets/ec5ab8fa-322c-4731-9568-a4f7c15e84e7" alt="After a forced staging failure: canvas retained with banner, text, and attachment restored; no stranded chat row" width="900">

## Tests
- New: `degrade_grace_tests` (blip-never-reports, persist-then-report, hide-fast, per-source independence), `sweep_spares_a_fresh_empty_staging_dir`.
- Full sweep: 709 engine/ui/rpc + 38 sync, 0 failures (re-run after every commit on the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789729723&installation_model_id=425430&pr_number=170&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F170&signature=1fd70afc5065c56ac5b78ba860b509383b686ceb5c65bdaf8e6aa7ce0ce04c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Screenshots

Degraded posture (dead edge, >4s — so the grace has expired and the state is real). Reconnecting is a transparent grayscale spinner + faint caption — no surface, no border:

<img src="https://github.com/user-attachments/assets/7e27bb93-2995-4c52-a872-c5ac5d5199d0" alt="App in reconnecting state: transparent grayscale spinner and caption in the sidebar, quiet composer line" width="900">

Detail — sidebar spinner line and composer caption:

<img src="https://github.com/user-attachments/assets/6940e8b1-4aab-44ae-af86-4e836a0cd733" alt="Detail of the grayscale reconnecting spinner line and composer notice" width="900">

On healthy networks neither element ever renders — sub-4s blips (room joins, idle-link wakes, navigation dials) report Connected.
