### PR TITLE
Send-hang fixes: chat2 cursor gap repair (root cause) + retry re-issues dead attempts

### DIFF
--- a/crates/engine/examples/doc_inspect.rs
+++ b/crates/engine/examples/doc_inspect.rs
@@ -1,0 +1,40 @@
+//! Postmortem inspector: print a chat doc's command entries + processed-ledger
+//! state straight from a data dir's docs store (no engine, no lock contention
+//! beyond sqlite's own).
+//!
+//!   cargo run -p zeron-engine --example doc_inspect -- <store-root> <chat-id>
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let root = args.next().expect("store root");
+    let chat_id = args.next().expect("chat id");
+    let store = zeron_sync::DocsStore::open(std::path::PathBuf::from(root))?;
+    let Some(bytes) = store.load_snapshot(&chat_id)? else {
+        println!("NO SNAPSHOT for {chat_id}");
+        return Ok(());
+    };
+    let raw = loro::LoroDoc::new();
+    raw.import(&bytes)?;
+    let doc = zeron_doc::SessionDoc::from_doc(raw);
+    let entries = doc.read_entries()?;
+    println!("== messages: {} ==", entries.len());
+    for e in &entries {
+        println!("  {} {:?} {:?}", e.id, e.role, e.status);
+    }
+    let commands = doc.read_commands()?;
+    println!("== commands: {} ==", commands.len());
+    for c in &commands {
+        let processed = store.is_processed(&c.id).unwrap_or(false);
+        println!(
+            "  id={} kind={:?} status={:?} processed={} issued_at={} expires_at={:?} resolution={:?}",
+            c.id,
+            c.kind(),
+            c.status,
+            processed,
+            c.issued_at,
+            c.expires_at,
+            c.resolution,
+        );
+    }
+    Ok(())
+}

--- a/crates/engine/src/chat2_host.rs
+++ b/crates/engine/src/chat2_host.rs
@@ -78,12 +78,25 @@ impl ChatDocSink for EngineChatSink {
         let Some(doc) = self.doc.upgrade() else {
             return;
         };
-        if let Err(err) = doc.doc().import(bytes) {
-            // Malformed remote bytes cost the row, never the doc (the same
-            // skip-not-fail rule as transcript reads). The cursor still
-            // advances: replaying a poison row forever is the wedge class.
-            tracing::warn!(chat = %self.chat_id, error = %err,
-                "chat2 sink: row import failed; skipping row");
+        match doc.doc().import(bytes) {
+            Ok(status) => {
+                if status.pending.is_some() {
+                    // Missing causal deps: loro parked these ops invisibly.
+                    // The client's cursor contiguity rule keeps `cursor`
+                    // honest (it never jumps a gap), so persisting is safe —
+                    // this warn is the tripwire that the 2026-08-19
+                    // empty-doc/advanced-cursor wedge shape was seen live.
+                    tracing::warn!(chat = %self.chat_id, cursor,
+                        "chat2 sink: row parked on missing deps (gap repair should follow)");
+                }
+            }
+            Err(err) => {
+                // Malformed remote bytes cost the row, never the doc (the same
+                // skip-not-fail rule as transcript reads). The cursor still
+                // advances: replaying a poison row forever is the wedge class.
+                tracing::warn!(chat = %self.chat_id, error = %err,
+                    "chat2 sink: row import failed; skipping row");
+            }
         }
         self.persist_with_cursor(cursor);
     }

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -241,6 +241,12 @@ struct DocHostInner {
     connectivity: OnceLock<watch::Sender<zeron_proto::Connectivity>>,
     connectivity_started: AtomicBool,
     connectivity_grace: Mutex<DegradeGrace>,
+    /// Command ids currently BETWEEN mark-processed and their resolution in a
+    /// drain. Distinguishes "executing right now" from "consumed by the
+    /// ledger but dead" (a crash between mark and resolve): the drain
+    /// terminalizes the latter as Rejected instead of leaving a forever-
+    /// Pending entry no retry could ever reach (2026-08-19 swallowed-send).
+    executing: Mutex<HashSet<String>>,
     /// Peer links (engine assembly, edge runtimes only) — the transport that
     /// pushes queued attachment bytes to a remote host.
     links: OnceLock<Arc<zeron_rpc::LinkCache>>,
@@ -251,6 +257,30 @@ struct DocHostInner {
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// The queued-attachment transfers a command's `pending://` refs imply —
+/// shared by the retry escort and the retry re-issue.
+fn command_transfers(entry: &SessionCommandEntry) -> Vec<crate::uploads::AttachmentTransfer> {
+    let refs: Vec<String> = match &entry.payload {
+        SessionCommandPayload::Run { request, .. } => request
+            .attachments
+            .iter()
+            .filter(|p| crate::uploads::is_pending_ref(p))
+            .cloned()
+            .collect(),
+        SessionCommandPayload::Steer { prompt, .. } => crate::uploads::pending_refs_in(prompt),
+        _ => Vec::new(),
+    };
+    refs.iter()
+        .filter_map(|r| crate::uploads::parse_pending_ref(r))
+        .map(
+            |(upload_id, file_name)| crate::uploads::AttachmentTransfer {
+                upload_id: upload_id.to_string(),
+                file_name: file_name.to_string(),
+            },
+        )
+        .collect()
 }
 
 /// How long raw degradation must persist before connectivity reports it.
@@ -513,6 +543,7 @@ impl DocHost {
                 connectivity: OnceLock::new(),
                 connectivity_started: AtomicBool::new(false),
                 connectivity_grace: Mutex::new(DegradeGrace::default()),
+                executing: Mutex::new(HashSet::new()),
                 links: OnceLock::new(),
                 http: reqwest::Client::builder()
                     .timeout(std::time::Duration::from_secs(30))
@@ -2341,36 +2372,112 @@ impl DocHost {
         self.nudge_remote_host(chat_id);
         let commands = handle.doc.read_commands()?;
         let pending: Vec<SessionCommandEntry> = commands
-            .into_iter()
+            .iter()
             .filter(|c| {
                 c.status == SessionCommandStatus::Pending
                     && !self.inner.store.is_processed(&c.id).unwrap_or(false)
             })
+            .cloned()
             .collect();
         for entry in pending {
-            let refs: Vec<String> = match &entry.payload {
-                SessionCommandPayload::Run { request, .. } => request
-                    .attachments
-                    .iter()
-                    .filter(|p| crate::uploads::is_pending_ref(p))
-                    .cloned()
-                    .collect(),
-                SessionCommandPayload::Steer { prompt, .. } => {
-                    crate::uploads::pending_refs_in(prompt)
-                }
-                _ => Vec::new(),
-            };
-            let transfers: Vec<crate::uploads::AttachmentTransfer> = refs
-                .iter()
-                .filter_map(|r| crate::uploads::parse_pending_ref(r))
-                .map(
-                    |(upload_id, file_name)| crate::uploads::AttachmentTransfer {
-                        upload_id: upload_id.to_string(),
-                        file_name: file_name.to_string(),
-                    },
-                )
-                .collect();
+            let transfers = command_transfers(&entry);
             self.spawn_command_delivery(chat_id, entry, transfers);
+        }
+        // Dead attempts: a Run/Steer whose user message never landed and
+        // whose command can never execute again — Rejected (execute failed,
+        // or the dead-command sweep terminalized it), or consumed by the
+        // ledger with no outcome and not currently executing (crash between
+        // mark and resolve). Exactly-once is per command ID, so a
+        // user-driven retry mints a FRESH attempt: new id, same payload and
+        // message id (the executor's user-entry pre-write dedupes by message
+        // id). One re-issue per message — the LATEST attempt speaks for it.
+        let messages = handle.doc.read_entries().unwrap_or_default();
+        let message_landed = |mid: &str| messages.iter().any(|m| m.id == mid);
+        let mut latest_dead: HashMap<String, &SessionCommandEntry> = HashMap::new();
+        for c in &commands {
+            let Some(mid) = (match &c.payload {
+                SessionCommandPayload::Run { message_id, .. } => Some(message_id.as_str()),
+                SessionCommandPayload::Steer { message_id, .. } => message_id.as_deref(),
+                _ => None,
+            }) else {
+                continue;
+            };
+            if message_landed(mid) {
+                continue;
+            }
+            let dead = match c.status {
+                SessionCommandStatus::Rejected => true,
+                SessionCommandStatus::Pending => {
+                    self.inner.store.is_processed(&c.id).unwrap_or(false)
+                        && !lock(&self.inner.executing).contains(&c.id)
+                }
+                _ => false,
+            };
+            if !dead {
+                continue;
+            }
+            // A LIVE pending attempt for the same message (queued or being
+            // escorted above) makes a re-issue a duplicate — skip.
+            let live_attempt = commands.iter().any(|o| {
+                o.id != c.id
+                    && o.status == SessionCommandStatus::Pending
+                    && !self.inner.store.is_processed(&o.id).unwrap_or(false)
+                    && match (&o.payload, &c.payload) {
+                        (
+                            SessionCommandPayload::Run { message_id: a, .. },
+                            SessionCommandPayload::Run { message_id: b, .. },
+                        ) => a == b,
+                        (
+                            SessionCommandPayload::Steer { message_id: a, .. },
+                            SessionCommandPayload::Steer { message_id: b, .. },
+                        ) => a == b,
+                        _ => false,
+                    }
+            });
+            if live_attempt {
+                continue;
+            }
+            match latest_dead.entry(mid.to_string()) {
+                std::collections::hash_map::Entry::Occupied(mut slot) => {
+                    if c.issued_at > slot.get().issued_at {
+                        slot.insert(c);
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(c);
+                }
+            }
+        }
+        for old in latest_dead.values() {
+            if old.status == SessionCommandStatus::Pending {
+                // Terminalize the consumed-but-dead original so the doc tells
+                // the truth and the next retry pass doesn't see it again.
+                self.resolve_command(
+                    &handle,
+                    &old.id,
+                    SessionCommandStatus::Rejected,
+                    Some("interrupted before completion — superseded by retry"),
+                );
+            }
+            let now = now_ms();
+            let reissue = SessionCommandEntry {
+                id: new_id(),
+                payload: old.payload.clone(),
+                issued_by: self.inner.config.device_id.clone(),
+                issued_at: now,
+                based_on: messages.last().map(|m| CommandBasedOn {
+                    turn_id: Some(m.id.clone()),
+                    frontier: None,
+                }),
+                expires_at: Some(now + COMMAND_DEFAULT_TTL_MS),
+                status: SessionCommandStatus::Pending,
+                resolution: None,
+            };
+            tracing::info!(chat = %chat_id, old = %old.id, new = %reissue.id,
+                "retry re-issues a dead send attempt");
+            handle.doc.queue_command(&reissue)?;
+            let transfers = command_transfers(&reissue);
+            self.spawn_command_delivery(chat_id, reissue, transfers);
         }
         // Locally-hosted (or already-synced) commands: a drain pass is the
         // whole retry.
@@ -2419,19 +2526,29 @@ impl DocHost {
         if matches!(disposition, CommandDisposition::Skip) {
             return Ok("duplicate");
         }
-        // Claim BEFORE executing (the drain's own mark-before-execute rule).
-        if !self.inner.store.mark_processed(&entry.id)? {
+        // In-flight claim first (the drain's dead-command sweep must see this
+        // id as alive, not crashed, while the execute below runs).
+        if !lock(&self.inner.executing).insert(entry.id.clone()) {
             return Ok("duplicate");
         }
-        match disposition {
-            CommandDisposition::Skip => Ok("duplicate"),
-            CommandDisposition::Expired => Ok("expired"),
-            CommandDisposition::Superseded => Ok("superseded"),
-            CommandDisposition::Execute => {
-                self.execute(&sessions, &handle, &entry).await?;
-                Ok("executed")
-            }
-        }
+        // Claim BEFORE executing (the drain's own mark-before-execute rule).
+        let marked = self.inner.store.mark_processed(&entry.id);
+        let result = match marked {
+            Err(err) => Err(err.into()),
+            Ok(false) => Ok("duplicate"),
+            Ok(true) => match disposition {
+                CommandDisposition::Skip => Ok("duplicate"),
+                CommandDisposition::Expired => Ok("expired"),
+                CommandDisposition::Superseded => Ok("superseded"),
+                CommandDisposition::Execute => match self.execute(&sessions, &handle, &entry).await
+                {
+                    Ok(_) => Ok("executed"),
+                    Err(err) => Err(err),
+                },
+            },
+        };
+        lock(&self.inner.executing).remove(&entry.id);
+        result
     }
 
     /// One transfer attempt: chunked `UploadChunk` + `UploadCommit` straight
@@ -2671,6 +2788,29 @@ impl DocHost {
                 }
             };
             let is_processed = |id: &str| self.inner.store.is_processed(id).unwrap_or(false);
+            // Dead-command sweep: Pending in the doc, consumed by the ledger,
+            // and NOT mid-execution in this process — the crash window
+            // between mark-processed and the outcome write. Left alone it is
+            // a send no drain or retry can ever reach ("Sending…" forever,
+            // 2026-08-19); terminalize it so the truth lands in the doc and
+            // a user retry can mint a fresh attempt.
+            for c in &commands {
+                if c.status == SessionCommandStatus::Pending
+                    && !skipped.contains(&c.id)
+                    && is_processed(&c.id)
+                    && !lock(&self.inner.executing).contains(&c.id)
+                {
+                    tracing::warn!(chat = %handle.chat_id, command = %c.id,
+                        "command consumed but never resolved (crash mid-execute?); rejecting");
+                    self.resolve_command(
+                        handle,
+                        &c.id,
+                        SessionCommandStatus::Rejected,
+                        Some("interrupted before completion — retry to send again"),
+                    );
+                    skipped.insert(c.id.clone());
+                }
+            }
             let Some(entry) = commands
                 .iter()
                 .find(|c| {
@@ -2725,10 +2865,18 @@ impl DocHost {
                     continue;
                 }
             }
+            // In-flight claim: guards the dead-command sweep (an id in
+            // `executing` is alive, not crashed) and serializes racing
+            // drains on the same entry.
+            if !lock(&self.inner.executing).insert(entry.id.clone()) {
+                skipped.insert(entry.id.clone());
+                continue;
+            }
             // Mark BEFORE executing: a crash mid-execution must never double-run a
             // command whose side effect may already have happened.
             if let Err(err) = self.inner.store.mark_processed(&entry.id) {
                 tracing::error!(chat = %handle.chat_id, error = %err, "processed-ledger write failed; halting drain");
+                lock(&self.inner.executing).remove(&entry.id);
                 return;
             }
             match disposition {
@@ -2749,6 +2897,7 @@ impl DocHost {
                     self.resolve_command(handle, &entry.id, status, resolution.as_deref());
                 }
             }
+            lock(&self.inner.executing).remove(&entry.id);
         }
     }
 

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -2406,7 +2406,10 @@ impl DocHost {
                 continue;
             }
             let dead = match c.status {
-                SessionCommandStatus::Rejected => true,
+                // Rejected: execute failed or the sweep terminalized a crash
+                // window. Expired: the entry outlived its TTL undelivered —
+                // an explicit user retry is exactly the consent to re-send.
+                SessionCommandStatus::Rejected | SessionCommandStatus::Expired => true,
                 SessionCommandStatus::Pending => {
                     self.inner.store.is_processed(&c.id).unwrap_or(false)
                         && !lock(&self.inner.executing).contains(&c.id)

--- a/crates/engine/tests/e2e.rs
+++ b/crates/engine/tests/e2e.rs
@@ -553,17 +553,26 @@ async fn processed_commands_are_skipped_on_redelivery() {
         },
     );
 
-    // Give the drain a moment: the command must be SKIPPED — no user entry, no run.
+    // Give the drain a moment: the command must not EXECUTE — no user entry,
+    // no run. But it must not stay a forever-Pending ghost either (v0.2.12
+    // swallowed-send: "Sending…" forever, retry a no-op): the dead-command
+    // sweep terminalizes it as Rejected so the doc tells the truth and a
+    // retry can mint a fresh attempt.
     tokio::time::sleep(Duration::from_millis(300)).await;
     assert!(
         entries(&core).is_empty(),
         "skipped command must not execute"
     );
-    assert_eq!(
-        command_status(&core, "cmd-crashed"),
-        Some((SessionCommandStatus::Pending, None)),
-        "skip leaves the entry pending without an outcome"
-    );
+    wait_for(
+        || {
+            matches!(
+                command_status(&core, "cmd-crashed"),
+                Some((SessionCommandStatus::Rejected, _))
+            )
+        },
+        "crash-window command terminalized as Rejected",
+    )
+    .await;
     assert!(core.sessions.session_status(CHAT).is_none());
 
     // Direct ledger-evaluation check: re-evaluating a processed command = Skip.
@@ -583,6 +592,88 @@ async fn processed_commands_are_skipped_on_redelivery() {
         },
     );
     assert_eq!(verdict, zeron_doc::CommandDisposition::Skip);
+}
+
+/// The v0.2.12 field report: a send whose command was consumed by the ledger
+/// but never executed (crash between mark and resolve) was invisible to
+/// every retry — the drain filters processed ids, so the session was dead
+/// forever while new sessions worked. Retry must mint a FRESH attempt.
+#[tokio::test]
+async fn retry_reissues_a_swallowed_send() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let store = DocsStore::open(dir.path().join("orgs/dev-org/dev-user")).unwrap();
+        assert!(store.mark_processed("cmd-dead").unwrap());
+    }
+    let core = assemble(
+        dir.path(),
+        Arc::new(MockHarness {
+            script: mock_script(),
+        }),
+    );
+    let handle = core.doc_host.open(CHAT).unwrap();
+    queue_as_viewer(
+        handle.doc(),
+        "cmd-dead",
+        SessionCommandPayload::Run {
+            request: run_request("try again"),
+            message_id: "m-retry".into(),
+        },
+    );
+    // The sweep terminalizes the dead attempt without executing it…
+    wait_for(
+        || {
+            matches!(
+                command_status(&core, "cmd-dead"),
+                Some((SessionCommandStatus::Rejected, _))
+            )
+        },
+        "dead attempt rejected",
+    )
+    .await;
+    assert!(entries(&core).is_empty(), "dead attempt must not execute");
+
+    // …and the user's retry mints a fresh attempt that actually runs.
+    core.doc_host.retry_delivery(CHAT).unwrap();
+    wait_for(
+        || {
+            entries_now(&core)
+                .iter()
+                .any(|e| e.id == "m-retry" && e.role == MessageRole::User)
+        },
+        "re-issued send writes the user entry",
+    )
+    .await;
+    wait_for(
+        || {
+            entries_now(&core)
+                .iter()
+                .any(|e| e.role == MessageRole::Assistant && e.status == Some(MessageStatus::Complete))
+        },
+        "re-issued send runs to completion",
+    )
+    .await;
+    let run_attempts = |cmds: &[SessionCommandEntry]| {
+        cmds.iter()
+            .filter(|c| {
+                matches!(&c.payload,
+                    SessionCommandPayload::Run { message_id, .. } if message_id == "m-retry")
+            })
+            .count()
+    };
+    assert_eq!(
+        run_attempts(&handle.doc().read_commands().unwrap()),
+        2,
+        "original + exactly one re-issue"
+    );
+    // A delivered message must never re-issue: retry while healthy is a no-op.
+    core.doc_host.retry_delivery(CHAT).unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        run_attempts(&handle.doc().read_commands().unwrap()),
+        2,
+        "retry after delivery must not duplicate the send"
+    );
 }
 
 #[tokio::test]

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -291,6 +291,14 @@ struct Shared {
     /// past N≈25), and each ack immediately re-arms the clock until the
     /// queue empties.
     quota_blocked: bool,
+    /// A row/ack arrived with `seq > cursor + 1`: rows exist that this
+    /// client never received (live broadcast outran the backfill — the
+    /// mid-join race). The cursor must NOT skip the hole (skipped rows'
+    /// dependents park invisibly in loro's pending buffer and the doc
+    /// reads empty forever — the 2026-08-19 empty-doc/advanced-cursor
+    /// wedge); instead this flag asks the session loop for a rowsReq
+    /// backfill from the honest cursor.
+    gap_repair: bool,
 }
 
 /// `zeron sync` surface (plan: cursor / headSeq / floorLag / pendingPushes).
@@ -840,6 +848,22 @@ impl Actor {
             return SessionEnd::Reconnect;
         };
         lock(&self.shared).server = Some(state);
+        // Server behind our cursor = the room was reset/wiped. Detect on the
+        // RAW persisted cursor, BEFORE the amnesty below rewrites it —
+        // plan_catch_up treats the cursor as fresh; SURFACE the signal too:
+        // the host's re-seed recovery (chat-room.ts /reset) hangs off this
+        // event, and masking it was exactly how the s2 wedge class stayed
+        // invisible.
+        if lock(&self.shared).cursor > state.head_seq {
+            self.flags.server_resets.fetch_add(1, Relaxed);
+            tracing::warn!(
+                cursor = lock(&self.shared).cursor,
+                head_seq = state.head_seq,
+                "chat2: server lost state (headSeq < cursor) — treating as \
+                 fresh; host should re-seed via checkpoint"
+            );
+            let _ = self.events.send(ChatEvent::ServerReset);
+        }
         // Cursor amnesty, once per client: a cursor above the checkpoint seq
         // claims history the doc may have silently parked and dropped —
         // parked imports vanish on export while the cursor advances, and
@@ -847,15 +871,27 @@ impl Actor {
         // cursor 75 over a checkpoint-only doc, 2026-08-18). Clamp and
         // refetch: re-imports are no-ops and the trim policy bounds the
         // cost to the rows since the last checkpoint.
-        if state.checkpoint_size > 0 && !self.cursor_amnesty_done.swap(true, Relaxed) {
+        if !self.cursor_amnesty_done.swap(true, Relaxed) {
+            // Checkpoint-less rooms amnesty to ZERO: the same parked-import
+            // wedge (empty doc under an advanced cursor — 2026-08-19: a live
+            // broadcast mid-join outran the backfill and the cursor skipped
+            // the hole) with no checkpoint to clamp to. Refetching the whole
+            // log is bounded by the checkpoint threshold policy (a room
+            // past ~200 rows/512KB HAS a checkpoint) and re-imports are
+            // no-ops, so this is the cheap universal heal.
+            let clamp_to = if state.checkpoint_size > 0 {
+                state.checkpoint_seq
+            } else {
+                0
+            };
             let mut shared = lock(&self.shared);
-            if shared.cursor > state.checkpoint_seq {
+            if shared.cursor > clamp_to {
                 tracing::info!(
                     from = shared.cursor,
-                    to = state.checkpoint_seq,
-                    "chat2: cursor amnesty — refetching rows above the checkpoint"
+                    to = clamp_to,
+                    "chat2: cursor amnesty — refetching rows the doc may have parked"
                 );
-                shared.cursor = state.checkpoint_seq;
+                shared.cursor = clamp_to;
             }
         }
         let cursor = lock(&self.shared).cursor;
@@ -864,21 +900,6 @@ impl Actor {
             self.flags.rejoins.fetch_add(1, Relaxed);
         }
         let _ = self.events.send(ChatEvent::Connected);
-
-        // Server behind our cursor = the room was reset/wiped. plan_catch_up
-        // treats the cursor as fresh; SURFACE the signal too — the host's
-        // re-seed recovery (chat-room.ts /reset) hangs off this event, and
-        // masking it was exactly how the s2 wedge class stayed invisible.
-        if cursor > state.head_seq {
-            self.flags.server_resets.fetch_add(1, Relaxed);
-            tracing::warn!(
-                cursor,
-                head_seq = state.head_seq,
-                "chat2: server lost state (headSeq < cursor) — treating as \
-                 fresh; host should re-seed via checkpoint"
-            );
-            let _ = self.events.send(ChatEvent::ServerReset);
-        }
 
         // ── catch-up: checkpoint precision + row backfill ───────────────────
         // Same presence rule as `plan_catch_up`: SIZE, not seq — a seeded
@@ -890,11 +911,11 @@ impl Actor {
             CatchUpPlan::RowsOnly { after } => after,
             CatchUpPlan::CheckpointThenRows { after } => after,
         };
-        // Clamp the persisted cursor into the room's honest range (server
-        // reset detection happened in plan_catch_up via after==0).
-        if after < cursor {
-            lock(&self.shared).cursor = after;
-        }
+        // The plan's `after` IS the cursor now — down (server reset / amnesty
+        // already applied) or UP (a contained checkpoint covers the skipped
+        // span). Without the raise, the backfill's first row (`after + 1`)
+        // reads as a contiguity gap against a stale lower cursor.
+        lock(&self.shared).cursor = after;
         // Rows request goes out BEFORE any checkpoint fetch: the row backfill
         // streams over the socket while the checkpoint downloads over HTTP in
         // parallel, instead of serializing download → request → backfill. On
@@ -1033,6 +1054,12 @@ impl Actor {
         // ── steady state ────────────────────────────────────────────────────
         let mut last_frame = tokio::time::Instant::now();
         let mut probe_deadline: Option<tokio::time::Instant> = None;
+        // Row-gap repairs this session (see `Shared::gap_repair`): a live
+        // frame during the backfill above may already have flagged one.
+        let mut gap_repairs = 0u32;
+        if !self.maybe_repair_gap(&mut pipe, &mut gap_repairs).await {
+            return SessionEnd::Reconnect;
+        }
         loop {
             let quiet_probe_at = last_frame + self.tuning.probe_quiet;
             let deadline_at = probe_deadline
@@ -1052,6 +1079,9 @@ impl Actor {
                         return SessionEnd::Reconnect;
                     };
                     if !self.handle_frame(frame) {
+                        return SessionEnd::Reconnect;
+                    }
+                    if !self.maybe_repair_gap(&mut pipe, &mut gap_repairs).await {
                         return SessionEnd::Reconnect;
                     }
                 }
@@ -1176,7 +1206,14 @@ impl Actor {
                             {
                                 let mut sh = lock(&shared);
                                 sh.pending.retain(|p| p.batch_id != b);
-                                sh.cursor = sh.cursor.max(seq);
+                                // Contiguity rule (see handle_frame ACK): an
+                                // own-push ack proves the server has rows up
+                                // to `seq`, not that WE have the interleaved
+                                // ones. The pull below starts at the honest
+                                // cursor and walks the gap.
+                                if seq <= sh.cursor + 1 {
+                                    sh.cursor = sh.cursor.max(seq);
+                                }
                                 let cursor = sh.cursor;
                                 drop(sh);
                                 sink.advance_cursor(cursor);
@@ -1259,10 +1296,21 @@ impl Actor {
                         else {
                             continue;
                         };
-                        sink.apply_row(&frame.payload, row.seq);
-                        let mut sh = lock(&shared);
-                        sh.cursor = sh.cursor.max(row.seq);
-                        drop(sh);
+                        // Pulls request `after = cursor`, so rows arrive
+                        // contiguous — but hold the rule anyway: a jump
+                        // (trimmed log, server surprise) must not stamp the
+                        // cursor over rows the doc never saw.
+                        let effective = {
+                            let mut sh = lock(&shared);
+                            if row.seq <= sh.cursor + 1 {
+                                sh.cursor = sh.cursor.max(row.seq);
+                            } else {
+                                tracing::warn!(seq = row.seq, cursor = sh.cursor,
+                                    "chat2: pull row gap; holding cursor");
+                            }
+                            sh.cursor
+                        };
+                        sink.apply_row(&frame.payload, effective);
                         applied = true;
                     }
                     frame_type::ROWS_DONE => {}
@@ -1274,6 +1322,36 @@ impl Actor {
             }
             busy.store(false, Relaxed);
         });
+    }
+
+    /// If a row/ack gap was flagged, request a backfill from the honest
+    /// cursor. Bounded per session: a gap the server can't fill (should be
+    /// impossible below the checkpoint floor) forces a redial, whose full
+    /// catch-up is the stronger repair.
+    async fn maybe_repair_gap(&self, pipe: &mut BinPipe, repairs: &mut u32) -> bool {
+        const MAX_GAP_REPAIRS_PER_SESSION: u32 = 3;
+        let (repair, after) = {
+            let mut shared = lock(&self.shared);
+            (std::mem::take(&mut shared.gap_repair), shared.cursor)
+        };
+        if !repair {
+            return true;
+        }
+        *repairs += 1;
+        if *repairs > MAX_GAP_REPAIRS_PER_SESSION {
+            tracing::warn!("chat2: gap repairs exhausted; redialing for a full catch-up");
+            return false;
+        }
+        tracing::info!(after, attempt = *repairs, "chat2: backfilling over a row gap");
+        let req = wire::encode(
+            frame_type::ROWS_REQ,
+            &wire::RowsReqHeader {
+                after,
+                exclude_own: false,
+            },
+            &[],
+        );
+        pipe.tx.send(req).await.is_ok()
     }
 
     async fn push_pending(&self, pipe: &mut BinPipe) -> bool {
@@ -1310,10 +1388,26 @@ impl Actor {
                 // Own-device rows can still arrive (live relay of a racing
                 // second socket, or a server that ignored excludeOwn) — Loro
                 // re-import is a no-op; the cursor advance is what matters.
-                self.sink.apply_row(&frame.payload, row.seq);
-                let mut shared = lock(&self.shared);
-                shared.cursor = shared.cursor.max(row.seq);
-                drop(shared);
+                // CONTIGUITY RULE: the cursor claims "every row ≤ cursor is
+                // reflected in the doc", so it may only walk, never jump. A
+                // gap means rows we never received (live broadcast mid-join)
+                // — apply the bytes (loro parks dependents harmlessly), keep
+                // the honest cursor, and ask for a backfill repair.
+                let effective = {
+                    let mut shared = lock(&self.shared);
+                    if row.seq > shared.cursor + 1 {
+                        shared.gap_repair = true;
+                        tracing::warn!(
+                            seq = row.seq,
+                            cursor = shared.cursor,
+                            "chat2: row gap detected; holding cursor and requesting backfill"
+                        );
+                    } else {
+                        shared.cursor = shared.cursor.max(row.seq);
+                    }
+                    shared.cursor
+                };
+                self.sink.apply_row(&frame.payload, effective);
                 let _ = self.events.send(ChatEvent::Applied);
             }
             frame_type::ACK => {
@@ -1322,7 +1416,19 @@ impl Actor {
                 };
                 let mut shared = lock(&self.shared);
                 shared.pending.retain(|p| p.batch_id != ack.batch_id);
-                shared.cursor = shared.cursor.max(ack.seq);
+                // Same contiguity rule as ROW: our own batch landing at
+                // `seq` proves rows up to seq exist server-side, not that we
+                // HAVE the interleaved ones from other devices.
+                if ack.seq > shared.cursor + 1 {
+                    shared.gap_repair = true;
+                    tracing::warn!(
+                        seq = ack.seq,
+                        cursor = shared.cursor,
+                        "chat2: ack gap detected; holding cursor and requesting backfill"
+                    );
+                } else {
+                    shared.cursor = shared.cursor.max(ack.seq);
+                }
                 let cursor = shared.cursor;
                 // Quota drain: each grant immediately probes the next head
                 // batch (one-per-grant, never a full-queue burst).

--- a/crates/sync/src/chat_client/tests.rs
+++ b/crates/sync/src/chat_client/tests.rs
@@ -1208,3 +1208,152 @@ async fn os_offline_parks_dials_and_the_online_event_unparks_immediately() {
     );
     client.shutdown().await;
 }
+
+// ── row-gap contiguity + repair (2026-08-19 empty-doc/advanced-cursor wedge) ─
+
+/// A live broadcast can outrun the backfill during a join, delivering seq N
+/// while seq N-1 was never received. The old `cursor.max(seq)` advance
+/// stamped the cursor over the hole — the skipped row's dependents parked
+/// invisibly in loro's pending buffer and the doc read empty forever while
+/// the client polled `after=cursor` ("new session hangs, retry no-op"). The
+/// cursor must HOLD at the last contiguous seq and a backfill repair must
+/// close the gap.
+#[tokio::test(start_paused = true)]
+async fn live_row_gap_holds_cursor_and_repairs() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, _) = fetcher(b"");
+
+    let server = tokio::spawn(async move {
+        let after = serve_join(
+            &mut end,
+            serde_json::json!({"headSeq": 1, "seqFloor": 0, "checkpointSeq": 0,
+                "checkpointSize": 0, "rowCount": 1, "rowBytes": 32}),
+            &[],
+            vec![(1, "dev-b", vec![0x01])],
+            false,
+        )
+        .await;
+        assert_eq!(after, 0);
+        // Live frame with a HOLE: seq 3 arrives, seq 2 never did.
+        send(
+            &end,
+            frame_type::ROW,
+            serde_json::json!({"seq": 3, "device": "dev-b", "batchId": "b3"}),
+            &[0x03],
+        )
+        .await;
+        // The client must answer with a backfill request from its HELD
+        // cursor (1) — not silently skip to 3.
+        let req = expect_kind(&mut end, frame_type::ROWS_REQ).await;
+        assert_eq!(
+            req.header["after"].as_u64().unwrap(),
+            1,
+            "repair starts at the honest cursor"
+        );
+        for (seq, bytes) in [(2u64, vec![0x02u8]), (3, vec![0x03])] {
+            send(
+                &end,
+                frame_type::ROW,
+                serde_json::json!({"seq": seq, "device": "dev-b", "batchId": format!("b{seq}")}),
+                &bytes,
+            )
+            .await;
+        }
+        send(
+            &end,
+            frame_type::ROWS_DONE,
+            serde_json::json!({"headSeq": 3}),
+            &[],
+        )
+        .await;
+        end
+    });
+
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        0,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+    let end = server.await.unwrap();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while client.stats().cursor != 3 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "gap repair never converged the cursor: {:?}",
+            client.stats()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    // The gap row applied with the HELD cursor (1), never with 3; the
+    // repair rows then walked it up contiguously.
+    assert_eq!(
+        *lock(&sink.rows),
+        vec![
+            (vec![0x01], 1),
+            (vec![0x03], 1),
+            (vec![0x02], 2),
+            (vec![0x03], 3),
+        ],
+        "cursor held through the gap and walked by the repair"
+    );
+    drop(end);
+    client.shutdown().await;
+}
+
+/// A persisted cursor over a CHECKPOINT-LESS room gets amnesty to zero on
+/// the first join: if any past import parked (the wedge left on disk by the
+/// pre-fix race), the full refetch materializes it — bounded by the
+/// checkpoint threshold policy, and re-imports are no-ops.
+#[tokio::test(start_paused = true)]
+async fn checkpointless_amnesty_refetches_from_zero() {
+    let (pipe, mut end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    let (fetch, _) = fetcher(b"");
+
+    let server = tokio::spawn(async move {
+        let after = serve_join(
+            &mut end,
+            serde_json::json!({"headSeq": 3, "seqFloor": 0, "checkpointSeq": 0,
+                "checkpointSize": 0, "rowCount": 3, "rowBytes": 96}),
+            &[],
+            vec![
+                (1, "dev-b", vec![0x01]),
+                (2, "dev-b", vec![0x02]),
+                (3, "dev-b", vec![0x03]),
+            ],
+            false,
+        )
+        .await;
+        assert_eq!(after, 0, "amnesty must refetch the whole log");
+        end
+    });
+
+    // Persisted cursor 3 — the on-disk wedge shape (doc may have parked).
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![pipe]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        3,
+        ChatTuning::default(),
+    )
+    .await
+    .expect("join succeeds");
+    let end = server.await.unwrap();
+
+    assert_eq!(
+        *lock(&sink.rows),
+        vec![(vec![0x01], 1), (vec![0x02], 2), (vec![0x03], 3)],
+        "all rows re-imported from zero"
+    );
+    assert_eq!(client.stats().cursor, 3);
+    drop(end);
+    client.shutdown().await;
+}


### PR DESCRIPTION
Fixes the stuck-session report (2026-08-19): one session's send hung on "Sending…" forever and **survived every retry click**, while new sessions worked fine.

## Root cause

`drain_commands` marks a command processed **before** executing (correct — a crash mid-execution must never double-run a side effect). But there was no recovery path on the other side of that trade: if the execute failed, or the engine died/restarted between mark and resolve, the doc kept a `Pending` entry whose id is in the processed ledger. Every drain filters processed ids → skips it forever. `retry_delivery` only escorts *unprocessed* pending entries → **retry was a structural no-op** for exactly the commands that needed it. The session is dead; new sessions (fresh ids) work — matching the report exactly.

## Fix

- **In-flight tracking** (`DocHostInner.executing`): ids between mark-processed and resolution, claimed by both the drain and the relayed-command ingest. Distinguishes "executing right now" from "consumed but dead", and serializes racing drains on the same entry.
- **Dead-command sweep in the drain**: `Pending` + processed + not in-flight → resolved `Rejected("interrupted before completion — retry to send again")`. The crash window terminalizes instead of ghosting.
- **`retry_delivery` re-issues dead attempts**: for a Run/Steer whose user message never landed and whose command is `Rejected` or consumed-dead, it mints a **fresh command** (new id, same payload + message id — the executor's user-entry pre-write dedupes by message id). One re-issue per message (latest attempt), skipped when a live pending attempt already exists. Exactly-once stays per command *id*; retry becomes per *attempt*.

**Existing stuck sessions heal on update**: the sweep terminalizes the ghost on the next drain, and the retry click actually re-sends.

## Tests

- `processed_commands_are_skipped_on_redelivery` updated: the crash-window command still must not execute, but now terminalizes as `Rejected` instead of staying forever-`Pending`.
- New `retry_reissues_a_swallowed_send`: crash-window setup → sweep rejects without executing → retry re-issues → user entry + run land → a second retry after delivery does **not** duplicate.
- Full sweep: 738 tests, 0 failures.

## Known limitation

The rejection *reason* still isn't surfaced in the UI (the trailer says "Not delivered — click to retry" without the why). If a deterministic execute failure recurs, retry will visibly re-fail; plumbing the resolution string into the trailer is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789740077&installation_model_id=425430&pr_number=172&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F172&signature=143a0469a2e60ca16efd62e3263e0865010cd32a86ac514b487f9f5d5a2ee064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


---

# Part 2: the actual root cause — chat2 cursor gap (live-reproduced)

The retry machinery above fixes recovery, but stress-testing new-session creation against a local edge found the **root cause of the random forever-hangs** (reported: "completely random whether a new session hangs, even on good internet"):

**Repro:** two engines (viewer + host) through `wrangler dev`; 20 new-session sends → **10 hung forever**, alternating with successes. Postmortem via the new `doc_inspect` example: the hung chats' host store held an **empty 430-byte doc with cursor=3** — the host "converged" on rows it never imported.

**Mechanism:** a live broadcast row outruns the join backfill (seq 3 arrives; seq 2 never received). The client advanced its cursor with `max(seq)`, stamping it over the hole. The skipped row's dependents **park invisibly in loro's pending buffer** — import "succeeds", export omits them — so the doc reads empty while the cursor claims convergence. Every subsequent pull asks `after=cursor` and gets nothing. The command never executes; retries re-push rows the cursor already skips; the wedge survives restarts (durable cursor, in-memory pending buffer). Timing-dependent → "completely random"; likelier on slow first contact (cold DO, plane wifi).

**Fix (client-side, no wire change):**
- **Contiguity rule** at every cursor advance (live ROW, ACK, HTTP pull, push-ack): the cursor may *walk*, never *jump*. A gap applies the bytes, holds the honest cursor, flags a repair.
- **Gap repair**: the session loop answers with a `rowsReq` from the held cursor (bounded, 3/session, then redial → full catch-up).
- **Cursor amnesty extended to checkpoint-less rooms** (first join clamps a suspicious cursor to 0; bounded by the checkpoint threshold policy). **This heals every already-wedged chat on disk** — no migration.
- Server-reset detection reordered before the amnesty; the catch-up plan now assigns the cursor in both directions.

**Validation:** post-fix, the same rig runs **20/20 new sessions clean at 0.7s** (was 10/20 hanging), and a chat wedged for 40 minutes healed on its next join (`cursor amnesty — refetching rows the doc may have parked from=3 to=0` → user message + assistant turn appeared). New deterministic tests: `live_row_gap_holds_cursor_and_repairs`, `checkpointless_amnesty_refetches_from_zero`. Full suite: 750 tests green.
