### PR TITLE
Move sidebar PR badge left of the branch name

### DIFF
--- a/crates/ui/src/change_requests.rs
+++ b/crates/ui/src/change_requests.rs
@@ -128,20 +128,29 @@ pub(crate) fn pull_request_badge(
 
     div()
         .id(id)
-        .h(px(if composer { 20.0 } else { 16.0 }))
+        .h(px(if composer { 20.0 } else { 14.0 }))
         .flex_none()
         .flex()
         .flex_row()
         .items_center()
-        .gap(px(if composer { 5.0 } else { 0.0 }))
-        .px(px(if composer { 7.0 } else { 4.0 }))
-        .rounded(px(if composer { 6.0 } else { 4.0 }))
-        .bg(color.opacity(0.08))
-        .text_size(px(if composer { 11.0 } else { 10.0 }))
+        .gap(px(if composer { 5.0 } else { 3.0 }))
+        .when(composer, |element| {
+            element
+                .px(px(7.0))
+                .rounded(px(6.0))
+                .bg(color.opacity(0.08))
+        })
+        .text_size(px(11.0))
         .font_weight(gpui::FontWeight::MEDIUM)
         .text_color(color.opacity(0.85))
         .cursor_pointer()
-        .hover(move |style| style.bg(color.opacity(0.16)).text_color(color))
+        .hover(move |style| {
+            if composer {
+                style.bg(color.opacity(0.16)).text_color(color)
+            } else {
+                style.text_color(color)
+            }
+        })
         .on_click(move |_, _, cx| {
             cx.stop_propagation();
             cx.open_url(&url);
@@ -151,14 +160,12 @@ pub(crate) fn pull_request_badge(
                 .into()
         })
         .tooltip_show_delay(std::time::Duration::from_millis(350))
-        .when(composer, |element| {
-            element.child(
-                crate::icons::icon(crate::icons::PULL_REQUEST)
-                    .size(px(11.0))
-                    .flex_none()
-                    .text_color(color.opacity(0.85)),
-            )
-        })
+        .child(
+            crate::icons::icon(crate::icons::PULL_REQUEST)
+                .size(px(11.0))
+                .flex_none()
+                .text_color(color.opacity(0.85)),
+        )
         // Monospace digits give the badge a stable tabular width as PR numbers change.
         .child(
             div()

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3660,9 +3660,9 @@ impl Shell {
                     .line_height(px(17.0))
                     .child(title),
             )
-            // Line 3 (always): harness brand mark, branch, optional PR badge
-            // pinned right, then the working spinner even further right.
-            // Branch remains the only shrinking item.
+            // Line 3 (always): optional PR badge on the far left, then
+            // harness brand mark, branch, and the working spinner pinned
+            // right. Branch remains the only shrinking item.
             .child(
                 div()
                     .w_full()
@@ -3670,6 +3670,14 @@ impl Shell {
                     .flex_row()
                     .items_center()
                     .gap(px(4.0))
+                    .when_some(change_request, |el, summary| {
+                        el.child(crate::change_requests::pull_request_badge(
+                            format!("chat-pr-{id}").into(),
+                            summary,
+                            crate::change_requests::ChangeRequestBadgeSurface::Sidebar,
+                            theme,
+                        ))
+                    })
                     .when_some(
                         harness.map(crate::pickers::harness_brand_icon),
                         |el, (path, tint)| {
@@ -3698,17 +3706,9 @@ impl Shell {
                                 .child(branch),
                         )
                     })
-                    // Stable invisible spring: keeps the optional PR badge
-                    // and spinner pinned right without changing no-PR paint.
+                    // Stable invisible spring: keeps the optional spinner
+                    // pinned right without changing no-PR paint.
                     .child(div().flex_1().min_w_0())
-                    .when_some(change_request, |el, summary| {
-                        el.child(crate::change_requests::pull_request_badge(
-                            format!("chat-pr-{id}").into(),
-                            summary,
-                            crate::change_requests::ChangeRequestBadgeSurface::Sidebar,
-                            theme,
-                        ))
-                    })
                     // Working rows animate the spinner at the row's
                     // bottom-right (the status word keeps its dot up top).
                     // Queued/Failed rows don't: a spinner would fake progress.

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3660,8 +3660,9 @@ impl Shell {
                     .line_height(px(17.0))
                     .child(title),
             )
-            // Line 3 (always): harness brand mark, branch, optional PR badge,
-            // and the working spinner. Branch remains the only shrinking item.
+            // Line 3 (always): harness brand mark, optional PR badge left of
+            // the branch, and the working spinner. Branch remains the only
+            // shrinking item — same order as the composer footer.
             .child(
                 div()
                     .w_full()
@@ -3680,6 +3681,14 @@ impl Shell {
                             )
                         },
                     )
+                    .when_some(change_request, |el, summary| {
+                        el.child(crate::change_requests::pull_request_badge(
+                            format!("chat-pr-{id}").into(),
+                            summary,
+                            crate::change_requests::ChangeRequestBadgeSurface::Sidebar,
+                            theme,
+                        ))
+                    })
                     .when_some(branch, |el, branch| {
                         el.child(
                             icon(icons::GIT_BRANCH)
@@ -3697,8 +3706,8 @@ impl Shell {
                                 .child(branch),
                         )
                     })
-                    // Stable invisible spring: keeps the optional spinner and
-                    // PR badge pinned right without changing no-PR paint.
+                    // Stable invisible spring: keeps the optional spinner
+                    // pinned right without changing no-PR paint.
                     .child(div().flex_1().min_w_0())
                     // Working rows animate the spinner at the row's
                     // bottom-right (the status word keeps its dot up top).
@@ -3713,15 +3722,7 @@ impl Shell {
                                 cx,
                             ))
                         },
-                    )
-                    .when_some(change_request, |el, summary| {
-                        el.child(crate::change_requests::pull_request_badge(
-                            format!("chat-pr-{id}").into(),
-                            summary,
-                            crate::change_requests::ChangeRequestBadgeSurface::Sidebar,
-                            theme,
-                        ))
-                    }),
+                    ),
             )
             .into_any_element()
     }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3660,9 +3660,9 @@ impl Shell {
                     .line_height(px(17.0))
                     .child(title),
             )
-            // Line 3 (always): harness brand mark, optional PR badge left of
-            // the branch, and the working spinner. Branch remains the only
-            // shrinking item — same order as the composer footer.
+            // Line 3 (always): harness brand mark, branch, optional PR badge
+            // pinned right, then the working spinner even further right.
+            // Branch remains the only shrinking item.
             .child(
                 div()
                     .w_full()
@@ -3681,14 +3681,6 @@ impl Shell {
                             )
                         },
                     )
-                    .when_some(change_request, |el, summary| {
-                        el.child(crate::change_requests::pull_request_badge(
-                            format!("chat-pr-{id}").into(),
-                            summary,
-                            crate::change_requests::ChangeRequestBadgeSurface::Sidebar,
-                            theme,
-                        ))
-                    })
                     .when_some(branch, |el, branch| {
                         el.child(
                             icon(icons::GIT_BRANCH)
@@ -3706,9 +3698,17 @@ impl Shell {
                                 .child(branch),
                         )
                     })
-                    // Stable invisible spring: keeps the optional spinner
-                    // pinned right without changing no-PR paint.
+                    // Stable invisible spring: keeps the optional PR badge
+                    // and spinner pinned right without changing no-PR paint.
                     .child(div().flex_1().min_w_0())
+                    .when_some(change_request, |el, summary| {
+                        el.child(crate::change_requests::pull_request_badge(
+                            format!("chat-pr-{id}").into(),
+                            summary,
+                            crate::change_requests::ChangeRequestBadgeSurface::Sidebar,
+                            theme,
+                        ))
+                    })
                     // Working rows animate the spinner at the row's
                     // bottom-right (the status word keeps its dot up top).
                     // Queued/Failed rows don't: a spinner would fake progress.


### PR DESCRIPTION
## Summary
- Sidebar session rows put the PR badge on the far left of the meta line, left of the harness mark.
- The working spinner stays pinned to the right; no-PR rows still paint the same.

## Screenshot
![Sidebar PR badge far left of the harness icon](https://github.com/user-attachments/assets/05b5728b-ef99-4833-b255-e6f67b3daabb)

## Test plan
- [ ] Open a session whose checkout has an open PR and confirm the `#N` badge sits left of the branch on the sidebar row
- [ ] Confirm a working session still shows the spinner on the far right
- [ ] Confirm a session without a PR still shows harness + branch only


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789818919&installation_model_id=425430&pr_number=187&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F187&signature=1ba3492bdeaa50553382e6f96dcfe5f8468c90ba153ab4c8fe10abb49ead0cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->