### PR TITLE
fix(acp): support Grok Build model switching

### DIFF
--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -67,9 +67,45 @@ struct HarnessSessionRef {
     cwd: String,
 }
 
+/// Configuration baked into a live harness runtime. The steering mailbox only
+/// carries prompt text, so routing a request whose model/effort/sandbox changed
+/// would silently run it with the old process configuration. Such requests
+/// must replace the runtime and resume its harness-native session instead.
+#[derive(Debug, Clone, PartialEq)]
+struct RuntimeConfig {
+    harness_id: HarnessId,
+    model: Option<String>,
+    reasoning: Option<zeron_proto::ReasoningLevel>,
+    model_options: serde_json::Map<String, serde_json::Value>,
+    cwd: String,
+    sandbox: zeron_proto::SandboxLevel,
+    auto_approve: bool,
+    worktree: Option<zeron_proto::WorktreeSpec>,
+}
+
+impl RuntimeConfig {
+    fn from_request(harness_id: HarnessId, request: &RunRequest) -> Self {
+        Self {
+            harness_id,
+            model: request.model.clone(),
+            reasoning: request.reasoning,
+            model_options: request.model_options.clone(),
+            cwd: request.cwd.clone(),
+            sandbox: request.sandbox,
+            auto_approve: request.auto_approve,
+            worktree: request.worktree.clone(),
+        }
+    }
+
+    fn can_route(&self, harness_id: HarnessId, request: &RunRequest) -> bool {
+        request.attachments.is_empty() && self == &Self::from_request(harness_id, request)
+    }
+}
+
 struct RunHandle {
     run_id: String,
     steerable: bool,
+    runtime_config: RuntimeConfig,
     steer_tx: mpsc::Sender<SteerMessage>,
     /// Harness-level cancellation (protocol interrupt + child teardown).
     interrupt_token: CancellationToken,
@@ -302,16 +338,17 @@ impl SessionsEngine {
             (
                 h.run_id.clone(),
                 h.steerable,
+                h.runtime_config.can_route(harness_id, &request),
                 h.steer_tx.clone(),
                 h.routed_steers.clone(),
             )
         });
-        if let Some((run_id, steerable, steer_tx, ledger)) = routed {
+        if let Some((run_id, steerable, same_runtime, steer_tx, ledger)) = routed {
             let message = SteerMessage {
                 prompt: request.prompt.clone(),
                 message_id: message_id.clone(),
             };
-            if steerable && steer_tx.try_send(message).is_ok() {
+            if steerable && same_runtime && steer_tx.try_send(message).is_ok() {
                 // The run can vanish between the send and here (the idle
                 // reaper, a parked child death): the ledger entry below is
                 // the at-least-once guarantee — the run task's exit drain
@@ -350,8 +387,15 @@ impl SessionsEngine {
                 // below (write_user_message dedupes by id).
                 message_id = Some(user_id);
             }
+            if !same_runtime {
+                tracing::debug!(
+                    chat = %chat_id,
+                    "restarting live harness to apply changed run configuration"
+                );
+            }
             // Mailbox closed (runtime mid-teardown / non-steering harness) or
-            // the routed run died with the message reclaimed: replace it.
+            // the routed run died with the message reclaimed, or configuration
+            // changed beyond what the text-only mailbox can carry: replace it.
             self.interrupt(chat_id).await?;
         }
 
@@ -408,6 +452,7 @@ impl SessionsEngine {
             RunHandle {
                 run_id: run_id.clone(),
                 steerable: harness.supports_steering(),
+                runtime_config: RuntimeConfig::from_request(harness_id, &request),
                 steer_tx,
                 interrupt_token,
                 cancel: cancel_tx,
@@ -2091,8 +2136,47 @@ async fn drive_run(
 }
 
 #[cfg(test)]
-mod subagent_id_tests {
-    use super::subagent_doc_id;
+mod tests {
+    use super::{RuntimeConfig, subagent_doc_id};
+    use zeron_proto::{HarnessId, RunRequest, SandboxLevel};
+
+    fn request() -> RunRequest {
+        RunRequest {
+            prompt: "first".into(),
+            harness: None,
+            model: Some("grok-4.6".into()),
+            reasoning: Some(zeron_proto::ReasoningLevel::High),
+            model_options: serde_json::Map::new(),
+            cwd: "/tmp".into(),
+            sandbox: SandboxLevel::WorkspaceWrite,
+            auto_approve: true,
+            resume: None,
+            attachments: Vec::new(),
+            worktree: None,
+        }
+    }
+
+    #[test]
+    fn live_routing_requires_the_same_runtime_configuration() {
+        let initial = request();
+        let config = RuntimeConfig::from_request(HarnessId::Grok, &initial);
+
+        let mut follow_up = initial.clone();
+        follow_up.prompt = "second".into();
+        follow_up.resume = Some("session-1".into());
+        assert!(config.can_route(HarnessId::Grok, &follow_up));
+
+        follow_up.model = Some("grok-4.5".into());
+        assert!(!config.can_route(HarnessId::Grok, &follow_up));
+        follow_up.model = initial.model.clone();
+
+        follow_up.reasoning = Some(zeron_proto::ReasoningLevel::Medium);
+        assert!(!config.can_route(HarnessId::Grok, &follow_up));
+        follow_up.reasoning = initial.reasoning;
+
+        follow_up.attachments.push("/tmp/image.png".into());
+        assert!(!config.can_route(HarnessId::Grok, &follow_up));
+    }
 
     #[test]
     fn clean_tool_ids_ride_verbatim_and_fit_id_re() {

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -1389,6 +1389,60 @@ fn pick_model_value(requested: &str, available: &[&str], context_1m: bool) -> Op
         .map(|v| (**v).to_owned())
 }
 
+/// Pick a first-class ACP model switch when the session uses the legacy
+/// `models` state instead of a category=model config option. Grok Build 1.0.5
+/// has exactly this shape and accepts the selected id through
+/// `session/set_model`; treating its advertised models as config options makes
+/// the picker look functional while every selection is silently ignored.
+///
+/// Config options remain preferred when present: org adapters can expose a
+/// legacy `models` matrix alongside the canonical base-model config option.
+fn first_class_model_change(
+    session_response: &Value,
+    requested: Option<&str>,
+) -> Result<Option<String>, HarnessError> {
+    let Some(requested) = requested else {
+        return Ok(None);
+    };
+    let has_model_config = session_response
+        .get("configOptions")
+        .and_then(Value::as_array)
+        .is_some_and(|options| {
+            options.iter().any(|option| {
+                option.get("type").and_then(Value::as_str) == Some("select")
+                    && option.get("category").and_then(Value::as_str) == Some("model")
+            })
+        });
+    if has_model_config {
+        return Ok(None);
+    }
+
+    let Some(models) = session_response.get("models") else {
+        return Ok(None);
+    };
+    let available: Vec<&str> = models
+        .get("availableModels")
+        .and_then(Value::as_array)
+        .map(|models| models.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|model| model.get("modelId").and_then(Value::as_str))
+        .collect();
+    if available.is_empty() {
+        return Ok(None);
+    }
+    if !available.contains(&requested) {
+        return Err(HarnessError::Protocol(format!(
+            "agent does not advertise requested model {requested}; available models: {}",
+            available.join(", ")
+        )));
+    }
+    if models.get("currentModelId").and_then(Value::as_str) == Some(requested) {
+        return Ok(None);
+    }
+    Ok(Some(requested.to_owned()))
+}
+
 /// The `session/set_config_option` calls a session response's `configOptions`
 /// warrant for this run:
 /// - the requested model (category `model`; a `contextWindow: "1m"` model
@@ -1915,13 +1969,35 @@ async fn run_session(session: Session) {
                 "session/new returned no sessionId".into(),
             ));
         }
+        // ACP has had two model-selection surfaces. Newer config-option agents
+        // use category=model below; Grok Build currently advertises only the
+        // first-class `models` state and requires `session/set_model`. Paseo
+        // follows the same split. Unlike the best-effort auxiliary options,
+        // an explicit model switch is strict: prompting with a different
+        // model than the picker shows is worse than surfacing the RPC error.
+        if let Some(model) = first_class_model_change(&session_response, request.model.as_deref())?
+        {
+            request_draining(
+                &client,
+                &mut incoming,
+                "session/set_model",
+                json!({
+                    "sessionId": session_id,
+                    "modelId": model,
+                }),
+            )
+            .await
+            .map_err(|error| {
+                HarnessError::Protocol(format!("agent rejected model switch to {model}: {error}"))
+            })?;
+        }
         // Apply the run's model + effort + model options through the
-        // session's advertised config options (ACP has no per-prompt model
-        // field). Best-effort: a rejected set is logged, never fatal — the
-        // agent's default runs.
+        // session's advertised config options. Best-effort for effort and
+        // traits: a rejected auxiliary set is logged and the agent default
+        // runs.
         let efforts = effort_values(request.reasoning, request.model.as_deref());
         let requested_model = request.model.as_deref();
-        let mut options_snapshot = session_response;
+        let options_snapshot = session_response;
         for (config_id, payload) in config_option_sets(
             &options_snapshot,
             requested_model,
@@ -3081,6 +3157,54 @@ mod tests {
         assert_eq!(
             config_option_sets(&json!({"sessionId": "s"}), Some("x"), &["high"], &no_opts),
             Vec::new()
+        );
+    }
+
+    #[test]
+    fn first_class_models_use_session_set_model_without_config_option() {
+        let response = json!({
+            "models": {
+                "currentModelId": "grok-4.6",
+                "availableModels": [
+                    { "modelId": "grok-4.6", "name": "Grok 4.6" },
+                    { "modelId": "grok-4.5", "name": "Grok 4.5" },
+                ],
+            },
+        });
+        assert_eq!(
+            first_class_model_change(&response, Some("grok-4.5")).unwrap(),
+            Some("grok-4.5".into())
+        );
+        assert_eq!(
+            first_class_model_change(&response, Some("grok-4.6")).unwrap(),
+            None
+        );
+        assert!(first_class_model_change(&response, Some("unknown")).is_err());
+    }
+
+    #[test]
+    fn model_config_option_takes_precedence_over_legacy_models_state() {
+        let response = json!({
+            "models": {
+                "currentModelId": "gpt-5.6-sol low",
+                "availableModels": [
+                    { "modelId": "gpt-5.6-sol low", "name": "GPT-5.6-Sol (low)" },
+                ],
+            },
+            "configOptions": [{
+                "id": "model",
+                "category": "model",
+                "type": "select",
+                "currentValue": "gpt-5.6-sol",
+                "options": [
+                    { "value": "gpt-5.6-sol", "name": "GPT-5.6-Sol" },
+                    { "value": "gpt-5.6-terra", "name": "GPT-5.6-Terra" },
+                ],
+            }],
+        });
+        assert_eq!(
+            first_class_model_change(&response, Some("gpt-5.6-terra")).unwrap(),
+            None
         );
     }
 

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -226,6 +226,22 @@ async fn config_options_apply_requested_model_and_effort() {
     );
     assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)]);
 }
+
+#[tokio::test]
+async fn resumed_first_class_model_is_switched_before_prompt() {
+    let (controls, _steer, _token) = controls();
+    let mut req = request("scenario:model-api");
+    req.resume = Some("existing-grok-session".into());
+    let events = run_to_end(&harness(), req, controls).await;
+    assert!(
+        events.contains(&AgentEvent::TextDelta {
+            text: "model switched".into()
+        }),
+        "{events:?}"
+    );
+    assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)]);
+}
+
 #[tokio::test]
 async fn permission_requests_auto_accept_the_preferred_allow_option() {
     let (controls, _steer, _token) = controls();

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -32,6 +32,10 @@ emit "{\"id\":$(rid "$line"),\"result\":{\"protocolVersion\":1,\"agentCapabiliti
 # ---- session new / load ----------------------------------------------------
 read -r line || exit 1
 SID="s-1"
+MODEL_API=0
+if has "$line" '"sessionId":"existing-grok-session"'; then
+  MODEL_API=1
+fi
 if has "$line" '"method":"session/load"'; then
   if has "$line" '"sessionId":"load-fail"'; then
     emit "{\"id\":$(rid "$line"),\"error\":{\"code\":-32602,\"message\":\"unknown session\"}}"
@@ -40,7 +44,11 @@ if has "$line" '"method":"session/load"'; then
     emit "{\"id\":$(rid "$line"),\"result\":{\"sessionId\":\"s-fresh\"}}"
     SID="s-fresh"
   else
-    SID="s-loaded"
+    if [ "$MODEL_API" -eq 1 ]; then
+      SID="existing-grok-session"
+    else
+      SID="s-loaded"
+    fi
     # Replay history BEFORE the load response resolves: the harness must
     # drain these without emitting events (the doc already has them) and
     # without deadlocking on a full incoming channel.
@@ -50,7 +58,11 @@ if has "$line" '"method":"session/load"'; then
       update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"old reply"}}'
       i=$((i+1))
     done
-    emit "{\"id\":$(rid "$line"),\"result\":{}}"
+    if [ "$MODEL_API" -eq 1 ]; then
+      emit "{\"id\":$(rid "$line"),\"result\":{\"models\":{\"currentModelId\":\"grok-4-fast\",\"availableModels\":[{\"modelId\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\"},{\"modelId\":\"grok-4.5\",\"name\":\"Grok 4.5\"}]}}}"
+    else
+      emit "{\"id\":$(rid "$line"),\"result\":{}}"
+    fi
   fi
 elif has "$line" '"method":"session/new"'; then
   has "$line" '"mcpServers":[]' || exit 1
@@ -58,23 +70,42 @@ elif has "$line" '"method":"session/new"'; then
   # forcing a set) and thought_level (current high). The model config option
   # feeds discovery first; the first-class `models` state (SessionModelState)
   # is the legacy fallback — codex-acp enumerates model × effort there.
-  emit "{\"id\":$(rid "$line"),\"result\":{\"sessionId\":\"s-1\",\"models\":{\"availableModels\":[{\"modelId\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\",\"description\":\"Fast tier\"},{\"modelId\":\"grok-4.5\",\"name\":\"Grok 4.5\"}],\"currentModelId\":\"grok-4.5\"},\"configOptions\":[{\"id\":\"model\",\"name\":\"Model\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":\"grok-4-fast\",\"options\":[{\"value\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\",\"description\":\"Fast tier\"},{\"value\":\"grok-4.5\",\"name\":\"Grok 4.5\"}]},{\"id\":\"effort\",\"name\":\"Reasoning effort\",\"category\":\"thought_level\",\"type\":\"select\",\"currentValue\":\"high\",\"options\":[{\"value\":\"low\",\"name\":\"Low\"},{\"value\":\"medium\",\"name\":\"Medium\"},{\"value\":\"high\",\"name\":\"High\"}]}]}}"
+  if [ "$MODEL_API" -eq 1 ]; then
+    emit "{\"id\":$(rid "$line"),\"result\":{\"sessionId\":\"s-1\",\"models\":{\"currentModelId\":\"grok-4-fast\",\"availableModels\":[{\"modelId\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\"},{\"modelId\":\"grok-4.5\",\"name\":\"Grok 4.5\"}]}}}"
+  else
+    emit "{\"id\":$(rid "$line"),\"result\":{\"sessionId\":\"s-1\",\"models\":{\"availableModels\":[{\"modelId\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\",\"description\":\"Fast tier\"},{\"modelId\":\"grok-4.5\",\"name\":\"Grok 4.5\"}],\"currentModelId\":\"grok-4.5\"},\"configOptions\":[{\"id\":\"model\",\"name\":\"Model\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":\"grok-4-fast\",\"options\":[{\"value\":\"grok-4-fast\",\"name\":\"Grok 4 Fast\",\"description\":\"Fast tier\"},{\"value\":\"grok-4.5\",\"name\":\"Grok 4.5\"}]},{\"id\":\"effort\",\"name\":\"Reasoning effort\",\"category\":\"thought_level\",\"type\":\"select\",\"currentValue\":\"high\",\"options\":[{\"value\":\"low\",\"name\":\"Low\"},{\"value\":\"medium\",\"name\":\"Medium\"},{\"value\":\"high\",\"name\":\"High\"}]}]}}"
+  fi
 else
   exit 1
 fi
 
-# ---- config option sets (0..n), then the first turn -------------------------
+# ---- model/config sets (0..n), then the first turn ---------------------------
 CONFIG_SETS=""
+MODEL_SETS=""
 read -r promptline || exit 1
-while has "$promptline" '"method":"session/set_config_option"'; do
+while has "$promptline" '"method":"session/set_config_option"' \
+  || has "$promptline" '"method":"session/set_model"'; do
   emit "{\"id\":$(rid "$promptline"),\"result\":{}}"
-  CONFIG_SETS="$CONFIG_SETS $promptline"
+  if has "$promptline" '"method":"session/set_model"'; then
+    MODEL_SETS="$MODEL_SETS $promptline"
+  else
+    CONFIG_SETS="$CONFIG_SETS $promptline"
+  fi
   read -r promptline || exit 1
 done
 has "$promptline" '"method":"session/prompt"' || exit 1
 pid=$(rid "$promptline")
 
 case "$promptline" in
+
+*scenario:model-api*)
+  if has "$MODEL_SETS" '"modelId":"grok-4.5"'; then
+    update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"model switched"}}'
+    emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
+  else
+    emit "{\"id\":$pid,\"result\":{\"stopReason\":\"refusal\"}}"
+  fi
+  ;;
 
 *scenario:config*)
   # The tests' request carries model grok-4.5 + medium effort; both differ


### PR DESCRIPTION
## Issue

When a user switched models during an existing Grok Build ACP session, the
selected model was not applied correctly. Grok Build advertises its models
through ACP's first-class `session.models` state and expects model changes via
`session/set_model`, rather than through a `configOptions` entry with
`category: "model"`.

The existing flow only handled the config-option path. As a result, the model
picker could appear to accept a new model while the running ACP session kept
using the old model. In failure cases, the prompt could stop without a useful
application-level response or diagnostic.

## Fix

- Detect first-class ACP model advertisements when no model config option is
  present.
- Validate the requested model against the agent's advertised models.
- Send `session/set_model` with the selected `modelId` before starting the
  prompt.
- Treat an explicitly rejected first-class model switch as a protocol error so
  the failure is surfaced instead of silently continuing with the wrong model.
- Preserve the existing config-option behavior for adapters that expose model
  selection through `configOptions`.
- Keep runtime routing aware of model and run configuration changes so a live
  harness is restarted/resumed when the existing process cannot apply the new
  configuration.
- Add fake-ACP integration coverage and unit tests for the first-class model
  path and runtime configuration behavior.

## Validation

- `cargo test -p zeron-harness --test acp resumed_first_class_model_is_switched_before_prompt`
- `cargo test -p zeron-engine live_routing_requires_the_same_runtime_configuration --lib`
- `cargo test -p zeron-harness first_class_models_use_session_set_model_without_config_option --lib`
- `sh -n crates/harness/tests/fixtures/fake-acp.sh`
- `git diff --cached --check`

No local low-RAM Cargo configuration or ignored development plan files are
included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789791858&installation_model_id=425430&pr_number=182&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F182&signature=03c56617a889f840aa68b066529b5ded6ac2258909f9ee32580d0bb25a6a3180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->