### PR TITLE
Attachment thumbnail percent ring tracks the real relay transfer

### DIFF
--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -240,6 +240,12 @@ struct DocHostInner {
     /// publishes the edge posture on change (see `watch_connectivity`).
     connectivity: OnceLock<watch::Sender<zeron_proto::Connectivity>>,
     connectivity_started: AtomicBool,
+    /// In-flight queued-attachment transfers, published per landed chunk
+    /// (see `watch_transfers`). Entries live exactly as long as bytes are
+    /// moving: added when a file's push starts, removed on commit or failure
+    /// (a retry re-adds), so consumers can render a real percent while the
+    /// relay leg runs and fall back to indeterminate otherwise.
+    transfers: watch::Sender<Vec<zeron_proto::TransferProgress>>,
     connectivity_grace: Mutex<DegradeGrace>,
     /// Command ids currently BETWEEN mark-processed and their resolution in a
     /// drain. Distinguishes "executing right now" from "consumed by the
@@ -281,6 +287,20 @@ fn command_transfers(entry: &SessionCommandEntry) -> Vec<crate::uploads::Attachm
             },
         )
         .collect()
+}
+
+/// Retires a transfer's progress entry on drop — the one exit point for
+/// `push_attachments`' many returns (commit landed, chunk timeout, host
+/// refusal), so no failure path can leave a phantom ring behind.
+struct TransferProgressGuard<'a> {
+    host: &'a DocHost,
+    upload_id: &'a str,
+}
+
+impl Drop for TransferProgressGuard<'_> {
+    fn drop(&mut self) {
+        self.host.transfer_progress_clear(self.upload_id);
+    }
 }
 
 /// How long raw degradation must persist before connectivity reports it.
@@ -542,6 +562,7 @@ impl DocHost {
                 uploads: OnceLock::new(),
                 connectivity: OnceLock::new(),
                 connectivity_started: AtomicBool::new(false),
+                transfers: watch::channel(Vec::new()).0,
                 connectivity_grace: Mutex::new(DegradeGrace::default()),
                 executing: Mutex::new(HashSet::new()),
                 links: OnceLock::new(),
@@ -1897,6 +1918,38 @@ impl DocHost {
         });
     }
 
+    /// The in-flight queued-attachment transfer set: current entries first,
+    /// then a fresh snapshot per landed chunk (see `push_attachments`).
+    pub fn watch_transfers(&self) -> watch::Receiver<Vec<zeron_proto::TransferProgress>> {
+        self.inner.transfers.subscribe()
+    }
+
+    /// Publish one transfer's progress (upserted by uploadId).
+    fn transfer_progress_set(&self, upload_id: &str, file_name: &str, done: u64, total: u64) {
+        self.inner.transfers.send_modify(|list| {
+            match list.iter_mut().find(|t| t.upload_id == upload_id) {
+                Some(t) => {
+                    t.done = done;
+                    t.total = total;
+                }
+                None => list.push(zeron_proto::TransferProgress {
+                    upload_id: upload_id.to_string(),
+                    file_name: file_name.to_string(),
+                    done,
+                    total,
+                }),
+            }
+        });
+    }
+
+    /// Retire a transfer's progress entry (commit landed, or the attempt
+    /// failed and the retry will re-publish).
+    fn transfer_progress_clear(&self, upload_id: &str) {
+        self.inner.transfers.send_modify(|list| {
+            list.retain(|t| t.upload_id != upload_id);
+        });
+    }
+
     /// The connectivity stream: current posture first, then every change.
     /// Lazily starts a monitor — a 1s recompute over in-memory stats
     /// (atomics + small locks), published only when the value changes. The
@@ -2582,6 +2635,16 @@ impl DocHost {
             let bytes = tokio::fs::read(&source)
                 .await
                 .map_err(|e| Permanent(format!("staged attachment missing: {e}")))?;
+            // Progress entry for the sender's thumbnail ring, updated per
+            // landed chunk. The guard retires it on EVERY exit — commit,
+            // timeout, refusal — so a dead attempt falls back to the
+            // indeterminate spinner and the retry re-publishes from 0.
+            let total = bytes.len() as u64;
+            self.transfer_progress_set(&transfer.upload_id, &transfer.file_name, 0, total);
+            let _progress = TransferProgressGuard {
+                host: self,
+                upload_id: &transfer.upload_id,
+            };
             let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
             let mut start = 0usize;
             let mut seq = 0u64;
@@ -2607,6 +2670,10 @@ impl DocHost {
                 }
                 start = end;
                 seq += 1;
+                // b64 → raw: 4 chars carry 3 bytes; min-clamp absorbs the
+                // final chunk's padding overshoot.
+                let done = ((start as u64) * 3 / 4).min(total);
+                self.transfer_progress_set(&transfer.upload_id, &transfer.file_name, done, total);
                 if start >= b64.len() {
                     break;
                 }
@@ -3389,6 +3456,76 @@ fn encode_part_segment(part_id: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod transfer_progress_tests {
+    use super::{DocHost, DocHostConfig, TransferProgressGuard};
+    use std::sync::Arc;
+
+    fn host() -> (tempfile::TempDir, DocHost) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(zeron_sync::DocsStore::open(dir.path()).expect("store opens"));
+        let host = DocHost::new(
+            store,
+            DocHostConfig {
+                device_id: "dev-test".into(),
+                default_harness: zeron_proto::HarnessId::Mock,
+                edge: None,
+            },
+        );
+        (dir, host)
+    }
+
+    #[test]
+    fn set_upserts_by_upload_id_and_clear_retires_only_its_entry() {
+        let (_dir, host) = host();
+        let rx = host.watch_transfers();
+        assert!(rx.borrow().is_empty());
+
+        host.transfer_progress_set("u1", "a.png", 0, 1_000);
+        host.transfer_progress_set("u2", "b.png", 0, 400);
+        host.transfer_progress_set("u1", "a.png", 300, 1_000);
+        let snapshot = rx.borrow().clone();
+        assert_eq!(snapshot.len(), 2, "upsert must not duplicate u1");
+        let u1 = snapshot.iter().find(|t| t.upload_id == "u1").unwrap();
+        assert_eq!((u1.done, u1.total), (300, 1_000));
+
+        host.transfer_progress_clear("u1");
+        let snapshot = rx.borrow().clone();
+        assert_eq!(snapshot.len(), 1, "u2 must survive u1's retirement");
+        assert_eq!(snapshot[0].upload_id, "u2");
+    }
+
+    #[test]
+    fn guard_retires_the_entry_on_every_exit_path() {
+        let (_dir, host) = host();
+        let rx = host.watch_transfers();
+        host.transfer_progress_set("u1", "a.png", 0, 9);
+        {
+            let _guard = TransferProgressGuard {
+                host: &host,
+                upload_id: "u1",
+            };
+            assert_eq!(rx.borrow().len(), 1);
+            // An early return / error propagation drops the guard here.
+        }
+        assert!(
+            rx.borrow().is_empty(),
+            "a failed attempt must not leave a phantom ring behind"
+        );
+    }
+
+    #[test]
+    fn late_subscriber_sees_current_set_first() {
+        let (_dir, host) = host();
+        host.transfer_progress_set("u1", "a.png", 750, 1_000);
+        // watch_stream's contract: current value first, then changes — a UI
+        // attaching mid-transfer must render the ring immediately.
+        let rx = host.watch_transfers();
+        assert_eq!(rx.borrow().len(), 1);
+        assert_eq!(rx.borrow()[0].done, 750);
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -1258,6 +1258,9 @@ impl RpcService for EngineRpc {
             methods::WATCH_CONNECTIVITY => Ok(RpcReply::Stream(watch_stream(
                 self.doc_host.watch_connectivity(),
             ))),
+            methods::WATCH_TRANSFERS => Ok(RpcReply::Stream(watch_stream(
+                self.doc_host.watch_transfers(),
+            ))),
             methods::WATCH_CHATS => {
                 Ok(RpcReply::Stream(watch_stream(self.workspace.watch_chats())))
             }

--- a/crates/proto/src/entities.rs
+++ b/crates/proto/src/entities.rs
@@ -565,6 +565,24 @@ pub enum TerminalEvent {
     },
 }
 
+/// One in-flight queued-attachment transfer (the `WatchTransfers` stream):
+/// raw-byte progress of the engine-side relay leg pushing staged bytes to a
+/// remote host. An entry appears when a file's chunks start moving, updates
+/// per landed chunk, and disappears when the host commits it (or the attempt
+/// fails — the retry re-adds it). Keyed by the send-minted uploadId, so the
+/// sender's thumbnails can resolve their `pending://{uploadId}/…` refs to a
+/// real percent instead of an indeterminate spinner.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferProgress {
+    pub upload_id: String,
+    pub file_name: String,
+    /// Raw bytes the host has acknowledged so far.
+    pub done: u64,
+    /// Total raw bytes of the staged file.
+    pub total: u64,
+}
+
 /// Live edge-connectivity posture (the `WatchConnectivity` stream): the truth
 /// the connection pill, composer honesty, and queued-send badges render.
 /// Derived engine-side from the registry room's reconnect state, the OS

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -65,6 +65,10 @@ pub mod methods {
     /// current value first, then every change — the connection pill /
     /// composer-honesty / queued-badge feed. No params; IPC-only.
     pub const WATCH_CONNECTIVITY: &str = "WatchConnectivity";
+    /// In-flight queued-attachment transfers (`zeron_proto::TransferProgress`
+    /// list): current set first, then a fresh snapshot per landed chunk —
+    /// the sending thumbnail's percent-ring feed. No params; IPC-only.
+    pub const WATCH_TRANSFERS: &str = "WatchTransfers";
     pub const WATCH_CHATS: &str = "WatchChats";
     pub const WATCH_DEVICES: &str = "WatchDevices";
     pub const WATCH_SESSIONS: &str = "WatchSessions";

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -626,6 +626,10 @@ pub struct AppState {
     pending_sends: HashMap<String, PendingSend>,
     /// The in-flight send's attachment upload, when it has one.
     upload_progress: Option<UploadProgress>,
+    /// Engine-side queued-attachment transfers by uploadId (`WatchTransfers`
+    /// snapshots): real relay-leg progress for the sending thumbnail's
+    /// percent ring, present exactly while bytes are moving.
+    transfers: HashMap<String, (u64, u64)>,
     /// Written by the changes pane, read by the composer.
     diff_comments: HashMap<String, Vec<DiffComment>>,
     /// This engine's device id (best-effort `LocalDevice` probe; `None` until
@@ -677,6 +681,7 @@ impl AppState {
             echoes: HashMap::new(),
             pending_sends: HashMap::new(),
             upload_progress: None,
+            transfers: HashMap::new(),
             diff_comments: HashMap::new(),
             local_device_id: None,
             update: None,
@@ -1037,6 +1042,29 @@ impl AppState {
         Some(((done * 100) / progress.total).min(99) as u8)
     }
 
+    /// A `WatchTransfers` snapshot: the engine-side relay leg's in-flight
+    /// queued-attachment transfers, replacing the whole set each frame.
+    pub fn apply_transfers(&mut self, transfers: Vec<zeron_proto::TransferProgress>) {
+        self.transfers = transfers
+            .into_iter()
+            .map(|t| (t.upload_id, (t.done, t.total)))
+            .collect();
+    }
+
+    /// Percent of one queued attachment's relay transfer, by the uploadId
+    /// its `pending://{uploadId}/…` ref names. Same 99-clamp as
+    /// [`Self::upload_progress_percent`]: the last point belongs to the
+    /// commit, so "100% but still spinning" never shows. `None` when no
+    /// bytes are moving for that upload (staged-but-waiting, retry backoff,
+    /// or done) — the thumbnail falls back to its indeterminate spinner.
+    pub fn transfer_percent(&self, upload_id: &str) -> Option<u8> {
+        let (done, total) = self.transfers.get(upload_id)?;
+        if *total == 0 {
+            return None;
+        }
+        Some(((done.min(total) * 100) / total).min(99) as u8)
+    }
+
     /// Is a send still in flight for this chat (unacked)? Inside the grace
     /// window normally; while the chat's delivery path is degraded the
     /// overlay holds indefinitely — the truth IS "Queued", and silently
@@ -1303,6 +1331,7 @@ impl AppState {
         self.echoes.clear();
         self.pending_sends.clear();
         self.upload_progress = None;
+        self.transfers.clear();
         self.local_device_id = None;
         self.update = None;
         cx.notify();
@@ -1374,6 +1403,12 @@ impl AppState {
                 handle.clone(),
                 methods::WATCH_CONNECTIVITY,
                 AppState::apply_connectivity,
+            ),
+            spawn_watch(
+                cx,
+                handle.clone(),
+                methods::WATCH_TRANSFERS,
+                AppState::apply_transfers,
             ),
             spawn_watch(
                 cx,
@@ -2563,6 +2598,35 @@ mod tests {
         upgraded.version = Some("0.2.3".into());
         state.apply_devices(vec![upgraded]);
         assert!(state.change_requests.is_supported("remote"));
+    }
+
+    #[test]
+    fn transfer_percent_tracks_snapshots_by_upload_id() {
+        let mut s = AppState::new();
+        assert_eq!(s.transfer_percent("u1"), None);
+
+        let frame = |id: &str, done, total| zeron_proto::TransferProgress {
+            upload_id: id.into(),
+            file_name: "a.png".into(),
+            done,
+            total,
+        };
+        s.apply_transfers(vec![frame("u1", 430, 1_000), frame("u2", 0, 400)]);
+        assert_eq!(s.transfer_percent("u1"), Some(43));
+        assert_eq!(s.transfer_percent("u2"), Some(0));
+        assert_eq!(s.transfer_percent("other"), None);
+
+        // The last point belongs to the commit — never a stuck 100%; b64
+        // padding overshoot stays clamped too.
+        s.apply_transfers(vec![frame("u1", 1_000, 1_000), frame("u3", 12, 0)]);
+        assert_eq!(s.transfer_percent("u1"), Some(99));
+        // Zero-total renders indeterminate, not a division blowup.
+        assert_eq!(s.transfer_percent("u3"), None);
+        // Snapshots REPLACE: u2's transfer retired with its entry.
+        assert_eq!(s.transfer_percent("u2"), None);
+
+        s.apply_transfers(Vec::new());
+        assert_eq!(s.transfer_percent("u1"), None);
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2875,16 +2875,29 @@ impl Transcript {
             // crossing": the queued flow's `pending://` (bytes ship
             // engine-side after the send; the host rewrites the ref to an
             // absolute path once they land and the run starts) and the
-            // legacy echo's synthetic `pending/`. The v0.2.12 queued cutover
-            // only matched the legacy shape, so the indicator vanished
-            // (2026-08-19 report). Percent exists only while the UI itself
-            // uploads (legacy / local staging); the engine-side relay leg
-            // has no percent — indeterminate spinner instead.
+            // legacy echo's synthetic `pending/`. Percent sources, in order:
+            // this attachment's own relay transfer (`WatchTransfers`, by the
+            // uploadId its ref names — the leg that actually takes time),
+            // else the send-wide staging/legacy upload percent. Neither → the
+            // indeterminate spinner (staged-but-waiting, retry backoff, or
+            // committed-awaiting-rewrite), so the ring never shows a number
+            // that isn't a real transfer position (2026-08-20 report: the
+            // staging-only percent blinked out in ~100ms and lied about the
+            // slow part).
             let sending =
                 att.path.starts_with("pending://") || att.path.starts_with("pending/");
-            let uploading = sending
-                .then(|| self.state.read(cx).upload_progress_percent())
-                .flatten();
+            let upload_id = att
+                .path
+                .strip_prefix("pending://")
+                .and_then(|rest| rest.split_once('/'))
+                .map(|(id, _)| id);
+            let uploading = upload_id
+                .and_then(|id| self.state.read(cx).transfer_percent(id))
+                .or_else(|| {
+                    sending
+                        .then(|| self.state.read(cx).upload_progress_percent())
+                        .flatten()
+                });
             let frame = div()
                 .flex_none()
                 .w(px(ATT_THUMB_W))


### PR DESCRIPTION
Follow-up to #180, from the v0.2.16 field report: the percent loader appeared for ~50–100ms, then switched to the dot loader.

## What was actually happening

The percent wasn't lying — it was measuring the wrong leg. `upload_progress_percent()` covers the UI staging bytes into the **local** engine's uploads dir, which is disk-speed and over in ~100ms. Then `end_upload_progress` fires, and the leg that actually takes time — the engine pushing the staged bytes over the relay to the host, in 45KB `UploadChunk` calls — reported no progress at all, so the thumbnail fell back to the indeterminate spinner for the whole real transfer.

## The fix

- **Engine** (`doc_host.rs`): `push_attachments` now publishes per-upload raw-byte progress (`done/total`) to a watch channel — an entry appears when a file's chunks start moving, updates per landed chunk, and an RAII guard retires it on **every** exit path (commit landed, chunk timeout, host refusal), so a dead attempt can't leave a phantom ring behind and the retry re-publishes from zero.
- **RPC**: new `WatchTransfers` subscription, mirroring `WatchConnectivity`'s shape — current set first, then a fresh snapshot per landed chunk. Wire type is `zeron_proto::TransferProgress` `{uploadId, fileName, done, total}`.
- **UI**: the sending thumbnail resolves its `pending://{uploadId}/…` ref against the stream. Percent sources in order: the attachment's **own relay transfer** (the slow leg, now measured), else the send-wide staging/legacy percent, else the spinner. The spinner now means exactly "no bytes are moving for this file right now" — staged-but-waiting, retry backoff, or committed-and-waiting-for-the-host-to-start-the-run.

With a multi-MB photo on a real uplink you'll see: brief staging ring → per-chunk relay ring climbing through the actual upload → short spinner while the host picks the run up → thumbnail settles.

## Tests

- Engine: registry upsert/retire semantics, guard-clears-on-every-exit, late-subscriber-sees-current-set (the mid-transfer UI-attach case).
- UI: snapshot application + percent lookup (99-clamp, zero-total → indeterminate, replaced-snapshot retirement).
- Full workspace suite: **1025 passed, 0 failed**.

One thing I could not exercise headlessly: the visual ring→spinner handoff pacing on a genuinely slow link (the unit tests pin the state machine, not the frames). Worth one eyeball on a real slow uplink before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789809789&installation_model_id=425430&pr_number=185&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F185&signature=b3fc01a989671fa317768ce92471f7757734e839f03350dc6e6b1890a70ec728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->