### PR TITLE
Fix selection edge scrolling and terminal scrollbar

### DIFF
--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -826,21 +826,28 @@ fn registry_point(position: gpui::Point<gpui::Pixels>) -> Option<(usize, usize)>
     })
 }
 
-/// Resolve the anchor + head into document-ordered spans over the frame's
-/// registry and store them; true if the selection changed.
-fn resolve_drag(anchor_key: &str, anchor_ix: usize, head: (usize, usize)) -> bool {
+/// Resolve the drag head into document-ordered spans over the frame's registry
+/// and store them; true if the selection changed. The selection model retains
+/// spans across overlapping virtualized frames once its anchor scrolls away.
+fn resolve_drag(head: (usize, usize)) -> bool {
     REGISTRY.with(|r| {
         let reg = r.borrow();
-        let Some(anchor_ei) = reg.iter().position(|e| e.key.as_ref() == anchor_key) else {
-            return false; // anchor scrolled out of the frame — keep spans
-        };
         let elements: Vec<(&str, &str)> = reg
             .iter()
             .map(|e| (e.key.as_ref(), e.text.as_ref()))
             .collect();
-        let spans = super::selection::resolve_spans(&elements, (anchor_ei, anchor_ix), head);
-        super::selection::update_spans(spans)
+        super::selection::update_drag(&elements, head)
     })
+}
+
+/// Continue the active drag at a window position. The transcript's edge-scroll
+/// driver calls this between scroll steps, so a stationary pointer keeps
+/// extending through newly painted rows.
+pub(crate) fn update_drag_at(position: gpui::Point<gpui::Pixels>) -> bool {
+    let Some(head) = registry_point(position) else {
+        return false;
+    };
+    resolve_drag(head)
 }
 
 /// Register this frame's window-level mouse listeners for one text element's
@@ -886,13 +893,10 @@ fn register_selection_listeners(
                 return;
             }
             // Only the anchor element's listener drives the drag.
-            let Some(anchor_ix) = super::selection::drag_anchor(&key) else {
+            if super::selection::drag_anchor(&key).is_none() {
                 return;
-            };
-            let Some(head) = registry_point(e.position) else {
-                return;
-            };
-            if resolve_drag(&key, anchor_ix, head) {
+            }
+            if update_drag_at(e.position) {
                 window.refresh();
             }
         });

--- a/crates/ui/src/markdown/selection.rs
+++ b/crates/ui/src/markdown/selection.rs
@@ -35,6 +35,10 @@ struct MdSelection {
     /// Byte offset of the anchor within its element.
     anchor_ix: usize,
     dragging: bool,
+    /// Document direction established while the anchor is still painted.
+    /// Once virtualization moves it out of the registry, this tells us which
+    /// side of the accumulated spans to preserve while extending the head.
+    forward: Option<bool>,
     /// Resolved spans, document order. Empty while a click hasn't moved.
     spans: Vec<Span>,
 }
@@ -75,6 +79,7 @@ pub fn begin(key: &str, ix: usize) {
         anchor_key: key.to_string(),
         anchor_ix: ix,
         dragging: true,
+        forward: None,
         spans: Vec::new(),
     });
 }
@@ -85,6 +90,7 @@ pub fn begin_with_span(key: &str, text: &str, range: Range<usize>) {
         anchor_key: key.to_string(),
         anchor_ix: range.start,
         dragging: true,
+        forward: None,
         spans: vec![Span {
             key: key.to_string(),
             range,
@@ -98,6 +104,90 @@ pub fn drag_anchor(key: &str) -> Option<usize> {
     let guard = state().lock().unwrap();
     let sel = guard.as_ref()?;
     (sel.dragging && sel.anchor_key == key).then_some(sel.anchor_ix)
+}
+
+/// Whether a markdown selection drag is currently in flight.
+pub fn is_dragging() -> bool {
+    state()
+        .lock()
+        .unwrap()
+        .as_ref()
+        .is_some_and(|selection| selection.dragging)
+}
+
+/// Resolve a drag head against this frame's visible elements.
+///
+/// While the anchor is visible this is a normal replacement, which lets the
+/// user contract or reverse the selection. Once a virtualized list scrolls the
+/// anchor away, merge through an overlapping selected element instead. The
+/// overlap preserves text that is no longer painted while allowing newly
+/// visible elements at the drag edge to join the selection.
+pub fn update_drag(elements: &[(&str, &str)], head: (usize, usize)) -> bool {
+    let mut guard = state().lock().unwrap();
+    let Some(selection) = guard.as_mut().filter(|selection| selection.dragging) else {
+        return false;
+    };
+    let spans = if let Some(anchor_ei) = elements
+        .iter()
+        .position(|(key, _)| *key == selection.anchor_key)
+    {
+        let anchor = (anchor_ei, selection.anchor_ix);
+        selection.forward = Some(anchor <= head);
+        resolve_spans(elements, anchor, head)
+    } else {
+        let Some(forward) = selection.forward else {
+            return false;
+        };
+        let Some(spans) = extend_virtualized_drag(&selection.spans, elements, head, forward) else {
+            return false;
+        };
+        spans
+    };
+    if selection.spans == spans {
+        return false;
+    }
+    selection.spans = spans;
+    true
+}
+
+fn extend_virtualized_drag(
+    existing: &[Span],
+    elements: &[(&str, &str)],
+    head: (usize, usize),
+    forward: bool,
+) -> Option<Vec<Span>> {
+    if forward {
+        let (element_ix, span_ix) =
+            elements
+                .iter()
+                .enumerate()
+                .find_map(|(element_ix, (key, _))| {
+                    existing
+                        .iter()
+                        .position(|span| span.key == *key)
+                        .map(|span_ix| (element_ix, span_ix))
+                })?;
+        let start = existing[span_ix].range.start;
+        let mut merged = existing[..span_ix].to_vec();
+        merged.extend(resolve_spans(elements, (element_ix, start), head));
+        Some(merged)
+    } else {
+        let (element_ix, span_ix) =
+            elements
+                .iter()
+                .enumerate()
+                .rev()
+                .find_map(|(element_ix, (key, _))| {
+                    existing
+                        .iter()
+                        .position(|span| span.key == *key)
+                        .map(|span_ix| (element_ix, span_ix))
+                })?;
+        let end = existing[span_ix].range.end;
+        let mut merged = resolve_spans(elements, head, (element_ix, end));
+        merged.extend_from_slice(&existing[span_ix + 1..]);
+        Some(merged)
+    }
 }
 
 /// Replace the resolved spans (drag update). Returns true if they changed.
@@ -122,6 +212,22 @@ pub fn end_drag(key: &str) -> Option<String> {
     }
     sel.dragging = false;
     if sel.spans.iter().all(|s| s.range.is_empty()) {
+        *guard = None;
+        return None;
+    }
+    Some(join_spans(&sel.spans))
+}
+
+/// End whichever drag is active, even when virtualization has removed the
+/// anchor element (and therefore its frame-scoped mouse-up listener).
+pub fn end_active_drag() -> Option<String> {
+    let mut guard = state().lock().unwrap();
+    let sel = guard.as_mut()?;
+    if !sel.dragging {
+        return None;
+    }
+    sel.dragging = false;
+    if sel.spans.iter().all(|span| span.range.is_empty()) {
         *guard = None;
         return None;
     }
@@ -266,6 +372,36 @@ mod tests {
         assert!(!clear_if_owner("p2"));
         assert!(clear_if_owner("p1"));
         assert_eq!(selected_text(), None);
+    }
+
+    #[test]
+    fn drag_survives_forward_virtualization() {
+        let _state = state_lock();
+        begin("p1", 6);
+        assert!(update_drag(&elems(), (2, 5)));
+        let shifted = [("p2", "second"), ("p3", "third one"), ("p4", "fourth")];
+        assert!(update_drag(&shifted, (2, 4)));
+        assert_eq!(
+            selected_text().as_deref(),
+            Some("paragraph\nsecond\nthird one\nfour")
+        );
+        assert_eq!(
+            end_active_drag().as_deref(),
+            Some("paragraph\nsecond\nthird one\nfour")
+        );
+        assert_eq!(drag_anchor("p1"), None);
+    }
+
+    #[test]
+    fn drag_survives_backward_virtualization() {
+        let _state = state_lock();
+        begin("p5", 4);
+        let first = [("p3", "third"), ("p4", "fourth"), ("p5", "fifth")];
+        assert!(update_drag(&first, (0, 2)));
+        let shifted = [("p2", "second"), ("p3", "third"), ("p4", "fourth")];
+        assert!(update_drag(&shifted, (0, 3)));
+        assert_eq!(selected_text().as_deref(), Some("ond\nthird\nfourth\nfift"));
+        assert_eq!(end_drag("p5").as_deref(), Some("ond\nthird\nfourth\nfift"));
     }
 
     #[test]

--- a/crates/ui/src/terminal/emulator.rs
+++ b/crates/ui/src/terminal/emulator.rs
@@ -260,6 +260,14 @@ impl Emulator {
         self.term.scroll_display(Scroll::Bottom);
     }
 
+    /// Set the scrollback offset directly (0 = live bottom).
+    pub fn scroll_to_offset(&mut self, offset: usize) {
+        let target = offset.min(self.history_lines());
+        let current = self.display_offset();
+        let delta = (target as i64 - current as i64).clamp(i32::MIN as i64, i32::MAX as i64) as i32;
+        self.scroll(delta);
+    }
+
     // ---- selection ----
     //
     // `Term` owns the selection outright, which is what makes this cheap: it
@@ -539,6 +547,11 @@ mod tests {
         e.scroll(100);
         assert_eq!(e.display_offset(), 6);
         assert_eq!(e.row_text(0), "line1");
+        e.scroll_to_offset(3);
+        assert_eq!(e.display_offset(), 3);
+        assert_eq!(e.row_text(0), "line4");
+        e.scroll_to_offset(usize::MAX);
+        assert_eq!(e.display_offset(), 6);
         e.scroll_to_bottom();
         assert_eq!(e.display_offset(), 0);
         assert_eq!(e.row_text(0), "line7");

--- a/crates/ui/src/terminal/panel.rs
+++ b/crates/ui/src/terminal/panel.rs
@@ -40,6 +40,12 @@ use super::view::{
 /// Fixed tab width — drag-reorder math stays analytic.
 pub const TAB_WIDTH: f32 = 118.0;
 pub const TAB_BAR_HEIGHT: f32 = 40.0;
+const SELECTION_SCROLL_TICK_MS: u64 = 24;
+const SCROLLBAR_TRACK_INSET: f32 = 4.0;
+const SCROLLBAR_HIT_WIDTH: f32 = 10.0;
+const SCROLLBAR_THUMB_WIDTH: f32 = 3.0;
+const SCROLLBAR_HOVER_THUMB_WIDTH: f32 = 4.5;
+const SCROLLBAR_MIN_THUMB: f32 = 24.0;
 
 actions!(terminal, [ToggleTerminal]);
 
@@ -184,6 +190,8 @@ pub struct GridSnapshot {
 /// after a resize.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GridGeometry {
+    /// Full terminal body bounds, used by edge scrolling and the scrollbar.
+    pub bounds: gpui::Bounds<Pixels>,
     /// Top-left of the first glyph (bounds origin plus padding).
     pub origin: gpui::Point<Pixels>,
     pub cell_w: f32,
@@ -204,7 +212,86 @@ struct SelectionDrag {
     /// selection's anchor, so the selection starts where the press landed
     /// rather than where the threshold happened to trip.
     origin: gpui::Point<Pixels>,
+    /// Latest pointer sample. Edge scrolling keeps using it while the pointer
+    /// is stationary, updating the selection after every scrollback step.
+    position: gpui::Point<Pixels>,
     armed: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScrollbarDrag {
+    grab_offset: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ScrollbarMetrics {
+    track_top: f32,
+    track_height: f32,
+    thumb_top: f32,
+    thumb_height: f32,
+    history_lines: usize,
+}
+
+impl ScrollbarMetrics {
+    fn travel(self) -> f32 {
+        (self.track_height - self.thumb_height).max(0.0)
+    }
+}
+
+fn scrollbar_metrics(
+    bounds: gpui::Bounds<Pixels>,
+    rows: usize,
+    history_lines: usize,
+    display_offset: usize,
+) -> Option<ScrollbarMetrics> {
+    if history_lines == 0 {
+        return None;
+    }
+    let track_height = (f32::from(bounds.size.height) - SCROLLBAR_TRACK_INSET * 2.0).max(0.0);
+    if track_height <= 0.0 {
+        return None;
+    }
+    let total_lines = history_lines.saturating_add(rows).max(1);
+    let thumb_height = (track_height * rows as f32 / total_lines as f32)
+        .max(SCROLLBAR_MIN_THUMB)
+        .min(track_height);
+    let travel = (track_height - thumb_height).max(0.0);
+    let offset = display_offset.min(history_lines);
+    let progress_from_top = 1.0 - offset as f32 / history_lines as f32;
+    Some(ScrollbarMetrics {
+        track_top: f32::from(bounds.top()) + SCROLLBAR_TRACK_INSET,
+        track_height,
+        thumb_top: travel * progress_from_top,
+        thumb_height,
+        history_lines,
+    })
+}
+
+/// Terminal scroll direction for a selection near the grid edge.
+///
+/// Alacritty uses positive deltas for history (up) and negative deltas for the
+/// live bottom. Speed is line-based because the terminal cannot expose partial
+/// rows without breaking its fixed grid.
+fn selection_scroll_lines(geometry: GridGeometry, position: gpui::Point<Pixels>) -> i32 {
+    let grid_height = geometry.line_h * geometry.rows as f32;
+    if grid_height <= 0.0 {
+        return 0;
+    }
+    let edge = geometry.line_h.min(grid_height / 3.0);
+    let y = f32::from(position.y);
+    let top = f32::from(geometry.origin.y);
+    let bottom = top + grid_height;
+    let speed = |penetration: f32| {
+        let t = (penetration / edge).clamp(0.0, 1.0);
+        (1.0 + 2.0 * t * t).round() as i32
+    };
+    if y < top + edge {
+        speed(top + edge - y)
+    } else if y > bottom - edge {
+        -speed(y - (bottom - edge))
+    } else {
+        0
+    }
 }
 
 struct TerminalTab {
@@ -284,6 +371,15 @@ pub struct TerminalPanel {
     geometry: Option<GridGeometry>,
     /// Left-button gesture in flight, if any.
     selection_drag: Option<SelectionDrag>,
+    /// One-shot timer rescheduled only while a live selection remains in an
+    /// edge zone.
+    selection_scroll_task: Option<Task<()>>,
+    /// Active scrollbar thumb/track drag.
+    scrollbar_drag: Option<ScrollbarDrag>,
+    /// The terminal owns the cursor. The scrollbar is an on-demand affordance
+    /// rather than a permanently painted rail beside the panel.
+    terminal_hovered: bool,
+    scrollbar_hovered: bool,
     _observe: Subscription,
 }
 
@@ -301,6 +397,10 @@ impl TerminalPanel {
             last_selected: None,
             geometry: None,
             selection_drag: None,
+            selection_scroll_task: None,
+            scrollbar_drag: None,
+            terminal_hovered: false,
+            scrollbar_hovered: false,
             _observe: observe,
         }
     }
@@ -922,6 +1022,7 @@ impl TerminalPanel {
             if extended {
                 self.selection_drag = Some(SelectionDrag {
                     origin: event.position,
+                    position: event.position,
                     armed: true,
                 });
                 cx.notify();
@@ -932,6 +1033,7 @@ impl TerminalPanel {
             self.with_active_emulator(cx, |emu| emu.clear_selection());
             self.selection_drag = Some(SelectionDrag {
                 origin: event.position,
+                position: event.position,
                 armed: false,
             });
         } else {
@@ -941,6 +1043,7 @@ impl TerminalPanel {
             self.with_active_emulator(cx, |emu| emu.start_selection(ty, point, side));
             self.selection_drag = Some(SelectionDrag {
                 origin: event.position,
+                position: event.position,
                 armed: true,
             });
         }
@@ -953,12 +1056,22 @@ impl TerminalPanel {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if let Some(drag) = self.scrollbar_drag {
+            if event.dragging() {
+                self.scrollbar_to_pointer(event.position.y, drag.grab_offset, cx);
+            } else {
+                self.scrollbar_drag = None;
+            }
+            return;
+        }
         if !event.dragging() {
             return;
         }
-        let Some(drag) = self.selection_drag else {
+        let Some(mut drag) = self.selection_drag else {
             return;
         };
+        drag.position = event.position;
+        self.selection_drag = Some(drag);
         if !drag.armed {
             let dx = f32::from(event.position.x - drag.origin.x);
             let dy = f32::from(event.position.y - drag.origin.y);
@@ -983,6 +1096,7 @@ impl TerminalPanel {
         };
         self.with_active_emulator(cx, |emu| emu.update_selection(point, side));
         cx.notify();
+        self.schedule_selection_scroll(cx);
     }
 
     fn on_mouse_up(
@@ -992,6 +1106,8 @@ impl TerminalPanel {
         _cx: &mut Context<Self>,
     ) {
         self.selection_drag = None;
+        self.selection_scroll_task = None;
+        self.scrollbar_drag = None;
     }
 
     /// Copy the selection. Returns whether anything was copied, so the caller
@@ -1022,6 +1138,160 @@ impl TerminalPanel {
             tab.emulator.scroll(delta_lines);
             cx.notify();
         }
+    }
+
+    fn schedule_selection_scroll(&mut self, cx: &mut Context<Self>) {
+        if self.selection_scroll_task.is_some() {
+            return;
+        }
+        let (Some(drag), Some(geometry)) = (self.selection_drag, self.geometry) else {
+            return;
+        };
+        if !drag.armed || selection_scroll_lines(geometry, drag.position) == 0 {
+            return;
+        }
+        self.selection_scroll_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(SELECTION_SCROLL_TICK_MS))
+                .await;
+            let _ = this.update(cx, |panel, cx| {
+                panel.selection_scroll_task = None;
+                panel.step_selection_scroll(cx);
+            });
+        }));
+    }
+
+    fn step_selection_scroll(&mut self, cx: &mut Context<Self>) {
+        let (Some(drag), Some(geometry)) = (self.selection_drag, self.geometry) else {
+            return;
+        };
+        if !drag.armed {
+            return;
+        }
+        let lines = selection_scroll_lines(geometry, drag.position);
+        if lines == 0 {
+            return;
+        }
+        self.scroll_active(lines, cx);
+        if let Some((point, side)) = self.grid_point_at(drag.position, cx) {
+            self.with_active_emulator(cx, |emu| emu.update_selection(point, side));
+        }
+        self.schedule_selection_scroll(cx);
+    }
+
+    fn active_scrollbar_metrics(&self, cx: &App) -> Option<ScrollbarMetrics> {
+        let geometry = self.geometry?;
+        let tab = self.active_tab(cx)?;
+        scrollbar_metrics(
+            geometry.bounds,
+            tab.emulator.rows(),
+            tab.emulator.history_lines(),
+            tab.emulator.display_offset(),
+        )
+    }
+
+    fn scrollbar_to_pointer(
+        &mut self,
+        pointer_y: Pixels,
+        grab_offset: f32,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(metrics) = self.active_scrollbar_metrics(cx) else {
+            return;
+        };
+        let thumb_top =
+            (f32::from(pointer_y) - metrics.track_top - grab_offset).clamp(0.0, metrics.travel());
+        let offset = if metrics.travel() <= 0.0 {
+            0
+        } else {
+            ((1.0 - thumb_top / metrics.travel()) * metrics.history_lines as f32).round() as usize
+        };
+        self.with_active_emulator(cx, |emu| emu.scroll_to_offset(offset));
+        cx.notify();
+    }
+
+    fn on_scrollbar_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(metrics) = self.active_scrollbar_metrics(cx) else {
+            return;
+        };
+        window.focus(&self.focus_handle, cx);
+        let pointer_on_track = f32::from(event.position.y) - metrics.track_top;
+        let grab_offset = if (metrics.thumb_top..=metrics.thumb_top + metrics.thumb_height)
+            .contains(&pointer_on_track)
+        {
+            pointer_on_track - metrics.thumb_top
+        } else {
+            metrics.thumb_height / 2.0
+        };
+        self.scrollbar_drag = Some(ScrollbarDrag { grab_offset });
+        self.scrollbar_to_pointer(event.position.y, grab_offset, cx);
+        cx.stop_propagation();
+    }
+
+    fn on_terminal_hover(
+        &mut self,
+        hovered: &bool,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.terminal_hovered != *hovered {
+            self.terminal_hovered = *hovered;
+            if !*hovered {
+                self.scrollbar_hovered = false;
+            }
+            cx.notify();
+        }
+    }
+
+    fn render_scrollbar(&self, theme: &Theme, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
+        if !self.terminal_hovered {
+            return None;
+        }
+        let metrics = self.active_scrollbar_metrics(cx)?;
+        let thumb_width = if self.scrollbar_hovered {
+            SCROLLBAR_HOVER_THUMB_WIDTH
+        } else {
+            SCROLLBAR_THUMB_WIDTH
+        };
+        Some(
+            div()
+                .id("terminal-scrollbar")
+                .absolute()
+                .top(px(0.0))
+                .bottom(px(0.0))
+                .right(px(0.0))
+                .w(px(SCROLLBAR_HIT_WIDTH))
+                .cursor_pointer()
+                .on_hover(cx.listener(|this, hovered: &bool, _, cx| {
+                    if this.scrollbar_hovered != *hovered {
+                        this.scrollbar_hovered = *hovered;
+                        cx.notify();
+                    }
+                }))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(Self::on_scrollbar_mouse_down),
+                )
+                .child(
+                    div()
+                        .absolute()
+                        .top(px(SCROLLBAR_TRACK_INSET + metrics.thumb_top))
+                        .right(px(2.0))
+                        // This is an absolute child inside a fixed-width hit
+                        // rail, so the hover expansion changes only paint
+                        // geometry and never reflows the terminal.
+                        .w(px(thumb_width))
+                        .h(px(metrics.thumb_height))
+                        .rounded(px(thumb_width / 2.0))
+                        .bg(theme.text_faint.opacity(0.52)),
+                )
+                .into_any_element(),
+        )
     }
 
     // ---- tab management ----
@@ -1378,6 +1648,7 @@ impl Render for TerminalPanel {
                 .into_any_element();
         };
         let focused = self.focus_handle.is_focused(window);
+        let scrollbar = self.render_scrollbar(&theme, cx);
 
         // Embedded (right-pane surface host): the shell's surface tabs
         // replace the internal bar.
@@ -1392,10 +1663,12 @@ impl Render for TerminalPanel {
             .child(
                 div()
                     .id("terminal-body")
+                    .relative()
                     .flex_1()
                     .min_h_0()
                     .key_context("Terminal")
                     .track_focus(&self.focus_handle)
+                    .on_hover(cx.listener(Self::on_terminal_hover))
                     .on_key_down(cx.listener(Self::on_key_down))
                     .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
                     .on_mouse_move(cx.listener(Self::on_mouse_move))
@@ -1415,7 +1688,8 @@ impl Render for TerminalPanel {
                         let step = lines.round() as i32;
                         this.scroll_active(step, cx);
                     }))
-                    .child(TerminalElement::new(cx.entity(), focused)),
+                    .child(TerminalElement::new(cx.entity(), focused))
+                    .children(scrollbar),
             )
             .into_any_element()
     }
@@ -1444,6 +1718,44 @@ mod tests {
         assert_eq!(backoff_ms(4), 8000);
         assert_eq!(backoff_ms(10), 8000);
         assert_eq!(backoff_ms(u32::MAX), 8000);
+    }
+
+    fn test_geometry() -> GridGeometry {
+        GridGeometry {
+            bounds: gpui::Bounds::new(
+                gpui::point(px(10.0), px(20.0)),
+                gpui::size(px(300.0), px(200.0)),
+            ),
+            origin: gpui::point(px(18.0), px(28.0)),
+            cell_w: 8.0,
+            line_h: 20.0,
+            cols: 35,
+            rows: 9,
+        }
+    }
+
+    #[test]
+    fn selection_edge_scroll_uses_terminal_direction() {
+        let geometry = test_geometry();
+        assert!(selection_scroll_lines(geometry, gpui::point(px(20.0), px(28.0))) > 0);
+        assert_eq!(
+            selection_scroll_lines(geometry, gpui::point(px(20.0), px(100.0))),
+            0
+        );
+        assert!(selection_scroll_lines(geometry, gpui::point(px(20.0), px(208.0))) < 0);
+    }
+
+    #[test]
+    fn scrollbar_thumb_maps_history_top_and_bottom() {
+        let bounds = test_geometry().bounds;
+        assert!(scrollbar_metrics(bounds, 20, 0, 0).is_none());
+
+        let bottom = scrollbar_metrics(bounds, 20, 80, 0).unwrap();
+        let top = scrollbar_metrics(bounds, 20, 80, 80).unwrap();
+        assert!((bottom.thumb_height - 38.4).abs() < 0.01);
+        assert!((bottom.thumb_top - bottom.travel()).abs() < 0.01);
+        assert_eq!(top.thumb_top, 0.0);
+        assert_eq!(top.thumb_height, bottom.thumb_height);
     }
 
     #[test]

--- a/crates/ui/src/terminal/view.rs
+++ b/crates/ui/src/terminal/view.rs
@@ -561,6 +561,7 @@ impl gpui::Element for TerminalElement {
         let snapshot = self.panel.update(cx, |panel, cx| {
             panel.on_grid_metrics(
                 super::panel::GridGeometry {
+                    bounds,
                     origin,
                     cell_w: f32::from(cell_w),
                     line_h: f32::from(line_h),

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -33,9 +33,10 @@ use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use gpui::{
-    AnyElement, BorderStyle, ClipboardItem, Context, Entity, ListAlignment, ListOffset,
-    ListScrollEvent, ListState, ObjectFit, SharedString, StyledImage as _, StyledText,
-    Subscription, Task, TextRun, Window, canvas, div, img, list, prelude::*, px, quad,
+    AnyElement, BorderStyle, Bounds, ClipboardItem, Context, Entity, ListAlignment, ListOffset,
+    ListScrollEvent, ListState, MouseButton, MouseMoveEvent, MouseUpEvent, ObjectFit, Pixels,
+    Point, SharedString, StyledImage as _, StyledText, Subscription, Task, TextRun, Window, canvas,
+    div, img, list, prelude::*, px, quad,
 };
 
 use zeron_doc::{MessagePart, MessageRole, MessageStatus, SessionMessageEntry, SubagentStatus};
@@ -60,6 +61,12 @@ pub const STICK_THRESHOLD_PX: f32 = 70.0;
 pub const OVERDRAW_PX: f32 = 320.0;
 /// Show the scroll-to-bottom button beyond this distance from the end.
 pub const SCROLL_BUTTON_THRESHOLD_PX: f32 = 320.0;
+/// Text-selection edge scrolling runs only during a drag. A 24 ms cadence is
+/// smooth enough to track text while avoiding a permanent animation-frame loop
+/// on low-end devices.
+const SELECTION_SCROLL_TICK_MS: u64 = 24;
+const SELECTION_SCROLL_EDGE_PX: f32 = 36.0;
+const SELECTION_SCROLL_MAX_STEP_PX: f32 = 24.0;
 /// Vertical gap opening a new turn (new message entry).
 pub const GAP_TURN: f32 = 14.0;
 /// Vertical gap between blocks within a turn.
@@ -73,6 +80,35 @@ pub const MAX_CONTENT_WIDTH: f32 = 736.0;
 pub const CHIP_HEIGHT: f32 = 38.0;
 pub const CHIP_GAP: f32 = 0.0;
 pub const CHIP_CARD_HEIGHT: f32 = 30.0;
+
+/// Signed list scroll step for a pointer near a viewport edge.
+///
+/// GPUI list offsets increase toward the document bottom. The quadratic ramp
+/// keeps entry into the edge zone gentle and reaches full speed at the edge.
+fn selection_scroll_step(bounds: Bounds<Pixels>, position: Point<Pixels>) -> f32 {
+    let height = f32::from(bounds.size.height);
+    if height <= 0.0 {
+        return 0.0;
+    }
+    let edge = SELECTION_SCROLL_EDGE_PX.min(height / 3.0);
+    if edge <= 0.0 {
+        return 0.0;
+    }
+    let y = f32::from(position.y);
+    let top = f32::from(bounds.top());
+    let bottom = f32::from(bounds.bottom());
+    let scaled = |penetration: f32| {
+        let t = (penetration / edge).clamp(0.0, 1.0);
+        SELECTION_SCROLL_MAX_STEP_PX * t * t
+    };
+    if y < top + edge {
+        -scaled(top + edge - y)
+    } else if y > bottom - edge {
+        scaled(y - (bottom - edge))
+    } else {
+        0.0
+    }
+}
 const CHIPS_TOP_PAD: f32 = 2.0;
 /// How long a user fold toggle keeps its height tween armed: the RESIZE
 /// spec's 200ms plus margin. Past this the fold renders statically — an armed
@@ -1475,6 +1511,11 @@ pub struct Transcript {
     /// One `on_next_frame` callback in flight at most.
     spring_scheduled: bool,
     scroll_anim: Option<Task<()>>,
+    /// Last pointer sample while markdown selection owns a left-button drag.
+    selection_drag_position: Option<Point<Pixels>>,
+    /// One-shot timer rescheduled only while the pointer remains in an edge
+    /// zone. Dropping it on mouse-up stops all selection scroll work.
+    selection_scroll_task: Option<Task<()>>,
     /// MessageRail width gate (set by the shell from the container width).
     rail_enabled: bool,
     /// Height of the shell's composer/status/terminal stack overlaying the
@@ -1637,6 +1678,8 @@ impl Transcript {
             spring_kick: false,
             spring_scheduled: false,
             scroll_anim: None,
+            selection_drag_position: None,
+            selection_scroll_task: None,
             rail_enabled,
             bottom_clearance: 0.0,
             rail_hover: None,
@@ -1842,6 +1885,93 @@ impl Transcript {
             })
             .ok();
         });
+    }
+
+    fn on_selection_mouse_move(
+        &mut self,
+        event: &MouseMoveEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !event.dragging() || !crate::markdown::selection::is_dragging() {
+            self.stop_selection_scroll();
+            return;
+        }
+        self.selection_drag_position = Some(event.position);
+        if render::update_drag_at(event.position) {
+            cx.notify();
+        }
+        self.schedule_selection_scroll(cx);
+    }
+
+    fn on_selection_mouse_up(
+        &mut self,
+        _event: &MouseUpEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.stop_selection_scroll();
+        if let Some(_text) = crate::markdown::selection::end_active_drag() {
+            // X11 middle-click paste parity, including the case where the
+            // anchor row has virtualized away and cannot receive mouse-up.
+            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+            cx.write_to_primary(ClipboardItem::new_string(_text));
+        }
+    }
+
+    fn stop_selection_scroll(&mut self) {
+        self.selection_drag_position = None;
+        self.selection_scroll_task = None;
+    }
+
+    fn schedule_selection_scroll(&mut self, cx: &mut Context<Self>) {
+        if self.selection_scroll_task.is_some() || !crate::markdown::selection::is_dragging() {
+            return;
+        }
+        let Some(position) = self.selection_drag_position else {
+            return;
+        };
+        if selection_scroll_step(self.list.viewport_bounds(), position) == 0.0 {
+            return;
+        }
+        self.selection_scroll_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(SELECTION_SCROLL_TICK_MS))
+                .await;
+            let _ = this.update(cx, |transcript, cx| {
+                transcript.selection_scroll_task = None;
+                transcript.step_selection_scroll(cx);
+            });
+        }));
+    }
+
+    fn step_selection_scroll(&mut self, cx: &mut Context<Self>) {
+        if !crate::markdown::selection::is_dragging() {
+            self.stop_selection_scroll();
+            return;
+        }
+        let Some(position) = self.selection_drag_position else {
+            return;
+        };
+        let step = selection_scroll_step(self.list.viewport_bounds(), position);
+        if step == 0.0 {
+            return;
+        }
+
+        // Resolve against the registry painted after the previous step before
+        // moving it again. This is what lets a stationary edge pointer consume
+        // successive virtualized rows.
+        render::update_drag_at(position);
+        self.scroll_anim = None;
+        self.release_own_turn_hold();
+        self.pinned = false;
+        self.spring.reset();
+        self.spring_last_tick = None;
+        self.list.scroll_by(px(step));
+        self.last_scroll_distance = self.distance_from_bottom();
+        self.show_jump_button = self.last_scroll_distance > SCROLL_BUTTON_THRESHOLD_PX;
+        cx.notify();
+        self.schedule_selection_scroll(cx);
     }
 
     /// Reserve the reply's space below a locally-sent prompt — EVERY send,
@@ -4547,6 +4677,9 @@ impl Render for Transcript {
             .relative()
             .size_full()
             .min_h_0()
+            .on_mouse_move(cx.listener(Self::on_selection_mouse_move))
+            .on_mouse_up(MouseButton::Left, cx.listener(Self::on_selection_mouse_up))
+            .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_selection_mouse_up))
             // FIRST child ⇒ paints first: clears the frame's markdown text-
             // selection registry before any row's text elements re-register
             // (document paint order = selection order; see markdown/render.rs).
@@ -4578,6 +4711,24 @@ impl Render for Transcript {
 mod tests {
     use super::*;
     use zeron_doc::MessagePart;
+
+    #[test]
+    fn selection_scroll_ramps_at_viewport_edges() {
+        let bounds = Bounds::new(
+            gpui::point(px(10.0), px(20.0)),
+            gpui::size(px(300.0), px(200.0)),
+        );
+        assert_eq!(
+            selection_scroll_step(bounds, gpui::point(px(20.0), px(120.0))),
+            0.0
+        );
+        assert!(selection_scroll_step(bounds, gpui::point(px(20.0), px(20.0))) < 0.0);
+        assert!(selection_scroll_step(bounds, gpui::point(px(20.0), px(220.0))) > 0.0);
+        assert!(
+            selection_scroll_step(bounds, gpui::point(px(20.0), px(220.0)))
+                > selection_scroll_step(bounds, gpui::point(px(20.0), px(200.0)))
+        );
+    }
 
     // ---- streaming parse wiring (the transcript side, not the parser) ----
 


### PR DESCRIPTION
## Summary
- add edge auto-scroll while selecting text in chat and terminal
- preserve chat selections across virtualized transcript rows
- add a thin terminal scrollbar with click/drag support
- show the scrollbar only while hovering the terminal and subtly widen its thumb without layout reflow

## Validation
- `cargo check -p zeron-ui`
- `cargo test -p zeron-ui --lib` (468 passed)
- terminal panel tests (14 passed)
- `git diff --check`

The local low-memory Rust build configuration changes in `.gitignore` and `Cargo.toml` were intentionally not staged or committed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789760622&installation_model_id=425430&pr_number=179&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F179&signature=d41a9020617a627f57712da3c020050b015f426555f2bc9b72fe107d60109c6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->