### PR TITLE
Attachment thumbnails: sending indicator restored, no post-send blink, corners clip properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2447,7 +2447,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2529,7 +2529,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "schemars",
  "serde",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "anyhow",
  "log",
@@ -2685,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2738,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3994,7 +3994,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4784,7 +4784,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "collections",
  "serde",
@@ -5621,7 +5621,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "derive_refineable",
 ]
@@ -5912,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6525,7 +6525,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -7680,7 +7680,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "perf",
  "quote",
@@ -9355,7 +9355,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9372,7 +9372,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=f8d8a90d914d26b68fb126040386fb08c2ada78a#f8d8a90d914d26b68fb126040386fb08c2ada78a"
+source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,14 +57,14 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/wingleeio/zed", rev = "f8d8a90d914d26b68fb126040386fb08c2ada78a" }
-gpui_platform = { git = "https://github.com/wingleeio/zed", rev = "f8d8a90d914d26b68fb126040386fb08c2ada78a", features = [
+gpui = { git = "https://github.com/wingleeio/zed", rev = "e2ddcc6805f8c5088e62a60dfe517abcccd61a9a" }
+gpui_platform = { git = "https://github.com/wingleeio/zed", rev = "e2ddcc6805f8c5088e62a60dfe517abcccd61a9a", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/wingleeio/zed", rev = "f8d8a90d914d26b68fb126040386fb08c2ada78a" }
+gpui_tokio = { git = "https://github.com/wingleeio/zed", rev = "e2ddcc6805f8c5088e62a60dfe517abcccd61a9a" }
 
 # diffs
 similar = "2"
@@ -119,3 +119,4 @@ opt-level = 0
 
 [profile.dev.package."*"]
 opt-level = 2
+

--- a/crates/ui/src/attachments.rs
+++ b/crates/ui/src/attachments.rs
@@ -641,8 +641,52 @@ pub fn attachment_snapshot(device_id: &str, path: &str) -> AttachmentSnapshot {
         Some(CacheEntry::Error { attempts, at }) => AttachmentSnapshot::Error {
             retry_in: retry_delay(attempts.saturating_sub(1)).saturating_sub(at.elapsed()),
         },
-        _ => AttachmentSnapshot::Loading,
+        Some(CacheEntry::Loading { .. }) => AttachmentSnapshot::Loading,
+        None => {
+            // Queued-send alias: the host materializes `pending://{id}/{name}`
+            // at `{uploads}/{id8}-{name}` and rewrites the persisted ref to
+            // that ABSOLUTE path — one the sender can't know up front (it's
+            // the host's disk). The id8 basename prefix IS derivable though,
+            // so the send seeds the bytes under an alias and this fallback
+            // resolves the rewritten ref instantly instead of blanking the
+            // thumbnail into a skeleton while the bytes round-trip
+            // (2026-08-19 "photo disappears after it finishes sending").
+            if let Some(image) = upload_alias_id8(path)
+                .and_then(|id8| match cache.map.get(&alias_key(device_id, &id8)) {
+                    Some(CacheEntry::Loaded { image, .. }) => Some(image.clone()),
+                    _ => None,
+                })
+            {
+                cache.insert_loaded(key(device_id, path), image.clone());
+                return AttachmentSnapshot::Loaded(image);
+            }
+            AttachmentSnapshot::Loading
+        }
     }
+}
+
+/// The uploadId fragment a committed upload's basename starts with
+/// (`{id8}-{name}` per the engine's `Uploads::pending_target`). `None` when
+/// the path can't be a committed upload.
+fn upload_alias_id8(path: &str) -> Option<String> {
+    let base = std::path::Path::new(path).file_name()?.to_str()?;
+    let (id8, _) = base.split_at_checked(8)?;
+    (base.as_bytes().get(8) == Some(&b'-')
+        && id8.bytes().all(|b| b.is_ascii_alphanumeric()))
+    .then(|| id8.to_string())
+}
+
+fn alias_key(device_id: &str, id8: &str) -> (String, String) {
+    key(device_id, &format!("upload-alias://{id8}"))
+}
+
+/// Seed the just-sent image under its upload identity so the persisted
+/// message's rewritten absolute ref (host-side path) resolves from the same
+/// local bytes — see the alias fallback in [`attachment_snapshot`].
+pub fn seed_attachment_alias(device_id: &str, upload_id: &str, name: &str, image: Arc<Image>) {
+    let id8: String = upload_id.chars().take(8).collect();
+    let (device, path) = alias_key(device_id, &id8);
+    store_loaded(&device, &path, name.to_string().into(), image);
 }
 
 /// Release gpui's decoded copies of evicted images: the asset-system entry

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -3678,7 +3678,16 @@ impl Composer {
                             }))
                             .child(
                                 img(att.image.clone())
-                                    .size_full()
+                                    // EXPLICIT dims, not size_full: img layout
+                                    // honors the image's intrinsic aspect
+                                    // ratio over a percent height (gpui
+                                    // f8d8a90 repoint), so size_full let a
+                                    // tall photo grow past the frame — the
+                                    // rectangular overflow clip then squared
+                                    // the bottom corners (2026-08-19 report).
+                                    // 56−2 = frame minus its 1px borders.
+                                    .w(px(STRIP_THUMB - 2.0))
+                                    .h(px(STRIP_THUMB - 2.0))
                                     // Own radii — the frame's rounding only
                                     // clips rectangularly (7 = 8 - border).
                                     .rounded(px(7.0))
@@ -4608,6 +4617,31 @@ impl Composer {
                 .collect()
         };
         let echo_text = attachments::with_attachments(&text, &echo_paths);
+        // Queued flow also seeds the UPLOAD ALIAS: the host rewrites the
+        // persisted ref to `{its uploads dir}/{id8}-{name}` — an absolute
+        // path the sender can't predict, but whose id8 it minted. The alias
+        // keeps the thumbnail on the already-local bytes through that
+        // rewrite instead of blanking into a reload skeleton.
+        if queued_flow {
+            for (upload_id, att) in upload_ids.iter().zip(&staged) {
+                attachments::seed_attachment_alias(
+                    &device_id,
+                    upload_id,
+                    &att.name,
+                    att.image.clone(),
+                );
+                if let Some(local) = local_device_id.as_deref()
+                    && local != device_id
+                {
+                    attachments::seed_attachment_alias(
+                        local,
+                        upload_id,
+                        &att.name,
+                        att.image.clone(),
+                    );
+                }
+            }
+        }
         for (path, att) in echo_paths.iter().zip(&staged) {
             attachments::seed_attachment(&device_id, path, &att.name, att.image.clone());
             if let Some(local) = local_device_id.as_deref()

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2740,13 +2740,19 @@ impl Transcript {
             .pt(px(4.0));
         for (aix, att) in atts.iter().enumerate() {
             let state = self.attachment_state(&device_ids, &att.path, cx);
-            // The in-flight send's upload progress belongs ON the thumbnail:
-            // only the un-refreshed echo carries synthetic `pending/` refs, so
-            // the pair (pending path, upload in flight) is exactly "this image
-            // is crossing the relay right now" (2026-08-18 user request).
-            let uploading = att
-                .path
-                .starts_with("pending/")
+            // The in-flight send's progress belongs ON the thumbnail
+            // (2026-08-18 user request). Two ref shapes mean "still
+            // crossing": the queued flow's `pending://` (bytes ship
+            // engine-side after the send; the host rewrites the ref to an
+            // absolute path once they land and the run starts) and the
+            // legacy echo's synthetic `pending/`. The v0.2.12 queued cutover
+            // only matched the legacy shape, so the indicator vanished
+            // (2026-08-19 report). Percent exists only while the UI itself
+            // uploads (legacy / local staging); the engine-side relay leg
+            // has no percent — indeterminate spinner instead.
+            let sending =
+                att.path.starts_with("pending://") || att.path.starts_with("pending/");
+            let uploading = sending
                 .then(|| self.state.read(cx).upload_progress_percent())
                 .flatten();
             let frame = div()
@@ -2775,7 +2781,14 @@ impl Transcript {
                         }))
                         .child(
                             img(image.image.clone())
-                                .size_full()
+                                // EXPLICIT dims, not size_full: img layout
+                                // honors the intrinsic aspect ratio over a
+                                // percent height (gpui f8d8a90 repoint), so
+                                // size_full let a tall photo grow past the
+                                // frame and the rectangular overflow clip
+                                // squared the bottom corners (2026-08-19).
+                                .w(px(ATT_THUMB_W - 2.0))
+                                .h(px(ATT_THUMB_H - 2.0))
                                 // The IMG needs its own radii: the frame's
                                 // rounding only clips rectangularly, so the
                                 // sprite must round its own corners (7 = the
@@ -2783,15 +2796,27 @@ impl Transcript {
                                 .rounded(px(7.0))
                                 .object_fit(ObjectFit::Cover),
                         )
-                        .when_some(uploading, |el, pct| {
+                        .when(sending, |el| {
                             // The pulse read registers this entity for frames,
-                            // so the percent stays live even once the trailer's
+                            // so the overlay stays live even once the trailer's
                             // 30s pending-send bridge has lapsed.
                             let pulse = motion::pulse_wave(motion::pulse_delta(
                                 &motion::ZERON_PULSE,
                                 cx.entity_id(),
                                 cx,
                             ));
+                            let indicator: AnyElement = match uploading {
+                                Some(pct) => {
+                                    crate::loaders::upload_progress_ring(pct, 34.0)
+                                }
+                                None => crate::loaders::mini_gradient_spinner(
+                                    format!("att-sending-{row_id}-{aix}"),
+                                    3.0,
+                                    cx.entity_id(),
+                                    cx,
+                                )
+                                .into_any_element(),
+                            };
                             el.child(
                                 div()
                                     .absolute()
@@ -2801,7 +2826,7 @@ impl Transcript {
                                     .items_center()
                                     .justify_center()
                                     .bg(gpui::hsla(0.0, 0.0, 0.0, 0.38 + 0.05 * pulse))
-                                    .child(crate::loaders::upload_progress_ring(pct, 34.0)),
+                                    .child(indicator),
                             )
                         })
                         .into_any_element()


### PR DESCRIPTION
Three v0.2.14 field reports on photo thumbnails — all three traced to the queued-attachment cutover (the `pending://` flow only went live once every device crossed the 0.2.12 version gate) plus one genuine gpui regression.

## 1. Sending indicator gone
The indicator itself was fine and genuinely shipped working: `a729ed4` (PR #164, v0.2.11) added the progress ring keyed to the ref prefix `pending/` — the only shape sends produced at the time. Six hours later, `8f3bce8` (PR #168) introduced the queued flow, whose refs are `pending://{uploadId}/…` — and that commit never touched `transcript.rs`, so the arming check kept matching only the legacy shape. The regression stayed invisible through v0.2.12–13 because the queued flow is version-gated (every involved engine ≥ 0.2.12): mixed-version device fleets kept taking the legacy path, where the ring still worked. The v0.2.14 update wave put every device past the gate, the queued flow activated, and the indicator stopped arming — which is why it *looked* like 0.2.14 removed it. Both shapes arm it now: the **percent ring** while the UI itself uploads (legacy / local staging), an **indeterminate spinner** while the engine ships the bytes over the relay (that leg has no percent to report). The overlay clears exactly when the host lands the bytes and rewrites the ref.

## 2. Photo disappears after the send lands
The host rewrites the persisted ref from `pending://…` to an **absolute path on its own disk** — a cache key the sender never had, so the thumbnail blanked into a loading skeleton while the just-sent bytes round-tripped back over the wire. The send now also seeds an **upload alias** keyed by the uploadId's `id8` (the committed file's basename prefix, `{id8}-{name}`), and a cache miss on an absolute path resolves through the alias instantly. Rig-verified: mid-send and settled captures are pixel-identical — no blink.

## 3. Bottom corners overflow the border radius
A real gpui regression from the f8d8a90 repoint: `img` layout stamped the image's **intrinsic aspect-ratio over explicit/percent dimensions**, so a tall photo's element grew past its frame (instrumented: 54×54 frame → 54×94.5 element). The rectangular overflow clip then squared the bottom corners while the element-level radii sat off-screen, and the Cover crop never engaged (the photo rendered squished at full aspect).

Fixed in the fork — [wingleeio/zed@e2ddcc68](https://github.com/wingleeio/zed/commit/e2ddcc6805f8c5088e62a60dfe517abcccd61a9a): intrinsic aspect applies only when a dimension is auto (the CSS `aspect-ratio` rule) — and the pin is bumped. Thumbnails also get explicit pixel dims as belt-and-braces.

## Verification (headless rig, tall 320×560 test image)

Before — full image squished into the thumb, bottom corners square:

<img src="https://github.com/user-attachments/assets/9851102a-b54f-4b01-8bb3-c4a0cbcc2ced" width="360">

After — proper center-crop (Cover), all four corners rounded (composer strip):

<img src="https://github.com/user-attachments/assets/85efce65-b857-489f-a88d-3d4189c694d9" width="360">

After — sent transcript bubble, settled state (identical to the mid-send frame — no disappear):

<img src="https://github.com/user-attachments/assets/51ece0da-b32e-4cfb-ae4a-87e1b3a30d3e" width="360">

Full sweep: 750 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789767347&installation_model_id=425430&pr_number=180&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F180&signature=d0d0fd21e1bf3a15f9e8d5f1d72c568547f53812513a3f3def0e468fd2b69be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
