### PR TITLE
ios: clean up build warnings

### DIFF
--- a/apps/ios/Zeron/App/AppConfig.swift
+++ b/apps/ios/Zeron/App/AppConfig.swift
@@ -43,20 +43,18 @@ final class AppConfig: @unchecked Sendable {
     }
 
     func updateTokens(_ new: AuthTokens) {
-        lock.lock(); defer { lock.unlock() }
-        tokens = new
+        lock.withLock {
+            tokens = new
+        }
     }
 
     /// Current bearer, refreshing the WorkOS access token when needed.
     func currentToken() async -> String? {
         switch mode {
         case .dev:
-            lock.lock(); defer { lock.unlock() }
-            return devBearer
+            return lock.withLock { devBearer }
         case .workos:
-            lock.lock()
-            let current = tokens
-            lock.unlock()
+            let current = lock.withLock { tokens }
             guard let current else { return nil }
             if !Self.isExpired(jwt: current.accessToken) {
                 return current.accessToken
@@ -69,31 +67,32 @@ final class AppConfig: @unchecked Sendable {
     /// under the lock as its last act, so a caller either joins a live
     /// refresh or starts a fresh one — never a second concurrent POST.
     private func refreshedToken(current: AuthTokens) async -> String? {
-        lock.lock()
-        if let existing = refreshTask {
-            lock.unlock()
-            return await existing.value
-        }
-        let task = Task<String?, Never> { [edgeURL, orgId] in
-            let client = AuthClient(baseURL: edgeURL)
-            let refreshed = try? await client.refresh(refreshToken: current.refreshToken,
-                                                      organizationId: orgId)
-            if let refreshed {
-                self.updateTokens(refreshed)
-                Keychain.save(refreshed.accessToken, key: "accessToken")
-                Keychain.save(refreshed.refreshToken, key: "refreshToken")
-            } else {
-                roomLog.error("auth: token refresh failed; using expired access token (server will reject and rooms will redial)")
+        let task = lock.withLock {
+            if let existing = refreshTask {
+                return existing
             }
-            self.lock.lock()
-            self.refreshTask = nil
-            self.lock.unlock()
-            // Failure falls back to the expired token: let the server
-            // reject; the rooms' backoff redials retry through here.
-            return refreshed?.accessToken ?? current.accessToken
+
+            let task = Task<String?, Never> { [edgeURL, orgId] in
+                let client = AuthClient(baseURL: edgeURL)
+                let refreshed = try? await client.refresh(refreshToken: current.refreshToken,
+                                                          organizationId: orgId)
+                if let refreshed {
+                    self.updateTokens(refreshed)
+                    Keychain.save(refreshed.accessToken, key: "accessToken")
+                    Keychain.save(refreshed.refreshToken, key: "refreshToken")
+                } else {
+                    roomLog.error("auth: token refresh failed; using expired access token (server will reject and rooms will redial)")
+                }
+                self.lock.withLock {
+                    self.refreshTask = nil
+                }
+                // Failure falls back to the expired token: let the server
+                // reject; the rooms' backoff redials retry through here.
+                return refreshed?.accessToken ?? current.accessToken
+            }
+            refreshTask = task
+            return task
         }
-        refreshTask = task
-        lock.unlock()
         return await task.value
     }
 

--- a/apps/ios/Zeron/Markdown/MarkdownBlockView.swift
+++ b/apps/ios/Zeron/Markdown/MarkdownBlockView.swift
@@ -80,10 +80,12 @@ extension [InlineRun] {
                 var piece = AttributedString(run.text)
                 piece.font = Theme.mono(size - 1.5)
                 piece.foregroundColor = Theme.inlineCodeText
-                result = result + Text(piece).customAttribute(InlineCodeAttribute())
+                let code = Text(piece).customAttribute(InlineCodeAttribute())
+                result = Text("\(result)\(code)")
             } else {
-                result = result + Text([run].attributed(size: size, weight: weight,
-                                                        baseColor: baseColor))
+                let styled = Text([run].attributed(size: size, weight: weight,
+                                                   baseColor: baseColor))
+                result = Text("\(result)\(styled)")
             }
         }
         return result
@@ -113,7 +115,8 @@ extension [InlineRun] {
                     var piece = AttributedString(slice)
                     piece.font = Theme.mono(size - 1.5)
                     piece.foregroundColor = Theme.inlineCodeText.opacity(segment.alpha)
-                    result = result + Text(piece).customAttribute(InlineCodeAttribute())
+                    let code = Text(piece).customAttribute(InlineCodeAttribute())
+                    result = Text("\(result)\(code)")
                 } else {
                     var sliced = run
                     sliced.text = slice
@@ -124,7 +127,7 @@ extension [InlineRun] {
                             attr[r.range].foregroundColor = base.opacity(segment.alpha)
                         }
                     }
-                    result = result + Text(attr)
+                    result = Text("\(result)\(Text(attr))")
                 }
             }
             offset += chars.count

--- a/apps/ios/Zeron/Sync/ChatRoomClient.swift
+++ b/apps/ios/Zeron/Sync/ChatRoomClient.swift
@@ -391,7 +391,7 @@ actor ChatRoomClient {
                 // confusing silent failure: everything cached renders,
                 // nothing syncs. Say so and back off.
                 roomLog.error("chat2 \(self.chatId, privacy: .public): no socket URL (token unavailable); backing off")
-                await self.scheduleReconnect(gen: gen)
+                self.scheduleReconnect(gen: gen)
                 return
             }
             await self.openSocket(url: url, gen: gen)
@@ -475,7 +475,7 @@ actor ChatRoomClient {
             // Parked while the OS path is offline; cut short by any online
             // event (a sibling dial success, path recovery, focus probe).
             await OnlineBus.shared.waitBackoff(ms: delay)
-            await self.connect()
+            self.connect()
         }
     }
 

--- a/apps/ios/Zeron/Sync/OnlineBus.swift
+++ b/apps/ios/Zeron/Sync/OnlineBus.swift
@@ -33,10 +33,11 @@ final class OnlineBus: @unchecked Sendable {
 
     /// Empirical "the network is back": resumes every parked waiter.
     func notifyOnline() {
-        lock.lock()
-        let resumed = waiters
-        waiters.removeAll()
-        lock.unlock()
+        let resumed = lock.withLock {
+            let resumed = waiters
+            waiters.removeAll()
+            return resumed
+        }
         for continuation in resumed.values {
             continuation.resume()
         }
@@ -45,18 +46,18 @@ final class OnlineBus: @unchecked Sendable {
     /// OS path status from NWPathMonitor. Only a definitive "unsatisfied"
     /// parks; the offline→online transition broadcasts the online event.
     func setPathOnline(_ online: Bool) {
-        lock.lock()
-        let wasOffline = pathOffline
-        pathOffline = !online
-        lock.unlock()
+        let wasOffline = lock.withLock {
+            let wasOffline = pathOffline
+            pathOffline = !online
+            return wasOffline
+        }
         if online, wasOffline {
             notifyOnline()
         }
     }
 
     var isPathOffline: Bool {
-        lock.lock(); defer { lock.unlock() }
-        return pathOffline
+        lock.withLock { pathOffline }
     }
 
     /// Sleep `ms`, cut short by an online event that fires during the wait.
@@ -82,29 +83,30 @@ final class OnlineBus: @unchecked Sendable {
 
     /// Await the next online broadcast (cancellation-safe).
     private func nextOnlineEvent() async {
-        lock.lock()
-        nextWaiterId += 1
-        let id = nextWaiterId
-        lock.unlock()
+        let id = lock.withLock {
+            nextWaiterId += 1
+            return nextWaiterId
+        }
         await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                var resumeNow = false
-                lock.lock()
-                if cancelledBeforeRegistration.remove(id) != nil {
-                    resumeNow = true
-                } else {
-                    waiters[id] = continuation
+                let resumeNow = lock.withLock {
+                    if cancelledBeforeRegistration.remove(id) != nil {
+                        return true
+                    } else {
+                        waiters[id] = continuation
+                        return false
+                    }
                 }
-                lock.unlock()
                 if resumeNow { continuation.resume() }
             }
         } onCancel: {
-            lock.lock()
-            let continuation = waiters.removeValue(forKey: id)
-            if continuation == nil {
-                cancelledBeforeRegistration.insert(id)
+            let continuation = lock.withLock {
+                let continuation = waiters.removeValue(forKey: id)
+                if continuation == nil {
+                    cancelledBeforeRegistration.insert(id)
+                }
+                return continuation
             }
-            lock.unlock()
             continuation?.resume()
         }
     }

--- a/apps/ios/Zeron/Sync/RegistryClient.swift
+++ b/apps/ios/Zeron/Sync/RegistryClient.swift
@@ -159,7 +159,7 @@ actor RegistryClient {
                 // confusing silent failure: everything cached renders, nothing
                 // syncs. Say so and back off.
                 roomLog.error("registry: no socket URL (token unavailable); backing off")
-                await self.scheduleReconnect(gen: gen)
+                self.scheduleReconnect(gen: gen)
                 return
             }
             await self.openSocket(url: url, gen: gen)
@@ -251,7 +251,7 @@ actor RegistryClient {
             // Parked while the OS path is offline; cut short by any online
             // event (a sibling dial success, path recovery, focus probe).
             await OnlineBus.shared.waitBackoff(ms: delay)
-            await self.connect()
+            self.connect()
         }
     }
 

--- a/apps/ios/Zeron/Views/NewSessionView.swift
+++ b/apps/ios/Zeron/Views/NewSessionView.swift
@@ -376,7 +376,7 @@ struct NewSessionView: View {
                                 reasoning: reasoning, sandbox: "workspace-write")
         Task { @MainActor in
             var cwd: String?
-            var branch = selectedRef
+            let branch = selectedRef
             var worktree: WorktreeSpec?
             switch checkoutKind {
             case .newWorktree:

--- a/apps/ios/Zeron/Views/SignInView.swift
+++ b/apps/ios/Zeron/Views/SignInView.swift
@@ -162,9 +162,14 @@ final class AuthSessionCoordinator: NSObject, ASWebAuthenticationPresentationCon
 
     nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         MainActor.assumeIsolated {
-            UIApplication.shared.connectedScenes
-                .compactMap { ($0 as? UIWindowScene)?.keyWindow }
-                .first ?? ASPresentationAnchor()
+            let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+            if let keyWindow = scenes.compactMap(\.keyWindow).first {
+                return keyWindow
+            }
+            guard let scene = scenes.first else {
+                preconditionFailure("Authentication requested without a connected window scene")
+            }
+            return ASPresentationAnchor(windowScene: scene)
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace async-context NSLock calls with scoped locking while preserving token-refresh and online-waiter synchronization
- update deprecated iOS 26 presentation-anchor and SwiftUI Text APIs
- remove redundant awaits and unnecessary mutability

## Verification
- 47 iOS tests pass on iPhone 17 simulator
- clean Release build for generic iOS device succeeds
- no application-source warnings remain

Xcode 26.6 still emits its App Intents metadata-skipped toolchain warning because the app does not use App Intents.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789848397&installation_model_id=425430&pr_number=191&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F191&signature=b7173172ee2220cd28e6c8d99ed1d35a2ec8b38dc8d7fe8dcc19bbd42c1b3a83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->