### PR TITLE
Fix tool rendering: only agent calls render as subagent chips

### DIFF
--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -389,10 +389,16 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
             for p in out.iter_mut() {
                 if let MessagePart::Tool {
                     id,
+                    call,
                     subagent_status,
                     ..
                 } = p
                     && id == parent_tool_use_id
+                    // Genus gate: only a SPAWN call ever carries subagent
+                    // lifecycle. A driver keying bug (claude's background
+                    // shells settled through the subagent subtype,
+                    // 2026-08-20) must not decorate an ordinary chip.
+                    && call.is_subagent_spawn()
                 {
                     match status {
                         Some(s) => *subagent_status = Some(s),
@@ -961,6 +967,42 @@ mod tests {
         }
         // Content never leaked into the parent parts.
         assert_eq!(parts.len(), 1);
+    }
+
+    #[test]
+    fn subagent_events_never_decorate_a_non_spawn_chip() {
+        // Mis-keyed tagged traffic (claude's background shells settled
+        // through the subagent subtype, 2026-08-20) must not stamp lifecycle
+        // onto an ordinary tool chip — the genus gate is the CALL.
+        use zeron_proto::DoneStatus;
+        let mut parts = Vec::new();
+        fold_event_into_parts(
+            &mut parts,
+            &AgentEvent::ToolCall {
+                id: "toolu_bash".into(),
+                call: ToolCall::Exec {
+                    command: "git clone …".into(),
+                },
+            },
+        );
+        fold_event_into_parts(
+            &mut parts,
+            &AgentEvent::Subagent {
+                parent_tool_use_id: "toolu_bash".into(),
+                event: Box::new(AgentEvent::Done {
+                    status: DoneStatus::Completed,
+                    result: None,
+                    error: None,
+                    session_id: None,
+                }),
+            },
+        );
+        match &parts[0] {
+            MessagePart::Tool {
+                subagent_status, ..
+            } => assert_eq!(*subagent_status, None),
+            other => panic!("{other:?}"),
+        }
     }
 
     #[test]

--- a/crates/doc/src/schema.rs
+++ b/crates/doc/src/schema.rs
@@ -554,6 +554,24 @@ impl SessionDoc {
                     Some(loro::ValueOrContainer::Value(LoroValue::String(s))) if s.as_str() == part_id
                 );
                 if is_tool && id_matches {
+                    // Genus gate: subagent lifecycle only ever lands on a
+                    // SPAWN call. Mis-keyed tagged traffic (a driver bug —
+                    // claude's background shells settled through the
+                    // subagent subtype, 2026-08-20) must not decorate an
+                    // ordinary chip with a ref to a doc it never had.
+                    let is_spawn = part
+                        .get("call")
+                        .and_then(|v| match v {
+                            loro::ValueOrContainer::Value(v) => serde_json::to_value(v).ok(),
+                            _ => None,
+                        })
+                        .and_then(|j| {
+                            serde_json::from_value::<zeron_proto::ToolCall>(j).ok()
+                        })
+                        .is_some_and(|c| c.is_subagent_spawn());
+                    if !is_spawn {
+                        return Ok(false);
+                    }
                     if let Some(r) = subagent_ref {
                         part.insert("subagentRef", r)?;
                     }
@@ -1175,6 +1193,83 @@ mod tests {
                 assert_eq!(subagent_ref.as_deref(), Some("c1--sub--call_alpha"));
                 assert_eq!(subagent_status, &Some(SubagentStatus::Running));
                 assert_eq!(subagent_tail.as_deref(), Some("scanning"));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_subagent_chip_refuses_non_spawn_parts() {
+        // The genus gate at the doc boundary: whatever id a driver keys its
+        // tagged traffic to, subagent lifecycle only ever lands on a SPAWN
+        // call (claude's background shells settled through the subagent
+        // subtype and turned Run chips into dead spawn links, 2026-08-20).
+        let doc = SessionDoc::init("c1").unwrap();
+        let mut w = SegmentWriter::begin(&doc, "e1", "dev", 1).unwrap();
+        let tool = |id: &str, call: zeron_proto::ToolCall| MessagePart::Tool {
+            id: id.into(),
+            call,
+            is_error: false,
+            resolved: true,
+            output: None,
+            diff: None,
+            output_ref: None,
+            output_bytes: None,
+            diff_ref: None,
+            diff_stats: None,
+            subagent_ref: None,
+            subagent_status: None,
+            subagent_tail: None,
+        };
+        let parts = vec![
+            tool(
+                "toolu_bash",
+                zeron_proto::ToolCall::Exec {
+                    command: "git clone …".into(),
+                },
+            ),
+            tool(
+                "toolu_spawn",
+                zeron_proto::ToolCall::Unknown {
+                    name: "Agent: scan".into(),
+                    input: None,
+                },
+            ),
+        ];
+        w.sync(&parts).unwrap();
+        assert!(
+            doc.update_subagent_chip(
+                "toolu_spawn",
+                Some("c1--sub--toolu_spawn"),
+                Some("running"),
+                None
+            )
+            .unwrap()
+        );
+        assert!(
+            !doc.update_subagent_chip(
+                "toolu_bash",
+                Some("c1--sub--toolu_bash"),
+                Some("done"),
+                None
+            )
+            .unwrap()
+        );
+        let entries = doc.read_entries().unwrap();
+        match &entries[0].parts[0] {
+            MessagePart::Tool {
+                subagent_ref,
+                subagent_status,
+                ..
+            } => {
+                assert!(subagent_ref.is_none());
+                assert!(subagent_status.is_none());
+            }
+            other => panic!("{other:?}"),
+        }
+        match &entries[0].parts[1] {
+            MessagePart::Tool { subagent_ref, .. } => {
+                assert_eq!(subagent_ref.as_deref(), Some("c1--sub--toolu_spawn"));
             }
             other => panic!("{other:?}"),
         }

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -1596,9 +1596,17 @@ async fn drive_run(
                 if !sink_known && !done_only {
                     for p in folded.iter_mut() {
                         if let MessagePart::Tool {
-                            id, subagent_ref, ..
+                            id,
+                            call,
+                            subagent_ref,
+                            ..
                         } = p
                             && id == parent_tool_use_id
+                            // Genus gate: a subagent ref may only ever bind
+                            // to a SPAWN call — mis-keyed tagged traffic
+                            // must not turn an ordinary chip into a spawn
+                            // link (empty tab on click).
+                            && call.is_subagent_spawn()
                         {
                             *subagent_ref = Some(sub_id.clone());
                         }

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -1586,8 +1586,14 @@ async fn drive_run(
                 .iter()
                 .any(|p| matches!(p, MessagePart::Tool { id, .. } if id == parent_tool_use_id));
             let sink_known = subagents.contains_key(parent_tool_use_id);
+            // A Done with NO sink (a subagent that never streamed — codex
+            // turn ends can beat registration) is chip-only: minting a doc
+            // just to freeze it empty helps no one, and stamping the ref
+            // would link the chip to that never-created doc (an empty tab
+            // on click).
+            let done_only = !sink_known && matches!(sub_event.as_ref(), AgentEvent::Done { .. });
             if chip_streaming {
-                if !sink_known {
+                if !sink_known && !done_only {
                     for p in folded.iter_mut() {
                         if let MessagePart::Tool {
                             id, subagent_ref, ..
@@ -1606,10 +1612,6 @@ async fn drive_run(
                 }
             }
             // Open the sink lazily; an open failure degrades to chip-only.
-            // A Done with NO sink (a subagent that never streamed — codex
-            // turn ends can beat registration) is chip-only: minting a doc
-            // just to freeze it empty helps no one.
-            let done_only = !sink_known && matches!(sub_event.as_ref(), AgentEvent::Done { .. });
             if !sink_known && !done_only {
                 let opened = inner.doc_host().and_then(|host| match host.open(&sub_id) {
                     Ok(handle) => Some(handle.doc_arc()),

--- a/crates/harness/src/claude/normalize.rs
+++ b/crates/harness/src/claude/normalize.rs
@@ -170,6 +170,14 @@ pub(crate) struct Normalizer {
     /// re-keys them onto the spawn chip's feed (the wire never echoes the
     /// steer on the child feed — live-verified 2.1.228).
     agent_tasks: std::collections::HashMap<String, String>,
+    /// tool_use ids of Agent/Task spawn calls, recorded from their own
+    /// assistant frames (plus `task_started`'s agent-task pairing). Gates
+    /// `task_notification`: background SHELL tasks settle through the same
+    /// subtype carrying their Bash call's id, and tagging that Done as
+    /// subagent traffic stamped a spawn ref onto an ordinary Run chip —
+    /// which then opened as an empty, never-created subagent doc (user
+    /// report 2026-08-20).
+    agent_spawn_tools: std::collections::HashSet<String>,
     /// Rotates at each assistant-frame close and at each steer; SessionStarted
     /// carries the first value so folds can attribute deltas from the start.
     assistant_message_id: String,
@@ -182,6 +190,7 @@ impl Normalizer {
         Self {
             saw_init: false,
             agent_tasks: std::collections::HashMap::new(),
+            agent_spawn_tools: std::collections::HashSet::new(),
             assistant_message_id: new_message_id(),
             session_id: None,
         }
@@ -209,6 +218,16 @@ impl Normalizer {
                     let Some(parent) = f.tool_use_id.as_deref().filter(|t| !t.is_empty()) else {
                         return Vec::new();
                     };
+                    // Only a KNOWN spawn settles as a subagent. Background
+                    // SHELL tasks (`Bash` with `run_in_background`) settle
+                    // through this same subtype carrying the Bash call's id —
+                    // tagging that Done would bind a subagent ref onto an
+                    // ordinary Run chip. A real spawn's tool_use frame always
+                    // precedes its notification on the wire, so the set is
+                    // populated by the time a genuine one arrives.
+                    if !self.agent_spawn_tools.contains(parent) {
+                        return Vec::new();
+                    }
                     let status = match f.status.as_deref().unwrap_or("") {
                         "completed" | "complete" | "succeeded" | "success" => {
                             DoneStatus::Completed
@@ -241,6 +260,7 @@ impl Normalizer {
                     )
                 {
                     self.agent_tasks.insert(task.to_owned(), tool.to_owned());
+                    self.agent_spawn_tools.insert(tool.to_owned());
                     return Vec::new();
                 }
                 if f.subtype != "init" || self.saw_init {
@@ -344,6 +364,13 @@ impl Normalizer {
                         ));
                     }
                     return out;
+                }
+                // Record spawn tool ids up front: `task_notification` keys on
+                // them, and only foreground spawns ever get a `task_started`.
+                for b in f.message.blocks() {
+                    if b.kind == "tool_use" && matches!(b.name.as_str(), "Agent" | "Task") {
+                        self.agent_spawn_tools.insert(b.id.clone());
+                    }
                 }
                 let mut out: Vec<AgentEvent> = f
                     .message
@@ -839,23 +866,36 @@ mod tests {
     fn task_notification_settles_the_subagent_with_a_tagged_done() {
         // The wire's ONLY terminal signal for a background subagent
         // (live-verified 2.1.228): an untagged system frame carrying the
-        // spawning tool's id. Shape from the captured fixture.
-        let ev = normalize_one(
+        // spawning tool's id. Shape from the captured fixture. The spawn's
+        // own tool_use frame always precedes it — that's what marks the id
+        // as an AGENT task (shell tasks share the subtype).
+        let spawn = |norm: &mut Normalizer| {
+            let frame = crate::claude::wire::parse_frame(
+                r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_agent","name":"Agent","input":{"description":"probe"}}]}}"#,
+            )
+            .expect("parses");
+            norm.normalize(frame, false);
+        };
+        let notify = |norm: &mut Normalizer, raw: &str| {
+            let frame = crate::claude::wire::parse_frame(raw).expect("parses");
+            norm.normalize(frame, false)
+        };
+        let mut norm = Normalizer::new();
+        spawn(&mut norm);
+        let ev = notify(
+            &mut norm,
             r#"{"type":"system","subtype":"task_notification","task_id":"t1","tool_use_id":"toolu_agent","status":"completed","summary":"DONE."}"#,
         );
-        assert_eq!(
-            ev,
-            vec![AgentEvent::Subagent {
-                parent_tool_use_id: "toolu_agent".into(),
-                event: Box::new(AgentEvent::Done {
-                    status: DoneStatus::Completed,
-                    result: None,
-                    error: None,
-                    session_id: None,
-                }),
-            }]
-        );
-        let ev = normalize_one(
+        assert!(matches!(
+            &ev[..],
+            [AgentEvent::Subagent { parent_tool_use_id, event }]
+                if parent_tool_use_id == "toolu_agent"
+                    && matches!(event.as_ref(), AgentEvent::Done { status: DoneStatus::Completed, .. })
+        ));
+        let mut norm = Normalizer::new();
+        spawn(&mut norm);
+        let ev = notify(
+            &mut norm,
             r#"{"type":"system","subtype":"task_notification","tool_use_id":"toolu_agent","status":"failed"}"#,
         );
         assert!(matches!(
@@ -864,7 +904,10 @@ mod tests {
                 if matches!(event.as_ref(), AgentEvent::Done { status: DoneStatus::Errored, .. })
         ));
         // Non-terminal or id-less notifications close nothing.
-        assert!(normalize_one(
+        let mut norm = Normalizer::new();
+        spawn(&mut norm);
+        assert!(notify(
+            &mut norm,
             r#"{"type":"system","subtype":"task_notification","tool_use_id":"toolu_agent","status":"running"}"#,
         )
         .is_empty());
@@ -872,6 +915,30 @@ mod tests {
             r#"{"type":"system","subtype":"task_notification","status":"completed"}"#,
         )
         .is_empty());
+    }
+
+    #[test]
+    fn shell_task_notification_never_settles_a_subagent() {
+        // `Bash` with `run_in_background` settles through the SAME
+        // `task_notification` subtype, carrying the Bash call's own id.
+        // Tagging that Done bound a subagent ref onto an ordinary Run chip,
+        // which then rendered as a spawn chip opening an empty, never-created
+        // subagent doc (user report 2026-08-20).
+        let mut norm = Normalizer::new();
+        for raw in [
+            // The shell task's start is already unmapped (no subagent_type)…
+            r#"{"type":"system","subtype":"task_started","task_id":"bg1","tool_use_id":"toolu_bash","task_type":"local_bash"}"#,
+            // …and the Bash call itself must not mark the id as a spawn.
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_bash","name":"Bash","input":{"command":"git clone …","run_in_background":true}}]}}"#,
+        ] {
+            let frame = crate::claude::wire::parse_frame(raw).expect("parses");
+            norm.normalize(frame, false);
+        }
+        let done = crate::claude::wire::parse_frame(
+            r#"{"type":"system","subtype":"task_notification","task_id":"bg1","tool_use_id":"toolu_bash","status":"completed"}"#,
+        )
+        .expect("parses");
+        assert!(norm.normalize(done, false).is_empty());
     }
 
     #[test]

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -203,6 +203,25 @@ pub enum ToolCall {
     },
 }
 
+impl ToolCall {
+    /// A subagent SPAWN call — the `Agent[: <description>]` naming convention
+    /// every driver decodes its spawn tool into (claude/codex `Task`, cursor
+    /// `task`, grok `spawn_subagent`, opencode `task`). This is the single
+    /// genus gate for subagent binding: tagged subagent traffic may only ever
+    /// stamp a ref/status onto a spawn call, so a driver keying bug can never
+    /// turn an ordinary Run/Read chip into a spawn chip (2026-08-20: claude's
+    /// background-shell `task_notification` did exactly that — the chip
+    /// linked to a never-created doc and opened an empty panel).
+    pub fn is_subagent_spawn(&self) -> bool {
+        let name = match self {
+            ToolCall::Unknown { name, .. } => name,
+            ToolCall::Mcp { tool, .. } => tool,
+            _ => return false,
+        };
+        name == "Agent" || name.starts_with("Agent: ")
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TodoItem {

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -292,20 +292,12 @@ pub struct ToolItem {
     pub subagent_tail: Option<SharedString>,
 }
 
-/// Subagent spawn chips — the "Agent[: <description>]" Unknown convention
-/// every native driver uses, or any tool the engine has already bound to a
-/// subagent doc. These stay out of the collapsible "Called N tools" wrap so
-/// a running subagent is visible without opening the fold.
-fn is_agent_name(name: &str) -> bool {
-    name == "Agent" || name.starts_with("Agent: ")
-}
-
+/// Subagent spawn chips — [`ToolCall::is_subagent_spawn`], the shared genus
+/// every driver decodes its spawn tool into. These stay out of the
+/// collapsible "Called N tools" wrap so a running subagent is visible
+/// without opening the fold.
 fn is_agent_call(call: &ToolCall) -> bool {
-    match call {
-        ToolCall::Unknown { name, .. } => is_agent_name(name),
-        ToolCall::Mcp { tool, .. } => is_agent_name(tool),
-        _ => false,
-    }
+    call.is_subagent_spawn()
 }
 
 /// The chip's GENUS is the call itself, never the ref: docs written before

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -308,8 +308,19 @@ fn is_agent_call(call: &ToolCall) -> bool {
     }
 }
 
+/// The chip's GENUS is the call itself, never the ref: docs written before
+/// the claude-driver fix carry stray `subagent_ref`s on ordinary Run chips
+/// (a background shell's `task_notification` was mis-tagged as subagent
+/// traffic), and honoring the ref alone turned those Runs into spawn chips
+/// that opened empty, never-created subagent docs.
 fn is_agent_tool(item: &ToolItem) -> bool {
-    item.subagent_ref.is_some() || is_agent_call(&item.call)
+    is_agent_call(&item.call)
+}
+
+/// A chip renders as the spawn LINK (whole-card click → subagent tab) only
+/// when an agent call has actually been bound to its doc.
+fn is_spawn_link(item: &ToolItem) -> bool {
+    is_agent_call(&item.call) && item.subagent_ref.is_some()
 }
 
 /// Ordinary tool groups fold behind a summary header; agent/spawn chips
@@ -3613,7 +3624,7 @@ impl Transcript {
                 // Spawn chips never expand — the subagent doc is the record
                 // of what the tool did, and an inline body would only repeat
                 // it. The whole chip is the "open that doc" click instead.
-                if tool.subagent_ref.is_some() {
+                if is_spawn_link(tool) {
                     return None;
                 }
                 // Among fetched blobs, the most recently REQUESTED one wins —
@@ -3638,7 +3649,7 @@ impl Transcript {
             .map(|tool| {
                 tool.invocation
                     .clone()
-                    .filter(|_| tool.subagent_ref.is_none())
+                    .filter(|_| !is_spawn_link(tool))
             })
             .collect();
         // Fetch affordance under each open detail whose full payload is still
@@ -3805,9 +3816,8 @@ impl Transcript {
                 // Spawn chips are LINKS, not accordions: the click opens the
                 // subagent's transcript as a right-pane tab (the shell hosts
                 // the surface — the chip only announces which doc it indexes).
-                if let Some(doc_id) = &tool.subagent_ref {
+                if let Some(doc_id) = tool.subagent_ref.clone().filter(|_| is_spawn_link(tool)) {
                     let chat_id = self.chat_id.clone().unwrap_or_default();
-                    let doc_id = doc_id.clone();
                     let title = subagent_tab_title(&tool.call);
                     let frozen = matches!(
                         tool.subagent_status,
@@ -5268,6 +5278,39 @@ mod tests {
         assert_eq!(tools.len(), 2);
         assert!(!tool_group_collapses(tools));
         assert!(tools.iter().all(is_agent_tool));
+    }
+
+    #[test]
+    fn stray_subagent_ref_on_a_run_chip_stays_an_ordinary_tool() {
+        // Docs written before the claude-driver fix carry subagent refs on
+        // ordinary Run chips (a background shell's task_notification was
+        // mis-tagged as subagent traffic). The ref alone must not change the
+        // chip's genus: it folds with its neighbors and renders as a plain
+        // tool, never as a spawn link to a doc that was never created.
+        let mut stray = tool_part("b", "git clone …");
+        if let MessagePart::Tool {
+            subagent_ref,
+            subagent_status,
+            ..
+        } = &mut stray
+        {
+            *subagent_ref = Some("chat--sub--b".into());
+            *subagent_status = Some(SubagentStatus::Done);
+        }
+        let entry = assistant(
+            "m-stray",
+            MessageStatus::Complete,
+            vec![tool_part("a", "ls"), stray, tool_part("c", "make")],
+        );
+        let rows = rows_for_entry(&entry, false, &mut parse);
+        assert_eq!(rows.len(), 1, "one folded group, no agent split");
+        let RowKind::ToolGroup { tools, .. } = &rows[0].kind else {
+            panic!("tool group expected")
+        };
+        assert_eq!(tools.len(), 3);
+        assert!(tool_group_collapses(tools));
+        assert!(tools.iter().all(|t| !is_agent_tool(t)));
+        assert!(tools.iter().all(|t| !is_spawn_link(t)));
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -3646,11 +3646,7 @@ impl Transcript {
         // always answers "what exactly was this call?", output or not.
         let invocations: Vec<Option<Arc<ToolDetail>>> = tools
             .iter()
-            .map(|tool| {
-                tool.invocation
-                    .clone()
-                    .filter(|_| !is_spawn_link(tool))
-            })
+            .map(|tool| tool.invocation.clone().filter(|_| !is_spawn_link(tool)))
             .collect();
         // Fetch affordance under each open detail whose full payload is still
         // sidecar-only: `(ref, label)`. Diff offered first (the richer


### PR DESCRIPTION
## Summary

Fixes a rendering regression where regular tool calls (like Run commands) were being rendered as clickable subagent chips. After PR #189 separated agent spawn chips from ordinary tools in the grouping logic, the rendering code needed clarification about which tools should actually render as subagent spawn UIs.

The fix ensures that only actual agent calls (matching the "Agent" naming pattern) with a document reference render as subagent spawn chips. Regular tools like Run, Read, etc. now correctly render as normal tool chips even if they have a subagent_ref field.

## Root Cause

The rendering check at line 3808 was only checking `tool.subagent_ref.is_some()` without verifying that the tool was actually an agent call. This could lead to non-agent tools appearing as clickable subagents that opened empty panels.

## Test Plan

- [x] Verify Run commands no longer appear with subagent chip styling
- [x] Verify actual Agent calls still render as subagent spawn chips when docs are available  
- [x] Verify mixed tool groups still render correctly (collapsed)
- [x] Code compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789853106&installation_model_id=425430&pr_number=192&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F192&signature=a693ef679c2bab0b24a3a062308569a0808954ca0b8911f8346e71c26017a7e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->