### PR TITLE
ios: port the network-reliability train (PRs #159/#164/#165/#168/#170) to mobile

### DIFF
--- a/apps/ios/Zeron/App/AppModel.swift
+++ b/apps/ios/Zeron/App/AppModel.swift
@@ -20,6 +20,9 @@ final class AppModel {
     var phase: Phase = .signedOut
     var workspace: WorkspaceStore?
     var demo: DemoDataset?
+    /// Graced connectivity truth — one stream every consumer inherits calm
+    /// from (home pill, composer notice, Queued/Failed badges).
+    let connectivity = ConnectivityCenter()
     private var sessionStores: [String: SessionStore] = [:]
     private var config: AppConfig?
     @ObservationIgnored private var pathMonitor: NWPathMonitor?
@@ -254,7 +257,27 @@ final class AppModel {
         let store = WorkspaceStore(config: config)
         workspace = store
         store.start()
+        startConnectivity()
         phase = .ready
+    }
+
+    /// Wire the graced-connectivity recompute over the live stores (the
+    /// engine's 1s compute_connectivity, phone edition).
+    private func startConnectivity() {
+        connectivity.registryConnected = { [weak self] in
+            guard let self, self.demo == nil, let workspace = self.workspace else { return true }
+            return workspace.connected
+        }
+        connectivity.chatRooms = { [weak self] in
+            guard let self else { return [] }
+            return self.sessionStores.compactMap { id, store in
+                store.roomActive ? (id: id, connected: store.connected) : nil
+            }
+        }
+        connectivity.hasPendingSends = { [weak self] in
+            self?.sessionStores.values.contains { !$0.pendingSends.isEmpty } ?? false
+        }
+        connectivity.start()
     }
 
     // MARK: Unified data accessors (demo or live — one path for views)
@@ -510,9 +533,24 @@ final class AppModel {
     /// Foreground hook: kick every room NOW (see ChatRoomClient.kick) — after
     /// a suspension the workspace room in particular stayed dead while chat
     /// views reconnected on open, freezing sidebar rows and Working
-    /// indicators against perfectly live transcripts (2026-08-04).
+    /// indicators against perfectly live transcripts (2026-08-04). Also the
+    /// focus fast path (PR #168): probe {edge}/health (3s) and broadcast the
+    /// online event on success, so every PARKED backoff (not just the rooms
+    /// the kick reaches) lands a redial in ~1 RTT.
     func foregrounded() {
         kickAllRooms()
+        probeEdgeHealth()
+    }
+
+    private func probeEdgeHealth() {
+        guard let config, demo == nil else { return }
+        Task.detached {
+            var request = URLRequest(url: config.edgeURL.appending(path: "health"))
+            request.timeoutInterval = 3
+            guard let (_, response) = try? await URLSession.shared.data(for: request),
+                  (response as? HTTPURLResponse)?.statusCode == 200 else { return }
+            OnlineBus.shared.notifyOnline()
+        }
     }
 
     private func kickAllRooms() {
@@ -563,6 +601,17 @@ final class AppModel {
         guard pathMonitor == nil else { return }
         let monitor = NWPathMonitor()
         monitor.pathUpdateHandler = { [weak self] path in
+            // net_path.rs semantics: only a definitive "unsatisfied" parks —
+            // requiresConnection/other stay optimistic (a confused monitor
+            // can only make us dial too much, never go silent). Every
+            // satisfied report also broadcasts online: satisfied→satisfied
+            // updates are interface handovers (wifi→cellular), and the old
+            // sockets are dead on the new path; redundant kicks are free
+            // because waiters drain stale events.
+            OnlineBus.shared.setPathOnline(path.status != .unsatisfied)
+            if path.status == .satisfied {
+                OnlineBus.shared.notifyOnline()
+            }
             // Interface set is part of the key: a satisfied→satisfied hop
             // (wifi→cellular) silently kills established sockets too.
             let key = path.status == .satisfied
@@ -570,6 +619,7 @@ final class AppModel {
                 : "down"
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                self.connectivity.setPathOffline(path.status == .unsatisfied)
                 let previous = self.lastPathKey
                 self.lastPathKey = key
                 // First callback reports the initial state — nothing to revive.
@@ -602,10 +652,57 @@ final class AppModel {
         }
         let store = SessionStore(chatId: chat.id, config: config)
         store.hostDeviceId = chat.deviceId
+        store.hostLiveness = { [weak self] deviceId in
+            self?.workspace?.peerLiveness(deviceId) ?? .unknown
+        }
         sessionStores[chat.id] = store
         store.start()
         store.updateRoomGen(chat.roomGen)
         return store
+    }
+
+    // MARK: Delivery truth (state.rs chat_delivery_degraded / send_* ports)
+
+    /// Queued-attachment version gate (composer.rs QUEUED_ATTACHMENTS_MIN):
+    /// the host must defer commands with pending:// refs, or the send would
+    /// dispatch with unresolvable paths.
+    static let queuedAttachmentsMin = (0, 2, 12)
+
+    func hostSupportsQueuedAttachments(_ chat: Chat) -> Bool {
+        hostSupportsQueuedAttachmentsOn(deviceId: chat.deviceId)
+    }
+
+    func hostSupportsQueuedAttachmentsOn(deviceId: String) -> Bool {
+        guard demo == nil else { return false }
+        return workspace?.deviceVersionAtLeast(deviceId, Self.queuedAttachmentsMin) ?? false
+    }
+
+    /// Whether a send to this chat would queue rather than deliver promptly:
+    /// OS offline, the chat's room degraded (graced), or the host device
+    /// presence-dark. Every chat is remote-hosted on the phone — there is no
+    /// "locally hosted, never degraded" branch.
+    func chatDeliveryDegraded(_ chat: Chat) -> Bool {
+        guard demo == nil else { return false }
+        if connectivity.state == .offline { return true }
+        if let store = sessionStores[chat.id], store.roomActive {
+            if connectivity.degradedChats.contains(chat.id) { return true }
+        } else if connectivity.state != .connected {
+            return true
+        }
+        if !deviceOnline(chat.deviceId) { return true }
+        return false
+    }
+
+    /// The user-visible truth of a chat's oldest unadopted send. `failed`
+    /// (unadopted past the 2-minute grace, with a retry affordance) wins over
+    /// `queued` (pending on a degraded path); a healthy in-flight send reads
+    /// `sending`. nil = nothing pending.
+    func sendState(for chat: Chat, now: Int64 = nowMs()) -> SendState? {
+        guard demo == nil, let store = sessionStores[chat.id],
+              let oldest = store.pendingSends.map(\.started).min() else { return nil }
+        if now - oldest > undeliveredGraceMs { return .failed }
+        if chatDeliveryDegraded(chat) { return .queued }
+        return .sending
     }
 
     func releaseSessionStore(chatId: String) {
@@ -635,6 +732,9 @@ final class AppModel {
         for chat in overviewChats where sessionStores[chat.id] == nil {
             let store = SessionStore(chatId: chat.id, config: config)
             store.hostDeviceId = chat.deviceId
+            store.hostLiveness = { [weak self] deviceId in
+                self?.workspace?.peerLiveness(deviceId) ?? .unknown
+            }
             sessionStores[chat.id] = store
             store.start(holdDial: true)
             store.updateRoomGen(chat.roomGen)

--- a/apps/ios/Zeron/Composer/Attachments.swift
+++ b/apps/ios/Zeron/Composer/Attachments.swift
@@ -83,8 +83,21 @@ func parseUserMessageImages(_ content: String) -> ParsedUserMessage {
 
 /// use-attachments.ts `MAX_ATTACHMENT_BYTES`.
 let maxAttachmentBytes = 24 * 1024 * 1024
-/// Base64 chars per `UploadChunk` — sized for the relay link.
-let uploadChunkB64Chars = 60_000
+/// Base64 chars per `UploadChunk` (attachments.rs UPLOAD_CHUNK_B64_CHARS,
+/// PR #164): ≈510KB binary — sized to clear Cloudflare's 1MiB WS message cap
+/// with envelope headroom, and % 4 == 0 so every slice decodes independently.
+/// The old 60k (~45KB) sequential chunks made a 5MB photo 112 round trips.
+let uploadChunkB64Chars = 680_000
+/// Chunks in flight at once (attachments.rs UPLOAD_CONCURRENCY): order is
+/// irrelevant — host `seq` slots are positional and idempotent.
+let uploadConcurrency = 3
+
+/// Whole-attachment deadline (attachments.rs attachment_deadline): a lawful
+/// crawl of retrying chunks must still FAIL visibly rather than spin for
+/// hours (the 2026-08-19 image-send incident class).
+func attachmentDeadlineSeconds(chunkCount: Int) -> Int {
+    min(120 + 15 * chunkCount, 900)
+}
 
 /// An image staged in the composer, before upload. Bytes are what uploads;
 /// the decoded UIImage feeds thumbnails, the lightbox, and the post-send
@@ -131,45 +144,117 @@ struct StagedAttachment: Identifiable, Hashable {
     }
 }
 
-// MARK: - Upload (attachments.rs upload_attachment)
+// MARK: - Upload (attachments.rs upload_attachment, PR #164 shape)
 
-/// Chunked upload straight to the host device's relay room: base64 the bytes,
-/// `UploadChunk {uploadId, seq, data}` per 60k-char slice (positional `seq`
-/// makes retries idempotent), then `UploadCommit {uploadId, fileName}` → the
-/// durable absolute path on the host.
-func uploadAttachmentChunked(relay: DeviceRelayClient, name: String, data: Data) async throws -> String {
+/// Concurrency-safe progress tally shared by the parallel chunk tasks.
+private final class UploadTally: @unchecked Sendable {
+    private let lock = NSLock()
+    private var done = 0
+
+    func add(_ bytes: Int) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        done += bytes
+        return done
+    }
+}
+
+/// Chunked upload straight to the host device's relay room: base64 slices as
+/// `UploadChunk {uploadId, seq, data}` — positional `seq` makes retries
+/// idempotent — 3 in flight at once, then `UploadCommit {uploadId, fileName}`
+/// → the durable absolute path on the host. The whole upload races a
+/// chunk-count-scaled deadline, and per-chunk retries stagger by seq so a
+/// window that failed together doesn't re-collide in lockstep.
+///
+/// The caller mints `uploadId`: on the queued flow the id is the persisted
+/// `pending://` ref's identity, and retries must re-commit the same file.
+/// Progress reports the fraction of committed binary bytes, clamped at 0.99 —
+/// the last point belongs to the commit.
+func uploadAttachmentChunked(relay: DeviceRelayClient, name: String, data: Data,
+                             uploadId: String? = nil,
+                             progress: (@MainActor @Sendable (Double) -> Void)? = nil) async throws -> String {
     struct OkReply: Decodable { var ok: Bool? }
     struct CommitReply: Decodable { var path: String }
 
-    let b64 = data.base64EncodedString()
-    let uploadId = UUID().uuidString.lowercased()
-    var start = b64.startIndex
-    var seq: UInt64 = 0
-    while start < b64.endIndex {
-        let end = b64.index(start, offsetBy: uploadChunkB64Chars, limitedBy: b64.endIndex) ?? b64.endIndex
-        let params: [String: Any] = ["uploadId": uploadId, "seq": seq, "data": String(b64[start..<end])]
-        // One transient blip must not abort a long upload; `seq` slots are
-        // idempotent engine-side, so a blind re-send is safe.
+    let id = uploadId ?? UUID().uuidString.lowercased()
+    // Slice the BINARY at a % 3 == 0 boundary (b64 chars / 4 * 3): each
+    // slice's independent base64 then concatenates to the whole file's.
+    let chunkBytes = uploadChunkB64Chars / 4 * 3
+    var ranges: [Range<Int>] = []
+    var offset = 0
+    // An empty file still sends one empty chunk (the commit needs the
+    // uploadId staged); an exact multiple gets no trailing empty chunk.
+    repeat {
+        let end = min(offset + chunkBytes, data.count)
+        ranges.append(offset..<end)
+        offset = end
+    } while offset < data.count
+
+    let tally = UploadTally()
+    let total = max(data.count, 1)
+
+    @Sendable func pushChunk(seq: Int, range: Range<Int>) async throws {
+        let slice = data.subdata(in: range).base64EncodedString()
+        // The whole first window shares the cold-dial allowance, not just
+        // seq 0 — its chunks all race the same handshake.
+        let timeout: UInt64 = seq < uploadConcurrency ? 90 : 30
         var attempt = 0
         while true {
             do {
-                let _: OkReply = try await relay.call(method: "UploadChunk", params: params,
-                                                      timeoutSeconds: seq == 0 ? 90 : 30)
+                let _: OkReply = try await relay.call(
+                    method: "UploadChunk",
+                    params: ["uploadId": id, "seq": seq, "data": slice],
+                    timeoutSeconds: timeout)
                 break
             } catch {
                 attempt += 1
-                if attempt > 2 { throw error }
+                guard attempt < 3 else { throw error }
+                // Degraded uploads must narrate (silent crawls read as hangs).
+                roomLog.warning("upload \(id, privacy: .public): chunk \(seq) attempt \(attempt) failed (\(error.localizedDescription, privacy: .public)); retrying")
+                try? await Task.sleep(nanoseconds: UInt64(50 * attempt * (seq + 1)) * 1_000_000)
             }
         }
-        start = end
-        seq += 1
+        let done = tally.add(range.count)
+        if let progress {
+            let fraction = min(Double(done) / Double(total), 0.99)
+            await progress(fraction)
+        }
     }
-    // Commit outlasts the engine's assemble + best-effort edge mirror.
-    let reply: CommitReply = try await relay.call(
-        method: "UploadCommit",
-        params: ["uploadId": uploadId, "fileName": name],
-        timeoutSeconds: 150)
-    return reply.path
+
+    let deadline = attachmentDeadlineSeconds(chunkCount: ranges.count)
+    return try await withThrowingTaskGroup(of: String?.self) { race in
+        race.addTask {
+            // 3-wide sliding window over the chunk list, then the commit
+            // (which outlasts the engine's assemble + best-effort mirror).
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                var iterator = ranges.enumerated().makeIterator()
+                var launched = 0
+                while launched < uploadConcurrency, let (seq, range) = iterator.next() {
+                    group.addTask { try await pushChunk(seq: seq, range: range) }
+                    launched += 1
+                }
+                while try await group.next() != nil {
+                    if let (seq, range) = iterator.next() {
+                        group.addTask { try await pushChunk(seq: seq, range: range) }
+                    }
+                }
+            }
+            let reply: CommitReply = try await relay.call(
+                method: "UploadCommit",
+                params: ["uploadId": id, "fileName": name],
+                timeoutSeconds: 150)
+            return reply.path
+        }
+        race.addTask {
+            try? await Task.sleep(nanoseconds: UInt64(deadline) * 1_000_000_000)
+            return nil  // deadline expired
+        }
+        defer { race.cancelAll() }
+        guard let path = try await race.next() ?? nil else {
+            roomLog.error("upload \(id, privacy: .public): exceeded the \(deadline)s deadline; failing the send")
+            throw RelayError.timeout
+        }
+        return path
+    }
 }
 
 // MARK: - Transcript image cache (attachments.rs image cache)

--- a/apps/ios/Zeron/Composer/ComposerView.swift
+++ b/apps/ios/Zeron/Composer/ComposerView.swift
@@ -214,6 +214,7 @@ struct ComposerView: View {
     @State private var pickerItems: [PhotosPickerItem] = []
     @State private var showPicker = false
     @State private var uploading = false
+    @State private var uploadProgress: Double?
     @State private var uploadError: String?
     @State private var showModelPicker = false
     @State private var showTraitPicker = false
@@ -237,7 +238,10 @@ struct ComposerView: View {
     }
 
     var body: some View {
-        VStack(spacing: 6) {
+        // Subscribe to the connectivity pulse so the degraded caption follows
+        // the graced stream (1Hz only while something is degraded/pending).
+        let _ = model.connectivity.pulse
+        return VStack(spacing: 6) {
             if let uploadError {
                 Text(uploadError)
                     .font(Theme.sans(12))
@@ -245,6 +249,27 @@ struct ComposerView: View {
                     .lineLimit(2)
                     .padding(.horizontal, 24)
                     .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            if uploading, let uploadProgress {
+                Text("Uploading… \(Int(uploadProgress * 100))%")
+                    .font(Theme.sans(11))
+                    .foregroundStyle(Theme.textMuted)
+                    .monospacedDigit()
+                    .padding(.horizontal, 24)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            // Pre-send honesty (composer.rs degraded notice, post-#170 copy):
+            // one quiet caption line, never a warning box — the send still
+            // works, it just queues.
+            if model.chatDeliveryDegraded(chat) {
+                Text(model.connectivity.state == .offline
+                    ? "Offline — messages will send when you're back online."
+                    : "Messages will send once the connection recovers.")
+                    .font(Theme.sans(11))
+                    .foregroundStyle(Theme.textFaint)
+                    .padding(.horizontal, 24)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .transition(.opacity)
             }
             ComposerShell(
                 draft: $text,
@@ -362,17 +387,49 @@ struct ComposerView: View {
             clearDraft()
             return
         }
-        // Upload first, send after: the refs trailer needs the committed
-        // paths, and the doc entry must never point at files that don't
-        // exist. The shell shows the spinner (`busy`) while chunks stream.
+        if model.hostSupportsQueuedAttachments(chat) {
+            // Queued flow (host ≥ 0.2.12): the send is a durable local write
+            // NOW — pending:// refs in the doc, bytes escorted afterwards
+            // with retry-forever — so an image send survives a dead link
+            // exactly like a text send does.
+            let transfers = staged.map {
+                AttachmentTransfer(uploadId: UUID().uuidString.lowercased(),
+                                   name: $0.name, data: $0.data)
+            }
+            for (transfer, att) in zip(transfers, staged) {
+                // Seed under the pending ref — the echo's thumbnail renders
+                // from local bytes while the upload crosses the relay.
+                AttachmentImageCache.shared.seed(
+                    deviceId: chat.deviceId,
+                    path: UploadStash.pendingRef(uploadId: transfer.uploadId, name: transfer.name),
+                    name: att.name, data: att.data)
+            }
+            store.sendWithTransfers(prompt: prompt, chat: chat, live: runLive,
+                                    transfers: transfers)
+            attachments = []
+            clearDraft()
+            return
+        }
+        // Legacy host-staged flow (host < 0.2.12): upload first, send after —
+        // the refs trailer needs the committed paths. Bounded by the
+        // whole-attachment deadline; progress narrates instead of a bare
+        // spinner (a lawful crawl must never read as a hang).
         uploading = true
         uploadError = nil
+        uploadProgress = 0
+        let progressBinding = $uploadProgress
         Task { @MainActor in
-            defer { uploading = false }
+            defer {
+                uploading = false
+                uploadProgress = nil
+            }
             do {
                 var paths: [String] = []
-                for att in staged {
-                    let path = try await store.uploadAttachment(name: att.name, data: att.data)
+                let total = staged.count
+                for (ix, att) in staged.enumerated() {
+                    let path = try await store.uploadAttachment(name: att.name, data: att.data) { fraction in
+                        progressBinding.wrappedValue = (Double(ix) + fraction) / Double(total)
+                    }
                     // Seed the cache so our own bubble renders from local
                     // bytes instead of a round-trip.
                     AttachmentImageCache.shared.seed(deviceId: chat.deviceId, path: path,

--- a/apps/ios/Zeron/Models/Entities.swift
+++ b/apps/ios/Zeron/Models/Entities.swift
@@ -13,6 +13,22 @@ struct DeviceRow: Identifiable, Hashable {
     var platform: String
     var lastSeenAt: Int64?
     var createdAt: Int64?
+    /// Engine version stamped by the device ("0.2.12"); gates the queued-
+    /// attachment flow and other capability checks. nil reads as "too old".
+    var version: String?
+}
+
+/// proto/src/lib.rs version_triple: parse a leading major.minor.patch,
+/// tolerating a -suffix or +build on the patch. Anything else is nil —
+/// version gates treat that as "too old".
+func versionTriple(_ raw: String) -> (Int, Int, Int)? {
+    let parts = raw.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
+    guard parts.count == 3, let major = Int(parts[0]), let minor = Int(parts[1]) else { return nil }
+    let digits = parts[2].prefix { $0.isNumber }
+    guard !digits.isEmpty, let patch = Int(digits) else { return nil }
+    let rest = parts[2].dropFirst(digits.count)
+    guard rest.isEmpty || rest.first == "-" || rest.first == "+" else { return nil }
+    return (major, minor, patch)
 }
 
 struct Space: Identifiable, Hashable {
@@ -283,6 +299,15 @@ struct RepoRef: Codable, Hashable, Identifiable {
 
 let commandDefaultTtlMs: Int64 = 86_400_000
 
+/// zeron-proto WorktreeSpec (agent.rs, PR #159): a worktree the HOST
+/// materializes at command-drain time — the client never blocks on a
+/// CreateWorktree relay RPC before a send. Old hosts ignore the field and run
+/// in `cwd` (the repo's main checkout): degraded, never hung.
+struct WorktreeSpec: Codable, Hashable {
+    var repoPath: String
+    var base: String
+}
+
 /// zeron-proto RunRequest (agent.rs:81). `reasoning` is lowercase
 /// ("high"/"xhigh"/…), `sandbox` kebab-case ("workspace-write"), harness ids
 /// kebab-case ("claude-code").
@@ -300,10 +325,15 @@ struct RunRequest: Codable {
     var autoApprove: Bool = true
     var resume: String?
     /// Absolute paths of image attachments already staged on the run device
-    /// (UploadChunk/UploadCommit). The same paths ride the prompt text as
-    /// `Attached images (local files …)` refs — this field additionally lets
+    /// (UploadChunk/UploadCommit) — or `pending://{uploadId}/{name}` refs on
+    /// the queued flow (host ≥ 0.2.12), which the host resolves to absolute
+    /// paths once the bytes land. The same refs ride the prompt text as
+    /// `Attached images (local files …)` lines — this field additionally lets
     /// a harness inline the bytes as image content blocks.
     var attachments: [String] = []
+    /// Worktree for the host to materialize at drain time (PR #159). Omitted
+    /// from the JSON when nil, so old hosts see the legacy shape.
+    var worktree: WorktreeSpec?
 }
 
 enum SessionCommandPayload {

--- a/apps/ios/Zeron/Sync/ChatRoomClient.swift
+++ b/apps/ios/Zeron/Sync/ChatRoomClient.swift
@@ -67,6 +67,11 @@ actor ChatRoomClient {
         /// already at or below). See the once-per-session clamp in
         /// handleState/pullSync.
         var clampCursor: @MainActor @Sendable (UInt64) -> Void
+        /// Assign the cursor outright — the catch-up plan's `after` IS the
+        /// cursor, down (server reset / amnesty) or UP (a contained
+        /// checkpoint covers the skipped span; without the raise the
+        /// backfill's first row reads as a contiguity gap).
+        var setCursor: @MainActor @Sendable (UInt64) -> Void
         var event: @MainActor @Sendable (ChatRoomEvent) -> Void
     }
 
@@ -109,6 +114,15 @@ actor ChatRoomClient {
     /// Once-per-client cursor amnesty (see handleState): a cursor above the
     /// room's checkpoint is re-verified by refetching the rows above it.
     private var cursorAmnestyDone = false
+    /// A row/ack arrived with `seq > cursor + 1`: rows exist that this client
+    /// never received (live broadcast outran the backfill — the mid-join
+    /// race). The cursor must NOT skip the hole (skipped rows' dependents
+    /// park invisibly in loro's pending buffer and the doc reads empty
+    /// forever — the 2026-08-19 empty-doc/advanced-cursor wedge); the flag
+    /// asks for a rowsReq backfill from the honest cursor.
+    private var gapRepair = false
+    /// Repairs this SESSION — exhaustion forces a redial (full catch-up).
+    private var gapRepairs = 0
     /// Partial download preserved across fetch attempts (Range-resumed).
     private var partialCheckpoint = Data()
     private var partialCheckpointSeq: String?
@@ -193,7 +207,15 @@ actor ChatRoomClient {
                let ack = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let seq = (ack["seq"] as? NSNumber)?.uint64Value {
                 pending.removeAll { $0.batchId == push.batchId }
-                await delegate.advanceCursor(seq)
+                // Contiguity rule (see the socket ACK path): a jump would
+                // stamp the cursor over interleaved rows we never pulled —
+                // hold, and this cycle's pull below walks the gap.
+                let cursor = await delegate.cursor()
+                if seq <= cursor + 1 {
+                    await delegate.advanceCursor(seq)
+                } else {
+                    roomLog.warning("chat2 \(self.chatId, privacy: .public): http ack gap (seq=\(seq), cursor=\(cursor)); holding cursor")
+                }
             } else if let err = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let code = err["error"] as? String,
                       ["bad_push", "too_large", "empty"].contains(code) {
@@ -243,9 +265,9 @@ actor ChatRoomClient {
             roomLog.error("chat2 \(self.chatId, privacy: .public): http pull body malformed (\(body.count)B, \(frames.count) frames)")
             return
         }
-        if !cursorAmnestyDone, state.checkpointSize > 0 {
+        if !cursorAmnestyDone {
             cursorAmnestyDone = true
-            await delegate.clampCursor(state.checkpointSeq)
+            await delegate.clampCursor(state.checkpointSize > 0 ? state.checkpointSeq : 0)
         }
         let planAfter = await delegate.cursor()
         var contained = state.checkpointSize == 0
@@ -356,6 +378,8 @@ actor ChatRoomClient {
         helloSentAt = nil
         backfillStartedAt = nil
         probeSentAt = nil
+        gapRepair = false
+        gapRepairs = 0
         lastProtocolRx = .now()
         for ix in pending.indices {
             pending[ix].inFlight = false
@@ -543,15 +567,26 @@ actor ChatRoomClient {
                 return
             }
             await applyRowFrame(frame)
+            await maybeRepairGap(gen: gen)
 
         case ChatFrameType.ack:
             guard let batchId = frame.header["batchId"] as? String,
                   let seq = (frame.header["seq"] as? NSNumber)?.uint64Value else { return }
             pending.removeAll { $0.batchId == batchId }
-            await delegate.advanceCursor(seq)
+            // Contiguity rule, ack flavor: our own batch landing at `seq`
+            // proves rows up to seq exist SERVER-side, not that we have the
+            // interleaved ones from other devices.
+            let cursor = await delegate.cursor()
+            if seq > cursor + 1 {
+                gapRepair = true
+                roomLog.warning("chat2 \(self.chatId, privacy: .public): ack gap (seq=\(seq), cursor=\(cursor)); holding cursor and requesting backfill")
+            } else {
+                await delegate.advanceCursor(seq)
+            }
             // A grant after a quota rejection: drain whatever the error
             // handler un-flagged (sparse mobile queues — no livelock risk).
             await pushPending()
+            await maybeRepairGap(gen: gen)
 
         case ChatFrameType.probeOk:
             break  // liveness proven; clocks already advanced above
@@ -595,10 +630,15 @@ actor ChatRoomClient {
         // Cursor amnesty, once per client: a cursor above the checkpoint seq
         // claims history the doc may have silently parked and dropped (the
         // "Add Tweets" wedge). Clamp and refetch — no-op re-imports, KB cost,
-        // converts a lying cursor into a true one.
-        if !cursorAmnestyDone, state.checkpointSize > 0 {
+        // converts a lying cursor into a true one. Checkpoint-LESS rooms
+        // amnesty to ZERO (PR #172): the same parked-import wedge with no
+        // checkpoint to clamp to; refetching the whole log is bounded by the
+        // checkpoint threshold policy (a room past ~200 rows/512KB HAS a
+        // checkpoint), so this is the cheap universal heal for every
+        // already-wedged chat on disk.
+        if !cursorAmnestyDone {
             cursorAmnestyDone = true
-            await delegate.clampCursor(state.checkpointSeq)
+            await delegate.clampCursor(state.checkpointSize > 0 ? state.checkpointSeq : 0)
         }
         let planCursor = await delegate.cursor()
         let plan = chatPlanCatchUp(cursor: planCursor, state: state, frontierContained: contained)
@@ -626,6 +666,11 @@ actor ChatRoomClient {
             }
             after = a
         }
+        // The plan's `after` IS the cursor now — down (server reset /
+        // amnesty already applied) or UP (a contained checkpoint covers the
+        // skipped span). Without the raise, the backfill's first row
+        // (`after + 1`) reads as a contiguity gap against a stale cursor.
+        await delegate.setCursor(after)
         await send(ChatWire.encode(ChatFrameType.rowsReq,
                                    header: ["after": after, "excludeOwn": resumed]))
         // Pending pushes go before catch-up completes: batchId dedupe makes
@@ -672,6 +717,7 @@ actor ChatRoomClient {
             guard !closed else { return }
         }
         checkpointBuffer = nil
+        await maybeRepairGap(gen: generation)
     }
 
     /// One backfill/broadcast frame: a row, or the ROWS_DONE terminator.
@@ -683,7 +729,22 @@ actor ChatRoomClient {
             // Own-device rows can still arrive (first-backfill redownload, a
             // racing second socket) — Loro re-import is a no-op; the cursor
             // advance is what matters.
-            await delegate.applyRow(frame.payload, seq)
+            //
+            // CONTIGUITY RULE (PR #172): the cursor claims "every row ≤
+            // cursor is reflected in the doc", so it may only walk, never
+            // jump. A gap means rows we never received (live broadcast
+            // mid-join) — apply the bytes (loro parks dependents
+            // harmlessly), hold the honest cursor, and ask for a backfill
+            // repair. Skipping the hole was the random new-session
+            // forever-hang: an empty doc under an advanced cursor.
+            let cursor = await delegate.cursor()
+            if seq > cursor + 1 {
+                gapRepair = true
+                roomLog.warning("chat2 \(self.chatId, privacy: .public): row gap (seq=\(seq), cursor=\(cursor)); holding cursor and requesting backfill")
+                await delegate.applyRow(frame.payload, cursor)
+            } else {
+                await delegate.applyRow(frame.payload, seq)
+            }
             return
         }
         guard backfillStartedAt != nil else { return }
@@ -699,6 +760,26 @@ actor ChatRoomClient {
         // Anything not yet in flight goes now — the server's batchId dedupe
         // makes replays exact no-ops.
         await pushPending()
+    }
+
+    /// If a row/ack gap was flagged, request a backfill from the honest
+    /// cursor. Bounded per session: a gap the server can't fill (should be
+    /// impossible below the checkpoint floor) forces a redial, whose full
+    /// catch-up is the stronger repair. The HTTP pull path needs no send —
+    /// its next cycle re-requests from the held cursor.
+    private func maybeRepairGap(gen: Int) async {
+        guard gapRepair, gen == generation, socket != nil, stateReceived else { return }
+        gapRepair = false
+        gapRepairs += 1
+        guard gapRepairs <= 3 else {
+            roomLog.warning("chat2 \(self.chatId, privacy: .public): gap repairs exhausted; redialing for a full catch-up")
+            await onSocketError(gen: gen)
+            return
+        }
+        let after = await delegate.cursor()
+        roomLog.info("chat2 \(self.chatId, privacy: .public): backfilling over a row gap (after=\(after), attempt \(self.gapRepairs))")
+        await send(ChatWire.encode(ChatFrameType.rowsReq,
+                                   header: ["after": after, "excludeOwn": false]))
     }
 
     private func handleErrorFrame(_ header: [String: Any], gen: Int) async {

--- a/apps/ios/Zeron/Sync/ChatRoomClient.swift
+++ b/apps/ios/Zeron/Sync/ChatRoomClient.swift
@@ -42,7 +42,11 @@ actor ChatRoomClient {
     static let probeQuietNs: UInt64 = 900_000_000_000  // 15min quiet-room probe
     static let livenessTickNs: UInt64 = 1_000_000_000
     static let backoffBaseMs = 250
-    static let backoffCapMs = 30_000
+    static let backoffCapMs = 16_000
+    /// Stability-gated backoff reset (chat_client.rs STABLE_RESET): only a
+    /// session that joined AND survived this long resets backoff to base —
+    /// reset-on-join let connect-and-die sockets hot-loop at 250ms forever.
+    static let stableResetNs: UInt64 = 30_000_000_000
     /// Re-push cadence after a `quota` rejection (server window is 60s).
     static let quotaRetryNs: UInt64 = 5_000_000_000
     /// Client-side push cap: the DO's per-row cap (1 MiB) minus frame-header
@@ -112,6 +116,8 @@ actor ChatRoomClient {
     /// liveness while it runs; the silence lease defers to it.
     private var checkpointProgressAt: DispatchTime?
     private var joined = false
+    /// When the current session joined — feeds the stability-gated reset.
+    private var joinedAt: DispatchTime?
     private var closed = false
     private var generation = 0
     private var backoffMs = ChatRoomClient.backoffBaseMs
@@ -431,10 +437,20 @@ actor ChatRoomClient {
         socket?.cancel(with: .abnormalClosure, reason: nil)
         socket = nil
         cancelTasks()
+        // Stability-gated reset: only a session that survived ≥30s earns a
+        // fresh 250ms; a connect-and-die session keeps growing the backoff.
+        if let joinedAt,
+           DispatchTime.now().uptimeNanoseconds - joinedAt.uptimeNanoseconds
+               >= ChatRoomClient.stableResetNs {
+            backoffMs = ChatRoomClient.backoffBaseMs
+        }
+        joinedAt = nil
         let delay = backoffMs
         backoffMs = min(backoffMs * 2, ChatRoomClient.backoffCapMs)
         Task {
-            try? await Task.sleep(nanoseconds: UInt64(delay) * 1_000_000)
+            // Parked while the OS path is offline; cut short by any online
+            // event (a sibling dial success, path recovery, focus probe).
+            await OnlineBus.shared.waitBackoff(ms: delay)
             await self.connect()
         }
     }
@@ -675,8 +691,10 @@ actor ChatRoomClient {
         let wasResumed = resumed
         resumed = true
         joined = true
-        backoffMs = ChatRoomClient.backoffBaseMs
+        joinedAt = .now()
         roomLog.info("chat2 \(self.chatId, privacy: .public): joined (converged, resumed=\(wasResumed))")
+        // One recovered socket un-parks the whole fleet's backoffs.
+        OnlineBus.shared.notifyOnline()
         await delegate.event(.connected)
         // Anything not yet in flight goes now — the server's batchId dedupe
         // makes replays exact no-ops.

--- a/apps/ios/Zeron/Sync/Connectivity.swift
+++ b/apps/ios/Zeron/Sync/Connectivity.swift
@@ -1,0 +1,124 @@
+// Connectivity truth — the iOS port of the engine's compute_connectivity +
+// DegradeGrace (crates/engine/src/doc_host.rs, PRs #168/#170) and the UI's
+// send-status derivations (crates/ui/src/state.rs).
+//
+// One graced stream feeds every consumer (home pill, composer notice, row
+// Queued/Failed badges): a source must be RAW-degraded for 4s continuously
+// before it reports degraded — sub-second blips (room joins on navigation,
+// idle-link wakes) never flash the UI — while recovery reports instantly
+// (hide-fast, show-slow). Sources are independent: the OS path, the registry
+// room, and each open chat room keep their own timers.
+
+import Foundation
+import Observation
+
+enum ConnectivityState: Equatable {
+    /// The OS path is definitively down (graced): sends are saved locally.
+    case offline
+    /// The registry room is down (graced) while the path looks fine.
+    case reconnecting
+    case connected
+}
+
+/// A pending send's user-visible truth (state.rs send_pending/send_queued/
+/// send_undelivered). `failed` wins over `queued` in the UI.
+enum SendState {
+    case sending
+    case queued
+    case failed
+}
+
+/// state.rs UNDELIVERED_GRACE_MS: a send unadopted past this is explicitly
+/// Failed (with a retry affordance), never a silent forever-spinner.
+let undeliveredGraceMs: Int64 = 120_000
+
+@MainActor
+@Observable
+final class ConnectivityCenter {
+    /// doc_host.rs DEGRADE_GRACE (PR #170).
+    static let degradeGraceMs: Int64 = 4_000
+
+    private(set) var state: ConnectivityState = .connected
+    /// Chat ids whose room is graced-degraded (only rooms that have dialed).
+    private(set) var degradedChats: Set<String> = []
+    /// 1Hz pulse, bumped only while something is degraded or a send is
+    /// pending — views showing elapsed-based send states read it to
+    /// subscribe; a healthy idle app never repaints on it.
+    private(set) var pulse: UInt64 = 0
+
+    /// Raw-source providers, wired by AppModel (poll-based, mirroring the
+    /// engine's 1s recompute over in-memory stats).
+    @ObservationIgnored var registryConnected: (() -> Bool)?
+    @ObservationIgnored var chatRooms: (() -> [(id: String, connected: Bool)])?
+    @ObservationIgnored var hasPendingSends: (() -> Bool)?
+
+    @ObservationIgnored private var pathOffline = false
+    /// Source key → when it first sampled raw-degraded (ms). Absent = healthy.
+    @ObservationIgnored private var degradedSince: [String: Int64] = [:]
+    @ObservationIgnored private var tickTask: Task<Void, Never>?
+
+    func start() {
+        guard tickTask == nil else { return }
+        tickTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                self?.recompute()
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+    }
+
+    func stop() {
+        tickTask?.cancel()
+        tickTask = nil
+    }
+
+    func setPathOffline(_ offline: Bool) {
+        pathOffline = offline
+        recompute()
+    }
+
+    /// DegradeGrace: report degraded only once the raw state has persisted
+    /// ≥ 4s; one healthy sample clears instantly.
+    private func graced(_ key: String, raw: Bool, now: Int64) -> Bool {
+        guard raw else {
+            degradedSince[key] = nil
+            return false
+        }
+        guard let since = degradedSince[key] else {
+            degradedSince[key] = now
+            return false
+        }
+        return now - since >= Self.degradeGraceMs
+    }
+
+    private func recompute() {
+        let now = nowMs()
+        let offline = graced("os", raw: pathOffline, now: now)
+        let registryDown = graced("registry", raw: !(registryConnected?() ?? true), now: now)
+
+        var chats: Set<String> = []
+        var liveKeys: Set<String> = ["os", "registry"]
+        for room in chatRooms?() ?? [] {
+            let key = "chat:\(room.id)"
+            liveKeys.insert(key)
+            if graced(key, raw: !room.connected, now: now) {
+                chats.insert(room.id)
+            }
+        }
+        // Drop timers for rooms that closed (doc_host.rs retain_chats).
+        if degradedSince.count > liveKeys.count {
+            degradedSince = degradedSince.filter { liveKeys.contains($0.key) }
+        }
+
+        let newState: ConnectivityState = offline ? .offline
+            : registryDown ? .reconnecting
+            : .connected
+        // Publish only on change — an idle connected app never invalidates.
+        if newState != state { state = newState }
+        if chats != degradedChats { degradedChats = chats }
+        if newState != .connected || !chats.isEmpty || !degradedSince.isEmpty
+            || (hasPendingSends?() ?? false) {
+            pulse &+= 1
+        }
+    }
+}

--- a/apps/ios/Zeron/Sync/DeviceRelayClient.swift
+++ b/apps/ios/Zeron/Sync/DeviceRelayClient.swift
@@ -43,6 +43,12 @@ final class DeviceRpcPending {
     var unaryCount: Int { unary.count }
     var streamCount: Int { streams.count }
 
+    /// Whether the request is still waiting — the timeout task checks this so
+    /// a deadline firing AFTER the reply landed can't tear down a live link.
+    func owns(id: UInt64) -> Bool {
+        unary[id] != nil || streams[id] != nil
+    }
+
     func registerUnary(id: UInt64, completion: @escaping UnaryCompletion) {
         unary[id] = completion
     }
@@ -154,12 +160,35 @@ final class DeviceRpcPending {
     }
 }
 
+/// Registry-presence verdict gating peer dials (workspace_host.rs
+/// PeerLiveness, PR #168): a `dark` verdict fails peer calls fast with ZERO
+/// dials; every ambiguity stays `unknown` so a rows-down/relay-up incident
+/// shape can never park the relay.
+enum PeerLiveness: Sendable {
+    case live
+    case dark
+    case unknown
+}
+
 actor DeviceRelayClient {
     static let rpcKind = "rpc"
     static let relayKind = " relay"  // leading space is intentional
+    /// End-to-end liveness frame (rpc/src/device_room.rs ECHO_KIND): the DO's
+    /// auto-pong answers from the EDGE, so a healthy client↔edge leg can mask
+    /// a dead edge↔host leg — the echo is answered by the HOST.
+    static let echoKind = "echo"
+    /// device_room.rs PING_INTERVAL (10s) / SILENCE_LEASE (25s — tolerates one
+    /// lost pong at +10/+20) / ECHO_DEADLINE (20s of host-echo silence on an
+    /// echo-capable host = zombie path → drop and redial).
+    static let pingIntervalNs: UInt64 = 10_000_000_000
+    static let silenceLeaseNs: UInt64 = 25_000_000_000
+    static let echoDeadlineNs: UInt64 = 20_000_000_000
 
     private let deviceId: String
     private let config: AppConfig
+    /// Presence-based dial gate, wired by the owning store (MainActor reads
+    /// the registry mirror). nil = never park (unknown).
+    private let liveness: (@MainActor @Sendable () -> PeerLiveness)?
 
     private var socket: URLSessionWebSocketTask?
     private var receiveTask: Task<Void, Never>?
@@ -167,16 +196,35 @@ actor DeviceRelayClient {
     private var nextId: UInt64 = 1
     private let pending = DeviceRpcPending()
     private var connected = false
+    /// Transport clock — any inbound (the DO's auto-pong included) counts.
+    private var lastInbound = DispatchTime.now()
+    /// Host-proof clock — echo replies and inbound RPC frames only.
+    private var lastHostProof = DispatchTime.now()
+    /// The host has echoed at least once on this link (feature detection:
+    /// old hosts keep transport-lease-only behavior).
+    private var echoSeen = false
 
-    init(deviceId: String, config: AppConfig) {
+    init(deviceId: String, config: AppConfig,
+         liveness: (@MainActor @Sendable () -> PeerLiveness)? = nil) {
         self.deviceId = deviceId
         self.config = config
+        self.liveness = liveness
     }
 
     // MARK: Lifecycle
 
     private func connect() async throws {
         if connected, socket != nil { return }
+        // Registry-dark dial parking: a device with positive stale-presence
+        // evidence fails fast with zero dials (it was 3-dial bursts every
+        // ~60s to a device offline for days). A live cached link above wins;
+        // unknown/ambiguous verdicts never park.
+        if let liveness {
+            let verdict = await liveness()
+            if case .dark = verdict {
+                throw RelayError.hostOffline
+            }
+        }
         guard let token = await config.currentToken() else { throw RelayError.notConnected }
         var components = URLComponents(url: config.edgeURL.appending(path: "device/\(deviceId)/ws"),
                                        resolvingAgainstBaseURL: false)!
@@ -193,6 +241,9 @@ actor DeviceRelayClient {
         socket = task
         task.resume()
         connected = true
+        lastInbound = .now()
+        lastHostProof = .now()
+        echoSeen = false
 
         receiveTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -209,11 +260,14 @@ actor DeviceRelayClient {
         }
         pingTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 30_000_000_000)
+                try? await Task.sleep(nanoseconds: DeviceRelayClient.pingIntervalNs)
                 guard let self else { return }
-                await self.sendPing()
+                await self.keepaliveTick()
             }
         }
+        // One echo immediately on connect: feature detection + instant proof
+        // the edge↔host leg is real, not just our own client↔edge leg.
+        await sendEcho()
     }
 
     func close() {
@@ -229,8 +283,34 @@ actor DeviceRelayClient {
         pending.failAll(error: error)
     }
 
-    private func sendPing() async {
+    /// Keepalive + liveness in one 10s tick: judge the transport lease and
+    /// the host-echo deadline, then ride a text ping (DO transport lease) and
+    /// an echo frame (host proof) out together.
+    private func keepaliveTick() async {
+        guard socket != nil else { return }
+        let now = DispatchTime.now().uptimeNanoseconds
+        if now - lastInbound.uptimeNanoseconds > Self.silenceLeaseNs {
+            roomLog.warning("relay \(self.deviceId, privacy: .public): socket silent past lease; dropping link")
+            teardown(error: .hostOffline)
+            return
+        }
+        // Echo enforcement is feature-detected: only a host that has echoed
+        // at least once on this link is held to the 20s deadline. This is
+        // what kills zombie paths where the DO's auto-pong keeps our leg
+        // looking healthy while the host's leg is dead.
+        if echoSeen, now - lastHostProof.uptimeNanoseconds > Self.echoDeadlineNs {
+            roomLog.warning("relay \(self.deviceId, privacy: .public): host echo silent; dropping zombie link")
+            teardown(error: .hostOffline)
+            return
+        }
         try? await socket?.send(.string("ping"))
+        await sendEcho()
+    }
+
+    private func sendEcho() async {
+        guard let socket else { return }
+        let frame = Self.encodeFrame(header: #"{"s":"echo","k":"echo"}"#, payload: Data())
+        try? await socket.send(.data(frame))
     }
 
     // MARK: RPC
@@ -313,7 +393,13 @@ actor DeviceRelayClient {
     }
 
     private func timeoutCall(id: UInt64) {
+        guard pending.owns(id: id) else { return }
         failRequest(id: id, error: .timeout)
+        // A lost reply on a socket the DO keeps auto-ponging is a zombie
+        // path (worktree-send hang, 2026-08-18): invalidate the link so the
+        // next call re-dials instead of hanging on the same dead leg.
+        roomLog.warning("relay \(self.deviceId, privacy: .public): call timed out; dropping link as suspect")
+        teardown(error: .notConnected)
     }
 
     /// A typed streaming ControlRpc call. Items remain registered until a
@@ -353,14 +439,23 @@ actor DeviceRelayClient {
     // MARK: Inbound
 
     private func handleInbound(_ message: URLSessionWebSocketTask.Message) {
+        lastInbound = .now()
         switch message {
         case .string:
-            return  // "pong"
+            return  // "pong" — transport lease refreshed; proves only OUR leg
         case .data(let data):
             guard let (header, payload) = Self.decodeFrame(data) else { return }
             switch header.k {
             case Self.rpcKind:
+                // An inbound RPC frame comes from the host — proof enough.
+                lastHostProof = .now()
+                echoSeen = true
                 handleRpcPayload(payload)
+            case Self.echoKind:
+                // The HOST echoed our keepalive back — the end-to-end path
+                // (client → edge → host → edge → client) is alive.
+                lastHostProof = .now()
+                echoSeen = true
             case Self.relayKind:
                 // {"error":"host_offline"|"host_closed"|...} — link down.
                 teardown(error: .hostOffline)

--- a/apps/ios/Zeron/Sync/DocDisk.swift
+++ b/apps/ios/Zeron/Sync/DocDisk.swift
@@ -94,7 +94,9 @@ enum DocDisk {
                                                       includingPropertiesForKeys: [.contentModificationDateKey])
         else { return }
         let sessions = files.filter {
-            !$0.lastPathComponent.hasPrefix("ws3_") && !$0.lastPathComponent.hasPrefix("registry1_")
+            $0.pathExtension == "loro"  // never the registry blob or uploads/
+                && !$0.lastPathComponent.hasPrefix("ws3_")
+                && !$0.lastPathComponent.hasPrefix("registry1_")
         }
         guard sessions.count > keep else { return }
         let sorted = sessions.sorted {

--- a/apps/ios/Zeron/Sync/OnlineBus.swift
+++ b/apps/ios/Zeron/Sync/OnlineBus.swift
@@ -1,0 +1,111 @@
+// The online/wake bus — a Swift port of crates/sync/src/wake.rs (PR #168's
+// event-driven recovery). One process-wide bus turns "the network is back"
+// into an event every parked backoff can select on, so recovery is
+// event-driven, never timer luck:
+//
+//  - Every successful room join broadcasts (one recovered socket un-parks the
+//    whole fleet — the desktop broadcasts on every successful WS dial).
+//  - NWPathMonitor's offline→online transition broadcasts; while the path is
+//    offline, waiters park on a coarse 30s safety recheck instead of burning
+//    dials (the monitor may be wrong, so never full silence).
+//  - The foreground health probe ({edge}/health, 3s) broadcasts on success so
+//    a focus lands a redial in ~1 RTT.
+//
+// Waiters register a continuation at wait time, so only events that fire
+// DURING the wait cut it short — the drain-stale-before-arming discipline the
+// Rust side needs falls out of the design (your own last dial can't zero
+// every future wait).
+
+import Foundation
+
+final class OnlineBus: @unchecked Sendable {
+    static let shared = OnlineBus()
+
+    /// While the OS path is offline, backoff waits park at least this long
+    /// between rechecks (wake.rs OFFLINE_PARK_RECHECK).
+    static let offlineParkRecheckMs = 30_000
+
+    private let lock = NSLock()
+    private var waiters: [UInt64: CheckedContinuation<Void, Never>] = [:]
+    private var cancelledBeforeRegistration: Set<UInt64> = []
+    private var nextWaiterId: UInt64 = 0
+    private var pathOffline = false
+
+    /// Empirical "the network is back": resumes every parked waiter.
+    func notifyOnline() {
+        lock.lock()
+        let resumed = waiters
+        waiters.removeAll()
+        lock.unlock()
+        for continuation in resumed.values {
+            continuation.resume()
+        }
+    }
+
+    /// OS path status from NWPathMonitor. Only a definitive "unsatisfied"
+    /// parks; the offline→online transition broadcasts the online event.
+    func setPathOnline(_ online: Bool) {
+        lock.lock()
+        let wasOffline = pathOffline
+        pathOffline = !online
+        lock.unlock()
+        if online, wasOffline {
+            notifyOnline()
+        }
+    }
+
+    var isPathOffline: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return pathOffline
+    }
+
+    /// Sleep `ms`, cut short by an online event that fires during the wait.
+    /// While the OS path reports offline the wait is stretched to at least
+    /// the 30s park recheck — dials against a dead path are pure battery.
+    func waitBackoff(ms: Int) async {
+        var wait = ms
+        if isPathOffline {
+            wait = max(wait, Self.offlineParkRecheckMs)
+        }
+        let nanos = UInt64(wait) * 1_000_000
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try? await Task.sleep(nanoseconds: nanos)
+            }
+            group.addTask { [self] in
+                await nextOnlineEvent()
+            }
+            await group.next()
+            group.cancelAll()
+        }
+    }
+
+    /// Await the next online broadcast (cancellation-safe).
+    private func nextOnlineEvent() async {
+        lock.lock()
+        nextWaiterId += 1
+        let id = nextWaiterId
+        lock.unlock()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                var resumeNow = false
+                lock.lock()
+                if cancelledBeforeRegistration.remove(id) != nil {
+                    resumeNow = true
+                } else {
+                    waiters[id] = continuation
+                }
+                lock.unlock()
+                if resumeNow { continuation.resume() }
+            }
+        } onCancel: {
+            lock.lock()
+            let continuation = waiters.removeValue(forKey: id)
+            if continuation == nil {
+                cancelledBeforeRegistration.insert(id)
+            }
+            lock.unlock()
+            continuation?.resume()
+        }
+    }
+}

--- a/apps/ios/Zeron/Sync/RegistryClient.swift
+++ b/apps/ios/Zeron/Sync/RegistryClient.swift
@@ -45,7 +45,10 @@ actor RegistryClient {
     static let probeQuietNs: UInt64 = 900_000_000_000  // 15min quiet-room probe
     static let livenessTickNs: UInt64 = 1_000_000_000
     static let backoffBaseMs = 250
-    static let backoffCapMs = 30_000
+    static let backoffCapMs = 16_000
+    /// Stability-gated backoff reset (registry.rs STABLE_RESET): only a
+    /// session that joined AND survived this long resets backoff to base.
+    static let stableResetNs: UInt64 = 30_000_000_000
 
     /// MainActor-isolated bridge to the store's RegistryDoc.
     struct Delegate: Sendable {
@@ -64,6 +67,8 @@ actor RegistryClient {
     private var presenceTask: Task<Void, Never>?
     private var livenessTask: Task<Void, Never>?
     private var joined = false
+    /// When the current session joined — feeds the stability-gated reset.
+    private var joinedAt: DispatchTime?
     private var closed = false
     private var generation = 0
     private var backoffMs = RegistryClient.backoffBaseMs
@@ -232,10 +237,20 @@ actor RegistryClient {
         socket?.cancel(with: .abnormalClosure, reason: nil)
         socket = nil
         cancelTasks()
+        // Stability-gated reset: only a session that survived ≥30s earns a
+        // fresh 250ms; a connect-and-die session keeps growing the backoff.
+        if let joinedAt,
+           DispatchTime.now().uptimeNanoseconds - joinedAt.uptimeNanoseconds
+               >= RegistryClient.stableResetNs {
+            backoffMs = RegistryClient.backoffBaseMs
+        }
+        joinedAt = nil
         let delay = backoffMs
         backoffMs = min(backoffMs * 2, RegistryClient.backoffCapMs)
         Task {
-            try? await Task.sleep(nanoseconds: UInt64(delay) * 1_000_000)
+            // Parked while the OS path is offline; cut short by any online
+            // event (a sibling dial success, path recovery, focus probe).
+            await OnlineBus.shared.waitBackoff(ms: delay)
             await self.connect()
         }
     }
@@ -313,11 +328,13 @@ actor RegistryClient {
             helloSentAt = nil
             let wasJoined = joined
             joined = true
-            backoffMs = RegistryClient.backoffBaseMs
+            joinedAt = .now()
             await delegate.event(.state(seq: seq, full: full, gcFloor: gcFloor,
                                         rows: rows, presence: presence))
             if !wasJoined {
                 roomLog.info("registry: joined (seq=\(seq), full=\(full), rows=\(rows.count))")
+                // One recovered socket un-parks the whole fleet's backoffs.
+                OnlineBus.shared.notifyOnline()
                 await delegate.event(.connected)
             }
             // Anything pending (offline writes, reseeds) pushes now, and our

--- a/apps/ios/Zeron/Sync/SessionStore.swift
+++ b/apps/ios/Zeron/Sync/SessionStore.swift
@@ -17,6 +17,24 @@ import Foundation
 import Loro
 import Observation
 
+/// One queued-flow attachment: client-minted uploadId (the pending:// ref's
+/// identity), original file name, and the bytes the escort pushes.
+struct AttachmentTransfer {
+    let uploadId: String
+    let name: String
+    let data: Data
+}
+
+/// An optimistic echo the host hasn't materialized yet. `at` is the send's
+/// wall time (display); `started` is the delivery-grace clock, reset by the
+/// retry affordance so the surface returns to Sending/Queued.
+struct PendingSend {
+    let messageId: String
+    let text: String
+    let at: Int64
+    var started: Int64
+}
+
 @MainActor
 @Observable
 final class SessionStore {
@@ -41,7 +59,7 @@ final class SessionStore {
     @ObservationIgnored let transcriptCache = TranscriptBuilderCache()
     private(set) var connected = false
     /// Client-minted ids of sends the host hasn't materialized yet.
-    private(set) var pendingSends: [(messageId: String, text: String, at: Int64)] = []
+    private(set) var pendingSends: [PendingSend] = []
 
     let doc = LoroDoc()
     /// The chat2 room cursor — the last server row seq folded into `doc`.
@@ -76,19 +94,33 @@ final class SessionStore {
     // MARK: Attachments (uploads target the chat's host device)
 
     @ObservationIgnored private var hostRelay: (deviceId: String, client: DeviceRelayClient)?
+    /// Registry-presence dial gate for the host relay, wired by AppModel.
+    @ObservationIgnored var hostLiveness: (@MainActor @Sendable (String) -> PeerLiveness)?
 
-    /// Chunked upload of one staged image to the host device; returns the
-    /// durable absolute path on that device (what the refs trailer carries).
-    func uploadAttachment(name: String, data: Data) async throws -> String {
+    private func relayToHost() throws -> DeviceRelayClient {
         guard let hostDeviceId else { throw RelayError.hostOffline }
-        let relay: DeviceRelayClient
         if let hostRelay, hostRelay.deviceId == hostDeviceId {
-            relay = hostRelay.client
-        } else {
-            relay = DeviceRelayClient(deviceId: hostDeviceId, config: config)
-            hostRelay = (hostDeviceId, relay)
+            return hostRelay.client
         }
-        return try await uploadAttachmentChunked(relay: relay, name: name, data: data)
+        let target = hostDeviceId
+        let relay: DeviceRelayClient
+        if let gate = hostLiveness {
+            relay = DeviceRelayClient(deviceId: target, config: config,
+                                      liveness: { gate(target) })
+        } else {
+            relay = DeviceRelayClient(deviceId: target, config: config)
+        }
+        hostRelay = (target, relay)
+        return relay
+    }
+
+    /// Chunked upload of one staged image to the host device (the LEGACY
+    /// host-staged flow, for hosts < 0.2.12); returns the durable absolute
+    /// path on that device (what the refs trailer carries).
+    func uploadAttachment(name: String, data: Data, uploadId: String? = nil,
+                          progress: (@MainActor @Sendable (Double) -> Void)? = nil) async throws -> String {
+        try await uploadAttachmentChunked(relay: relayToHost(), name: name, data: data,
+                                          uploadId: uploadId, progress: progress)
     }
 
     /// Demo-mode injection point (also used by previews).
@@ -137,6 +169,9 @@ final class SessionStore {
         subscriptions.append(localSub)
         connectIfReady()
         project()
+        // A relaunch mid-send: re-arm the attachment escorts for any of our
+        // still-pending commands whose bytes sit in the stash.
+        respawnEscorts()
     }
 
     /// Registry projection hook (AppModel forwards the chat row's roomGen).
@@ -481,7 +516,8 @@ final class SessionStore {
 
     // MARK: Command plane (ledger rule 1: append-only, own entries only)
 
-    func sendRun(prompt: String, chat: Chat, attachments: [String] = []) {
+    func sendRun(prompt: String, chat: Chat, attachments: [String] = [],
+                 worktree: WorktreeSpec? = nil) {
         if offline {
             demoResponder?(prompt)
             return
@@ -494,13 +530,15 @@ final class SessionStore {
                                  modelOptions: chat.config?.modelOptions ?? [:],
                                  cwd: chat.cwd ?? "",
                                  sandbox: chat.config?.sandbox ?? "workspace-write",
-                                 attachments: attachments)
+                                 attachments: attachments,
+                                 worktree: worktree)
         queueCommand(kind: "run", payload: [
             "kind": "run",
             "request": encodableJSON(request),
             "messageId": messageId,
         ])
-        pendingSends.append((messageId, prompt, nowMs()))
+        let now = nowMs()
+        pendingSends.append(PendingSend(messageId: messageId, text: prompt, at: now, started: now))
         revision &+= 1
     }
 
@@ -515,8 +553,33 @@ final class SessionStore {
             "prompt": prompt,
             "messageId": messageId,
         ])
-        pendingSends.append((messageId, prompt, nowMs()))
+        let now = nowMs()
+        pendingSends.append(PendingSend(messageId: messageId, text: prompt, at: now, started: now))
         revision &+= 1
+    }
+
+    /// The queued-attachment send (PR #168, host ≥ 0.2.12): the command
+    /// queues IMMEDIATELY with `pending://{uploadId}/{name}` refs — a durable
+    /// local write — and the bytes chase it over the relay (retry-forever on
+    /// the online bus). The host defers the command until every ref's bytes
+    /// land, then rewrites the refs to absolute paths at dispatch. An image
+    /// send no longer dies with a dead link.
+    func sendWithTransfers(prompt: String, chat: Chat, live: Bool,
+                           transfers: [AttachmentTransfer],
+                           worktree: WorktreeSpec? = nil) {
+        // Stash bytes FIRST — before anything references them — so escorts
+        // survive a relaunch and retries can re-derive their transfers.
+        for transfer in transfers {
+            UploadStash.save(uploadId: transfer.uploadId, data: transfer.data)
+        }
+        let refs = transfers.map { UploadStash.pendingRef(uploadId: $0.uploadId, name: $0.name) }
+        let content = withAttachments(text: prompt, paths: refs)
+        if live {
+            sendSteer(prompt: content)
+        } else {
+            sendRun(prompt: content, chat: chat, attachments: refs, worktree: worktree)
+        }
+        spawnEscort(transfers: transfers)
     }
 
     func sendInterrupt() {
@@ -562,6 +625,121 @@ final class SessionStore {
         Task { [config, chatId] in
             await config.nudge(deviceId: hostDeviceId, chatId: chatId)
         }
+    }
+
+    // MARK: Delivery escorts (doc_host.rs spawn_command_delivery, phone half)
+
+    /// doc_host.rs TRANSFER_BACKOFF_BASE / TRANSFER_BACKOFF_CAP /
+    /// ATTACHMENT_WAIT_MAX: the escort retries until the bytes land or the
+    /// host's own 15-minute defer window closes.
+    private static let transferBackoffBaseMs = 2_000
+    private static let transferBackoffCapMs = 30_000
+    private static let attachmentWaitMaxMs: Int64 = 15 * 60_000
+
+    /// uploadIds an escort is actively pushing — retry/respawn dedupes on it.
+    @ObservationIgnored private var activeEscorts: Set<String> = []
+
+    /// Whether this store has ever dialed its chat2 room (feeds the
+    /// connectivity center — an undialed room is not "degraded").
+    var roomActive: Bool { chatRoom != nil }
+
+    /// Push a queued send's bytes to the host: retry-forever (event-driven
+    /// backoff, cut short by online events) up to the host's defer window.
+    /// Success commits every upload and nudges the drain; the command stays
+    /// durably queued in the doc no matter what happens here.
+    private func spawnEscort(transfers: [AttachmentTransfer]) {
+        let remaining = transfers.filter { !activeEscorts.contains($0.uploadId) }
+        guard !remaining.isEmpty else { return }
+        for transfer in remaining {
+            activeEscorts.insert(transfer.uploadId)
+        }
+        Task { @MainActor [weak self] in
+            defer {
+                for transfer in remaining {
+                    self?.activeEscorts.remove(transfer.uploadId)
+                }
+            }
+            var pending = remaining
+            var backoffMs = Self.transferBackoffBaseMs
+            let deadline = nowMs() + Self.attachmentWaitMaxMs
+            while let self, !pending.isEmpty, nowMs() < deadline {
+                do {
+                    while let transfer = pending.first {
+                        _ = try await uploadAttachmentChunked(
+                            relay: self.relayToHost(),
+                            name: transfer.name, data: transfer.data,
+                            uploadId: transfer.uploadId)
+                        UploadStash.delete(uploadId: transfer.uploadId)
+                        pending.removeFirst()
+                    }
+                    self.nudgeHost()
+                    return
+                } catch {
+                    roomLog.warning("chat2 \(self.chatId, privacy: .public): attachment transfer failed (\(error.localizedDescription, privacy: .public)); retrying in \(backoffMs)ms")
+                    await OnlineBus.shared.waitBackoff(ms: backoffMs)
+                    backoffMs = min(backoffMs * 2, Self.transferBackoffCapMs)
+                }
+            }
+            if !pending.isEmpty {
+                roomLog.error("chat2 \(self?.chatId ?? "?", privacy: .public): attachment transfer gave up after 15min; the send stays queued — retry re-derives the transfers")
+            }
+        }
+    }
+
+    /// Re-derive escorts from the doc's own pending commands (retry taps,
+    /// app relaunch): scan our unexpired pending entries for pending:// refs
+    /// and re-push any whose bytes are still stashed. Idempotent — a re-push
+    /// re-commits the same file; the host's processed ledger keeps execution
+    /// exactly-once.
+    private func respawnEscorts() {
+        guard let root = doc.getDeepValue().mapValue,
+              let commands = root["commands"]?.listValue, !commands.isEmpty else { return }
+        let now = nowMs()
+        var transfers: [AttachmentTransfer] = []
+        var seen = Set<String>()
+        for value in commands {
+            guard let m = value.mapValue,
+                  m["status"]?.stringValue == "pending",
+                  m["issuedBy"]?.stringValue == config.deviceId,
+                  let payload = m["payload"]?.mapValue else { continue }
+            if let expires = m["expiresAt"]?.i64Value, expires <= now { continue }
+            var refs: [String] = []
+            if let request = payload["request"]?.mapValue,
+               let attachments = request["attachments"]?.listValue {
+                refs += attachments.compactMap(\.stringValue)
+            }
+            if let prompt = payload["prompt"]?.stringValue {
+                refs += prompt.split(separator: "\n").compactMap { line in
+                    let trimmed = line.trimmingCharacters(in: .whitespaces)
+                    guard trimmed.hasPrefix("- \(UploadStash.pendingRefPrefix)") else { return nil }
+                    return String(trimmed.dropFirst(2))
+                }
+            }
+            for ref in refs {
+                guard let (uploadId, name) = UploadStash.parseRef(ref),
+                      seen.insert(uploadId).inserted,
+                      let data = UploadStash.load(uploadId: uploadId) else { continue }
+                transfers.append(AttachmentTransfer(uploadId: uploadId, name: name, data: data))
+            }
+        }
+        guard !transfers.isEmpty else { return }
+        roomLog.info("chat2 \(self.chatId, privacy: .public): respawning \(transfers.count) attachment escort(s)")
+        spawnEscort(transfers: transfers)
+    }
+
+    /// The "Not delivered — tap to retry" affordance (doc_host.rs
+    /// retry_delivery): restart the grace clock so the surface returns to
+    /// Sending/Queued, kick the room on fresh backoff, nudge the host, and
+    /// re-derive attachment escorts from the still-pending refs.
+    func retryDelivery() {
+        let now = nowMs()
+        for ix in pendingSends.indices {
+            pendingSends[ix].started = now
+        }
+        revision &+= 1
+        kickRoom()
+        nudgeHost()
+        respawnEscorts()
     }
 }
 

--- a/apps/ios/Zeron/Sync/SessionStore.swift
+++ b/apps/ios/Zeron/Sync/SessionStore.swift
@@ -259,6 +259,11 @@ final class SessionStore {
                 self.cursor = seq
                 self.saver?.poke()
             },
+            setCursor: { [weak self] seq in
+                guard let self, self.cursor != seq else { return }
+                self.cursor = seq
+                self.saver?.poke()
+            },
             event: { [weak self] event in self?.handle(event) }
         )
         let client = ChatRoomClient(
@@ -638,6 +643,10 @@ final class SessionStore {
 
     /// uploadIds an escort is actively pushing — retry/respawn dedupes on it.
     @ObservationIgnored private var activeEscorts: Set<String> = []
+    /// Fraction of the current escort batch's bytes committed to the host
+    /// (PR #185's "the ring tracks the real relay transfer" — the status
+    /// strip narrates it as "Uploading… N%"). nil = no transfer in flight.
+    private(set) var transferProgress: Double?
 
     /// Whether this store has ever dialed its chat2 room (feeds the
     /// connectivity center — an undialed room is not "degraded").
@@ -658,17 +667,24 @@ final class SessionStore {
                 for transfer in remaining {
                     self?.activeEscorts.remove(transfer.uploadId)
                 }
+                self?.transferProgress = nil
             }
             var pending = remaining
             var backoffMs = Self.transferBackoffBaseMs
             let deadline = nowMs() + Self.attachmentWaitMaxMs
+            let totalBytes = max(remaining.reduce(0) { $0 + $1.data.count }, 1)
             while let self, !pending.isEmpty, nowMs() < deadline {
                 do {
                     while let transfer = pending.first {
+                        let doneBytes = totalBytes - pending.reduce(0) { $0 + $1.data.count }
                         _ = try await uploadAttachmentChunked(
                             relay: self.relayToHost(),
                             name: transfer.name, data: transfer.data,
-                            uploadId: transfer.uploadId)
+                            uploadId: transfer.uploadId) { [weak self] fraction in
+                            self?.transferProgress = min(
+                                (Double(doneBytes) + fraction * Double(transfer.data.count))
+                                    / Double(totalBytes), 0.99)
+                        }
                         UploadStash.delete(uploadId: transfer.uploadId)
                         pending.removeFirst()
                     }
@@ -729,17 +745,69 @@ final class SessionStore {
 
     /// The "Not delivered — tap to retry" affordance (doc_host.rs
     /// retry_delivery): restart the grace clock so the surface returns to
-    /// Sending/Queued, kick the room on fresh backoff, nudge the host, and
-    /// re-derive attachment escorts from the still-pending refs.
+    /// Sending/Queued, re-issue dead attempts, kick the room on fresh
+    /// backoff, nudge the host, and re-derive attachment escorts from the
+    /// still-pending refs (a re-issued command's refs are included).
     func retryDelivery() {
         let now = nowMs()
         for ix in pendingSends.indices {
             pendingSends[ix].started = now
         }
         revision &+= 1
+        reissueDeadSends()
         kickRoom()
         nudgeHost()
         respawnEscorts()
+    }
+
+    /// PR #172's retry semantics, phone half: exactly-once is per command
+    /// ID, so a Run/Steer whose user message never landed and whose command
+    /// can never execute again — Rejected (the host's dead-command sweep
+    /// terminalized it, synced back over chat2), Expired status, or Pending
+    /// past its own TTL (the host will never drain it; an explicit user
+    /// retry is exactly the consent to re-send) — gets a FRESH attempt: new
+    /// id, same payload and messageId (the host's user-entry pre-write
+    /// dedupes by message id). One re-issue per message (latest attempt);
+    /// a live pending unexpired attempt for the same message skips it.
+    func reissueDeadSends() {
+        guard let root = doc.getDeepValue().mapValue,
+              let commands = root["commands"]?.listValue, !commands.isEmpty else { return }
+        let landed = Set(entries.map(\.id))
+        let now = nowMs()
+        struct DeadAttempt {
+            var kind: String
+            var payload: [String: Any]
+            var issuedAt: Int64
+            var oldId: String
+        }
+        var latestDead: [String: DeadAttempt] = [:]
+        var liveMessageIds: Set<String> = []
+        for value in commands {
+            guard let m = value.mapValue,
+                  m["issuedBy"]?.stringValue == config.deviceId,
+                  let kind = m["kind"]?.stringValue, kind == "run" || kind == "steer",
+                  let id = m["id"]?.stringValue,
+                  let payload = m["payload"]?.mapValue,
+                  let messageId = payload["messageId"]?.stringValue,
+                  !landed.contains(messageId) else { continue }
+            let status = m["status"]?.stringValue ?? "pending"
+            let expired = (m["expiresAt"]?.i64Value).map { $0 <= now } ?? false
+            if status == "pending", !expired {
+                liveMessageIds.insert(messageId)
+                continue
+            }
+            guard status == "rejected" || status == "expired"
+                || (status == "pending" && expired) else { continue }
+            let issuedAt = m["issuedAt"]?.i64Value ?? 0
+            if let existing = latestDead[messageId], existing.issuedAt >= issuedAt { continue }
+            guard let object = LoroValue.map(value: payload).jsonObject as? [String: Any] else { continue }
+            latestDead[messageId] = DeadAttempt(kind: kind, payload: object,
+                                                issuedAt: issuedAt, oldId: id)
+        }
+        for (messageId, attempt) in latestDead where !liveMessageIds.contains(messageId) {
+            roomLog.info("chat2 \(self.chatId, privacy: .public): retry re-issues a dead send attempt (old=\(attempt.oldId, privacy: .public))")
+            queueCommand(kind: attempt.kind, payload: attempt.payload)
+        }
     }
 }
 

--- a/apps/ios/Zeron/Sync/UploadStash.swift
+++ b/apps/ios/Zeron/Sync/UploadStash.swift
@@ -1,0 +1,71 @@
+// Durable staging for queued attachments (PR #168's "a send is a local
+// write"): the bytes of every pending://-referenced attachment persist on
+// device, keyed by uploadId, so the delivery escort can re-derive its
+// transfers after a retry, a relaunch, or a tapped "retry" — the command in
+// the doc names the ref; the stash holds the bytes it points at.
+//
+// Lives under DocDisk's directory so sign-out hygiene (wipeAll) covers it.
+// Entries are deleted when the host commits the upload; anything older than
+// the command TTL (24h) is swept on demand.
+
+import Foundation
+
+enum UploadStash {
+    static let pendingRefPrefix = "pending://"
+
+    static var directory: URL {
+        let base = DocDisk.directory.appendingPathComponent("uploads", isDirectory: true)
+        try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        return base
+    }
+
+    /// The persisted ref (uploads.rs PENDING_REF_PREFIX): the ORIGINAL file
+    /// name rides the ref; both ends sanitize at resolution.
+    static func pendingRef(uploadId: String, name: String) -> String {
+        "\(pendingRefPrefix)\(uploadId)/\(name)"
+    }
+
+    /// Parse a pending ref back into (uploadId, fileName).
+    static func parseRef(_ ref: String) -> (uploadId: String, name: String)? {
+        guard ref.hasPrefix(pendingRefPrefix) else { return nil }
+        let body = ref.dropFirst(pendingRefPrefix.count)
+        guard let slash = body.firstIndex(of: "/") else { return nil }
+        let id = String(body[..<slash])
+        let name = String(body[body.index(after: slash)...])
+        guard !id.isEmpty, !name.isEmpty else { return nil }
+        return (id, name)
+    }
+
+    private static func url(uploadId: String) -> URL {
+        let safe = uploadId.filter { $0.isLetter || $0.isNumber || $0 == "-" }
+        return directory.appendingPathComponent("\(safe).bin")
+    }
+
+    static func save(uploadId: String, data: Data) {
+        try? data.write(to: url(uploadId: uploadId), options: .atomic)
+    }
+
+    static func load(uploadId: String) -> Data? {
+        try? Data(contentsOf: url(uploadId: uploadId))
+    }
+
+    static func delete(uploadId: String) {
+        try? FileManager.default.removeItem(at: url(uploadId: uploadId))
+    }
+
+    /// Drop entries older than the command TTL — their commands have expired,
+    /// so no escort will ever want the bytes again.
+    static func sweep(ttlMs: Int64 = commandDefaultTtlMs) {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: [.contentModificationDateKey]) else { return }
+        let cutoff = Date(timeIntervalSinceNow: -Double(ttlMs) / 1000)
+        for file in files {
+            let modified = (try? file.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate) ?? .distantPast
+            if modified < cutoff {
+                try? fm.removeItem(at: file)
+            }
+        }
+    }
+}

--- a/apps/ios/Zeron/Sync/WorkspaceStore.swift
+++ b/apps/ios/Zeron/Sync/WorkspaceStore.swift
@@ -35,11 +35,19 @@ final class WorkspaceStore {
     /// client's 30s TTL, measured from RECEIPT — beats carry the sender's
     /// wall clock, which we never trust for freshness).
     static let presenceTtlMs: Int64 = 30_000
+    /// Dial-gate thresholds (workspace_host.rs PRESENCE_FRESH_MS /
+    /// DIAL_GATE_DARK_MS / DIAL_GATE_WARMUP_MS, PR #168).
+    static let presenceLiveFreshMs: Int64 = 45_000
+    static let dialGateDarkMs: Int64 = 5 * 60_000
+    static let dialGateWarmupMs: Int64 = 60_000
 
     @ObservationIgnored private var doc: RegistryDoc
     @ObservationIgnored private var client: RegistryClient?
     @ObservationIgnored private var saver: RegistrySaver?
     @ObservationIgnored private var presenceReceivedAt: [String: Int64] = [:]
+    /// When the registry room (re)joined — the dial-gate warm-up clock
+    /// restarts on every rejoin.
+    @ObservationIgnored private var registryJoinedAt: Int64?
     private let config: AppConfig
 
     init(config: AppConfig) {
@@ -214,6 +222,7 @@ final class WorkspaceStore {
         case .connected:
             let reconnected = !connected
             connected = true
+            registryJoinedAt = nowMs()
             if reconnected {
                 restartChangeRequestStreams(resetUnsupported: true)
             }
@@ -233,6 +242,7 @@ final class WorkspaceStore {
             presenceReceivedAt[device] = nowMs()
         case .disconnected:
             connected = false
+            registryJoinedAt = nil
             doc.markDisconnected()
         }
     }
@@ -259,6 +269,37 @@ final class WorkspaceStore {
         return nowMs() - received < Self.presenceTtlMs
     }
 
+    /// Dial-gate verdict (workspace_host.rs peer_liveness): `dark` requires
+    /// POSITIVE evidence of absence — a joined, warmed-up registry room and a
+    /// freshest heartbeat older than 5 minutes. Registry-down and every
+    /// ambiguity stay `unknown`, so a rows-down/relay-up incident shape can
+    /// never park the relay.
+    func peerLiveness(_ deviceId: String) -> PeerLiveness {
+        guard connected, let joinedAt = registryJoinedAt else { return .unknown }
+        let now = nowMs()
+        if let received = presenceReceivedAt[deviceId] {
+            if now - received < Self.presenceLiveFreshMs { return .live }
+            if now - received >= Self.dialGateDarkMs { return .dark }
+            return .unknown
+        }
+        // Never heard this session: only a warmed-up room may consult the
+        // durable device row's own stamp.
+        guard now - joinedAt >= Self.dialGateWarmupMs else { return .unknown }
+        if let seen = devices.first(where: { $0.id == deviceId })?.lastSeenAt,
+           now - seen >= Self.dialGateDarkMs {
+            return .dark
+        }
+        return .unknown
+    }
+
+    /// Version gates (state.rs device_version_at_least): unknown device or an
+    /// unparsable/unstamped version reads as "too old" → legacy behavior.
+    func deviceVersionAtLeast(_ deviceId: String, _ min: (Int, Int, Int)) -> Bool {
+        guard let raw = devices.first(where: { $0.id == deviceId })?.version,
+              let v = versionTriple(raw) else { return false }
+        return v >= min
+    }
+
     // MARK: Projection (rows → typed entities)
 
     private func project() {
@@ -269,7 +310,8 @@ final class WorkspaceStore {
                              name: f["name"]?.stringValue ?? id,
                              platform: f["platform"]?.stringValue ?? "",
                              lastSeenAt: f["lastSeenAt"]?.int64Value,
-                             createdAt: f["createdAt"]?.int64Value)
+                             createdAt: f["createdAt"]?.int64Value,
+                             version: f["version"]?.stringValue)
         }.sorted { $0.name < $1.name }
 
         spaces = doc.overlayRows(kind: "spaces").compactMap { row in
@@ -375,9 +417,23 @@ final class WorkspaceStore {
 
     private func relay(for deviceId: String) -> DeviceRelayClient {
         if let existing = relayClients[deviceId] { return existing }
-        let client = DeviceRelayClient(deviceId: deviceId, config: config)
+        let client = DeviceRelayClient(deviceId: deviceId, config: config,
+                                       liveness: { [weak self] in
+                                           self?.peerLiveness(deviceId) ?? .unknown
+                                       })
         relayClients[deviceId] = client
         return client
+    }
+
+    /// Chunked upload straight to a device (the legacy host-staged path for
+    /// hosts that predate queued attachments) — used by the new-session
+    /// canvas, where no SessionStore exists yet.
+    func uploadAttachment(deviceId: String, name: String, data: Data,
+                          uploadId: String,
+                          progress: (@MainActor @Sendable (Double) -> Void)? = nil) async throws -> String {
+        try await uploadAttachmentChunked(relay: relay(for: deviceId), name: name,
+                                          data: data, uploadId: uploadId,
+                                          progress: progress)
     }
 
     private func reconcileChangeRequestStreams() {

--- a/apps/ios/Zeron/Transcript/TranscriptRows.swift
+++ b/apps/ios/Zeron/Transcript/TranscriptRows.swift
@@ -53,7 +53,7 @@ enum TranscriptRowBuilder {
     /// "{entryId}#{partId}" so the streaming tail re-parses O(delta + tail);
     /// `completed` memoizes settled parts so they parse exactly once.
     static func rows(entries: [MessageEntry],
-                     pendingSends: [(messageId: String, text: String, at: Int64)],
+                     pendingSends: [PendingSend],
                      parsers: inout [String: IncrementalMarkdownParser],
                      completed: inout [String: CompletedParse]) -> [TranscriptRow] {
         var rows: [TranscriptRow] = []

--- a/apps/ios/Zeron/Transcript/TranscriptView.swift
+++ b/apps/ios/Zeron/Transcript/TranscriptView.swift
@@ -495,7 +495,7 @@ final class TranscriptBuilderCache {
     /// does — gate on the revision and hand back the same array.
     func rows(revision: UInt64,
               entries: [MessageEntry],
-              pendingSends: [(messageId: String, text: String, at: Int64)]) -> [TranscriptRow] {
+              pendingSends: [PendingSend]) -> [TranscriptRow] {
         if cachedRevision == revision { return cachedRows }
         cachedRows = TranscriptRowBuilder.rows(entries: entries, pendingSends: pendingSends,
                                                parsers: &parsers, completed: &completed)

--- a/apps/ios/Zeron/Views/HomeView.swift
+++ b/apps/ios/Zeron/Views/HomeView.swift
@@ -62,12 +62,41 @@ struct HomeView: View {
                             .padding(.leading, -10)
                         // In the bar, not the list: as a list row it appeared
                         // and vanished with the connection and shoved the
-                        // content down.
-                        if !model.connected {
-                            ProgressView()
-                                .controlSize(.mini)
-                                .tint(Theme.textMuted)
-                                .accessibilityLabel("Connecting")
+                        // content down. Degraded states are GRACED (4s of
+                        // continuous raw degradation before anything shows;
+                        // recovery hides instantly) and quiet — a bare
+                        // grayscale spinner or dot with a faint caption, no
+                        // surface, no border (shell.rs render_connection_pill).
+                        switch model.connectivity.state {
+                        case .offline:
+                            HStack(spacing: 5) {
+                                Circle()
+                                    .fill(Theme.warning)
+                                    .frame(width: 5, height: 5)
+                                Text("Offline — sends are saved")
+                                    .font(Theme.sans(11))
+                                    .foregroundStyle(Theme.textFaint)
+                            }
+                            .transition(.opacity)
+                        case .reconnecting:
+                            HStack(spacing: 5) {
+                                ProgressView()
+                                    .controlSize(.mini)
+                                    .tint(Theme.textMuted)
+                                Text("Reconnecting…")
+                                    .font(Theme.sans(11))
+                                    .foregroundStyle(Theme.textFaint)
+                            }
+                            .transition(.opacity)
+                        case .connected:
+                            // Initial catch-up (within the grace): the old
+                            // quiet "connecting" spinner, gone on first sync.
+                            if !model.connected {
+                                ProgressView()
+                                    .controlSize(.mini)
+                                    .tint(Theme.textMuted)
+                                    .accessibilityLabel("Connecting")
+                            }
                         }
                     }
                 }
@@ -281,11 +310,16 @@ struct ChatRow: View {
     private var subline: Color { Theme.textMuted.opacity(0.5) }
 
     var body: some View {
+        // The 1Hz pulse (live only while something is degraded or pending)
+        // re-derives the send badge as its grace clocks advance.
+        let _ = model.connectivity.pulse
         let indicator = model.indicator(for: chat)
+        let sendState = model.sendState(for: chat)
         let pullRequest = model.changeRequest(for: chat)
         ZStack(alignment: .bottomTrailing) {
             Button(action: onSelect) {
-                content(indicator: indicator, reservesPullRequest: pullRequest != nil)
+                content(indicator: indicator, sendState: sendState,
+                        reservesPullRequest: pullRequest != nil)
             }
             .buttonStyle(PressWashButtonStyle())
             if let pullRequest {
@@ -297,8 +331,21 @@ struct ChatRow: View {
         }
     }
 
-    private func content(indicator: ChatIndicator, reservesPullRequest: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+    /// Undelivered-send override for the corner slot (shell.rs precedence:
+    /// Failed > Queued > the normal indicator). Suppresses the Working
+    /// spinner too — no fake progress on a send that hasn't left.
+    private func sendBadge(_ state: SendState) -> (label: String, color: Color)? {
+        switch state {
+        case .failed: return ("Failed", Theme.danger)
+        case .queued: return ("Queued", Theme.warning)
+        case .sending: return nil
+        }
+    }
+
+    private func content(indicator: ChatIndicator, sendState: SendState?,
+                         reservesPullRequest: Bool) -> some View {
+        let badge = sendState.flatMap(sendBadge)
+        return VStack(alignment: .leading, spacing: 2) {
             // Line 1: space @ device, status corner (time-ago when idle).
             HStack(spacing: 8) {
                 if showLocation {
@@ -311,7 +358,16 @@ struct ChatRow: View {
                 } else {
                     Spacer(minLength: 4)
                 }
-                if indicator == .idle {
+                if let badge {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(badge.color)
+                            .frame(width: 6, height: 6)
+                        Text(badge.label)
+                            .font(Theme.sans(10, weight: .medium))
+                            .foregroundStyle(badge.color)
+                    }
+                } else if indicator == .idle {
                     Text(relativeTime(chat.lastMessageAt ?? chat.createdAt))
                         .font(Theme.sans(10, weight: .medium))
                         .foregroundStyle(subline)
@@ -343,7 +399,7 @@ struct ChatRow: View {
                         .truncationMode(.tail)
                 }
                 Spacer(minLength: 0)
-                if indicator == .working {
+                if indicator == .working, badge == nil {
                     MiniSpinner()
                 }
             }

--- a/apps/ios/Zeron/Views/NewSessionView.swift
+++ b/apps/ios/Zeron/Views/NewSessionView.swift
@@ -361,8 +361,13 @@ struct NewSessionView: View {
     }
 
     /// Mint the chat per the checkout plan, queue the first run, swap to the
-    /// live session (composer.rs on-send: current checkout as-is, reuse the
-    /// picked ref's worktree, or CreateWorktree off the base first).
+    /// live session. The atomic ordering (PRs #159/#170): anything that can
+    /// FAIL stages before anything is created — a legacy attachment upload
+    /// aborts with no chat row anywhere — and nothing left in the pipeline
+    /// blocks on a relay RPC. A New-worktree plan rides the queued Run as a
+    /// WorktreeSpec the HOST materializes at drain time; the old
+    /// CreateWorktree-before-send was the one new-chat path that could hang
+    /// forever on a zombie link (the 2026-08-18 "Sending…" incident).
     private func send() {
         guard let space, canSend else { return }
         let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -372,21 +377,50 @@ struct NewSessionView: View {
         Task { @MainActor in
             var cwd: String?
             var branch = selectedRef
+            var worktree: WorktreeSpec?
             switch checkoutKind {
             case .newWorktree:
-                if let base = selectedRef {
-                    guard let worktreePath = await model.createWorktree(space: space, base: base) else {
-                        busy = false
-                        return
-                    }
-                    cwd = worktreePath
-                    branch = base
-                }
+                // Base defaults to HEAD (PR #165): a branch list that never
+                // loaded over a flapping relay must not silently drop
+                // isolation. cwd stays the space folder — the old-host
+                // degradation path (run in main checkout, never hung).
+                worktree = WorktreeSpec(repoPath: space.path, base: selectedRef ?? "HEAD")
+                cwd = space.path
             case .local:
-                if let worktree = selectedRefRow?.worktreePath {
-                    cwd = worktree  // reuse the ref's existing checkout
+                if let reused = selectedRefRow?.worktreePath {
+                    cwd = reused  // reuse the ref's existing checkout
                 }
             }
+
+            let staged = attachments
+            let queued = model.hostSupportsQueuedAttachmentsOn(deviceId: space.deviceId)
+
+            // Legacy hosts (< 0.2.12) stage attachments FIRST — before the
+            // chat row or store exist — so an upload failure aborts with
+            // nothing created (no stranded empty chat in the sidebar).
+            var legacyPaths: [String] = []
+            if !staged.isEmpty, !queued, model.demo == nil {
+                guard let workspace = model.workspace else {
+                    busy = false
+                    return
+                }
+                do {
+                    for att in staged {
+                        let uploadId = UUID().uuidString.lowercased()
+                        let uploaded = try await workspace.uploadAttachment(
+                            deviceId: space.deviceId, name: att.name, data: att.data,
+                            uploadId: uploadId)
+                        AttachmentImageCache.shared.seed(deviceId: space.deviceId, path: uploaded,
+                                                         name: att.name, data: att.data)
+                        legacyPaths.append(uploaded)
+                    }
+                } catch {
+                    attachError = "Attachment upload failed — \(error.localizedDescription)"
+                    busy = false
+                    return
+                }
+            }
+
             guard let chatId = model.createChat(space: space, config: config,
                                                 branch: branch, cwd: cwd),
                   let chat = model.chat(id: chatId),
@@ -394,23 +428,27 @@ struct NewSessionView: View {
                 busy = false
                 return
             }
-            // Upload staged images now that the chat's store exists; the doc
-            // entry must never point at files that don't (ComposerView.send).
-            var paths: [String] = []
-            for att in attachments {
-                do {
-                    let path = try await store.uploadAttachment(name: att.name, data: att.data)
-                    AttachmentImageCache.shared.seed(deviceId: chat.deviceId, path: path,
-                                                     name: att.name, data: att.data)
-                    paths.append(path)
-                } catch {
-                    attachError = "Attachment upload failed — \(error.localizedDescription)"
-                    busy = false
-                    return
+            if queued, !staged.isEmpty {
+                // Queued flow: pending:// refs make the whole send a durable
+                // local write; the escort pushes bytes afterwards.
+                let transfers = staged.map {
+                    AttachmentTransfer(uploadId: UUID().uuidString.lowercased(),
+                                       name: $0.name, data: $0.data)
                 }
+                for (transfer, att) in zip(transfers, staged) {
+                    AttachmentImageCache.shared.seed(
+                        deviceId: chat.deviceId,
+                        path: UploadStash.pendingRef(uploadId: transfer.uploadId,
+                                                     name: transfer.name),
+                        name: att.name, data: att.data)
+                }
+                store.sendWithTransfers(prompt: prompt, chat: chat, live: false,
+                                        transfers: transfers, worktree: worktree)
+            } else {
+                store.sendRun(prompt: legacyPaths.isEmpty ? prompt
+                                  : withAttachments(text: prompt, paths: legacyPaths),
+                              chat: chat, attachments: legacyPaths, worktree: worktree)
             }
-            store.sendRun(prompt: paths.isEmpty ? prompt : withAttachments(text: prompt, paths: paths),
-                          chat: chat, attachments: paths)
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
             draft = ""
             attachments = []

--- a/apps/ios/Zeron/Views/SessionView.swift
+++ b/apps/ios/Zeron/Views/SessionView.swift
@@ -243,9 +243,18 @@ struct SessionView: View {
                         .font(Theme.sans(11))
                         .foregroundStyle(Theme.warning.opacity(0.9))
                 case .sending?:
-                    Text("Sending…")
-                        .font(Theme.sans(11))
-                        .foregroundStyle(Theme.textMuted)
+                    // The percent tracks the REAL relay transfer (escort
+                    // bytes committed to the host), not just local staging.
+                    if let progress = store.transferProgress {
+                        Text("Uploading… \(Int(progress * 100))%")
+                            .font(Theme.sans(11))
+                            .foregroundStyle(Theme.textMuted)
+                            .monospacedDigit()
+                    } else {
+                        Text("Sending…")
+                            .font(Theme.sans(11))
+                            .foregroundStyle(Theme.textMuted)
+                    }
                 case nil:
                     normalStatus(chat: chat, status: status)
                 }

--- a/apps/ios/Zeron/Views/SessionView.swift
+++ b/apps/ios/Zeron/Views/SessionView.swift
@@ -162,8 +162,9 @@ struct SessionView: View {
                     // The strip reserves its 24pt whether or not a run is
                     // live, so the composer never shifts. It sits on the
                     // solid floor right where the transcript's fade completes.
-                    statusStrip(chat: chat, status: status)
-                        .allowsHitTesting(false)
+                    // Hit-testing stays off except for the retry affordance.
+                    statusStrip(chat: chat, status: status, store: store)
+                        .allowsHitTesting(model.sendState(for: chat) == .failed)
                     Group {
                         if let request = store.openInputRequest {
                             QuestionPanel(requestId: request.requestId, questions: request.questions) { requestId, answers in
@@ -217,10 +218,47 @@ struct SessionView: View {
     /// Reserved 24pt status strip (shell.rs render_status_strip) — Working
     /// shows the sunrise spinner + rotating flavour word + elapsed; Errored
     /// shows "Run failed"; the strip always reserves its height so the
-    /// composer never shifts.
-    private func statusStrip(chat: Chat, status: SessionStatus?) -> some View {
+    /// composer never shifts. An unadopted send's truth takes precedence:
+    /// "Sending…" (healthy, within the 2-minute grace), "Queued — will send
+    /// automatically" (degraded path — no fake progress), or the explicit
+    /// "Not delivered — tap to retry" (transcript.rs retry_send).
+    private func statusStrip(chat: Chat, status: SessionStatus?, store: SessionStore) -> some View {
         TimelineView(.periodic(from: .now, by: 1)) { _ in
             HStack(spacing: 6) {
+                switch model.sendState(for: chat) {
+                case .failed?:
+                    Button {
+                        store.retryDelivery()
+                    } label: {
+                        Text("Not delivered — tap to retry")
+                            .font(Theme.sans(11))
+                            .foregroundStyle(Theme.danger)
+                    }
+                    .buttonStyle(.plain)
+                case .queued?:
+                    Circle()
+                        .fill(Theme.warning)
+                        .frame(width: 5, height: 5)
+                    Text("Queued — will send automatically")
+                        .font(Theme.sans(11))
+                        .foregroundStyle(Theme.warning.opacity(0.9))
+                case .sending?:
+                    Text("Sending…")
+                        .font(Theme.sans(11))
+                        .foregroundStyle(Theme.textMuted)
+                case nil:
+                    normalStatus(chat: chat, status: status)
+                }
+            }
+            .frame(height: 24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, 26)  // aligns with the composer's text start
+        }
+    }
+
+    @ViewBuilder
+    private func normalStatus(chat: Chat, status: SessionStatus?) -> some View {
+        Group {
                 switch status {
                 case .working:
                     WorkingSpinner()
@@ -240,10 +278,6 @@ struct SessionView: View {
                 default:
                     EmptyView()
                 }
-            }
-            .frame(height: 24)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 26)  // aligns with the composer's text start
         }
     }
 

--- a/apps/ios/ZeronTests/NetworkReliabilityTests.swift
+++ b/apps/ios/ZeronTests/NetworkReliabilityTests.swift
@@ -2,6 +2,7 @@
 // #170): version gates, pending:// ref round-trips, the upload chunk plan's
 // wire invariants, the whole-attachment deadline, and the relay echo frame.
 
+import Loro
 import XCTest
 @testable import Zeron
 
@@ -100,6 +101,47 @@ final class NetworkReliabilityTests: XCTestCase {
         let json = String(data: try JSONEncoder().encode(request), encoding: .utf8)!
         XCTAssertFalse(json.contains("worktree"), "old hosts must see the legacy shape")
     }
+
+    // MARK: retry re-issue (PR #172 phone half)
+
+    @MainActor
+    func testRetryReissuesADeadSendAttemptExactlyOnce() throws {
+        let config = AppConfig(edgeURL: URL(string: "http://localhost:1")!, mode: .dev,
+                               userId: "u", orgId: "o", deviceId: "phone",
+                               deviceName: "phone", tokens: nil, devBearer: "u@o")
+        let store = SessionStore(chatId: "c-reissue", config: config)
+        let commands = store.doc.getList(id: "commands")
+        let dead = try commands.pushContainer(child: LoroMap())
+        try dead.insert(key: "id", v: "cmd-old")
+        try dead.insert(key: "kind", v: "run")
+        try dead.insert(key: "payload", v: LoroValue.fromJSON([
+            "kind": "run",
+            "request": ["prompt": "hi", "cwd": "/repo"],
+            "messageId": "msg-1",
+        ]))
+        try dead.insert(key: "issuedBy", v: "phone")
+        try dead.insert(key: "issuedAt", v: Int64(1_000))
+        try dead.insert(key: "expiresAt", v: nowMs() + 60_000)
+        try dead.insert(key: "status", v: "rejected")
+        store.doc.commit()
+
+        store.reissueDeadSends()
+
+        let after = try XCTUnwrap(store.doc.getDeepValue().mapValue?["commands"]?.listValue)
+        XCTAssertEqual(after.count, 2, "a rejected attempt whose message never landed re-issues")
+        let fresh = try XCTUnwrap(after[1].mapValue)
+        XCTAssertEqual(fresh["status"]?.stringValue, "pending")
+        XCTAssertNotEqual(fresh["id"]?.stringValue, "cmd-old", "exactly-once is per command id — retry mints a fresh one")
+        XCTAssertEqual(fresh["payload"]?.mapValue?["messageId"]?.stringValue, "msg-1",
+                       "the message id survives so the host's user-entry pre-write dedupes")
+
+        // A live pending attempt for the message makes a re-issue a duplicate.
+        store.reissueDeadSends()
+        let again = try XCTUnwrap(store.doc.getDeepValue().mapValue?["commands"]?.listValue)
+        XCTAssertEqual(again.count, 2, "a second retry with a live attempt queued must not duplicate")
+    }
+
+    // MARK: RunRequest wire shape (proto agent.rs, PR #159)
 
     func testWorktreeSpecEncodesCamelCase() throws {
         var request = RunRequest(prompt: "hi", cwd: "/repo")

--- a/apps/ios/ZeronTests/NetworkReliabilityTests.swift
+++ b/apps/ios/ZeronTests/NetworkReliabilityTests.swift
@@ -1,0 +1,113 @@
+// Tests for the network-reliability port (desktop PRs #159/#164/#165/#168/
+// #170): version gates, pending:// ref round-trips, the upload chunk plan's
+// wire invariants, the whole-attachment deadline, and the relay echo frame.
+
+import XCTest
+@testable import Zeron
+
+final class NetworkReliabilityTests: XCTestCase {
+    // MARK: versionTriple (proto version_triple port)
+
+    func testVersionTripleParsesPlainAndSuffixed() {
+        XCTAssertTrue(versionTriple("0.2.12")! == (0, 2, 12))
+        XCTAssertTrue(versionTriple("1.10.3-beta.1")! == (1, 10, 3))
+        XCTAssertTrue(versionTriple("0.2.12+build7")! == (0, 2, 12))
+    }
+
+    func testVersionTripleRejectsJunk() {
+        XCTAssertNil(versionTriple(""))
+        XCTAssertNil(versionTriple("0.2"))
+        XCTAssertNil(versionTriple("a.b.c"))
+        XCTAssertNil(versionTriple("0.2.x"))
+        XCTAssertNil(versionTriple("0.2.12rc1"), "junk directly after the patch digits is not a version")
+    }
+
+    func testVersionGateComparison() {
+        let min = (0, 2, 12)
+        XCTAssertTrue(versionTriple("0.2.12")! >= min)
+        XCTAssertTrue(versionTriple("0.3.0")! >= min)
+        XCTAssertTrue(versionTriple("1.0.0")! >= min)
+        XCTAssertFalse(versionTriple("0.2.11")! >= min)
+    }
+
+    // MARK: pending:// refs (uploads.rs PENDING_REF_PREFIX)
+
+    func testPendingRefRoundTrip() {
+        let ref = UploadStash.pendingRef(uploadId: "abc-123", name: "photo one.png")
+        XCTAssertEqual(ref, "pending://abc-123/photo one.png")
+        let parsed = UploadStash.parseRef(ref)
+        XCTAssertEqual(parsed?.uploadId, "abc-123")
+        XCTAssertEqual(parsed?.name, "photo one.png")
+    }
+
+    func testParseRefRejectsForeignAndMalformedRefs() {
+        XCTAssertNil(UploadStash.parseRef("/Users/x/uploads/abc-photo.png"))
+        XCTAssertNil(UploadStash.parseRef("pending://no-slash"))
+        XCTAssertNil(UploadStash.parseRef("pending:///name.png"))
+        XCTAssertNil(UploadStash.parseRef("pending://id/"))
+    }
+
+    func testStashSaveLoadDelete() {
+        let id = "test-\(UUID().uuidString.lowercased())"
+        let bytes = Data([1, 2, 3, 4])
+        UploadStash.save(uploadId: id, data: bytes)
+        XCTAssertEqual(UploadStash.load(uploadId: id), bytes)
+        UploadStash.delete(uploadId: id)
+        XCTAssertNil(UploadStash.load(uploadId: id))
+    }
+
+    // MARK: upload chunk plan (attachments.rs PR #164 invariants)
+
+    func testChunkSizeWireInvariants() {
+        // % 4 == 0: every base64 slice decodes independently.
+        XCTAssertEqual(uploadChunkB64Chars % 4, 0)
+        // The binary slice boundary is % 3 == 0, so per-slice base64
+        // concatenates to the whole file's encoding.
+        XCTAssertEqual((uploadChunkB64Chars / 4 * 3) % 3, 0)
+        // Envelope headroom under Cloudflare's 1 MiB WS message cap.
+        XCTAssertLessThan(uploadChunkB64Chars + 1_024, 1_048_576)
+    }
+
+    func testAttachmentDeadlineFormula() {
+        XCTAssertEqual(attachmentDeadlineSeconds(chunkCount: 1), 135)
+        XCTAssertEqual(attachmentDeadlineSeconds(chunkCount: 10), 270)
+        XCTAssertEqual(attachmentDeadlineSeconds(chunkCount: 1_000), 900, "capped at 15 minutes")
+    }
+
+    // MARK: relay echo frame (device_room.rs ECHO_KIND)
+
+    func testEchoFrameRoundTrip() {
+        let frame = DeviceRelayClient.encodeFrame(header: #"{"s":"echo","k":"echo"}"#,
+                                                  payload: Data())
+        let decoded = DeviceRelayClient.decodeFrame(frame)
+        XCTAssertEqual(decoded?.0.k, DeviceRelayClient.echoKind)
+        XCTAssertEqual(decoded?.1.count, 0)
+    }
+
+    func testPendingOwnsTracksLifecycle() {
+        let pending = DeviceRpcPending()
+        XCTAssertFalse(pending.owns(id: 1))
+        pending.registerUnary(id: 1) { _ in }
+        XCTAssertTrue(pending.owns(id: 1))
+        pending.fail(id: 1, error: .timeout)
+        XCTAssertFalse(pending.owns(id: 1), "a resolved call must not read as pending — the timeout task keys link teardown on it")
+    }
+
+    // MARK: RunRequest wire shape (proto agent.rs, PR #159)
+
+    func testWorktreeSpecOmittedWhenNil() throws {
+        let request = RunRequest(prompt: "hi", cwd: "/repo")
+        let json = String(data: try JSONEncoder().encode(request), encoding: .utf8)!
+        XCTAssertFalse(json.contains("worktree"), "old hosts must see the legacy shape")
+    }
+
+    func testWorktreeSpecEncodesCamelCase() throws {
+        var request = RunRequest(prompt: "hi", cwd: "/repo")
+        request.worktree = WorktreeSpec(repoPath: "/repo", base: "HEAD")
+        let data = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let worktree = try XCTUnwrap(object["worktree"] as? [String: Any])
+        XCTAssertEqual(worktree["repoPath"] as? String, "/repo")
+        XCTAssertEqual(worktree["base"] as? String, "HEAD")
+    }
+}


### PR DESCRIPTION
None of the recent reliability work had reached the iOS client — it landed entirely in the Rust crates, and the phone's parallel Swift stack kept every incident class the desktop just fixed. This ports the client-side halves. The engine-host halves (worktree materialization at drain, pending-ref defer + rewrite, staging sweep fix, echo reply) are already deployed on hosts ≥ 0.2.12, so the phone gets them by speaking the same wire.

## Transport (PR #168)
- **OnlineBus** (wake.rs port): every room join broadcasts "network is back"; `NWPathMonitor` parks backoffs while the path is definitively down (30s safety recheck) and broadcasts on recovery — including satisfied→satisfied interface handovers; the foreground hook probes `{edge}/health` (3s) so a focus lands redials in ~1 RTT.
- **Room clients**: backoff cap 30s→16s, stability-gated reset (a join must survive 30s — reset-on-join lets connect-and-die sockets hot-loop at 250ms), backoff waits ride the bus.
- **DeviceRelayClient** (was the least-defended client: 30s blind ping, no liveness, no backoff): 10s keepalive / 25s transport lease / end-to-end `echo` frame with a 20s host-proof deadline (feature-detected; inbound RPC frames count). The DO's auto-pong answers from the edge, so a healthy client↔edge leg masked a dead edge↔host leg for 6 minutes in the Aug 19 zombie-peer-link incident — this kills that class. A timed-out call drops the link as suspect (next call re-dials); a registry-dark liveness verdict (positive evidence only: joined + 60s warm-up + freshest heartbeat ≥ 5min old) fails peer calls fast with zero dials.

## Send truth (PRs #165/#168/#170)
- **ConnectivityCenter**: graced connectivity — a source (OS path / registry / per-chat room) must be raw-degraded **4s continuously** before it reports; recovery is instant. Sub-second blips (room joins on navigation) never flash the UI.
- Home bar shows a quiet grayscale "Reconnecting…" / amber "Offline — sends are saved" only while degraded; rows get **Queued**/**Failed** corner pills that suppress the fake Working spinner; the session strip shows "Sending…" / "Queued — will send automatically" / "**Not delivered — tap to retry**" (2-minute undelivered grace; retry restarts the clock, kicks the room on fresh backoff, nudges the host, re-derives attachment escorts). The composer gets one caption line of pre-send honesty on a degraded path.

## Attachments (PRs #164/#168)
- Uploader parity with #164: **~510KB chunks** (was ~45KB sequential — 112 round trips for a 5MB photo), 3-wide parallel window, retries staggered by seq, whole-upload deadline `min(120+15/chunk, 900)s`, "Uploading… N%" narration.
- **Queued flow** (host ≥ 0.2.12, gated on the registry device row's `version`): the command queues immediately with `pending://{uploadId}/{name}` refs — a durable local write — bytes stash to disk (`UploadStash`, survives relaunch; re-derived from the doc's pending refs on start/retry) and an escort pushes them with retry-forever on the online bus (2s→30s, 15min cap), then nudges the drain. An image send no longer dies with its link. Old hosts keep the legacy upload-first flow, now bounded and narrated.

## New chats (PRs #159/#170)
- New-worktree sends attach `RunRequest.worktree {repoPath, base}` for the **host to materialize at drain time** — the blocking `CreateWorktree` relay RPC before send (the one new-chat path that could hang forever on a zombie link) is gone. Base defaults to `HEAD` so a branch list that never loaded over a flapping relay can't silently drop isolation. Old hosts ignore the field and run in the main checkout: degraded, never hung.
- On legacy hosts, attachments stage **before** the chat row exists — an upload failure aborts with nothing created (no stranded empty chat).

## Not ported (follow-ups)
- **RelayCommand second road** (engine forwards the queued entry over the peer link when rows can't reach the edge): the phone already has an HTTPS push/pull fallback per room, so the marginal win is small; needs a rows-flushed signal from ChatRoomClient if we want it.
- The attachment **read-back** cache keeps its own ungated relays (it inherits the new echo/timeout hygiene, not dial parking).

## Tests
- 12 new unit tests (`NetworkReliabilityTests`): version-gate parsing, pending:// round-trips, stash lifecycle, chunk-plan wire invariants (b64 %4, CF 1MiB cap headroom), deadline formula, echo frame codec, timeout `owns` gating, `RunRequest.worktree` wire shape (omitted-when-nil for old hosts).
- Full suite: 46 tests, 0 failures. Demo-mode smoke on the iPhone 17 Pro sim renders clean (no spurious connectivity pill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789740064&installation_model_id=425430&pr_number=171&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F171&signature=9e03a70471791b62a9c57d5e6fd654735b0078d5ef5d37c44a9be19c48df3580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->