### PR TITLE
iOS: configure App Store bundle identifier

### DIFF
--- a/apps/ios/Zeron.xcodeproj/project.pbxproj
+++ b/apps/ios/Zeron.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5XY3M483YQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Zeron/Info.plist;
@@ -271,7 +272,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = sh.zeron.Zeron;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.zeron.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -288,6 +289,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5XY3M483YQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Zeron/Info.plist;
@@ -296,7 +298,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = sh.zeron.Zeron;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.zeron.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -314,7 +316,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = sh.zeron.ZeronTests;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.zeron.ios.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -332,7 +334,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = sh.zeron.ZeronTests;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.zeron.ios.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/apps/ios/Zeron/Auth/AuthClient.swift
+++ b/apps/ios/Zeron/Auth/AuthClient.swift
@@ -86,7 +86,7 @@ struct AuthClient {
 // MARK: - Keychain storage
 
 enum Keychain {
-    private static let service = "sh.zeron.Zeron"
+    private static let service = "sh.zeron.ios"
 
     static func save(_ value: String, key: String) {
         let data = Data(value.utf8)

--- a/apps/ios/Zeron/Info.plist
+++ b/apps/ios/Zeron/Info.plist
@@ -20,11 +20,13 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>sh.zeron.Zeron.auth</string>
+			<string>sh.zeron.ios.auth</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>zeron</string>

--- a/apps/ios/Zeron/Sync/ChatRoomClient.swift
+++ b/apps/ios/Zeron/Sync/ChatRoomClient.swift
@@ -20,7 +20,7 @@ import os
 /// Sync must never fail silently (2026-07-31: a send that never left the
 /// device was indistinguishable from a working one — `try?` all the way
 /// down). Visible in Console.app / `log stream` under this subsystem.
-let roomLog = Logger(subsystem: "sh.zeron.Zeron", category: "sync")
+let roomLog = Logger(subsystem: "sh.zeron.ios", category: "sync")
 
 enum ChatRoomEvent: Sendable {
     /// Joined (or re-joined) and the initial catch-up (checkpoint if needed +


### PR DESCRIPTION
## Summary

- change the iOS app bundle ID to `sh.zeron.ios` and tests to `sh.zeron.ios.tests`
- configure automatic signing for Apple team `5XY3M483YQ`
- align the Keychain service, auth callback identifier, and logging subsystem
- declare that the app does not use non-exempt encryption

## Verification

- `xcodebuild -quiet -project Zeron.xcodeproj -scheme Zeron -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`
- uploaded successfully and verified running through internal TestFlight

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789754574&installation_model_id=425430&pr_number=175&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F175&signature=312543fd50906dd561c0c4a913295d332c84cd12b6b614a8c19ad712e90a03e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->