### PR TITLE
iOS: slash commands and @-mentions in the composer

### DIFF
--- a/apps/ios/Zeron/App/AppModel.swift
+++ b/apps/ios/Zeron/App/AppModel.swift
@@ -349,6 +349,33 @@ final class AppModel {
         return HarnessCatalog.models(for: harness)
     }
 
+    /// Slash commands the harness advertises in one folder on one device, for
+    /// the composer popover. Both composers go through here rather than
+    /// straight to the store, so demo mode answers the same way it answers for
+    /// harnesses, models and refs. Signed out there is no store and no answer.
+    func listCommands(deviceId: String, harness: String,
+                      cwd: String) async throws -> [SlashCommand] {
+        if demo != nil {
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            return DemoDataset.commands
+        }
+        guard let workspace else { return [] }
+        return try await workspace.listCommands(deviceId: deviceId, harness: harness, cwd: cwd)
+    }
+
+    /// Fuzzy file search for the composer's `@` popover. The engine needs
+    /// exactly one of `chatId` or `spaceId`.
+    func searchFiles(deviceId: String, chatId: String?, spaceId: String?,
+                     query: String) async throws -> [FileSearchMatch] {
+        if let demo {
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            return demo.searchFiles(query: query)
+        }
+        guard let workspace else { return [] }
+        return try await workspace.searchFiles(deviceId: deviceId, chatId: chatId,
+                                               spaceId: spaceId, query: query)
+    }
+
     /// Refs of the space's repo (git spaces only).
     func listRefs(space: Space) async -> [RepoRef]? {
         if let demo {

--- a/apps/ios/Zeron/App/DemoDataset.swift
+++ b/apps/ios/Zeron/App/DemoDataset.swift
@@ -128,6 +128,32 @@ final class DemoDataset {
 
     private static let repoNames: Set<String> = ["zeron", "dotfiles", "blog", "playground", "edge", "landing"]
 
+    /// What a harness advertises, for the composer's `/` popover. Live mode
+    /// asks the host device; demo mode has no host, and an empty answer left
+    /// the popover permanently on "No matching commands.". Long enough to
+    /// scroll, so the panel's height cap is exercised too.
+    static let commands: [SlashCommand] = [
+        SlashCommand(name: "review", description: "Review the working tree", inputHint: nil),
+        SlashCommand(name: "plan", description: "Write an implementation plan first", inputHint: nil),
+        SlashCommand(name: "test", description: "Run the suite and read the failures", inputHint: nil),
+        SlashCommand(name: "commit", description: "Stage and commit the current change", inputHint: nil),
+        SlashCommand(name: "explain", description: "Explain this file, top to bottom", inputHint: nil),
+        SlashCommand(name: "clear", description: "Start the conversation over", inputHint: nil),
+    ]
+
+    /// Fuzzy file search over the fake tree — the demo twin of `SearchFiles`.
+    /// Directories only, because the tree holds only directories.
+    func searchFiles(query: String) -> [FileSearchMatch] {
+        let needle = query.lowercased()
+        var matches: [FileSearchMatch] = []
+        for (parent, children) in Self.fileTree.sorted(by: { $0.key < $1.key }) {
+            for child in children where needle.isEmpty || child.lowercased().contains(needle) {
+                matches.append(FileSearchMatch(path: "\(parent)/\(child)", isDir: true))
+            }
+        }
+        return Array(matches.prefix(20))
+    }
+
     func listFolders(deviceId: String, path: String) -> FolderListing {
         let entries = (Self.fileTree[path] ?? []).map { name in
             FolderEntry(name: name, isDir: true, isRepo: Self.repoNames.contains(name))

--- a/apps/ios/Zeron/Composer/ComposerPopover.swift
+++ b/apps/ios/Zeron/Composer/ComposerPopover.swift
@@ -15,7 +15,7 @@ struct ComposerPopover: View {
     /// Height of the rows, measured. A `ScrollView` is greedy: it takes every
     /// point offered up to its `maxHeight`, so a `.frame(maxHeight: 180)` alone
     /// left a single result floating in a 180pt panel. Measuring the content and
-    /// setting an exact height makes the panel hug one row and still cap at 180.
+    /// capping at it makes the panel hug one row and still stop at 180.
     @State private var contentHeight: CGFloat = 0
 
     private var surfaceShape: RoundedRectangle { RoundedRectangle(cornerRadius: 20) }
@@ -65,11 +65,23 @@ struct ComposerPopover: View {
                         contentHeight = height
                     }
                 }
-                .frame(height: min(contentHeight, Self.maxListHeight))
+                // maxHeight, NOT height. An exact height cannot compress, so on
+                // a page whose other rows already fill the space above the
+                // keyboard the panel kept its full 180pt and the whole column
+                // overflowed instead: the canvas behind it was squeezed under
+                // its own content's minimum and drew over the navigation bar,
+                // and the pill's chip row went under the keyboard (user report,
+                // new-session page on a real device). A maximum is the same
+                // hug — the ScrollView is greedy up to it — but it yields when
+                // the parent has less to give.
+                .frame(maxHeight: min(contentHeight, Self.maxListHeight))
                 .scrollDisabled(contentHeight <= Self.maxListHeight)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        // Clip to the same shape the glass draws, so a row the panel had to
+        // compress away cannot bleed past the rounded bottom edge.
+        .clipShape(surfaceShape)
         .background(whiteAlpha(0.04), in: surfaceShape)
         .glassEffect(.regular, in: surfaceShape)
         .overlay(surfaceShape.strokeBorder(whiteAlpha(0.05), lineWidth: 1))

--- a/apps/ios/Zeron/Composer/ComposerPopover.swift
+++ b/apps/ios/Zeron/Composer/ComposerPopover.swift
@@ -1,0 +1,118 @@
+// The suggestion list that floats above the composer pill. Presentation only:
+// it takes values and hands back a pick. Matching the app's glass language, it
+// reuses Theme and the same rounded-surface treatment as ComposerShell.
+
+import SwiftUI
+
+struct ComposerPopover: View {
+
+    let items: [SuggestionItem]
+    let kind: TriggerKind
+    let isLoading: Bool
+    let errorText: String?
+    let onPick: (SuggestionItem) -> Void
+
+    /// Height of the rows, measured. A `ScrollView` is greedy: it takes every
+    /// point offered up to its `maxHeight`, so a `.frame(maxHeight: 180)` alone
+    /// left a single result floating in a 180pt panel. Measuring the content and
+    /// setting an exact height makes the panel hug one row and still cap at 180.
+    @State private var contentHeight: CGFloat = 0
+
+    private var surfaceShape: RoundedRectangle { RoundedRectangle(cornerRadius: 20) }
+
+    private static let maxListHeight: CGFloat = 180
+
+    private var header: String {
+        switch kind {
+        case .command: "Commands"
+        case .path: "Files"
+        }
+    }
+
+    private var emptyText: String {
+        if let errorText { return errorText }
+        if isLoading { return kind == .path ? "Searching files…" : "Loading…" }
+        switch kind {
+        case .command: return "No matching commands."
+        case .path: return "No matching files or folders."
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(header.uppercased())
+                .font(Theme.sans(10, weight: .bold))
+                .kerning(0.8)
+                .foregroundStyle(Theme.textMuted)
+                .padding(.horizontal, 14)
+                .padding(.top, 10)
+                .padding(.bottom, 4)
+
+            if items.isEmpty {
+                Text(emptyText)
+                    .font(Theme.sans(12))
+                    .foregroundStyle(errorText == nil ? Theme.textFaint : Theme.danger)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+            } else {
+                ScrollView {
+                    VStack(spacing: 0) {
+                        ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                            row(item, isLast: index == items.count - 1)
+                        }
+                    }
+                    .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
+                        contentHeight = height
+                    }
+                }
+                .frame(height: min(contentHeight, Self.maxListHeight))
+                .scrollDisabled(contentHeight <= Self.maxListHeight)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(whiteAlpha(0.04), in: surfaceShape)
+        .glassEffect(.regular, in: surfaceShape)
+        .overlay(surfaceShape.strokeBorder(whiteAlpha(0.05), lineWidth: 1))
+    }
+
+    private func row(_ item: SuggestionItem, isLast: Bool) -> some View {
+        Button {
+            onPick(item)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: icon(for: item))
+                    .font(.system(size: 12))
+                    .foregroundStyle(Theme.textMuted)
+                    .frame(width: 16)
+                Text(item.label)
+                    .font(Theme.sans(15, weight: .medium))
+                    .foregroundStyle(Theme.text)
+                    .lineLimit(1)
+                if !item.detail.isEmpty {
+                    Text(item.detail)
+                        .font(Theme.sans(12))
+                        .foregroundStyle(Theme.textMuted)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+            .overlay(alignment: .bottom) {
+                if !isLast {
+                    Rectangle().fill(whiteAlpha(0.06)).frame(height: 0.5)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func icon(for item: SuggestionItem) -> String {
+        switch item.payload {
+        case .command: "terminal"
+        case .path(_, let isDir): isDir ? "folder" : "doc"
+        }
+    }
+}

--- a/apps/ios/Zeron/Composer/ComposerSuggestions.swift
+++ b/apps/ios/Zeron/Composer/ComposerSuggestions.swift
@@ -31,6 +31,33 @@ struct SuggestionContext: Equatable {
     var spaceId: String?
 }
 
+/// Where the popover's commands come from: the chat's own directory, else the
+/// picked space's folder, else the host's home.
+///
+/// Two rules come from the desktop's `slash_cwd` (crates/ui/src/composer.rs):
+/// a blank path counts as absent, and a draft with no chat falls to the space's
+/// folder. The checkout plan is ignored for the same reason the desktop ignores
+/// it — a draft that will mint a fresh worktree has no directory yet when the
+/// popover opens, and a worktree of the same repo carries the same tracked
+/// commands anyway.
+///
+/// One rule does NOT come from the desktop: a chat whose own `cwd` is absent
+/// falls through to its space's folder here, where the desktop stops at `~`.
+/// That is what this composer already did before the draft case existed, and
+/// the space's folder is the better answer of the two.
+///
+/// Blank counts as absent because `listCommands` drops an empty `cwd` from the
+/// params, and the host then answers for its home — a different list than the
+/// space's.
+func slashCwd(chatCwd: String?, spacePath: String?) -> String {
+    func present(_ value: String?) -> String? {
+        guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return value
+    }
+    return present(chatCwd) ?? present(spacePath) ?? "~"
+}
+
 /// Cache identity for one command list. The device belongs in the key because
 /// every project-less chat, on every device, shares the path `~`
 /// (crates/ui/src/composer.rs:3236-3241).

--- a/apps/ios/Zeron/Composer/ComposerSuggestions.swift
+++ b/apps/ios/Zeron/Composer/ComposerSuggestions.swift
@@ -1,0 +1,241 @@
+// Suggestion state for the composer popover: what to show, whether it is
+// loading, and why it failed. Works on plain values only — no AttributedString
+// — so it stays testable with no socket and no simulator UI.
+//
+// Freshness is stale-while-revalidate: a cached list draws at once and one
+// request per popover open refreshes it. This type holds NO TTL. The engine's
+// command cache owns expiry (crates/engine/src/commands.rs), so there is one
+// expiry policy, in one place.
+
+import Foundation
+
+struct SuggestionItem: Identifiable, Equatable {
+    enum Payload: Equatable {
+        case command(String)
+        case path(String, isDir: Bool)
+    }
+
+    let id: String
+    let label: String
+    let detail: String
+    let payload: Payload
+}
+
+/// Everything the fetchers need that the trigger does not carry.
+struct SuggestionContext: Equatable {
+    var harness: String
+    var deviceId: String
+    /// A path on the HOST device. `~` travels unexpanded.
+    var cwd: String
+    var chatId: String?
+    var spaceId: String?
+}
+
+/// Cache identity for one command list. The device belongs in the key because
+/// every project-less chat, on every device, shares the path `~`
+/// (crates/ui/src/composer.rs:3236-3241).
+struct CommandKey: Hashable {
+    let harness: String
+    let device: String
+    let cwd: String
+}
+
+@Observable
+@MainActor
+final class ComposerSuggestions {
+
+    private(set) var items: [SuggestionItem] = []
+    private(set) var isLoading = false
+    private(set) var errorText: String?
+
+    /// Injected so tests run with no socket. Wired to WorkspaceStore at the
+    /// call site.
+    var fetchCommands: (_ harness: String, _ device: String, _ cwd: String) async throws -> [SlashCommand] = { _, _, _ in [] }
+    var fetchPaths: (_ context: SuggestionContext, _ query: String) async throws -> [FileSearchMatch] = { _, _ in [] }
+
+    private var commandCache: [CommandKey: [SlashCommand]] = [:]
+    /// The kind the current `items` belong to. Switching kinds must clear them:
+    /// otherwise the popover reopens instantly with the PREVIOUS kind's rows
+    /// under the new kind's header, and keeps them — tappable — for the whole
+    /// RPC round trip. `isLoading` does not mask it, because ComposerPopover
+    /// only shows its loading line when `items` is empty.
+    private var lastKind: TriggerKind?
+    /// The token the user closed the popover on: its span AND its full text.
+    /// Keyed on both because a caret move inside a dismissed token must keep it
+    /// closed, while any edit reopens it (composer.rs:3301-3304). The span alone
+    /// would misread a same-length replacement as "unchanged"; the text alone
+    /// would misread the same token typed twice.
+    private var dismissed: (range: Range<Int>, token: String)?
+    private var generation = 0
+
+    func dismiss(_ trigger: Trigger) {
+        dismissed = (trigger.range, trigger.token)
+        items = []
+        errorText = nil
+        isLoading = false
+    }
+
+    /// Drop everything. Called when the trigger closes, so a later trigger of
+    /// the same kind cannot reopen onto the previous query's rows.
+    func reset() {
+        items = []
+        errorText = nil
+        isLoading = false
+        lastKind = nil
+        generation += 1
+    }
+
+    /// Mark a fetch as pending the moment a trigger appears, before the
+    /// debounce elapses. Without this the popover renders its no-match line in
+    /// the window between the keystroke and the first request.
+    func beginPending() {
+        isLoading = true
+        errorText = nil
+    }
+
+    func update(trigger: Trigger, context: SuggestionContext) async {
+        // Bumped BEFORE the dismissed check, not after: the dismissed branch
+        // below returns early, and an in-flight request from before the
+        // dismissal is still reading the OLD generation. Without this bump
+        // that request stays "current", writes `items` once it lands, and
+        // reopens a popover the user just closed.
+        generation += 1
+
+        if let dismissed, dismissed.range == trigger.range, dismissed.token == trigger.token {
+            items = []
+            // Clearing here matters: a superseded in-flight request returns at
+            // its own generation guard WITHOUT touching isLoading (correctly —
+            // it must not clobber a newer request's state), so any path that
+            // ends a request synchronously has to clear the spinner itself.
+            isLoading = false
+            return
+        }
+        dismissed = nil
+
+        if lastKind != trigger.kind {
+            items = []
+        }
+        lastKind = trigger.kind
+
+        let mine = generation
+        errorText = nil
+
+        switch trigger.kind {
+        case .command:
+            await loadCommands(trigger: trigger, context: context, generation: mine)
+        case .path:
+            await loadPaths(trigger: trigger, context: context, generation: mine)
+        }
+    }
+
+    // MARK: Commands
+
+    private func loadCommands(trigger: Trigger, context: SuggestionContext,
+                              generation mine: Int) async {
+        let key = CommandKey(harness: context.harness, device: context.deviceId, cwd: context.cwd)
+
+        if let cached = commandCache[key] {
+            items = Self.filter(cached, query: trigger.query)
+            // Same reason as the dismissed path: this ends the request without
+            // ever awaiting, so it owns clearing the spinner. Omitting it strands
+            // isLoading == true forever when this hit supersedes an in-flight miss.
+            isLoading = false
+            return
+        }
+
+        isLoading = true
+        do {
+            let fetched = try await fetchCommands(context.harness, context.deviceId, context.cwd)
+            guard mine == generation else { return }
+            commandCache[key] = fetched
+            items = Self.filter(fetched, query: trigger.query)
+        } catch {
+            guard mine == generation else { return }
+            items = []
+            errorText = Self.commandError(error)
+        }
+        isLoading = false
+    }
+
+    /// Name matches first, then description matches. The host returns the full
+    /// list, so filtering is the client's job.
+    private static func filter(_ commands: [SlashCommand], query: String) -> [SuggestionItem] {
+        let needle = query.lowercased()
+        var byName: [SuggestionItem] = []
+        var byDescription: [SuggestionItem] = []
+        for command in commands {
+            let item = SuggestionItem(id: "cmd:\(command.name)",
+                                      label: "/\(command.name)",
+                                      detail: command.description,
+                                      payload: .command(command.name))
+            if needle.isEmpty || command.name.lowercased().contains(needle) {
+                byName.append(item)
+            } else if command.description.lowercased().contains(needle) {
+                byDescription.append(item)
+            }
+        }
+        return byName + byDescription
+    }
+
+    // MARK: Paths
+
+    private func loadPaths(trigger: Trigger, context: SuggestionContext,
+                           generation mine: Int) async {
+        isLoading = true
+        do {
+            let matches = try await fetchPaths(context, trigger.query)
+            guard mine == generation else { return }
+            // The host already ranked and capped these (repos.rs:1082).
+            items = matches.map { match in
+                SuggestionItem(id: "path:\(match.path)",
+                               label: MentionLink.basename(of: match.path),
+                               detail: Self.parentPath(match.path),
+                               payload: .path(match.path, isDir: match.isDir))
+            }
+        } catch {
+            guard mine == generation else { return }
+            items = []
+            errorText = Self.pathError(error)
+        }
+        isLoading = false
+    }
+
+    private static func parentPath(_ path: String) -> String {
+        let parts = path.split(separator: "/")
+        guard parts.count > 1 else { return "" }
+        return parts.dropLast().joined(separator: "/")
+    }
+
+    // MARK: Errors
+    //
+    // A failure must NEVER render as "no matching files": cross-device searches
+    // fail for reasons the user can act on, and the empty state hid them
+    // (crates/ui/src/composer.rs:3296-3300). These strings are verbatim from
+    // the desktop (composer.rs:3311-3335).
+
+    private static func pathError(_ error: Error) -> String {
+        guard let relay = error as? RelayError else { return "File search failed" }
+        if relay.isUnknownMethod("SearchFiles") {
+            return "The session's device runs an older zeron — update it to search its files"
+        }
+        switch relay {
+        case .notConnected, .hostOffline, .timeout:
+            return "The session's device is unreachable"
+        case .rpc:
+            return "File search failed"
+        }
+    }
+
+    private static func commandError(_ error: Error) -> String {
+        guard let relay = error as? RelayError else { return "Couldn't load this agent's commands" }
+        if relay.isUnknownMethod("ListCommands") {
+            return "The session's device runs an older zeron — update it to list commands"
+        }
+        switch relay {
+        case .notConnected, .hostOffline, .timeout:
+            return "The session's device is unreachable"
+        case .rpc:
+            return "Couldn't load this agent's commands"
+        }
+    }
+}

--- a/apps/ios/Zeron/Composer/ComposerText.swift
+++ b/apps/ios/Zeron/Composer/ComposerText.swift
@@ -1,0 +1,311 @@
+// The composer's text model. This is the ONLY file that knows AttributedString
+// exists: ComposerTrigger, ComposerSuggestions, and ComposerPopover all work on
+// plain text and a caret offset. If rich text ever has to be abandoned, the
+// blast radius is this file.
+//
+// A mention chip is styled text, not an embedded view — the desktop defines the
+// same look (crates/ui/src/composer.rs:643-647). The PATH lives in the
+// attribute, never in the visible text, so editing the label cannot silently
+// retarget a mention.
+
+import SwiftUI
+
+struct MentionValue: Hashable, Sendable {
+    let path: String
+    let isDir: Bool
+}
+
+enum MentionAttribute: AttributedStringKey {
+    typealias Value = MentionValue
+    static let name = "zeronMention"
+    /// Text typed beside a chip must never join it.
+    static let inheritedByAddedText = false
+    /// Ask the framework to drop the attribute when the run's own text
+    /// changes. `enforceInvariant` re-checks regardless: this is a fast path,
+    /// not the contract.
+    static let invalidationConditions: Set<AttributedString.AttributeInvalidationCondition>? = [.textChanged]
+}
+
+extension AttributeScopes {
+    struct ZeronScope: AttributeScope {
+        let zeronMention: MentionAttribute
+        let swiftUI: AttributeScopes.SwiftUIAttributes
+    }
+
+    var zeron: ZeronScope.Type { ZeronScope.self }
+}
+
+// MARK: - Chip paint, derived
+
+/// Chip styling is DERIVED from the mention key. It is never stored on the run.
+///
+/// The Task 0 spike proved both halves of why, and both are load-bearing:
+///
+///   - Visual attributes inherit FORWARD. Text typed at a chip's trailing edge
+///     picks up a *stored* mono font and wash, because
+///     `inheritedByAddedText = false` holds back only the custom key.
+///   - `invalidationConditions` strips the custom key without stripping stored
+///     paint, so a dead mention would keep looking like a live chip.
+///
+/// Deriving fixes both ends at once: the paint follows the key, and only the
+/// key. Store styling on the run and you reintroduce both bugs.
+///
+/// A `ValueConstraint` may READ any attribute but may WRITE only its own
+/// `AttributeKey` (`SwiftUICore.swiftinterface:9535-9547`), so font and
+/// background are two constraints rather than one.
+struct MentionFormatting: AttributedTextFormattingDefinition {
+    typealias Scope = AttributeScopes.ZeronScope
+
+    var body: some AttributedTextFormattingDefinition<Scope> {
+        MentionFont()
+        MentionWash()
+    }
+}
+
+struct MentionFont: AttributedTextValueConstraint {
+    typealias Scope = AttributeScopes.ZeronScope
+    typealias AttributeKey = AttributeScopes.SwiftUIAttributes.FontAttribute
+
+    func constrain(_ container: inout Attributes) {
+        container[AttributeKey.self] = container[MentionAttribute.self] == nil
+            ? nil
+            : .system(size: 15, design: .monospaced)
+    }
+}
+
+struct MentionWash: AttributedTextValueConstraint {
+    typealias Scope = AttributeScopes.ZeronScope
+    typealias AttributeKey = AttributeScopes.SwiftUIAttributes.BackgroundColorAttribute
+
+    func constrain(_ container: inout Attributes) {
+        container[AttributeKey.self] = container[MentionAttribute.self] == nil
+            ? nil
+            : Color.white.opacity(0.10)
+    }
+}
+
+struct ComposerText: Equatable {
+
+    var attributed: AttributedString
+
+    init(_ plain: String = "") {
+        attributed = AttributedString(plain)
+    }
+
+    // MARK: Plain projection
+
+    var plainText: String { String(attributed.characters) }
+
+    var isEmpty: Bool { attributed.characters.isEmpty }
+
+    // MARK: Selection
+
+    /// The caret offset in Characters, or nil when the selection covers a
+    /// range. `.ranges` can be discontiguous, so both cases fall out here.
+    func caretOffset(_ selection: AttributedTextSelection) -> Int? {
+        switch selection.indices(in: attributed) {
+        case .insertionPoint(let index):
+            return attributed.characters.distance(from: attributed.startIndex, to: index)
+        case .ranges:
+            return nil
+        }
+    }
+
+    /// A trigger, vetoed when it overlaps an existing chip. A chip's visible
+    /// text IS `@basename`, so the pure detector cannot tell one from a token
+    /// the user typed. Only this file can see the attribute, so the veto lives
+    /// here.
+    func trigger(at selection: AttributedTextSelection) -> Trigger? {
+        guard let caret = caretOffset(selection),
+              let candidate = ComposerTrigger.detect(text: plainText, caret: caret),
+              !intersectsMention(candidate.range)
+        else { return nil }
+        return candidate
+    }
+
+    private func intersectsMention(_ range: Range<Int>) -> Bool {
+        for (lower, upper) in mentionRuns() where range.lowerBound < upper && lower < range.upperBound {
+            return true
+        }
+        return false
+    }
+
+    // MARK: Serialization
+
+    /// The draft as the host sees it. Non-mention runs pass through; each
+    /// mention run becomes the canonical link built from its ATTRIBUTE.
+    func markdown() -> String {
+        var out = ""
+        // Iterate the MENTION-KEYED run view, never `attributed.runs`. The plain
+        // view splits at EVERY attribute boundary, so an unrelated attribute
+        // landing on part of a chip — the iOS 26 editor's own formatting menu can
+        // underline half a chip, and pasted styled text does it too — breaks one
+        // chip into several runs that each carry the same value. This loop would
+        // then emit the same link once per fragment. The keyed view coalesces
+        // them back into a single slice.
+        for (mention, range) in attributed.runs[MentionAttribute.self] {
+            if let mention {
+                out += MentionLink.serialize(path: mention.path, isDir: mention.isDir)
+            } else {
+                out += String(attributed[range].characters)
+            }
+        }
+        return out
+    }
+
+    // MARK: The invariant
+
+    /// Strip the mention attribute from every run that fails either clause:
+    ///
+    ///   1. the run's visible text is exactly `@basename`, and
+    ///   2. the serialized draft re-parses to that mention at that position.
+    ///
+    /// Clause 1 keeps the screen and the wire honest — `markdown()` builds the
+    /// label from the attribute, so a mangled run would otherwise serialize to
+    /// a perfectly valid link for a path the user can no longer see. Clause 2
+    /// catches what clause 1 cannot: an unsafe path, an encoding that does not
+    /// round-trip, and surrounding text that swallows the link (the desktop
+    /// parser reads the WHOLE draft — crates/ui/src/composer.rs:752-795).
+    mutating func enforceInvariant() {
+        let serialized = markdown()
+        let parsed = MentionLink.parse(serialized)
+
+        var doomed: [Range<AttributedString.Index>] = []
+        var offset = 0
+
+        // Keyed run view, for the same reason as `markdown()`: a chip split by
+        // an unrelated attribute must be judged as ONE mention, or clause 1 fails
+        // on every fragment and a visually intact chip dies for no reason.
+        for (mention, range) in attributed.runs[MentionAttribute.self] {
+            let visible = String(attributed[range].characters)
+            guard let mention else {
+                offset += visible.count
+                continue
+            }
+
+            let link = MentionLink.serialize(path: mention.path, isDir: mention.isDir)
+            let expected = offset..<(offset + link.count)
+            let clauseOne = visible == "@" + MentionLink.basename(of: mention.path)
+            let clauseTwo = parsed.contains { candidate in
+                candidate.range == expected
+                    && candidate.path == mention.path
+                    && candidate.isDir == mention.isDir
+            }
+            if !clauseOne || !clauseTwo {
+                doomed.append(range)
+            }
+            offset += link.count
+        }
+
+        for range in doomed {
+            attributed[range][MentionAttribute.self] = nil
+        }
+    }
+
+    // MARK: Mutation
+
+    mutating func apply(command: String, over range: Range<Int>,
+                        selection: inout AttributedTextSelection) {
+        let suppressed = hasSeparator(after: range.upperBound)
+        let separator = suppressed ? "" : " "
+        replace(range, with: AttributedString("/\(command)\(separator)"),
+               selection: &selection, skipExistingSeparator: suppressed)
+    }
+
+    mutating func apply(path: String, isDir: Bool, over range: Range<Int>,
+                        selection: inout AttributedTextSelection) {
+        var chip = AttributedString("@" + MentionLink.basename(of: path))
+        if MentionLink.isSafe(path) {
+            chip[MentionAttribute.self] = MentionValue(path: path, isDir: isDir)
+        }
+        var replacement = chip
+        let suppressed = hasSeparator(after: range.upperBound)
+        if !suppressed {
+            replacement.append(AttributedString(" "))
+        }
+        replace(range, with: replacement, selection: &selection, skipExistingSeparator: suppressed)
+    }
+
+    /// True when the character right after the replaced range — in the text
+    /// as it stands BEFORE this pick — is whitespace other than a newline.
+    /// Matches the desktop rule exactly, including the newline exclusion
+    /// (crates/ui/src/composer.rs:1483-1489): a pick never doubles up a space
+    /// that is already there, but a hard newline right after the token still
+    /// gets its own trailing space rather than folding onto the next line.
+    private func hasSeparator(after upper: Int) -> Bool {
+        let count = attributed.characters.count
+        let clamped = max(0, min(count, upper))
+        guard clamped < count else { return false }
+        let index = attributed.index(attributed.startIndex, offsetByCharacters: clamped)
+        let ch = attributed.characters[index]
+        return ch.isWhitespace && ch != "\n" && ch != "\r"
+    }
+
+    mutating func clear(selection: inout AttributedTextSelection) {
+        attributed = AttributedString("")
+        selection = AttributedTextSelection(insertionPoint: attributed.startIndex)
+    }
+
+    /// Every text mutation goes through here so the invariant is re-checked
+    /// exactly once per change. `transform(updating:)` keeps `selection` valid
+    /// across the edit; the final caret is then placed deliberately after the
+    /// inserted text, so that assignment — not the `updating:` argument — is what
+    /// determines where the caret ends up.
+    ///
+    /// `skipExistingSeparator` is the other half of the desktop's separator
+    /// rule (crates/ui/src/composer.rs:1489): when a pick suppresses its own
+    /// trailing space because one is already there, the caret still lands
+    /// PAST that pre-existing character, not just before it. Landing before
+    /// it would glue the next keystroke onto the token, and — for the picks
+    /// the mention veto does not cover (commands; unsafe paths, which carry
+    /// no attribute) — would leave the caret sitting exactly on the token's
+    /// own trigger boundary, reopening the popover on the pick that just
+    /// resolved it.
+    private mutating func replace(_ range: Range<Int>, with replacement: AttributedString,
+                                  selection: inout AttributedTextSelection,
+                                  skipExistingSeparator: Bool = false) {
+        let count = attributed.characters.count
+        let lower = max(0, min(count, range.lowerBound))
+        let upper = max(lower, min(count, range.upperBound))
+
+        attributed.transform(updating: &selection) { text in
+            let start = text.index(text.startIndex, offsetByCharacters: lower)
+            let end = text.index(text.startIndex, offsetByCharacters: upper)
+            text.replaceSubrange(start..<end, with: replacement)
+        }
+        enforceInvariant()
+
+        let advance = replacement.characters.count + (skipExistingSeparator ? 1 : 0)
+        let caret = attributed.index(attributed.startIndex,
+                                     offsetByCharacters: lower + advance)
+        selection = AttributedTextSelection(insertionPoint: caret)
+    }
+
+    // MARK: Helpers
+
+    /// (lowerOffset, upperOffset) for each mention span. The keyed view keeps a
+    /// chip that an unrelated attribute has split reported as one span, so the
+    /// trigger veto covers the whole chip rather than one fragment of it.
+    private func mentionRuns() -> [(Int, Int)] {
+        var out: [(Int, Int)] = []
+        for (mention, range) in attributed.runs[MentionAttribute.self] where mention != nil {
+            let lower = attributed.characters.distance(from: attributed.startIndex,
+                                                       to: range.lowerBound)
+            let upper = attributed.characters.distance(from: attributed.startIndex,
+                                                       to: range.upperBound)
+            out.append((lower, upper))
+        }
+        return out
+    }
+}
+
+#if DEBUG
+extension ComposerText {
+    /// Simulate a raw user edit: replace a character range and re-check the
+    /// invariant, exactly as the text view's binding write does. Tests only.
+    mutating func replaceForTesting(_ range: Range<Int>, with plain: String) {
+        var selection = AttributedTextSelection(insertionPoint: attributed.startIndex)
+        replace(range, with: AttributedString(plain), selection: &selection)
+    }
+}
+#endif

--- a/apps/ios/Zeron/Composer/ComposerTrigger.swift
+++ b/apps/ios/Zeron/Composer/ComposerTrigger.swift
@@ -1,0 +1,116 @@
+// Composer trigger detection: a port of the desktop composer's slash_token
+// and mention_token (crates/ui/src/composer.rs:3179-3233). Pure — no SwiftUI,
+// no attributed text, no I/O — so it is testable without a simulator and it
+// stays correct if the rich-text layer above it is ever replaced.
+//
+// All offsets count Characters. Rust counts UTF-8 bytes; do not mix them.
+
+import Foundation
+
+enum TriggerKind {
+    case command
+    case path
+}
+
+struct Trigger: Equatable {
+    let kind: TriggerKind
+    /// Text between the sigil and the caret. What the popover filters on.
+    let query: String
+    /// The FULL text of `range`, including the sigil and anything after the
+    /// caret. The dismissal rule keys on this, not on `query`: moving the caret
+    /// inside a dismissed token must keep it closed, while any edit reopens it
+    /// (crates/ui/src/composer.rs:3302-3304). `query` changes on a caret move;
+    /// `token` does not.
+    let token: String
+    /// The span the pick replaces, including the sigil. For a path this
+    /// extends past the caret to the end of the token.
+    let range: Range<Int>
+}
+
+enum ComposerTrigger {
+
+    static func detect(text: String, caret: Int) -> Trigger? {
+        let chars = Array(text)
+        guard caret >= 0, caret <= chars.count else { return nil }
+        return command(chars, caret) ?? path(chars, caret)
+    }
+
+    static func replace(_ text: String, range: Range<Int>,
+                        with replacement: String) -> (text: String, caret: Int) {
+        let chars = Array(text)
+        let lower = max(0, min(chars.count, range.lowerBound))
+        let upper = max(lower, min(chars.count, range.upperBound))
+        let next = String(chars[0..<lower]) + replacement + String(chars[upper...])
+        return (next, lower + replacement.count)
+    }
+
+    // MARK: Command
+
+    /// The `/` must open the whole draft: slash commands are whole-prompt
+    /// prefixes (`/compact`, `/goal ship it`), so only the first token
+    /// triggers, and a query holding another `/` (a typed path) never does.
+    private static func command(_ chars: [Character], _ caret: Int) -> Trigger? {
+        guard chars.first == "/" else { return nil }
+        let end = chars.firstIndex(where: \.isWhitespace) ?? chars.count
+        guard caret > 0, caret <= end else { return nil }
+        let query = String(chars[1..<caret])
+        guard !query.contains("/") else { return nil }
+        return Trigger(kind: .command, query: query,
+                       token: String(chars[0..<end]), range: 0..<end)
+    }
+
+    // MARK: Path
+
+    /// The `@` must begin a token. This excludes `name@example.com` and
+    /// ordinary words while allowing punctuation such as `(@src`.
+    private static func path(_ chars: [Character], _ caret: Int) -> Trigger? {
+        var tokenStart = 0
+        var back = caret - 1
+        while back >= 0 {
+            if chars[back].isWhitespace {
+                tokenStart = back + 1
+                break
+            }
+            back -= 1
+        }
+
+        var at: Int?
+        var scan = caret - 1
+        while scan >= tokenStart {
+            if chars[scan] == "@" {
+                at = scan
+                break
+            }
+            scan -= 1
+        }
+        guard let at else { return nil }
+
+        let validBoundary: Bool
+        if at == 0 {
+            validBoundary = true
+        } else {
+            let previous = chars[at - 1]
+            validBoundary = previous.isWhitespace
+                || previous == "(" || previous == "[" || previous == "{"
+        }
+        guard validBoundary else { return nil }
+
+        let query = String(chars[(at + 1)..<caret])
+        guard !query.contains("@") else { return nil }
+
+        // The token ends at the first whitespace AT OR AFTER the caret, so
+        // editing the middle of a mention replaces the whole token.
+        var end = chars.count
+        var forward = caret
+        while forward < chars.count {
+            if chars[forward].isWhitespace {
+                end = forward
+                break
+            }
+            forward += 1
+        }
+
+        return Trigger(kind: .path, query: query,
+                       token: String(chars[at..<end]), range: at..<end)
+    }
+}

--- a/apps/ios/Zeron/Composer/ComposerView.swift
+++ b/apps/ios/Zeron/Composer/ComposerView.swift
@@ -505,15 +505,15 @@ struct ComposerView: View {
             // that empty list under the real key — permanently, for the life of
             // the view. Every later `/` then silently shows nothing.
             //
-            // AppModel.workspace is Optional (AppModel.swift:21): signed out or
-            // in demo mode there is no store, and so no suggestions.
+            // Both fetchers go through AppModel, not straight to the store, so
+            // demo mode answers from its own dataset instead of returning [].
             suggestions.fetchCommands = { [weak model] harness, device, cwd in
-                guard let store = model?.workspace else { return [] }
-                return try await store.listCommands(deviceId: device, harness: harness, cwd: cwd)
+                guard let model else { return [] }
+                return try await model.listCommands(deviceId: device, harness: harness, cwd: cwd)
             }
             suggestions.fetchPaths = { [weak model] context, query in
-                guard let store = model?.workspace else { return [] }
-                return try await store.searchFiles(deviceId: context.deviceId,
+                guard let model else { return [] }
+                return try await model.searchFiles(deviceId: context.deviceId,
                                                    chatId: context.chatId,
                                                    spaceId: context.spaceId,
                                                    query: query)
@@ -542,7 +542,8 @@ struct ComposerView: View {
     private var suggestionContext: SuggestionContext {
         SuggestionContext(harness: harness,
                          deviceId: chat.deviceId,
-                         cwd: chat.cwd ?? model.space(for: chat)?.path ?? "~",
+                         cwd: slashCwd(chatCwd: chat.cwd,
+                                       spacePath: model.space(for: chat)?.path),
                          chatId: chat.id,
                          spaceId: nil)
     }

--- a/apps/ios/Zeron/Composer/ComposerView.swift
+++ b/apps/ios/Zeron/Composer/ComposerView.swift
@@ -14,7 +14,8 @@ import SwiftUI
 /// Shared glass shell + input + action row. `chips` render in the expanded
 /// toolbar row between the attach and send circles.
 struct ComposerShell<Chips: View>: View {
-    @Binding var draft: String
+    @Binding var draft: ComposerText
+    @Binding var selection: AttributedTextSelection
     var placeholder = "Message"
     var sendEnabled: Bool
     var showStop: Bool
@@ -37,25 +38,35 @@ struct ComposerShell<Chips: View>: View {
     /// Screenshot rig (-focuscomposer): take keyboard focus shortly after
     /// appearing, so the keyboard-up transcript states can be driven headless.
     var autoFocus = false
+    /// Reports focus changes out, so a caller can close floating UI on blur.
+    var onFocusChange: (Bool) -> Void = { _ in }
     @ViewBuilder var chips: Chips
 
     @FocusState private var focused: Bool
+    @State private var measuredHeight: CGFloat = 22
 
     private var expanded: Bool {
         alwaysExpanded || keepExpanded || focused || !attachments.isEmpty
-            || draft.contains("\n") || draft.count > 26
+            || draft.plainText.contains("\n") || draft.plainText.count > 26
     }
 
-    /// One animatable shape for background/glass/hairline: capsule-radius
-    /// collapsed (46pt tall pill), 20pt card expanded (t3's 999↔20 morph).
+    /// One animatable shape for background/glass/hairline: a true capsule
+    /// collapsed, a 20pt card expanded (t3's 999↔20 morph).
+    ///
+    /// The collapsed radius is 999, not a literal half-height. `RoundedRectangle`
+    /// clamps its radius to half the smaller dimension, so 999 is always exactly
+    /// a capsule no matter how tall the pill is. The previous `24` only looked
+    /// like a capsule because the pill was pinned at 46pt; once the editor's
+    /// height became measured rather than fixed, 24 stopped being half of it and
+    /// the pill visibly squared off.
     private var surfaceShape: RoundedRectangle {
-        RoundedRectangle(cornerRadius: expanded ? 20 : 24)
+        RoundedRectangle(cornerRadius: expanded ? 20 : 999)
     }
 
     // Switching between VStack/HStack via AnyLayout (rather than an if/else
     // that swaps container types) keeps `input`'s view identity stable across
     // the compact↔expanded flip — an if/else here would tear down and rebuild
-    // the TextField, dropping keyboard focus mid-type.
+    // the TextEditor, dropping keyboard focus mid-type.
     private var shellLayout: AnyLayout {
         expanded
             ? AnyLayout(VStackLayout(alignment: .leading, spacing: 0))
@@ -75,6 +86,7 @@ struct ComposerShell<Chips: View>: View {
                     focused = true
                 }
             }
+            .onChange(of: focused) { _, now in onFocusChange(now) }
     }
 
     /// The glass surface: collapsed = editor + send in one capsule row;
@@ -117,7 +129,7 @@ struct ComposerShell<Chips: View>: View {
         .background(whiteAlpha(0.04), in: surfaceShape)
         .glassEffect(.regular.interactive(), in: surfaceShape)
         .overlay(surfaceShape.strokeBorder(whiteAlpha(0.05), lineWidth: 1))
-        // The whole glass surface focuses the editor, not just the TextField's
+        // The whole glass surface focuses the editor, not just the TextEditor's
         // own text box: the collapsed pill is mostly padding, and a tap that
         // misses the text box falls through to the transcript underneath —
         // whose tap-to-blur then RESIGNS the keyboard. That's the "have to
@@ -129,13 +141,146 @@ struct ComposerShell<Chips: View>: View {
                  including: focused ? .subviews : .all)
     }
 
+    // TextEditor, not TextField: only the AttributedString overload can carry
+    // mention chips (iOS 26+). It gives up three things TextField had, so each
+    // is rebuilt here: the placeholder is an overlay, the 1...7 line limit is
+    // an explicit height range, and the opaque background is hidden so the
+    // glass shows through.
     private var input: some View {
-        TextField(placeholder, text: $draft, axis: .vertical)
+        TextEditor(text: editorText, selection: $selection)
             .font(Theme.sans(16))
             .foregroundStyle(Theme.text)
             .tint(Theme.text)
-            .lineLimit(1...7)
+            .attributedTextFormattingDefinition(MentionFormatting())
+            .scrollContentBackground(.hidden)
+            .frame(height: clampedHeight)
+            .scrollDisabled(measuredHeight <= lineHeight * 7)
             .focused($focused)
+            .background(alignment: .topLeading) { heightMirror }
+            // Collapsed, the pill is exactly one line, so the placeholder is
+            // CENTRED with no vertical offset — `.leading` does that on its own,
+            // at any height. Expanded, the editor is multi-line and the
+            // placeholder belongs on the first line, so it top-aligns.
+            //
+            // The previous `.topLeading` + `.padding(.top, 8)` was a constant
+            // tuned against the old fixed editor height. Once that height became
+            // measured, the constant stopped meaning "first line" and just
+            // pushed the text low — which is exactly what it looked like.
+            .overlay(alignment: expanded ? .topLeading : .leading) {
+                if draft.isEmpty {
+                    Text(placeholder)
+                        .font(Theme.sans(16))
+                        .foregroundStyle(Theme.textFaint)
+                        .padding(.leading, 4)
+                        .padding(.top, expanded ? 8 : 0)
+                        .allowsHitTesting(false)
+                }
+            }
+    }
+
+    /// One line of the composer font, used to bound the editor's growth the way
+    /// `lineLimit(1...7)` used to.
+    private var lineHeight: CGFloat { 22 }
+
+    /// Collapsed is pinned, not measured. The mirror adds its own vertical
+    /// padding on top of the paddings the shell already applies, which pushed
+    /// the one-line pill from its original 46pt to about 60pt — visibly taller
+    /// and, with a capsule radius, visibly fatter. One line has no wrapping to
+    /// discover, so there is nothing to measure: pin it and let the mirror do
+    /// the job it exists for, which is growth.
+    private var collapsedEditorHeight: CGFloat { 26 }
+
+    private var clampedHeight: CGFloat {
+        guard expanded else { return collapsedEditorHeight }
+        return min(max(measuredHeight, lineHeight), lineHeight * 7)
+    }
+
+    /// Height measurement, taken from a hidden `Text` MIRROR rather than from
+    /// the editor's own content size.
+    ///
+    /// This distinction is the whole point. The editor's content height depends
+    /// on the frame we set from it, so reading one to set the other makes them
+    /// chase each other — the oscillation this file's own comments already warn
+    /// about. A mirror's height depends only on the text and the available
+    /// width, never on the frame we apply to the editor, so the loop is broken.
+    ///
+    /// It is also what solves WRAPPING. The Task 0 spike verified 1-to-7 growth
+    /// from hard newlines only and left wrapped growth unsolved. `Text` wraps at
+    /// the same width with the same font, so its height IS the wrapped height.
+    ///
+    /// Three details here are load-bearing, and each one silently breaks growth
+    /// if it is dropped:
+    ///
+    /// `.fixedSize(horizontal: false, vertical: true)` — `.background` proposes
+    /// the PRIMARY view's size to its content, so without this the mirror is
+    /// proposed `clampedHeight` and can report exactly that back, pinning
+    /// `measuredHeight` at one line and freezing the editor forever. The file
+    /// already uses this modifier for the same reason at the question panel.
+    ///
+    /// `.padding(.horizontal, 5)` — the editor wraps at its frame width MINUS
+    /// its own text inset; a mirror with no inset wraps a character or two
+    /// later, so at every wrap boundary the editor has a line the mirror has not
+    /// counted. With `scrollDisabled` true in that window, the new line and the
+    /// caret are clipped. Insetting the mirror over-measures instead, which is
+    /// the harmless direction.
+    ///
+    /// Per-line height is over-measured too (chips render at mono 15, the mirror
+    /// measures everything at sans 16), and that is also harmless. Note the
+    /// width bias runs the OTHER way — mono advances are wider than the
+    /// proportional average, so a chip-heavy line wraps earlier in the editor
+    /// than in the mirror. The horizontal inset above is what absorbs that.
+    private var heightMirror: some View {
+        Text(mirroredText)
+            .font(Theme.sans(16))
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .hidden()
+            .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
+                measuredHeight = height
+            }
+    }
+
+    /// What the mirror measures, with two deliberate distortions.
+    ///
+    /// A trailing newline gets a sentinel space. TextKit gives the editor an
+    /// extra line fragment for a trailing paragraph break and SwiftUI `Text`
+    /// does not, so pressing Return at the end of a draft would measure the same
+    /// height as before: the frame would not grow, and the caret would sit
+    /// inside a scroll-disabled clip until the next keystroke. Return is the
+    /// explicit "I want another line" gesture, so this is the most visible of
+    /// the mirror's failure modes.
+    ///
+    /// An empty draft measures a single space, so the collapsed pill is one line
+    /// tall rather than zero.
+    private var mirroredText: String {
+        let plain = draft.plainText
+        if plain.isEmpty { return " " }
+        return plain.hasSuffix("\n") ? plain + " " : plain
+    }
+
+    /// THE ONLY PATH USER TYPING TAKES. `ComposerText.apply(…)` enforces the
+    /// invariant for programmatic picks, but a keystroke never goes through it
+    /// — the text view writes straight to the binding. Without this setter, a
+    /// chip typed into would keep its attribute on device while the unit tests
+    /// still passed, because those drive `apply` instead.
+    ///
+    /// Enforcing here rather than in an `.onChange` is deliberate: mutating the
+    /// binding from inside its own change notification is the re-entrancy the
+    /// `clearDraft` comment warns about. The pass settles in one step — a run
+    /// that has already lost its attribute is no longer a mention run, so a
+    /// second pass finds nothing to strip.
+    private var editorText: Binding<AttributedString> {
+        Binding(
+            get: { draft.attributed },
+            set: { next in
+                var updated = draft
+                updated.attributed = next
+                updated.enforceInvariant()
+                draft = updated
+            }
+        )
     }
 
     private var attachButton: some View {
@@ -156,7 +301,8 @@ struct ComposerShell<Chips: View>: View {
 
     /// Attachments count as content: an image-only send is a send, never a stop.
     private var hasContent: Bool {
-        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty
+        !draft.plainText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !attachments.isEmpty
     }
 
     private var actionButton: some View {
@@ -209,7 +355,9 @@ struct ComposerView: View {
     let chat: Chat
     let runLive: Bool
 
-    @State private var text = ""
+    @State private var text = ComposerText()
+    @State private var selection = AttributedTextSelection()
+    @State private var suggestions = ComposerSuggestions()
     @State private var attachments: [StagedAttachment] = []
     @State private var pickerItems: [PhotosPickerItem] = []
     @State private var showPicker = false
@@ -219,6 +367,14 @@ struct ComposerView: View {
     @State private var showTraitPicker = false
     /// Live catalog for the chat's harness from its space's device.
     @State private var catalogs: [String: [ModelInfo]] = [:]
+    /// Mirrors ComposerShell's own `@FocusState`, reported out through
+    /// `onFocusChange`. Gates the popover: on desktop, tap-outside blurs the
+    /// editor AND dismisses the mention popup in the same gesture
+    /// (crates/ui/src/composer.rs:3966). SwiftUI has no equivalent of
+    /// `on_mouse_down_out`, so blur is the signal this reaches for instead —
+    /// a tap on the transcript resigns focus, and the popover must follow it
+    /// down rather than floating over a dismissed keyboard.
+    @State private var composerFocused = false
 
     private var harness: String { chat.config?.harness ?? "claude-code" }
 
@@ -246,8 +402,42 @@ struct ComposerView: View {
                     .padding(.horizontal, 24)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+            // Gate is trigger-open AND focused, nothing about `items` or
+            // `errorText` or `isLoading`. Focus is required so a tap on the
+            // transcript — which blurs the editor without changing the draft,
+            // so the trigger alone would still match — closes the popover the
+            // same way desktop's `.on_mouse_down_out(… dismiss_mention …)`
+            // does (crates/ui/src/composer.rs:3966). Items/error/loading used
+            // to gate visibility too, but that left the zero-match empty state
+            // ("No matching commands.") unreachable — with only a trigger and
+            // focus needed, `scheduleRefresh`'s `beginPending()` call keeps
+            // `isLoading` true through the whole 80ms debounce window, so the
+            // popover shows "Searching files…" rather than flashing the
+            // empty-state line before the first request has even gone out.
+            //
+            // A SIBLING in this VStack, not a ZStack over ComposerShell:
+            // ZStack(alignment: .bottom) aligns both children's bottom edges and
+            // draws the later one (the pill) in front, so the pill would cover the
+            // popover completely at one to three rows and swallow taps on every
+            // covered row through its own contentShape. The VStack's 6pt spacing
+            // is the gap the two glass surfaces want anyway.
+            if let trigger = text.trigger(at: selection), composerFocused {
+                ComposerPopover(items: suggestions.items,
+                                kind: trigger.kind,
+                                isLoading: suggestions.isLoading,
+                                errorText: suggestions.errorText) { item in
+                    pick(item, over: trigger.range)
+                }
+                // 10, not 16: ComposerShell narrows its own margins to 10 while
+                // focused (ComposerView.swift:68), and the popover only ever shows
+                // while focused. 16 would leave its edges visibly inset from the
+                // pill directly beneath it.
+                .padding(.horizontal, 10)
+                .transition(.opacity)
+            }
             ComposerShell(
                 draft: $text,
+                selection: $selection,
                 sendEnabled: true,
                 showStop: runLive,
                 busy: uploading,
@@ -257,7 +447,8 @@ struct ComposerView: View {
                 attachments: attachments,
                 onAttach: { showPicker = true },
                 onRemoveAttachment: { id in attachments.removeAll { $0.id == id } },
-                autoFocus: model.launchFocusComposer
+                autoFocus: model.launchFocusComposer,
+                onFocusChange: { composerFocused = $0 }
             ) {
                 if let pullRequest = model.changeRequest(for: chat) {
                     PullRequestBadge(summary: pullRequest, surface: .composer)
@@ -307,14 +498,100 @@ struct ComposerView: View {
             )
         }
         .task(id: "\(chat.id)/\(harness)") {
+            // Wire the fetchers FIRST, before the guard and before any await.
+            // `listModels` is an RPC to the host and can stall for seconds when
+            // the device is offline. If the user types `/` in that window, the
+            // default no-op fetcher returns [] and ComposerSuggestions caches
+            // that empty list under the real key — permanently, for the life of
+            // the view. Every later `/` then silently shows nothing.
+            //
+            // AppModel.workspace is Optional (AppModel.swift:21): signed out or
+            // in demo mode there is no store, and so no suggestions.
+            suggestions.fetchCommands = { [weak model] harness, device, cwd in
+                guard let store = model?.workspace else { return [] }
+                return try await store.listCommands(deviceId: device, harness: harness, cwd: cwd)
+            }
+            suggestions.fetchPaths = { [weak model] context, query in
+                guard let store = model?.workspace else { return [] }
+                return try await store.searchFiles(deviceId: context.deviceId,
+                                                   chatId: context.chatId,
+                                                   spaceId: context.spaceId,
+                                                   query: query)
+            }
+
             guard let space = model.space(for: chat) else { return }
             catalogs[harness] = await model.listModels(space: space, harness: harness)
         }
+        .onChange(of: text) { _, _ in scheduleRefresh() }
+        .onChange(of: selection) { _, _ in scheduleRefresh() }
         .onAppear {
             if model.launchSheet == "config" {
                 model.launchSheet = nil
                 showModelPicker = true
             }
+        }
+    }
+
+    /// Everything the fetchers need. The chat's own device hosts the run, so it
+    /// is the device to dial: a `chatId` search only works there
+    /// (crates/engine/src/rpc.rs:501-502) — `chat.deviceId`, not the space's,
+    /// is the authority for that, and the engine rejects a `chatId` search
+    /// whose chat does not belong to the dialed device ("chat belongs to
+    /// another device"). Reading it off `space.deviceId` disabled the whole
+    /// feature for any space-less chat, since `space` is Optional.
+    private var suggestionContext: SuggestionContext {
+        SuggestionContext(harness: harness,
+                         deviceId: chat.deviceId,
+                         cwd: chat.cwd ?? model.space(for: chat)?.path ?? "~",
+                         chatId: chat.id,
+                         spaceId: nil)
+    }
+
+    private func pick(_ item: SuggestionItem, over range: Range<Int>) {
+        switch item.payload {
+        case .command(let name):
+            text.apply(command: name, over: range, selection: &selection)
+        case .path(let path, let isDir):
+            text.apply(path: path, isDir: isDir, over: range, selection: &selection)
+        }
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    private func refreshSuggestions() async {
+        guard let trigger = text.trigger(at: selection) else { return }
+        await suggestions.update(trigger: trigger, context: suggestionContext)
+    }
+
+    @State private var refreshTask: Task<Void, Never>?
+
+    /// Debounce and cancel, for two reasons. One keystroke changes BOTH `text`
+    /// and `selection`, so without this every character fires two refreshes and
+    /// two `SearchFiles` RPCs, one of which the generation guard always throws
+    /// away. And an un-cancelled `Task` per keystroke lets a fast typist queue
+    /// an unbounded number of them. The desktop debounces the same way
+    /// (crates/ui/src/composer.rs:3871-3876).
+    ///
+    /// The trigger check runs SYNCHRONOUSLY here, before any debounce, for two
+    /// reasons that both have to happen on this exact keystroke rather than
+    /// 80ms later:
+    ///   - No trigger: `reset()` drops any stale rows from a trigger that just
+    ///     closed, so a later trigger of the same kind can't reopen onto the
+    ///     previous query's results while the new fetch is in flight.
+    ///   - A trigger: `beginPending()` marks the fetch pending immediately, so
+    ///     the popover's "Loading…" / "Searching files…" state covers the
+    ///     debounce window too, and the empty-state line never flashes between
+    ///     the keystroke and the first request going out.
+    private func scheduleRefresh() {
+        refreshTask?.cancel()
+        guard text.trigger(at: selection) != nil else {
+            suggestions.reset()
+            return
+        }
+        suggestions.beginPending()
+        refreshTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(80))
+            guard !Task.isCancelled else { return }
+            await refreshSuggestions()
         }
     }
 
@@ -353,7 +630,7 @@ struct ComposerView: View {
     }
 
     private func send() {
-        let prompt = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prompt = text.markdown().trimmingCharacters(in: .whitespacesAndNewlines)
         let staged = attachments
         guard !prompt.isEmpty || !staged.isEmpty else { return }
 
@@ -397,15 +674,15 @@ struct ComposerView: View {
     }
 
     private func clearDraft() {
-        text = ""
+        text.clear(selection: &selection)
         // The clear above is unconditional, so a prompt left sitting in the
         // composer after a successful send is not this path failing to run —
         // it is the text view writing the pre-send string back. A focused
-        // multiline TextField commits pending autocorrect/marked text through
+        // multiline editor commits pending autocorrect/marked text through
         // the binding AFTER a programmatic change, which restores the prompt.
         // Re-clear once that has drained; a keystroke can't land inside the
         // same main-actor turn, so this can never eat real input.
-        Task { @MainActor in text = "" }
+        Task { @MainActor in text.clear(selection: &selection) }
     }
 }
 

--- a/apps/ios/Zeron/Composer/MentionLink.swift
+++ b/apps/ios/Zeron/Composer/MentionLink.swift
@@ -1,0 +1,173 @@
+// The mention wire format, ported from crates/ui/src/composer.rs:670-795.
+// A private URI scheme keeps file mentions distinguishable from ordinary
+// Markdown links pasted into the composer.
+//
+// This must agree with the Rust byte for byte. The desktop parser rejects a
+// link whose label is not the path's basename, whose path is unsafe, or whose
+// encoding does not round-trip — and it parses the WHOLE draft, so a stray
+// bracket elsewhere can invalidate an otherwise perfect link. ComposerText
+// relies on `parse` to notice exactly that.
+//
+// Offsets count Characters, matching ComposerTrigger.
+
+import Foundation
+
+struct ParsedMention: Equatable {
+    let range: Range<Int>
+    let basename: String
+    let path: String
+    let isDir: Bool
+}
+
+enum MentionLink {
+
+    static let scheme = "zeron-file:"
+
+    // MARK: Encoding
+
+    static func percentEncode(_ path: String) -> String {
+        var out = ""
+        for byte in Array(path.utf8) {
+            let unreserved = (byte >= 0x30 && byte <= 0x39)   // 0-9
+                || (byte >= 0x41 && byte <= 0x5A)             // A-Z
+                || (byte >= 0x61 && byte <= 0x7A)             // a-z
+                || byte == 0x2D || byte == 0x2E               // - .
+                || byte == 0x5F || byte == 0x7E               // _ ~
+                || byte == 0x2F                               // /
+            if unreserved {
+                out.append(Character(UnicodeScalar(byte)))
+            } else {
+                out.append("%")
+                out += String(format: "%02X", byte)
+            }
+        }
+        return out
+    }
+
+    static func percentDecode(_ encoded: String) -> String? {
+        var bytes: [UInt8] = []
+        let raw = Array(encoded.utf8)
+        var at = 0
+        while at < raw.count {
+            if raw[at] == UInt8(ascii: "%") {
+                guard at + 2 < raw.count,
+                      let hex = String(bytes: raw[(at + 1)...(at + 2)], encoding: .utf8),
+                      hex.allSatisfy(\.isHexDigit),
+                      let byte = UInt8(hex, radix: 16)
+                else { return nil }
+                bytes.append(byte)
+                at += 3
+            } else {
+                bytes.append(raw[at])
+                at += 1
+            }
+        }
+        return String(bytes: bytes, encoding: .utf8)
+    }
+
+    // MARK: Labels and safety
+
+    static func escapeLabel(_ label: String) -> String {
+        label
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "[", with: "\\[")
+            .replacingOccurrences(of: "]", with: "\\]")
+    }
+
+    static func isSafe(_ path: String) -> Bool {
+        guard !path.isEmpty,
+              !path.hasPrefix("/"),
+              !path.contains("\\"),
+              !path.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) })
+        else { return false }
+        for part in path.split(separator: "/", omittingEmptySubsequences: false)
+        where part.isEmpty || part == "." || part == ".." {
+            return false
+        }
+        return true
+    }
+
+    static func basename(of path: String) -> String {
+        let trimmed = trimTrailingSlashes(path)
+        guard let last = trimmed.split(separator: "/").last else { return trimmed }
+        return String(last)
+    }
+
+    // MARK: Serialize
+
+    static func serialize(path rawPath: String, isDir: Bool) -> String {
+        let path = trimTrailingSlashes(rawPath)
+        let target = path + (isDir ? "/" : "")
+        return "[\(escapeLabel(basename(of: path)))](\(scheme)\(percentEncode(target)))"
+    }
+
+    // MARK: Parse
+
+    static func parse(_ text: String) -> [ParsedMention] {
+        let chars = Array(text)
+        var links: [ParsedMention] = []
+        var search = 0
+
+        while search < chars.count {
+            guard let start = chars[search...].firstIndex(of: "[") else { break }
+            guard let labelEnd = labelClose(chars, from: start + 1) else {
+                search = start + 1
+                continue
+            }
+            let targetStart = labelEnd + 2
+            guard targetStart <= chars.count,
+                  let closeIndex = chars[targetStart...].firstIndex(of: ")") else {
+                search = start + 1
+                continue
+            }
+            let end = closeIndex + 1
+            let label = String(chars[(start + 1)..<labelEnd])
+            let target = String(chars[targetStart..<(end - 1)])
+
+            guard target.hasPrefix(scheme) else {
+                search = end
+                continue
+            }
+            let encoded = String(target.dropFirst(scheme.count))
+
+            if let decoded = percentDecode(encoded) {
+                let isDir = decoded.hasSuffix("/")
+                let path = isDir ? String(decoded.dropLast()) : decoded
+                let name = basename(of: path)
+                if isSafe(path),
+                   percentEncode(decoded) == encoded,
+                   escapeLabel(name) == label {
+                    links.append(ParsedMention(range: start..<end, basename: name,
+                                               path: path, isDir: isDir))
+                }
+            }
+            search = end
+        }
+        return links
+    }
+
+    // MARK: Helpers
+
+    /// The first unescaped `]` that is followed by `(`.
+    private static func labelClose(_ chars: [Character], from start: Int) -> Int? {
+        var escaped = false
+        var at = start
+        while at < chars.count {
+            if escaped {
+                escaped = false
+            } else if chars[at] == "\\" {
+                escaped = true
+            } else if chars[at] == "]", at + 1 < chars.count, chars[at + 1] == "(" {
+                return at
+            }
+            at += 1
+        }
+        return nil
+    }
+
+    private static func trimTrailingSlashes(_ path: String) -> String {
+        var out = path
+        while out.hasSuffix("/") { out.removeLast() }
+        return out
+    }
+}

--- a/apps/ios/Zeron/Markdown/MarkdownBlockView.swift
+++ b/apps/ios/Zeron/Markdown/MarkdownBlockView.swift
@@ -56,7 +56,13 @@ extension [InlineRun] {
             if let link = run.style.link {
                 // Monochrome links: primary text + muted hairline underline,
                 // never accent (desktop render.rs:536).
-                piece.link = URL(string: link)
+                // A zeron-file: mention is styled like a link but carries no
+                // destination: the scheme is private to the UI, and openURL
+                // has no handler for it. Desktop renders these as chips
+                // (transcript.rs:671); that is a follow-up here.
+                if !link.hasPrefix(MentionLink.scheme) {
+                    piece.link = URL(string: link)
+                }
                 piece.foregroundColor = baseColor
                 piece.underlineStyle = Text.LineStyle(pattern: .solid, color: Theme.textMuted)
             }

--- a/apps/ios/Zeron/Models/Entities.swift
+++ b/apps/ios/Zeron/Models/Entities.swift
@@ -325,3 +325,26 @@ enum SessionCommandPayload {
 func nowMs() -> Int64 {
     Int64(Date().timeIntervalSince1970 * 1000)
 }
+
+// MARK: - Composer autocomplete
+
+/// One entry from `ListCommands`. Mirrors `SlashCommand`
+/// (crates/proto/src/agent.rs:195). `description` is `#[serde(default)]` on the
+/// Rust side and always serialized; `inputHint` is skipped when absent.
+struct SlashCommand: Decodable, Identifiable, Hashable {
+    let name: String
+    let description: String
+    let inputHint: String?
+
+    var id: String { name }
+}
+
+/// One entry from `SearchFiles`. Mirrors `FileSearchMatch`
+/// (crates/proto/src/entities.rs:299). Paths are relative to the search root
+/// and already ranked and capped by the host (crates/engine/src/repos.rs:1082).
+struct FileSearchMatch: Decodable, Identifiable, Hashable {
+    let path: String
+    let isDir: Bool
+
+    var id: String { path }
+}

--- a/apps/ios/Zeron/Sync/DeviceRelayClient.swift
+++ b/apps/ios/Zeron/Sync/DeviceRelayClient.swift
@@ -154,6 +154,21 @@ final class DeviceRpcPending {
     }
 }
 
+extension RelayError {
+    /// True when the host answered "no such method". The relay flattens the
+    /// typed Rust error into a plain string (see `handleRpcPayload`), so this
+    /// is the only signal on the wire. Matched exactly, not by prefix, the same
+    /// way the desktop does it (crates/ui/src/state.rs).
+    ///
+    /// A helper rather than a `RelayError` case because the pending table holds
+    /// only continuations and does not know which method a reply belongs to.
+    /// The caller does.
+    func isUnknownMethod(_ method: String) -> Bool {
+        guard case .rpc(let message) = self else { return false }
+        return message == "unknown method: \(method)"
+    }
+}
+
 actor DeviceRelayClient {
     static let rpcKind = "rpc"
     static let relayKind = " relay"  // leading space is intentional

--- a/apps/ios/Zeron/Sync/WorkspaceStore.swift
+++ b/apps/ios/Zeron/Sync/WorkspaceStore.swift
@@ -524,6 +524,38 @@ final class WorkspaceStore {
         }
     }
 
+    /// Slash commands for one harness in one workspace. `cwd` is a path on the
+    /// HOST device and travels unexpanded — the host expands `~`
+    /// (crates/engine/src/commands.rs:109-117). Absent means the host's home,
+    /// which is what an engine older than that field always answered.
+    func listCommands(deviceId: String, harness: String,
+                      cwd: String?) async throws -> [SlashCommand] {
+        var params: [String: Any] = ["harness": harness]
+        if let cwd, !cwd.isEmpty { params["cwd"] = cwd }
+        return try await relay(for: deviceId).call(method: "ListCommands", params: params)
+    }
+
+    /// Fuzzy file search inside a chat's checkout or a space. The engine needs
+    /// exactly one of `chatId` or `spaceId` (crates/engine/src/rpc.rs:484-493)
+    /// and rejects a query longer than 256 characters (rpc.rs:1551). A `chatId`
+    /// search only works on the device that owns the chat (rpc.rs:501-502), so
+    /// dial the chat's host.
+    func searchFiles(deviceId: String, chatId: String?, spaceId: String?,
+                     query: String) async throws -> [FileSearchMatch] {
+        // Truncate on UNICODE SCALARS, not Characters. The engine's cap is
+        // `p.query.chars().count() > 256` (crates/engine/src/rpc.rs:1551), and a
+        // Rust `char` is a scalar value, while Swift's `prefix` counts extended
+        // grapheme clusters. One flag emoji is 1 Character but 2 scalars, so a
+        // Character-based truncation is a no-op on input the engine then
+        // rejects with BadParams.
+        var params: [String: Any] = [
+            "query": String(String.UnicodeScalarView(query.unicodeScalars.prefix(256)))
+        ]
+        if let chatId { params["chatId"] = chatId }
+        if let spaceId { params["spaceId"] = spaceId }
+        return try await relay(for: deviceId).call(method: "SearchFiles", params: params)
+    }
+
     /// SwitchRef — `git checkout` in the given folder on the target device.
     /// Returns git's error message on failure (dirty tree, held ref, …).
     func switchRef(deviceId: String, repoPath: String, refName: String) async -> String? {

--- a/apps/ios/Zeron/Views/NewSessionView.swift
+++ b/apps/ios/Zeron/Views/NewSessionView.swift
@@ -18,7 +18,8 @@ struct NewSessionView: View {
     @AppStorage("newSessionModel") private var storedModel = ""
     @AppStorage("newSessionReasoning") private var storedReasoning = ""
 
-    @State private var draft = ""
+    @State private var draft = ComposerText()
+    @State private var selection = AttributedTextSelection()
     @State private var showPicker = false
     @State private var showTraitPicker = false
     @State private var showRefPicker = false
@@ -197,7 +198,7 @@ struct NewSessionView: View {
             focused = true
             if model.launchAutosend {
                 model.launchAutosend = false
-                draft = "Sketch the plan for porting the diff pane."
+                draft = ComposerText("Sketch the plan for porting the diff pane.")
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 800_000_000)
                     send()
@@ -220,6 +221,7 @@ struct NewSessionView: View {
             }
             ComposerShell(
                 draft: $draft,
+                selection: $selection,
                 placeholder: "Do anything…",
                 sendEnabled: space != nil,
                 showStop: false,
@@ -344,7 +346,7 @@ struct NewSessionView: View {
 
     private var canSend: Bool {
         guard !busy, space != nil else { return false }
-        return !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return !draft.plainText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             || !attachments.isEmpty
     }
 
@@ -365,7 +367,7 @@ struct NewSessionView: View {
     /// picked ref's worktree, or CreateWorktree off the base first).
     private func send() {
         guard let space, canSend else { return }
-        let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prompt = draft.markdown().trimmingCharacters(in: .whitespacesAndNewlines)
         busy = true
         let config = ChatConfig(harness: harness, model: selectedModel.id,
                                 reasoning: reasoning, sandbox: "workspace-write")
@@ -412,7 +414,7 @@ struct NewSessionView: View {
             store.sendRun(prompt: paths.isEmpty ? prompt : withAttachments(text: prompt, paths: paths),
                           chat: chat, attachments: paths)
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            draft = ""
+            draft.clear(selection: &selection)
             attachments = []
             busy = false
             // Replace the canvas with the live session (in-place swap, no

--- a/apps/ios/Zeron/Views/NewSessionView.swift
+++ b/apps/ios/Zeron/Views/NewSessionView.swift
@@ -20,6 +20,7 @@ struct NewSessionView: View {
 
     @State private var draft = ComposerText()
     @State private var selection = AttributedTextSelection()
+    @State private var suggestions = ComposerSuggestions()
     @State private var showPicker = false
     @State private var showTraitPicker = false
     @State private var showRefPicker = false
@@ -37,7 +38,13 @@ struct NewSessionView: View {
     @State private var selectedRef: String?
     @State private var checkoutKind: CheckoutKind = .local
     @State private var busy = false
-    @FocusState private var focused: Bool
+    /// Mirrors ComposerShell's own focus, reported out through
+    /// `onFocusChange`. Gates the popover for the same reason it does in a live
+    /// chat (ComposerView.swift): a tap on the canvas resigns focus without
+    /// changing the draft, so the trigger alone would hold the popover open
+    /// over a dismissed keyboard.
+    @State private var composerFocused = false
+    @State private var refreshTask: Task<Void, Never>?
     /// Basis for the leading header's fixed width (SessionView's pattern —
     /// iOS 26 proposes leading toolbar items almost nothing).
     @State private var viewWidth: CGFloat = 0
@@ -67,19 +74,34 @@ struct NewSessionView: View {
     var body: some View {
         VStack(spacing: 0) {
             // Canvas — tap dismisses the keyboard, like the old app.
+            //
+            // The mark and the line under it are decoration, and they hold a
+            // ~126pt floor under this row. The suggestion popover is the one
+            // thing on this page tall enough to need that floor back, so it
+            // takes it: with the keyboard up there is not enough room for both
+            // on a small device, and the loser of that fight was the whole
+            // column (the canvas overflowed over the navigation bar and the
+            // pill's chip row went under the keyboard). Empty, the row is a
+            // plain colour and compresses to nothing.
             ZStack {
                 Theme.bg
-                VStack(spacing: 24) {
-                    ZeronMark()
-                        .frame(width: 84, height: 84)
-                        .opacity(0.22)
-                    Text("What are we building?")
-                        .font(Theme.sans(15))
-                        .foregroundStyle(Theme.textFaint)
+                if !suggestionsOpen {
+                    VStack(spacing: 24) {
+                        ZeronMark()
+                            .frame(width: 84, height: 84)
+                            .opacity(0.22)
+                        Text("What are we building?")
+                            .font(Theme.sans(15))
+                            .foregroundStyle(Theme.textFaint)
+                    }
                 }
             }
+            // Belt and braces for the frame the decoration is mid-fade on: a
+            // ZStack centres its content and lets it spill both ways, and this
+            // row's neighbour is the navigation bar.
+            .clipped()
             .contentShape(Rectangle())
-            .onTapGesture { focused = false }
+            .onTapGesture { dismissKeyboard() }
 
             if let space, !model.deviceOnline(space.deviceId), model.demo == nil {
                 offlineNotice(space: space)
@@ -91,11 +113,11 @@ struct NewSessionView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 8) {
                         chip(icon: checkoutIcon, label: checkoutLabel) {
-                            focused = false
+                            dismissKeyboard()
                             showCheckoutPicker = true
                         }
                         chip(icon: .gitBranch, label: refLabel) {
-                            focused = false
+                            dismissKeyboard()
                             showRefPicker = true
                         }
                     }
@@ -106,6 +128,17 @@ struct NewSessionView: View {
 
             composer
                 .padding(.bottom, 8)
+                // The composer is served its ideal height BEFORE the canvas
+                // above it. Both rows are flexible — the canvas is a bare
+                // colour, and the popover's list is a scroll view that will
+                // take any height up to its cap — and a VStack splits the free
+                // space between flexible children rather than filling one
+                // first. With the keyboard up that split starved the popover
+                // to a single clipped row while the canvas above it sat empty
+                // (user report). Priority reverses the order: the popover
+                // takes what it wants, the canvas keeps the rest, and the
+                // popover only compresses once the canvas has nothing left.
+                .layoutPriority(1)
         }
         .background(Theme.bg.ignoresSafeArea())
         .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { viewWidth = $0 }
@@ -194,8 +227,27 @@ struct NewSessionView: View {
             guard !items.isEmpty else { return }
             stage(items)
         }
+        .task {
+            // Wire the fetchers FIRST, before any await. The default no-op
+            // fetcher returns [], and ComposerSuggestions caches that empty
+            // list under the real key for the life of the view — every later
+            // `/` would then silently show nothing (ComposerView.swift).
+            //
+            suggestions.fetchCommands = { [weak model] harness, device, cwd in
+                guard let model else { return [] }
+                return try await model.listCommands(deviceId: device, harness: harness, cwd: cwd)
+            }
+            suggestions.fetchPaths = { [weak model] context, query in
+                guard let model else { return [] }
+                return try await model.searchFiles(deviceId: context.deviceId,
+                                                   chatId: context.chatId,
+                                                   spaceId: context.spaceId,
+                                                   query: query)
+            }
+        }
+        .onChange(of: draft) { _, _ in scheduleRefresh() }
+        .onChange(of: selection) { _, _ in scheduleRefresh() }
         .onAppear {
-            focused = true
             if model.launchAutosend {
                 model.launchAutosend = false
                 draft = ComposerText("Sketch the plan for porting the diff pane.")
@@ -219,6 +271,19 @@ struct NewSessionView: View {
                     .padding(.horizontal, 24)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+            // A SIBLING above the pill, not a ZStack over it, and gated on
+            // trigger-plus-focus only — same shape and same reasons as the live
+            // chat's popover (ComposerView.swift).
+            if let trigger = draft.trigger(at: selection), suggestionsOpen {
+                ComposerPopover(items: suggestions.items,
+                                kind: trigger.kind,
+                                isLoading: suggestions.isLoading,
+                                errorText: suggestions.errorText) { item in
+                    pick(item, over: trigger.range)
+                }
+                .padding(.horizontal, 10)
+                .transition(.opacity)
+            }
             ComposerShell(
                 draft: $draft,
                 selection: $selection,
@@ -230,21 +295,98 @@ struct NewSessionView: View {
                 onSend: send,
                 attachments: attachments,
                 onAttach: { showPhotoPicker = true },
-                onRemoveAttachment: { id in attachments.removeAll { $0.id == id } }
+                onRemoveAttachment: { id in attachments.removeAll { $0.id == id } },
+                onFocusChange: { composerFocused = $0 }
             ) {
                 // Model + trait chips, split like the desktop's footer pickers
                 // (they ride right of the shell's attach button).
                 ComposerChip(label: selectedModel.label, badgeHarness: harness) {
-                    focused = false
+                    dismissKeyboard()
                     showPicker = true
                 }
                 if let reasoning {
                     ComposerChip(label: HarnessCatalog.reasoningLabel(reasoning)) {
-                        focused = false
+                        dismissKeyboard()
                         showTraitPicker = true
                     }
                 }
             }
+        }
+    }
+
+    /// Resign the editor's first responder from outside it. ComposerShell owns
+    /// its own `@FocusState` and exposes no binding for it, so a local
+    /// `@FocusState` here was never attached to anything: the canvas tap and
+    /// the picker chips both set it and neither ever put the keyboard down.
+    /// Going through the responder chain does, and ComposerShell reports the
+    /// resulting blur back through `onFocusChange`, which also closes the
+    /// suggestion popover — the same gesture the desktop closes it on.
+    private func dismissKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                        to: nil, from: nil, for: nil)
+    }
+
+    // MARK: Suggestions
+
+    /// Popover visibility: an open trigger AND focus, the live chat's gate. Two
+    /// rows read it — the popover itself, and the canvas that gives up its
+    /// space for it — so they can never disagree about whether it is up.
+    private var suggestionsOpen: Bool {
+        draft.trigger(at: selection) != nil && composerFocused
+    }
+
+    /// Everything the fetchers need, for a draft that has no chat yet. The
+    /// space fixes both the device and the folder, and the file search goes out
+    /// as a `spaceId` search: the engine needs exactly one of `chatId` or
+    /// `spaceId` (crates/engine/src/rpc.rs), and there is no chat to name.
+    ///
+    /// `harness` is read here, not captured, so flipping the agent chip
+    /// mid-draft re-keys the command cache and fetches the new agent's list.
+    private var suggestionContext: SuggestionContext {
+        SuggestionContext(harness: harness,
+                          deviceId: space?.deviceId ?? "",
+                          cwd: slashCwd(chatCwd: nil, spacePath: space?.path),
+                          chatId: nil,
+                          spaceId: space?.id)
+    }
+
+    private func pick(_ item: SuggestionItem, over range: Range<Int>) {
+        switch item.payload {
+        case .command(let name):
+            draft.apply(command: name, over: range, selection: &selection)
+        case .path(let path, let isDir):
+            draft.apply(path: path, isDir: isDir, over: range, selection: &selection)
+        }
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    private func refreshSuggestions() async {
+        // No space means no device and no folder to ask. Reset rather than
+        // return: `scheduleRefresh` has already marked the fetch pending, and
+        // nothing else would ever clear that spinner.
+        guard space != nil, let trigger = draft.trigger(at: selection) else {
+            suggestions.reset()
+            return
+        }
+        await suggestions.update(trigger: trigger, context: suggestionContext)
+    }
+
+    /// Debounce and cancel — ComposerView.scheduleRefresh's twin, and for the
+    /// same reasons: one keystroke changes BOTH `draft` and `selection`, and
+    /// the trigger check has to run synchronously on this keystroke so a closed
+    /// trigger drops its stale rows and an open one shows its pending state
+    /// through the debounce window.
+    private func scheduleRefresh() {
+        refreshTask?.cancel()
+        guard draft.trigger(at: selection) != nil else {
+            suggestions.reset()
+            return
+        }
+        suggestions.beginPending()
+        refreshTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(80))
+            guard !Task.isCancelled else { return }
+            await refreshSuggestions()
         }
     }
 

--- a/apps/ios/ZeronTests/ComposerSuggestionsTests.swift
+++ b/apps/ios/ZeronTests/ComposerSuggestionsTests.swift
@@ -4,6 +4,7 @@
 // caret moves inside one token (composer.rs:3301-3304), and error text that is
 // never rendered as "no results" (composer.rs:3296-3300).
 
+import SwiftUI
 import XCTest
 @testable import Zeron
 
@@ -164,5 +165,29 @@ final class ComposerSuggestionsTests: XCTestCase {
                       "the B request must genuinely be in flight when A re-enters")
         XCTAssertFalse(store.isLoading,
                        "a superseded cache hit must not strand the spinner on")
+    }
+
+    // MARK: cwd
+
+    /// The rule both composers key their command list on, mirroring the
+    /// desktop's `slash_cwd`. The blank cases are the ones that bite: a blank
+    /// `cwd` is dropped from the RPC params, so the host answers for its home
+    /// instead of the space's folder.
+    func testSlashCwdPrefersTheChatThenTheSpaceThenHome() {
+        XCTAssertEqual(slashCwd(chatCwd: "~/chat", spacePath: "~/space"), "~/chat")
+        XCTAssertEqual(slashCwd(chatCwd: nil, spacePath: "~/space"), "~/space")
+        XCTAssertEqual(slashCwd(chatCwd: nil, spacePath: nil), "~")
+        XCTAssertEqual(slashCwd(chatCwd: "  ", spacePath: "~/space"), "~/space")
+        XCTAssertEqual(slashCwd(chatCwd: "", spacePath: ""), "~")
+    }
+
+    /// The new-session composer sends `draft.markdown()`, not the plain text a
+    /// live chat sends, so a picked command has to survive that serialization.
+    func testPickedCommandSurvivesTheNewSessionSerialization() {
+        var draft = ComposerText()
+        var selection = AttributedTextSelection()
+        draft.replaceForTesting(0..<0, with: "/pl")
+        draft.apply(command: "plan", over: 0..<3, selection: &selection)
+        XCTAssertEqual(draft.markdown(), "/plan ")
     }
 }

--- a/apps/ios/ZeronTests/ComposerSuggestionsTests.swift
+++ b/apps/ios/ZeronTests/ComposerSuggestionsTests.swift
@@ -1,0 +1,168 @@
+// The suggestion store. Both fetchers are injected closures so these run with
+// no socket. The rules pinned here mirror the desktop composer: a cache key
+// that includes the device (composer.rs:3236-3241), a dismissal that survives
+// caret moves inside one token (composer.rs:3301-3304), and error text that is
+// never rendered as "no results" (composer.rs:3296-3300).
+
+import XCTest
+@testable import Zeron
+
+@MainActor
+final class ComposerSuggestionsTests: XCTestCase {
+
+    private let context = SuggestionContext(harness: "claude-code", deviceId: "dev-a",
+                                            cwd: "~/proj", chatId: "chat-1", spaceId: nil)
+
+    private func command(_ name: String) -> SlashCommand {
+        SlashCommand(name: name, description: "does \(name)", inputHint: nil)
+    }
+
+    func testCommandsAreFetchedOnceAndServedFromCache() async {
+        var calls = 0
+        let store = ComposerSuggestions()
+        store.fetchCommands = { _, _, _ in
+            calls += 1
+            return [self.command("tdd"), self.command("plan")]
+        }
+
+        await store.update(trigger: Trigger(kind: .command, query: "", token: "/", range: 0..<1),
+                           context: context)
+        XCTAssertEqual(store.items.map(\.label), ["/tdd", "/plan"])
+
+        await store.update(trigger: Trigger(kind: .command, query: "t", token: "/t", range: 0..<2),
+                           context: context)
+        XCTAssertEqual(store.items.map(\.label), ["/tdd"])
+        XCTAssertEqual(calls, 1, "a cached list must not re-fetch on every keystroke")
+    }
+
+    func testCommandCacheKeyIncludesTheDevice() async {
+        var seen: [String] = []
+        let store = ComposerSuggestions()
+        store.fetchCommands = { _, device, _ in
+            seen.append(device)
+            return [self.command("tdd")]
+        }
+        let trigger = Trigger(kind: .command, query: "", token: "/", range: 0..<1)
+
+        await store.update(trigger: trigger, context: context)
+        var other = context
+        other.deviceId = "dev-b"
+        await store.update(trigger: trigger, context: other)
+
+        XCTAssertEqual(seen, ["dev-a", "dev-b"],
+                       "two devices share the path ~ for every project-less chat")
+    }
+
+    func testCommandFilterMatchesNameBeforeDescription() async {
+        let store = ComposerSuggestions()
+        store.fetchCommands = { _, _, _ in
+            [SlashCommand(name: "plan", description: "no match", inputHint: nil),
+             SlashCommand(name: "zzz", description: "make a plan", inputHint: nil)]
+        }
+        await store.update(trigger: Trigger(kind: .command, query: "plan", token: "/plan", range: 0..<5),
+                           context: context)
+        XCTAssertEqual(store.items.map(\.label), ["/plan", "/zzz"])
+    }
+
+    func testPathResultsKeepHostOrder() async {
+        let store = ComposerSuggestions()
+        store.fetchPaths = { _, _ in
+            [FileSearchMatch(path: "z.rs", isDir: false),
+             FileSearchMatch(path: "a.rs", isDir: false)]
+        }
+        await store.update(trigger: Trigger(kind: .path, query: "rs", token: "@rs", range: 0..<3),
+                           context: context)
+        XCTAssertEqual(store.items.map(\.label), ["z.rs", "a.rs"],
+                       "the host already ranked these; do not re-sort")
+    }
+
+    func testAFailureShowsAnErrorNotAnEmptyList() async {
+        let store = ComposerSuggestions()
+        store.fetchPaths = { _, _ in throw RelayError.hostOffline }
+        await store.update(trigger: Trigger(kind: .path, query: "a", token: "@a", range: 0..<2),
+                           context: context)
+        XCTAssertTrue(store.items.isEmpty)
+        XCTAssertEqual(store.errorText, "The session's device is unreachable")
+    }
+
+    func testVersionSkewGetsItsOwnMessage() async {
+        let store = ComposerSuggestions()
+        store.fetchPaths = { _, _ in throw RelayError.rpc("unknown method: SearchFiles") }
+        await store.update(trigger: Trigger(kind: .path, query: "a", token: "@a", range: 0..<2),
+                           context: context)
+        XCTAssertEqual(store.errorText,
+                       "The session's device runs an older zeron — update it to search its files")
+    }
+
+    func testDismissSurvivesACaretMoveInsideTheSameToken() async {
+        let store = ComposerSuggestions()
+        store.fetchCommands = { _, _, _ in [self.command("tdd")] }
+        let trigger = Trigger(kind: .command, query: "td", token: "/td", range: 0..<3)
+
+        await store.update(trigger: trigger, context: context)
+        store.dismiss(trigger)
+
+        // Same token, caret moved back one: still dismissed. `query` changed
+        // and `token` did not, which is exactly why the key is `token`.
+        await store.update(trigger: Trigger(kind: .command, query: "t", token: "/td", range: 0..<3),
+                           context: context)
+        XCTAssertTrue(store.items.isEmpty)
+
+        // A same-LENGTH edit: the span is unchanged but the token is not, so
+        // this reopens. A range-only key would wrongly stay closed here. The
+        // query still matches the fixture, so an empty list would mean the
+        // dismissal held — not that the filter came up dry.
+        await store.update(trigger: Trigger(kind: .command, query: "Td", token: "/Td", range: 0..<3),
+                           context: context)
+        XCTAssertEqual(store.items.map(\.label), ["/tdd"])
+        store.dismiss(Trigger(kind: .command, query: "Td", token: "/Td", range: 0..<3))
+
+        // The token grew: an edit reopens it.
+        await store.update(trigger: Trigger(kind: .command, query: "tdd", token: "/tdd", range: 0..<4),
+                           context: context)
+        XCTAssertEqual(store.items.map(\.label), ["/tdd"])
+    }
+
+    // Regression: a cache hit that ends its request synchronously must clear
+    // isLoading itself. If it does not, this interleaving strands the spinner
+    // on forever: an in-flight miss (request B) sets isLoading = true and
+    // suspends; before it resolves, a cache hit for an already-primed key
+    // (request A) supersedes it and returns without ever awaiting; B then
+    // resolves, loses its generation check against A, and correctly bails out
+    // WITHOUT touching isLoading — so nothing is left to clear it unless A's
+    // cache-hit branch owned that job itself.
+    //
+    // The interleaving is driven directly, not with a sleep or a yield: A is
+    // re-entrantly called from inside B's own fetcher closure, while B is
+    // genuinely suspended on that same await.
+    func testSupersededCacheHitClearsTheSpinner() async {
+        let store = ComposerSuggestions()
+        var reentrantSawLoading = false
+
+        // Prime the cache for context A so a later hit on it resolves
+        // synchronously, without ever awaiting.
+        store.fetchCommands = { _, _, _ in [self.command("tdd")] }
+        let triggerA = Trigger(kind: .command, query: "", token: "/", range: 0..<1)
+        await store.update(trigger: triggerA, context: context)
+
+        var contextB = context
+        contextB.cwd = "~/other"
+        let triggerB = Trigger(kind: .command, query: "", token: "/", range: 0..<1)
+
+        // The B fetch is a cache miss: it sets isLoading = true, then suspends
+        // here, in flight. From inside that suspension, re-enter update() for
+        // the already-cached A key.
+        store.fetchCommands = { _, _, _ in
+            reentrantSawLoading = store.isLoading
+            await store.update(trigger: triggerA, context: self.context)
+            return [self.command("tdd")]
+        }
+
+        await store.update(trigger: triggerB, context: contextB)
+
+        XCTAssertTrue(reentrantSawLoading,
+                      "the B request must genuinely be in flight when A re-enters")
+        XCTAssertFalse(store.isLoading,
+                       "a superseded cache hit must not strand the spinner on")
+    }
+}

--- a/apps/ios/ZeronTests/ComposerTextTests.swift
+++ b/apps/ios/ZeronTests/ComposerTextTests.swift
@@ -1,0 +1,220 @@
+// The rich-text composer model. These tests pin the two-clause invariant:
+// a run keeps its mention attribute only if (1) its visible text is exactly
+// "@basename" and (2) the serialized draft re-parses to that mention at that
+// position. Neither clause implies the other — see the spec's "round-trip
+// invariant" section.
+
+import XCTest
+// AttributedTextSelection is a SwiftUI type, and `@testable import` does not
+// re-export the module's own imports. Without this the test file will not
+// compile.
+import SwiftUI
+@testable import Zeron
+
+final class ComposerTextTests: XCTestCase {
+
+    /// A draft reading "see @a.rs " with the chip attributed.
+    private func draftWithChip(prefix: String = "see ",
+                               path: String = "a.rs",
+                               isDir: Bool = false) -> ComposerText {
+        var text = ComposerText(prefix)
+        var selection = AttributedTextSelection(insertionPoint: text.attributed.endIndex)
+        let end = text.plainText.count
+        text.apply(path: path, isDir: isDir, over: end..<end, selection: &selection)
+        return text
+    }
+
+    // MARK: Serialization
+
+    func testIntactChipSerializesToTheCanonicalLink() {
+        let text = draftWithChip()
+        XCTAssertEqual(text.markdown(), "see [a.rs](zeron-file:a.rs) ")
+    }
+
+    func testPlainTextShowsTheChipAsAtBasename() {
+        XCTAssertEqual(draftWithChip().plainText, "see @a.rs ")
+    }
+
+    func testDirectoryPickSerializesWithTrailingSlash() {
+        let text = draftWithChip(prefix: "", path: "src/one", isDir: true)
+        XCTAssertEqual(text.markdown(), "[one](zeron-file:src/one/) ")
+    }
+
+    func testDraftWithNoChipsSerializesUnchanged() {
+        XCTAssertEqual(ComposerText("plain words").markdown(), "plain words")
+    }
+
+    // MARK: Clause 1 — visible text
+
+    func testTypingInsideAChipDropsTheAttribute() {
+        var text = draftWithChip()          // "see @a.rs "
+        text.replaceForTesting(6..<6, with: "X")   // "see @aX.rs "
+        XCTAssertEqual(text.markdown(), "see @aX.rs ")
+    }
+
+    func testBackspaceAtTheChipEdgeDropsTheAttribute() {
+        var text = draftWithChip()          // "see @a.rs "
+        text.replaceForTesting(8..<9, with: "")   // "see @a.r "
+        XCTAssertEqual(text.markdown(), "see @a.r ")
+    }
+
+    func testDeletingTheSpaceBetweenTwoSameFileChipsDropsBoth() {
+        var text = draftWithChip(prefix: "")            // "@a.rs "
+        var selection = AttributedTextSelection(insertionPoint: text.attributed.endIndex)
+        let end = text.plainText.count
+        text.apply(path: "a.rs", isDir: false, over: end..<end, selection: &selection)
+        XCTAssertEqual(text.plainText, "@a.rs @a.rs ")
+        text.replaceForTesting(5..<6, with: "")         // "@a.rs@a.rs "
+        XCTAssertEqual(text.markdown(), "@a.rs@a.rs ")
+    }
+
+    func testAnUntouchedChipSurvivesAnEditElsewhere() {
+        var text = draftWithChip()
+        text.replaceForTesting(0..<0, with: "hey ")
+        XCTAssertEqual(text.markdown(), "hey see [a.rs](zeron-file:a.rs) ")
+    }
+
+    func testTextTypedAfterAChipDoesNotInheritTheAttribute() {
+        var text = draftWithChip()               // "see @a.rs "
+        text.replaceForTesting(9..<9, with: "Z") // "see @a.rsZ "
+        // `inheritedByAddedText = false` means "Z" lands OUTSIDE the run, so
+        // the chip still reads exactly "@a.rs" and both clauses hold. The chip
+        // survives and "Z" is plain text beside it. If this ever asserts the
+        // chip was dropped, the attribute is bleeding into typed text.
+        XCTAssertEqual(text.markdown(), "see [a.rs](zeron-file:a.rs)Z ")
+        XCTAssertEqual(text.plainText, "see @a.rsZ ")
+    }
+
+    // MARK: Clause 2 — round trip
+
+    /// THE REVIEW'S FAILURE CASE.
+    func testStrayOpenBracketBeforeAChipDropsThatChip() {
+        var text = draftWithChip(prefix: "see ")   // "see @a.rs "
+        text.replaceForTesting(4..<4, with: "[ notes ")  // "see [ notes @a.rs "
+        XCTAssertEqual(text.markdown(), "see [ notes @a.rs ")
+    }
+
+    func testAnUnsafePathNeverGetsAnAttribute() {
+        var text = ComposerText("")
+        var selection = AttributedTextSelection(insertionPoint: text.attributed.startIndex)
+        text.apply(path: "../secret", isDir: false, over: 0..<0, selection: &selection)
+        XCTAssertEqual(text.markdown(), "@secret ")
+    }
+
+    // MARK: Run splitting
+
+    func testAnUnrelatedAttributeSplittingAChipDoesNotDuplicateItsLink() {
+        var text = draftWithChip()          // "see @a.rs "
+        // Colour two characters in the middle of the chip. Foundation's plain
+        // `runs` view splits at that boundary; the mention-keyed view must not.
+        // Iterating the plain view emits the link once PER FRAGMENT, and clause 1
+        // then fails on every fragment and kills a visually intact chip.
+        let start = text.attributed.index(text.attributed.startIndex, offsetByCharacters: 6)
+        let end = text.attributed.index(text.attributed.startIndex, offsetByCharacters: 8)
+        text.attributed[start..<end].foregroundColor = .red
+
+        XCTAssertEqual(text.markdown(), "see [a.rs](zeron-file:a.rs) ",
+                       "a split chip must serialize to ONE link, not one per fragment")
+        text.enforceInvariant()
+        XCTAssertEqual(text.markdown(), "see [a.rs](zeron-file:a.rs) ",
+                       "a visually intact chip must survive an unrelated attribute")
+    }
+
+    // MARK: Trigger veto
+
+    func testCaretInsideAnIntactChipOpensNoTrigger() {
+        let text = draftWithChip()          // "see @a.rs "
+        let index = text.attributed.index(text.attributed.startIndex, offsetByCharacters: 7)
+        XCTAssertNil(text.trigger(at: AttributedTextSelection(insertionPoint: index)))
+    }
+
+    func testCaretAtTheChipTrailingEdgeOpensNoTrigger() {
+        let text = draftWithChip()
+        let index = text.attributed.index(text.attributed.startIndex, offsetByCharacters: 9)
+        XCTAssertNil(text.trigger(at: AttributedTextSelection(insertionPoint: index)))
+    }
+
+    func testAFreshlyTypedAtStillTriggers() {
+        let text = ComposerText("look @Inf")
+        let index = text.attributed.index(text.attributed.startIndex, offsetByCharacters: 9)
+        XCTAssertEqual(text.trigger(at: AttributedTextSelection(insertionPoint: index))?.query, "Inf")
+    }
+
+    // MARK: Index adapter
+
+    func testCaretOffsetCountsCharactersAcrossMultibyteText() {
+        let text = ComposerText("é🙂ab")
+        let index = text.attributed.index(text.attributed.startIndex, offsetByCharacters: 3)
+        XCTAssertEqual(text.caretOffset(AttributedTextSelection(insertionPoint: index)), 3)
+    }
+
+    func testARangeSelectionHasNoCaretAndNoTrigger() {
+        let text = ComposerText("/td")
+        let start = text.attributed.startIndex
+        let end = text.attributed.index(start, offsetByCharacters: 3)
+        let selection = AttributedTextSelection(range: start..<end)
+        XCTAssertNil(text.caretOffset(selection))
+        XCTAssertNil(text.trigger(at: selection))
+    }
+
+    // MARK: Command insertion
+
+    func testCommandPickInsertsPlainTextWithNoAttribute() {
+        var text = ComposerText("/td")
+        var selection = AttributedTextSelection(insertionPoint: text.attributed.endIndex)
+        text.apply(command: "tdd", over: 0..<3, selection: &selection)
+        XCTAssertEqual(text.plainText, "/tdd ")
+        XCTAssertEqual(text.markdown(), "/tdd ")
+    }
+
+    // MARK: Separator suppression (desktop composer.rs:1483-1489)
+
+    /// THE REVIEW'S FAILURE CASE: picking mid-draft used to double the space.
+    func testPathPickDoesNotDoubleAnExistingSeparator() {
+        var text = ComposerText("check @ma out")
+        var selection = AttributedTextSelection(insertionPoint: text.attributed.startIndex)
+        // "@ma" spans offsets 6..<9; a space already sits at offset 9.
+        text.apply(path: "main.rs", isDir: false, over: 6..<9, selection: &selection)
+        XCTAssertEqual(text.plainText, "check @main.rs out")
+    }
+
+    /// A newline right after the token is excluded from the desktop rule, so
+    /// the pick still gets its own trailing space rather than folding onto it.
+    func testPathPickAddsASeparatorBeforeANewline() {
+        var text = ComposerText("check @ma\nout")
+        var selection = AttributedTextSelection(insertionPoint: text.attributed.startIndex)
+        text.apply(path: "main.rs", isDir: false, over: 6..<9, selection: &selection)
+        XCTAssertEqual(text.plainText, "check @main.rs \nout")
+    }
+
+    func testCommandPickDoesNotDoubleAnExistingSeparator() {
+        var text = ComposerText("/td more")
+        var selection = AttributedTextSelection(insertionPoint: text.attributed.startIndex)
+        text.apply(command: "tdd", over: 0..<3, selection: &selection)
+        XCTAssertEqual(text.plainText, "/tdd more")
+    }
+
+    /// A command pick carries no mention attribute, so nothing else stops the
+    /// popover from reopening the instant the caret lands back on the token's
+    /// own trigger boundary. The caret has to clear that boundary — desktop
+    /// does this by landing PAST the separator it declined to duplicate
+    /// (composer.rs:1489's `existing_separator.map(char::len_utf8)`), not just
+    /// before it.
+    func testCommandPickAdvancesTheCaretPastAnExistingSeparatorSoItDoesNotReopen() {
+        var text = ComposerText("/td more")
+        var selection = AttributedTextSelection(insertionPoint: text.attributed.startIndex)
+        text.apply(command: "tdd", over: 0..<3, selection: &selection)
+        XCTAssertNil(text.trigger(at: selection))
+    }
+
+    /// Same rule, for the other case the mention veto does not cover: an
+    /// unsafe path carries no attribute either, so it needs the same caret
+    /// hop as a command pick.
+    func testUnsafePathPickAdvancesTheCaretPastAnExistingSeparatorSoItDoesNotReopen() {
+        var text = ComposerText("open @x more")
+        var selection = AttributedTextSelection(insertionPoint: text.attributed.startIndex)
+        text.apply(path: "../secret", isDir: false, over: 5..<7, selection: &selection)
+        XCTAssertEqual(text.plainText, "open @secret more")
+        XCTAssertNil(text.trigger(at: selection))
+    }
+}

--- a/apps/ios/ZeronTests/ComposerTriggerTests.swift
+++ b/apps/ios/ZeronTests/ComposerTriggerTests.swift
@@ -1,0 +1,92 @@
+// Trigger rules ported from the desktop composer: slash_token
+// (crates/ui/src/composer.rs:3212-3233) and mention_token (3179-3208).
+// Desktop and iOS must agree on what counts as a trigger, or the same draft
+// behaves differently on two clients.
+
+import XCTest
+@testable import Zeron
+
+final class ComposerTriggerTests: XCTestCase {
+
+    // MARK: Command
+
+    func testSlashAtStartTriggers() {
+        let t = ComposerTrigger.detect(text: "/td", caret: 3)
+        XCTAssertEqual(t, Trigger(kind: .command, query: "td", token: "/td", range: 0..<3))
+    }
+
+    func testSlashNotAtStartDoesNotTrigger() {
+        // Slash commands are whole-prompt prefixes: only offset 0 counts.
+        XCTAssertNil(ComposerTrigger.detect(text: "hi /td", caret: 6))
+        XCTAssertNil(ComposerTrigger.detect(text: "hi\n/td", caret: 6))
+    }
+
+    func testCaretPastCommandTokenDoesNotTrigger() {
+        // Typing the argument closes the popup.
+        XCTAssertNil(ComposerTrigger.detect(text: "/goal ship it", caret: 13))
+    }
+
+    func testCaretInsideCommandTokenTriggersWithFullTokenRange() {
+        let t = ComposerTrigger.detect(text: "/goal ship it", caret: 3)
+        XCTAssertEqual(t, Trigger(kind: .command, query: "go", token: "/goal", range: 0..<5))
+    }
+
+    func testCommandQueryWithSlashDoesNotTrigger() {
+        // A typed path must not open the command popup.
+        XCTAssertNil(ComposerTrigger.detect(text: "/src/main", caret: 9))
+    }
+
+    func testCaretAtZeroDoesNotTrigger() {
+        XCTAssertNil(ComposerTrigger.detect(text: "/td", caret: 0))
+    }
+
+    // MARK: Path
+
+    func testAtBeginningTokenTriggers() {
+        let t = ComposerTrigger.detect(text: "look @Inf", caret: 9)
+        XCTAssertEqual(t, Trigger(kind: .path, query: "Inf", token: "@Inf", range: 5..<9))
+    }
+
+    func testEmailDoesNotTrigger() {
+        XCTAssertNil(ComposerTrigger.detect(text: "name@example.com", caret: 16))
+    }
+
+    func testOpenParenBoundaryTriggers() {
+        let t = ComposerTrigger.detect(text: "(@src", caret: 5)
+        XCTAssertEqual(t, Trigger(kind: .path, query: "src", token: "@src", range: 1..<5))
+    }
+
+    func testSecondAtInQueryDoesNotTrigger() {
+        XCTAssertNil(ComposerTrigger.detect(text: "@a@b", caret: 4))
+    }
+
+    func testPathRangeExtendsPastCaretToWhitespace() {
+        // Editing the middle of a mention replaces the whole token.
+        let t = ComposerTrigger.detect(text: "@Info.plist tail", caret: 5)
+        XCTAssertEqual(t, Trigger(kind: .path, query: "Info", token: "@Info.plist", range: 0..<11))
+    }
+
+    func testAtWithNoTriggerReturnsNil() {
+        XCTAssertNil(ComposerTrigger.detect(text: "plain words", caret: 11))
+    }
+
+    // MARK: Replace
+
+    func testReplaceSubstitutesRangeAndMovesCaret() {
+        let result = ComposerTrigger.replace("look @Inf here", range: 5..<9, with: "@Info.plist ")
+        XCTAssertEqual(result.text, "look @Info.plist  here")
+        XCTAssertEqual(result.caret, 17)
+    }
+
+    func testReplaceClampsOutOfRangeBounds() {
+        let result = ComposerTrigger.replace("ab", range: 1..<99, with: "X")
+        XCTAssertEqual(result.text, "aX")
+        XCTAssertEqual(result.caret, 2)
+    }
+
+    func testOffsetsCountCharactersNotBytes() {
+        // "é" and "🙂" are one Character each.
+        let t = ComposerTrigger.detect(text: "é🙂 @a", caret: 5)
+        XCTAssertEqual(t, Trigger(kind: .path, query: "a", token: "@a", range: 3..<5))
+    }
+}

--- a/apps/ios/ZeronTests/MentionLinkTests.swift
+++ b/apps/ios/ZeronTests/MentionLinkTests.swift
@@ -1,0 +1,123 @@
+// Conformance vectors for the mention link codec. Every expected value here
+// is lifted from the Rust tests in crates/ui/src/composer.rs; the two
+// implementations must agree byte for byte or a chip written on the phone
+// renders as raw Markdown on the desktop.
+
+import XCTest
+@testable import Zeron
+
+final class MentionLinkTests: XCTestCase {
+
+    // MARK: Encoding
+
+    func testPercentEncodeLeavesUnreservedBytes() {
+        XCTAssertEqual(MentionLink.percentEncode("src/a-b_c.d~e"), "src/a-b_c.d~e")
+    }
+
+    func testPercentEncodeUsesUppercaseHex() {
+        XCTAssertEqual(MentionLink.percentEncode("a b"), "a%20b")
+        XCTAssertEqual(MentionLink.percentEncode("a\nb"), "a%0Ab")
+    }
+
+    func testPercentEncodeIsPerByteForMultibyte() {
+        XCTAssertEqual(MentionLink.percentEncode("é"), "%C3%A9")
+    }
+
+    func testPercentDecodeRoundTrips() {
+        for raw in ["src/a.rs", "a b", "é", "a\nb", "sr(c)/x"] {
+            XCTAssertEqual(MentionLink.percentDecode(MentionLink.percentEncode(raw)), raw)
+        }
+    }
+
+    func testPercentDecodeRejectsTruncatedEscape() {
+        XCTAssertNil(MentionLink.percentDecode("a%2"))
+        XCTAssertNil(MentionLink.percentDecode("a%zz"))
+    }
+
+    // MARK: Escaping
+
+    func testEscapeLabelEscapesBackslashFirst() {
+        XCTAssertEqual(MentionLink.escapeLabel("a\\b"), "a\\\\b")
+        XCTAssertEqual(MentionLink.escapeLabel("a[b]c"), "a\\[b\\]c")
+    }
+
+    // MARK: Safety
+
+    func testIsSafeRejectsUnsafePaths() {
+        XCTAssertFalse(MentionLink.isSafe(""))
+        XCTAssertFalse(MentionLink.isSafe("/abs/path"))
+        XCTAssertFalse(MentionLink.isSafe("src\\win"))
+        XCTAssertFalse(MentionLink.isSafe("../a.rs"))
+        XCTAssertFalse(MentionLink.isSafe("src/./a.rs"))
+        XCTAssertFalse(MentionLink.isSafe("src//a.rs"))
+        XCTAssertFalse(MentionLink.isSafe("src/a\nb.rs"))
+    }
+
+    func testIsSafeAcceptsOrdinaryRelativePaths() {
+        XCTAssertTrue(MentionLink.isSafe("a.rs"))
+        XCTAssertTrue(MentionLink.isSafe("src/one/mod.rs"))
+        XCTAssertTrue(MentionLink.isSafe("src/a file.rs"))
+    }
+
+    // MARK: Serialize
+
+    func testSerializeFile() {
+        XCTAssertEqual(MentionLink.serialize(path: "src/a.rs", isDir: false),
+                       "[a.rs](zeron-file:src/a.rs)")
+    }
+
+    func testSerializeDirectoryCarriesTrailingSlash() {
+        XCTAssertEqual(MentionLink.serialize(path: "src/one", isDir: true),
+                       "[one](zeron-file:src/one/)")
+    }
+
+    func testSerializeEscapesLabelAndEncodesPath() {
+        XCTAssertEqual(MentionLink.serialize(path: "src/a b.rs", isDir: false),
+                       "[a b.rs](zeron-file:src/a%20b.rs)")
+    }
+
+    // MARK: Parse — these mirror the Rust rejection assertions at composer.rs:5955-5961
+
+    func testParseAcceptsAWellFormedLink() {
+        let parsed = MentionLink.parse("see [a.rs](zeron-file:src/a.rs) ok")
+        XCTAssertEqual(parsed, [ParsedMention(range: 4..<31, basename: "a.rs",
+                                              path: "src/a.rs", isDir: false)])
+    }
+
+    func testParseRejectsForeignScheme() {
+        XCTAssertTrue(MentionLink.parse("[site](https://example.com/a)").isEmpty)
+    }
+
+    func testParseRejectsUnsafePath() {
+        XCTAssertTrue(MentionLink.parse("[a.rs](zeron-file:../a.rs)").isEmpty)
+        XCTAssertTrue(MentionLink.parse("[a.rs](zeron-file:src%5Cfake%5Ca.rs)").isEmpty)
+        XCTAssertTrue(MentionLink.parse("[a.rs](zeron-file:src/a%0A.rs)").isEmpty)
+    }
+
+    func testParseRejectsUnencodedPath() {
+        // percent_encode_path(&target) == encoded — a raw space fails.
+        XCTAssertTrue(MentionLink.parse("[a file.rs](zeron-file:src/a file.rs)").isEmpty)
+    }
+
+    func testParseRejectsLabelThatIsNotTheBasename() {
+        XCTAssertTrue(MentionLink.parse("[other](zeron-file:src/a.rs)").isEmpty)
+    }
+
+    func testParseAcceptsADirectory() {
+        let parsed = MentionLink.parse("[one](zeron-file:src/one/)")
+        XCTAssertEqual(parsed, [ParsedMention(range: 0..<26, basename: "one",
+                                              path: "src/one", isDir: true)])
+    }
+
+    /// THE REVIEW'S FAILURE CASE. A stray `[` before a chip makes the parser
+    /// consume the chip's `](` as the close of the earlier label, and line 792
+    /// of the Rust then skips past the whole link. Nothing is found.
+    func testStrayOpenBracketSwallowsAFollowingChip() {
+        XCTAssertTrue(MentionLink.parse("see [ notes [a.rs](zeron-file:a.rs)").isEmpty)
+    }
+
+    func testParseFindsTwoChips() {
+        let text = "[a.rs](zeron-file:a.rs) and [b.rs](zeron-file:b.rs)"
+        XCTAssertEqual(MentionLink.parse(text).map(\.path), ["a.rs", "b.rs"])
+    }
+}


### PR DESCRIPTION
Slash commands and `@` file mentions in the iOS composer, ported from the desktop composer's rules.

![iOS composer slash commands and @-mentions](https://raw.githubusercontent.com/tobi404/comet/media/ios-slash-commands.gif)

*A new session: `/` opens the command panel with the keyboard up, `pl` filters it live, and `@zer` finds a file. Recorded in demo mode, played at 2x.*

## What it does

Typing `/` in the composer opens a panel of the harness's advertised commands; typing `@` opens a fuzzy file search of the session's checkout. Picking a command inserts it; picking a file inserts a mention chip that serializes to the same `zeron-file` link the desktop and the engine already speak.

Both work in a live chat **and** on the new-session page. The new-session case is the one the desktop handles with `slash_cwd(None, space)`: a draft has no chat yet, so the space fixes the device and the folder, and the file search goes out keyed on `spaceId` rather than `chatId`.

## How it works

- **Triggers** follow `crates/ui/src/composer.rs`: `/` only opens the whole draft, `@` opens mid-token, an e-mail address does not trigger, and a trigger overlapping an existing chip is vetoed.
- **The list** comes from the host over the device relay: `ListCommands` for `/`, `SearchFiles` for `@`. Commands are cached per harness, device and cwd, stale-while-revalidate, with no TTL here - the engine's command cache owns expiry, so there is one expiry policy in one place. The file search is debounced by 80ms and generation-guarded, the same way the desktop debounces it.
- **Errors never render as "no results".** A cross-device search fails for reasons the user can act on - the host runs an older daemon, the device is unreachable - and the empty state hid them. The panel carries the desktop's error copy verbatim.
- **Mentions survive editing.** The text model coalesces mention runs through a keyed view, so a chip split by an unrelated attribute stays one mention, and typing inside a chip drops the attribute rather than silently corrupting the link.

## Notes for review

- The suggestion panel caps at 180pt and compresses below that rather than overflowing. An exact height cannot compress, and on the new-session page with the keyboard up that pushed the canvas under its own minimum and the composer's chip row under the keyboard.
- While the panel is open, the new-session canvas hides its mark and its "What are we building?" line. That decoration holds a ~126pt floor, and with the keyboard up there is not room for both.
- Both composers fetch through `AppModel` rather than the store directly, the way the harness, model and ref lists already do, so demo mode answers from its own dataset.

## Tests

`ComposerTriggerTests`, `MentionLinkTests`, `ComposerTextTests` and `ComposerSuggestionsTests` - 101 tests, green on this branch. They run on plain values with both fetchers injected, so no socket and no simulator UI.

Checked by hand on a simulator (demo mode) and on a physical iPhone against a live host: `/` lists the host's real commands in a new session and in a live chat, `@` finds files, and the panel and the pill never collide.
