### PR TITLE
Fix decorated ranges at soft-wrap boundaries

### DIFF
--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -923,21 +923,48 @@ pub(crate) fn range_rects(
     pad_x: f32,
     inset_y: f32,
 ) -> Vec<Bounds<gpui::Pixels>> {
+    range_rects_with_positions(
+        layout.bounds(),
+        layout.line_height(),
+        range,
+        pad_x,
+        inset_y,
+        |ix| layout.position_for_index(ix),
+    )
+}
+
+fn range_rects_with_positions(
+    bounds: Bounds<gpui::Pixels>,
+    line_height: gpui::Pixels,
+    range: &Range<usize>,
+    pad_x: f32,
+    inset_y: f32,
+    position_for_index: impl Fn(usize) -> Option<gpui::Point<gpui::Pixels>>,
+) -> Vec<Bounds<gpui::Pixels>> {
     let mut rects = Vec::new();
-    let line_height = layout.line_height();
     let mut cur = range.start;
     // Walk the range one visual row at a time: find the furthest index that
     // still sits on the current row (binary search over glyph positions).
     let mut guard = 0;
     while cur < range.end && guard < 256 {
         guard += 1;
-        let Some(p1) = layout.position_for_index(cur) else {
+        let Some(mut p1) = position_for_index(cur) else {
             break;
         };
+        // GPUI gives a soft-wrap boundary upstream affinity: the boundary
+        // index is reported at the end of the preceding visual row. When the
+        // following byte advances to a lower row, `cur` is also the start of
+        // that row; use its downstream position for the range start.
+        if let Some(after) = position_for_index(cur.saturating_add(1))
+            && after.y > p1.y
+        {
+            p1 = point(bounds.left(), after.y);
+        }
         // `seg_end` closes the wash on this row; `next` is the first index on
-        // the following row (strict progress even though a row-end index's
-        // position still reports the earlier row).
-        let (seg_end, next) = match layout.position_for_index(range.end) {
+        // the following row. A soft-wrap boundary belongs to both rows, so it
+        // closes this rectangle with upstream affinity and starts the next
+        // rectangle with the downstream correction above.
+        let (seg_end, next) = match position_for_index(range.end) {
             Some(pe) if pe.y == p1.y => (range.end, range.end),
             _ => {
                 // Largest ix on this row (probes stay on char boundaries only
@@ -945,15 +972,15 @@ pub(crate) fn range_rects(
                 let (mut lo, mut hi) = (cur, range.end);
                 while hi - lo > 1 {
                     let mid = lo + (hi - lo) / 2;
-                    match layout.position_for_index(mid) {
+                    match position_for_index(mid) {
                         Some(pm) if pm.y == p1.y => lo = mid,
                         _ => hi = mid,
                     }
                 }
-                (lo, hi)
+                (lo, lo)
             }
         };
-        if let Some(p2) = layout.position_for_index(seg_end)
+        if let Some(p2) = position_for_index(seg_end)
             && p2.x > p1.x
         {
             rects.push(Bounds::new(
@@ -1209,6 +1236,48 @@ pub fn runs_for_syntax_line_with_plain(
 mod tests {
     use super::*;
     use crate::markdown::parser::InlineStyle;
+
+    /// Model GPUI's upstream affinity at a soft-wrap boundary: byte 5 is
+    /// reported at the end of row 0, while byte 6 is after the first glyph on
+    /// row 1.
+    fn wrapped_position(ix: usize) -> Option<gpui::Point<gpui::Pixels>> {
+        (ix <= 9).then(|| {
+            if ix <= 5 {
+                point(px(ix as f32 * 10.0), px(0.0))
+            } else {
+                point(px((ix - 5) as f32 * 10.0), px(22.0))
+            }
+        })
+    }
+
+    fn wrapped_range_rects(range: Range<usize>) -> Vec<Bounds<gpui::Pixels>> {
+        range_rects_with_positions(
+            Bounds::new(point(px(0.0), px(0.0)), size(px(50.0), px(44.0))),
+            px(22.0),
+            &range,
+            0.0,
+            0.0,
+            wrapped_position,
+        )
+    }
+
+    #[test]
+    fn range_starting_at_soft_wrap_includes_first_glyph() {
+        let rects = wrapped_range_rects(5..9);
+        assert_eq!(rects.len(), 1);
+        assert_eq!(rects[0].origin, point(px(0.0), px(22.0)));
+        assert_eq!(rects[0].size, size(px(40.0), px(22.0)));
+    }
+
+    #[test]
+    fn range_crossing_soft_wrap_includes_first_continuation_glyph() {
+        let rects = wrapped_range_rects(2..9);
+        assert_eq!(rects.len(), 2);
+        assert_eq!(rects[0].origin, point(px(20.0), px(0.0)));
+        assert_eq!(rects[0].size, size(px(30.0), px(22.0)));
+        assert_eq!(rects[1].origin, point(px(0.0), px(22.0)));
+        assert_eq!(rects[1].size, size(px(40.0), px(22.0)));
+    }
 
     #[test]
     fn code_line_runs_cover_exactly() {


### PR DESCRIPTION
## Summary

- preserve the first decorated glyph when an inline-code or selection range starts at a soft-wrap boundary
- keep continuation rectangles anchored to the start of their visual row
- add focused regression coverage for ranges that start at and cross a soft wrap

Closes #177

## Root cause

GPUI reports a soft-wrap boundary with upstream affinity, placing the boundary index at the end of the preceding visual row. The range walker then advanced past that shared boundary and omitted the first glyph on the continuation row.

## Before / after

| Before | After |
| --- | --- |
| <img width="781" alt="Before: first inline-code glyph omitted from the background" src="https://github.com/user-attachments/assets/6fe2f306-ade9-47a7-ae23-cfbe432cc7ef" /> | <img width="781" alt="After: inline-code background includes the first continuation glyph" src="https://raw.githubusercontent.com/gaelcado/comet/pr-assets-177/.github/pr-assets/177-after.png" /> |

## Validation

- `cargo test -p zeron-ui soft_wrap` (3 passed)
- `git diff --check origin/main...HEAD`

## Scope

This changes only Markdown decorated-range geometry and its unit tests. It introduces no settings, migrations, or accessibility changes.