### PR TITLE
composer: a full-width @-mention panel over an indexed file search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4266,6 +4266,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9143,6 +9153,7 @@ dependencies = [
  "libc",
  "loro",
  "notify",
+ "nucleo-matcher",
  "portable-pty",
  "reqwest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ pulldown-cmark = "0.12"
 unicode-segmentation = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 ignore = "0.4"
+nucleo-matcher = "0.3"
 
 [profile.release]
 # Distribution profile (scripts/package-linux.sh): thin LTO buys most of fat

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -33,6 +33,7 @@ tokio-util = { workspace = true, features = ["rt"] }
 sha2.workspace = true
 reqwest.workspace = true
 ignore.workspace = true
+nucleo-matcher.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/engine/src/repos.rs
+++ b/crates/engine/src/repos.rs
@@ -39,6 +39,9 @@ const DRIVE_LIST_MAX_ENTRIES: usize = 50;
 const FILE_SEARCH_MAX_RESULTS: usize = 8;
 /// A dead network mount must not leave the composer search spinning forever.
 const FILE_SEARCH_TIMEOUT: Duration = Duration::from_secs(6);
+const FILE_INDEX_TTL: Duration = Duration::from_secs(10);
+const FILE_INDEX_MAX_ENTRIES: usize = 250_000;
+const RANK_BUFFER: usize = 1_024;
 pub const GIT_HISTORY_DEFAULT_LIMIT: usize = 100;
 pub const GIT_HISTORY_MAX_LIMIT: usize = 200;
 
@@ -90,7 +93,21 @@ struct ReposInner {
     device_id: String,
     worktrees_root: PathBuf,
     file_searches: std::sync::Mutex<HashMap<PathBuf, std::sync::Weak<tokio::sync::Mutex<()>>>>,
+    file_index: FileIndexCache,
 }
+
+struct IndexedPath {
+    path: String,
+    haystack: nucleo_matcher::Utf32String,
+    is_dir: bool,
+}
+
+struct FileIndex {
+    entries: Vec<IndexedPath>,
+    built: std::time::Instant,
+}
+
+type FileIndexCache = std::sync::Mutex<HashMap<PathBuf, std::sync::Arc<FileIndex>>>;
 
 #[derive(Clone)]
 pub struct Repos {
@@ -112,6 +129,7 @@ impl Repos {
                 device_id: device_id.to_string(),
                 worktrees_root,
                 file_searches: std::sync::Mutex::new(HashMap::new()),
+                file_index: std::sync::Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -822,12 +840,14 @@ impl Repos {
         let cancelled = std::sync::Arc::new(AtomicBool::new(false));
         let _cancel_on_drop = CancelOnDrop(cancelled.clone());
         let worker_cancelled = cancelled.clone();
+        let cache = self.inner.clone();
         let (tx, rx) = tokio::sync::oneshot::channel();
         std::thread::Builder::new()
             .name("file-search".into())
             .spawn(move || {
                 let _gate = gate;
-                let _ = tx.send(search_files_blocking_with_cancel(
+                let _ = tx.send(search_files_cached(
+                    &cache.file_index,
                     &root,
                     &query,
                     &featured_paths,
@@ -1131,31 +1151,7 @@ fn unescape_mount_point(raw: &str) -> String {
     out
 }
 
-/// Case-insensitive subsequence score. Lower is better: adjacent and earlier
-/// characters win, while still allowing `cmp rs` to find `composer.rs`.
-fn fuzzy_score(query: &str, candidate: &str) -> Option<usize> {
-    let candidate = candidate.to_lowercase();
-    query
-        .split_whitespace()
-        .map(str::to_lowercase)
-        .try_fold(0usize, |total, term| {
-            let mut at = 0;
-            let mut score = 0usize;
-            let mut previous_end = None;
-            for needle in term.chars() {
-                let found = candidate[at..].find(needle)? + at;
-                score += found;
-                if previous_end == Some(found) {
-                    score = score.saturating_sub(2);
-                }
-                at = found + needle.len_utf8();
-                previous_end = Some(at);
-            }
-            Some(total.saturating_add(score))
-        })
-}
-
-type RankedFileMatch = (Option<usize>, usize, String, bool);
+type RankedFileMatch = (Option<usize>, u32, String, bool);
 
 fn compare_file_matches(
     query: &str,
@@ -1167,7 +1163,7 @@ fn compare_file_matches(
         .is_none()
         .cmp(&featured_b.is_none())
         .then_with(|| featured_a.cmp(featured_b))
-        .then_with(|| score_a.cmp(score_b))
+        .then_with(|| score_b.cmp(score_a))
         .then_with(|| {
             empty_query
                 .then(|| path_a.split('/').count().cmp(&path_b.split('/').count()))
@@ -1191,14 +1187,160 @@ fn search_files_blocking(
     search_files_blocking_with_cancel(root, query, featured_paths, || false)
 }
 
-fn search_files_blocking_with_cancel<F: Fn() -> bool>(
+#[cfg(test)]
+fn search_files_blocking_with_cancel<F: Fn() -> bool + Sync>(
     root: &Path,
     query: &str,
     featured_paths: &[String],
     cancelled: F,
 ) -> Result<Vec<FileSearchMatch>, EngineError> {
-    let root = std::fs::canonicalize(root)
-        .map_err(|e| EngineError::Other(format!("could not search workspace: {e}")))?;
+    let root = canonical_search_root(root)?;
+    let index = walk_file_index(&root, &cancelled)?;
+    Ok(rank_file_matches(&index, &root, query, featured_paths))
+}
+
+fn search_files_cached<F: Fn() -> bool + Sync>(
+    cache: &FileIndexCache,
+    root: &Path,
+    query: &str,
+    featured_paths: &[String],
+    cancelled: F,
+) -> Result<Vec<FileSearchMatch>, EngineError> {
+    let root = canonical_search_root(root)?;
+    let fresh = cache
+        .lock()
+        .ok()
+        .and_then(|indexes| indexes.get(&root).cloned())
+        .filter(|index| index.built.elapsed() < FILE_INDEX_TTL);
+    let index = match fresh {
+        Some(index) => index,
+        None => {
+            let index = std::sync::Arc::new(FileIndex {
+                entries: walk_file_index(&root, &cancelled)?,
+                built: std::time::Instant::now(),
+            });
+            if let Ok(mut indexes) = cache.lock() {
+                indexes.retain(|_, index| index.built.elapsed() < FILE_INDEX_TTL);
+                indexes.insert(root.clone(), index.clone());
+            }
+            index
+        }
+    };
+    if cancelled() {
+        return Err(EngineError::Other("file search cancelled".into()));
+    }
+    Ok(rank_file_matches(
+        &index.entries,
+        &root,
+        query,
+        featured_paths,
+    ))
+}
+
+fn canonical_search_root(root: &Path) -> Result<PathBuf, EngineError> {
+    std::fs::canonicalize(root)
+        .map_err(|e| EngineError::Other(format!("could not search workspace: {e}")))
+}
+
+fn walk_file_index<F: Fn() -> bool + Sync>(
+    root: &Path,
+    cancelled: &F,
+) -> Result<Vec<IndexedPath>, EngineError> {
+    if cancelled() {
+        return Err(EngineError::Other("file search cancelled".into()));
+    }
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get().min(12))
+        .unwrap_or(4);
+    let collected: std::sync::Mutex<Vec<IndexedPath>> = std::sync::Mutex::new(Vec::new());
+    let was_cancelled = AtomicBool::new(false);
+    ignore::WalkBuilder::new(root)
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .threads(threads)
+        .filter_entry(|entry| entry.depth() == 0 || entry.file_name() != ".git")
+        .build_parallel()
+        .run(|| {
+            const BATCH: usize = 512;
+            struct Batch<'a> {
+                items: Vec<IndexedPath>,
+                sink: &'a std::sync::Mutex<Vec<IndexedPath>>,
+            }
+            impl Drop for Batch<'_> {
+                fn drop(&mut self) {
+                    if self.items.is_empty() {
+                        return;
+                    }
+                    if let Ok(mut all) = self.sink.lock() {
+                        all.append(&mut self.items);
+                    }
+                }
+            }
+            let mut batch = Batch {
+                items: Vec::with_capacity(BATCH),
+                sink: &collected,
+            };
+            let was_cancelled = &was_cancelled;
+            Box::new(move |entry| {
+                if was_cancelled.load(Ordering::Relaxed) {
+                    return ignore::WalkState::Quit;
+                }
+                if cancelled() {
+                    was_cancelled.store(true, Ordering::Relaxed);
+                    return ignore::WalkState::Quit;
+                }
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(err) => {
+                        tracing::debug!(%err, "file mention index skipped entry");
+                        return ignore::WalkState::Continue;
+                    }
+                };
+                let path = entry.path();
+                if path == root {
+                    return ignore::WalkState::Continue;
+                }
+                let Ok(relative) = path.strip_prefix(root) else {
+                    return ignore::WalkState::Continue;
+                };
+                let relative = relative.to_string_lossy().replace('\\', "/");
+                if relative == ".git" || relative.starts_with(".git/") {
+                    return ignore::WalkState::Continue;
+                }
+                batch.items.push(IndexedPath {
+                    haystack: nucleo_matcher::Utf32String::from(relative.as_str()),
+                    path: relative,
+                    is_dir: entry.file_type().is_some_and(|kind| kind.is_dir()),
+                });
+                if batch.items.len() >= BATCH
+                    && let Ok(mut all) = batch.sink.lock()
+                {
+                    all.append(&mut batch.items);
+                    if all.len() >= FILE_INDEX_MAX_ENTRIES {
+                        return ignore::WalkState::Quit;
+                    }
+                }
+                ignore::WalkState::Continue
+            })
+        });
+    if was_cancelled.load(Ordering::Relaxed) || cancelled() {
+        return Err(EngineError::Other("file search cancelled".into()));
+    }
+    let mut entries = collected
+        .into_inner()
+        .map_err(|_| EngineError::Other("file index poisoned".into()))?;
+    entries.truncate(FILE_INDEX_MAX_ENTRIES);
+    Ok(entries)
+}
+
+fn rank_file_matches(
+    entries: &[IndexedPath],
+    root: &Path,
+    query: &str,
+    featured_paths: &[String],
+) -> Vec<FileSearchMatch> {
     let featured: HashMap<String, usize> = featured_paths
         .iter()
         .filter_map(|path| {
@@ -1209,7 +1351,7 @@ fn search_files_blocking_with_cancel<F: Fn() -> bool>(
                 root.join(path)
             };
             let canonical = std::fs::canonicalize(full).ok()?;
-            let relative = canonical.strip_prefix(&root).ok()?;
+            let relative = canonical.strip_prefix(root).ok()?;
             Some(relative.to_string_lossy().replace('\\', "/"))
         })
         .enumerate()
@@ -1217,60 +1359,38 @@ fn search_files_blocking_with_cancel<F: Fn() -> bool>(
             paths.entry(path).or_insert(rank);
             paths
         });
-    let mut matches = Vec::new();
-    let walker = ignore::WalkBuilder::new(&root)
-        .hidden(false)
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
-        .filter_entry(|entry| entry.depth() == 0 || entry.file_name() != ".git")
-        .build();
-    for entry in walker {
-        if cancelled() {
-            return Err(EngineError::Other("file search cancelled".into()));
-        }
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(err) => {
-                tracing::debug!(%err, "file mention search walk skipped entry");
-                continue;
-            }
-        };
-        let path = entry.path();
-        if path == root {
-            continue;
-        }
-        let Ok(relative) = path.strip_prefix(&root) else {
+    let mut matcher = nucleo_matcher::Matcher::new({
+        let mut config = nucleo_matcher::Config::DEFAULT;
+        config.set_match_paths();
+        config
+    });
+    let pattern = nucleo_matcher::pattern::Pattern::parse(
+        query,
+        nucleo_matcher::pattern::CaseMatching::Smart,
+        nucleo_matcher::pattern::Normalization::Smart,
+    );
+    let mut matches: Vec<RankedFileMatch> = Vec::new();
+    for entry in entries {
+        let Some(score) = pattern.score(entry.haystack.slice(..), &mut matcher) else {
             continue;
         };
-        let relative = relative.to_string_lossy().replace('\\', "/");
-        if relative.starts_with(".git/") || relative == ".git" {
-            continue;
-        }
-        let Some(path_score) = fuzzy_score(query, &relative) else {
-            continue;
-        };
-        let score = relative
-            .rsplit('/')
-            .next()
-            .and_then(|name| fuzzy_score(query, name))
-            .unwrap_or_else(|| path_score.saturating_add(1_000));
         matches.push((
-            featured.get(&relative).copied(),
+            featured.get(&entry.path).copied(),
             score,
-            relative,
-            entry.file_type().is_some_and(|kind| kind.is_dir()),
+            entry.path.clone(),
+            entry.is_dir,
         ));
-        if matches.len() > FILE_SEARCH_MAX_RESULTS {
+        if matches.len() >= RANK_BUFFER {
             matches.sort_by(|a, b| compare_file_matches(query, a, b));
             matches.truncate(FILE_SEARCH_MAX_RESULTS);
         }
     }
     matches.sort_by(|a, b| compare_file_matches(query, a, b));
-    Ok(matches
+    matches.truncate(FILE_SEARCH_MAX_RESULTS);
+    matches
         .into_iter()
         .map(|(_, _, path, is_dir)| FileSearchMatch { path, is_dir })
-        .collect())
+        .collect()
 }
 
 /// Turn a generated chat title into the semantic portion of a Zeron branch
@@ -1409,6 +1529,23 @@ pub(crate) fn hex(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    fn score(query: &str, candidate: &str) -> Option<u32> {
+        let mut matcher = nucleo_matcher::Matcher::new({
+            let mut config = nucleo_matcher::Config::DEFAULT;
+            config.set_match_paths();
+            config
+        });
+        nucleo_matcher::pattern::Pattern::parse(
+            query,
+            nucleo_matcher::pattern::CaseMatching::Smart,
+            nucleo_matcher::pattern::Normalization::Smart,
+        )
+        .score(
+            nucleo_matcher::Utf32String::from(candidate).slice(..),
+            &mut matcher,
+        )
+    }
+
     #[test]
     fn linux_drives_take_media_and_mnt_mounts_system_first() {
         let mounts = "\
@@ -1495,9 +1632,9 @@ tmpfs /run tmpfs rw 0 0
 
     #[test]
     fn fuzzy_score_matches_a_path_subsequence() {
-        assert!(fuzzy_score("cmp rs", "crates/ui/src/composer.rs").is_some());
-        assert!(fuzzy_score("composer crates", "crates/ui/src/composer.rs").is_some());
-        assert!(fuzzy_score("xyz", "crates/ui/src/composer.rs").is_none());
+        assert!(score("cmp rs", "crates/ui/src/composer.rs").is_some());
+        assert!(score("composer crates", "crates/ui/src/composer.rs").is_some());
+        assert!(score("xyzq", "crates/ui/src/composer.rs").is_none());
     }
 
     #[test]
@@ -1565,6 +1702,19 @@ tmpfs /run tmpfs rw 0 0
             .position(|entry| entry.path == "composer/docs/readme.md")
             .unwrap();
         assert!(composer < path_only);
+    }
+
+    #[test]
+    fn cached_search_reuses_one_walk_within_the_ttl() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("alpha.rs"), "").unwrap();
+        let cache: FileIndexCache = std::sync::Mutex::new(HashMap::new());
+
+        let first = search_files_cached(&cache, root.path(), "alpha", &[], || false).unwrap();
+        assert_eq!(first.first().map(|m| m.path.as_str()), Some("alpha.rs"));
+        std::fs::write(root.path().join("beta.rs"), "").unwrap();
+        let second = search_files_cached(&cache, root.path(), "beta", &[], || false).unwrap();
+        assert!(second.is_empty(), "{second:?}");
     }
 
     #[test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -3989,8 +3989,8 @@ impl Composer {
     ) -> Option<gpui::AnyElement> {
         let token = self.mention.token.as_ref()?;
         let mut card = crate::popover::popover_card(theme)
-            .w(px(380.0))
-            .max_h(px(280.0))
+            .w_full()
+            .max_h(px(320.0))
             .overflow_hidden()
             .on_mouse_down_out(cx.listener(|this, _, _, cx| this.dismiss_mention(cx)));
         if self.mention.loading && self.mention.results.is_empty() {
@@ -4026,24 +4026,20 @@ impl Composer {
         } else {
             for (ix, result) in self.mention.results.iter().enumerate() {
                 let selected = self.mention.active == Some(ix);
-                let path = result.path.clone();
-                let tooltip_path: SharedString = path.clone().into();
+                let (directory, name) = match result.path.rsplit_once('/') {
+                    Some((directory, name)) => (directory.to_string(), name.to_string()),
+                    None => (String::new(), result.path.clone()),
+                };
                 card = card.child(
                     crate::popover::menu_row(theme, selected, format!("file-mention-result-{ix}"))
                         .id(("file-mention-result", ix))
-                        .tooltip(move |_, cx| {
-                            cx.new(|_| MentionPathTooltip {
-                                path: tooltip_path.clone(),
-                                activation: ix as u64,
-                            })
-                            .into()
-                        })
                         .on_click(cx.listener(move |this, _, _, cx| {
                             this.mention.active = Some(ix);
                             this.accept_mention(cx);
                         }))
                         .child(
                             div()
+                                .w_full()
                                 .flex()
                                 .flex_row()
                                 .items_center()
@@ -4055,32 +4051,34 @@ impl Composer {
                                         crate::icons::DOCUMENT
                                     })
                                     .size(px(14.0))
+                                    .flex_none()
                                     .text_color(theme.text_muted),
                                 )
                                 .child(
                                     div()
-                                        .min_w_0()
-                                        .flex_1()
-                                        .overflow_hidden()
-                                        .truncate()
-                                        .text_size(px(12.5))
+                                        .flex_none()
+                                        .text_size(px(13.0))
                                         .text_color(theme.text)
-                                        .child(path),
-                                ),
+                                        .child(name),
+                                )
+                                .when(!directory.is_empty(), |row| {
+                                    row.child(
+                                        div()
+                                            .min_w_0()
+                                            .flex_1()
+                                            .overflow_hidden()
+                                            .truncate()
+                                            .text_size(px(12.5))
+                                            .text_color(theme.text_muted)
+                                            .child(directory),
+                                    )
+                                }),
                         ),
                 );
             }
         }
-        let anchor = self
-            .input
-            .read(cx)
-            .visible_point_for_index(token.range.start)?;
-        // No exit phase: the completion popup tracks the token under the
-        // caret — a fade-out on every keystroke-driven dismissal would read
-        // as input lag, not polish.
-        Some(crate::popover::anchored_menu_above_at(
+        Some(crate::popover::full_width_menu_above(
             "file-mention-popup",
-            anchor,
             card.into_any_element(),
             None,
         ))
@@ -4090,7 +4088,6 @@ impl Composer {
         div()
             .relative()
             .child(self.input.clone())
-            .children(self.render_file_mention_popup(theme, cx))
             .children(self.render_slash_popup(theme, cx))
     }
 
@@ -6022,11 +6019,16 @@ impl Render for Composer {
         // via `add_paths`.
         // Frosted: the pill backdrop-blurs the transcript scrolling under it
         // (the popover glass treatment; radius matches the pill's rounding).
-        let container = container.child(crate::frost::frosted(
-            26.0,
-            16.0,
-            motion::fade_quick("composer-input", body),
-        ));
+        let container = container.child(
+            div()
+                .relative()
+                .child(crate::frost::frosted(
+                    26.0,
+                    16.0,
+                    motion::fade_quick("composer-input", body),
+                ))
+                .children(self.render_file_mention_popup(&theme, cx)),
+        );
         // Branch/worktree toolbar under the pill (t3code BranchToolbar): the
         // checkout-kind selector + ref picker for new sessions, read-only
         // labels once the session exists. Git spaces only.

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -504,6 +504,29 @@ pub fn anchored_menu_above_at(
         .into_any_element()
 }
 
+pub fn full_width_menu_above(
+    id: impl Into<SharedString>,
+    content: AnyElement,
+    closing: Option<std::time::Instant>,
+) -> AnyElement {
+    let exit = closing.map(exit_progress);
+    let content = frosted_menu(exit, content);
+    div()
+        .absolute()
+        .bottom_full()
+        .left_0()
+        .right_0()
+        .child(
+            gpui::deferred(menu_motion(
+                id.into(),
+                exit,
+                div().occlude().pb(px(6.0)).child(content),
+            ))
+            .priority(1),
+        )
+        .into_any_element()
+}
+
 /// [`anchored_menu_above`] right-aligned to the trigger's right edge (t3code
 /// ComboboxPopup `align="end"` — right-side triggers like the composer's ref
 /// picker open leftward instead of running off the window).


### PR DESCRIPTION
Before

<img width="1652" height="536" alt="image" src="https://github.com/user-attachments/assets/9576fd53-22a4-4d8b-94d3-d330c6f858e5" />


After
<img width="1688" height="742" alt="image" src="https://github.com/user-attachments/assets/eb389abc-8868-4a33-a171-7f318a8345c4" />



The `@` panel was a narrow card hanging off the caret, one long grey path per row, and every keystroke re-walked the whole checkout to fill it.

## The panel

It now spans the composer and stacks on its top edge, and a row reads `{filename} {directory}` — the name carries the match and never truncates, the dimmed directory disambiguates same-named files and is the side that gives up space. New `popover::full_width_menu_above` mounts it: an absolute layer inset to `left-0 right-0` of a `relative()` wrapper around the pill, deferred so it paints and takes hits over the transcript it overhangs. Mounting had to move from around the input to around the pill — the input's box is not the width the panel wants.

The per-row path tooltip is gone; the row already shows the whole path.

## The search

Two changes, both in `repos.rs`:

**One walk, not one per keystroke.** The walk is now `ignore`'s `build_parallel()` (ripgrep's own crate, already a dependency — `.gitignore`, `.ignore`, global excludes and `.git` pruning all unchanged) and its result is cached per checkout for 10s. A keystroke ranks that cache in memory. Visitors batch 512 entries per lock and flush their tail on drop, since the walker drops one visitor per thread. Stale indexes are evicted whenever one is rebuilt, so a long session does not accumulate a file list per folder ever searched.

**A matcher built for source trees.** Scoring was a hand-rolled subsequence distance that lowercased both sides per candidate per keystroke. It is now `nucleo-matcher` (Helix's) in `match_paths` mode, which weights the last path segment — the property that ranks `src/composer.rs` over `composer/docs/readme.md`. Each entry's haystack is pre-built at walk time (ASCII paths stay a boxed str, no UTF-32 expansion), and one matcher plus one parsed pattern serves the whole pass. Ranking keeps a bounded buffer, so `@` with no query never sorts the whole tree to pick 8 rows.

Score direction flipped — nucleo's is higher-is-better — so the comparator's score arm inverted; the featured-paths and empty-query tiebreaks are untouched.

## Testing

`cargo test -p comet-engine` and `cargo clippy` clean. Existing search tests carry over unchanged (gitignore, featured paths, filename-over-path ranking, cancellation), plus a new one pinning that a second keystroke ranks the cache instead of re-walking.

Driven in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789741409&installation_model_id=425430&pr_number=173&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F173&signature=3e3189ac5ebfa82ecb66cace1fd146764249dcb60c6e5754cca9b5773730dafd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->