### PR TITLE
Spawn chips name their subagent's model; stop the killed-subagent spinner

### DIFF
--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use zeron_proto::{AgentEvent, ToolCall, ToolDiff, UserInputQuestion};
+use zeron_proto::{AgentEvent, SUBAGENT_INPUT_KEEP, ToolCall, ToolDiff, UserInputQuestion};
 
 use crate::constants::MSG_INLINE_MAX;
 
@@ -426,7 +426,6 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
     }
 }
 
-
 /// Stamp sidecar keys onto resolved tool parts that have sidecar content.
 ///
 /// Separate from the fold because the fold is chat-agnostic and pure; the
@@ -485,7 +484,9 @@ pub fn sidecar_payload(event: &AgentEvent) -> Option<SidecarPayload> {
 
 /// Render-only privacy policy — strip heavy/sensitive tool inputs before a call enters the doc.
 ///
-/// Keeps: command / path / pattern / url / query / todo items / server+tool names.
+/// Keeps: command / path / pattern / url / query / todo items / server+tool names,
+/// and a subagent spawn's model/type (see [`spawn_badge`] — a couple of short
+/// identifiers the chip names the child by).
 /// Drops: WriteFile content, EditFile old/new strings, WebFetch prompt, Mcp/Unknown input.
 /// Full inputs remain only in the host's local run journal. Idempotent.
 pub fn sanitize_tool_call(call: &ToolCall) -> ToolCall {
@@ -506,14 +507,41 @@ pub fn sanitize_tool_call(call: &ToolCall) -> ToolCall {
         ToolCall::Mcp { server, tool, .. } => ToolCall::Mcp {
             server: server.clone(),
             tool: tool.clone(),
-            input: None,
+            input: spawn_badge(call),
         },
         ToolCall::Unknown { name, .. } => ToolCall::Unknown {
             name: name.clone(),
-            input: None,
+            input: spawn_badge(call),
         },
         other => other.clone(),
     }
+}
+
+/// The only slice of a tool input allowed into the doc: a subagent spawn's
+/// [`SUBAGENT_INPUT_KEEP`] keys, so the chip can say WHICH model the child
+/// runs on (`Agent · haiku`) without the reader opening the subagent tab.
+///
+/// Everything else — the prompt above all — stays in the host's run journal,
+/// so this stays a whitelist of short identifiers rather than a size cap.
+/// `None` for anything that is not a spawn, and for a spawn that named
+/// neither, which keeps it idempotent: re-sanitizing a sanitized call is a
+/// fixpoint (the kept keys are themselves kept).
+fn spawn_badge(call: &ToolCall) -> Option<serde_json::Value> {
+    if !call.is_subagent_spawn() {
+        return None;
+    }
+    let input = match call {
+        ToolCall::Unknown { input, .. } | ToolCall::Mcp { input, .. } => input.as_ref()?,
+        _ => return None,
+    };
+    let kept: serde_json::Map<String, serde_json::Value> = SUBAGENT_INPUT_KEEP
+        .iter()
+        .filter_map(|key| {
+            let value = input.get(key)?.as_str()?.trim();
+            (!value.is_empty()).then(|| ((*key).to_owned(), serde_json::Value::from(value)))
+        })
+        .collect();
+    (!kept.is_empty()).then(|| serde_json::Value::Object(kept))
 }
 
 /// Deterministic continuation id: `"{root}#c{n}"`.
@@ -690,6 +718,70 @@ mod tests {
             }
         );
         assert_eq!(sanitize_tool_call(&clean), clean);
+    }
+
+    /// A spawn keeps the two short identifiers its chip names the child by and
+    /// drops the prompt — the whole point of the whitelist. Still a fixpoint.
+    #[test]
+    fn sanitize_keeps_a_spawns_model_and_drops_its_prompt() {
+        let call = ToolCall::Unknown {
+            name: "Agent: Explore theme system".into(),
+            input: Some(serde_json::json!({
+                "description": "Explore theme system",
+                "subagent_type": "Explore",
+                "model": "haiku",
+                "prompt": "a very long private prompt",
+            })),
+        };
+        let clean = sanitize_tool_call(&call);
+        assert_eq!(
+            clean,
+            ToolCall::Unknown {
+                name: "Agent: Explore theme system".into(),
+                input: Some(serde_json::json!({
+                    "model": "haiku",
+                    "subagent_type": "Explore",
+                })),
+            }
+        );
+        assert_eq!(clean.subagent_model(), Some("haiku"));
+        assert_eq!(sanitize_tool_call(&clean), clean);
+    }
+
+    /// An ordinary tool's input still goes, even when it happens to carry a
+    /// `model` argument — the badge is gated on the spawn genus, not the key.
+    #[test]
+    fn sanitize_still_strips_a_non_spawn_carrying_a_model_argument() {
+        let call = ToolCall::Unknown {
+            name: "SomeTool".into(),
+            input: Some(serde_json::json!({ "model": "haiku", "prompt": "secret" })),
+        };
+        assert_eq!(
+            sanitize_tool_call(&call),
+            ToolCall::Unknown {
+                name: "SomeTool".into(),
+                input: None,
+            }
+        );
+    }
+
+    /// A spawn that named no model keeps no input at all — `None`, not an
+    /// empty object, so the doc gains nothing and the fixpoint is exact.
+    #[test]
+    fn sanitize_drops_a_spawn_input_that_names_nothing_worth_keeping() {
+        let call = ToolCall::Unknown {
+            name: "Agent".into(),
+            input: Some(serde_json::json!({ "prompt": "secret", "model": "  " })),
+        };
+        let clean = sanitize_tool_call(&call);
+        assert_eq!(
+            clean,
+            ToolCall::Unknown {
+                name: "Agent".into(),
+                input: None,
+            }
+        );
+        assert_eq!(clean.subagent_model(), None);
     }
 
     #[test]

--- a/crates/harness/src/claude/normalize.rs
+++ b/crates/harness/src/claude/normalize.rs
@@ -153,6 +153,26 @@ fn tag(parent: &str, event: AgentEvent) -> AgentEvent {
     }
 }
 
+/// CLI-synthesized text that rides a user frame but is NOT conversation:
+/// `<system-reminder>` context injections and the interruption marker the CLI
+/// stamps into the transcript when a turn (or a subagent) is stopped.
+///
+/// On a TAGGED frame the distinction is load-bearing, not cosmetic. A tagged
+/// user message means "the parent steered its subagent", which announces more
+/// work and is therefore the one event allowed to resurrect a settled spawn
+/// chip. The CLI emits `[Request interrupted by user]` on the child feed
+/// immediately AFTER the subagent's `done{interrupted}` — read as a steer it
+/// un-settled a chip that nothing would ever settle again, and the spinner ran
+/// forever (2026-08-21: "orchestrator killed them but spinner doesn't stop").
+/// It announces the opposite of more work.
+///
+/// Prefix-matched: the CLI ships at least two spellings of the marker
+/// (`…by user]` and `…by user for tool use]`).
+fn is_synthetic_user_text(text: &str) -> bool {
+    let text = text.trim_start();
+    text.starts_with("<system-reminder>") || text.starts_with("[Request interrupted")
+}
+
 /// Per-run normalization state.
 ///
 /// `saw_init` dedupes `system:init` — the CLI re-emits it every time the model
@@ -463,14 +483,15 @@ impl Normalizer {
                     // A tagged user frame's TEXT blocks are the parent
                     // steering its subagent (SendMessage-style follow-ups —
                     // tool results ride their own blocks, filtered above).
-                    // Synthetic harness injections are not conversation.
+                    // Synthetic harness injections are not conversation, and
+                    // must not read as a steer — see [`is_synthetic_user_text`].
                     out.extend(
                         f.message
                             .blocks()
                             .filter(|b: &ContentBlock| {
                                 b.kind == "text"
                                     && !b.text.trim().is_empty()
-                                    && !b.text.trim_start().starts_with("<system-reminder>")
+                                    && !is_synthetic_user_text(&b.text)
                             })
                             .map(|b| tag(parent, AgentEvent::UserMessage { text: b.text })),
                     );
@@ -774,6 +795,41 @@ mod tests {
                 "{frame}: {ev:?}"
             );
         }
+    }
+
+    /// Killing a subagent puts `done{interrupted}` on the child feed and then
+    /// an interruption MARKER as a tagged user frame. Read as a steer, that
+    /// marker resurrects the spawn chip the `done` just settled — and nothing
+    /// ever settles it again, so the chip spins forever. It is CLI
+    /// bookkeeping, filtered like a `<system-reminder>`; a real steer on the
+    /// same frame shape still gets through.
+    #[test]
+    fn the_interruption_marker_is_not_a_steer() {
+        for marker in [
+            "[Request interrupted by user]",
+            "[Request interrupted by user for tool use]",
+        ] {
+            let frame = format!(
+                r#"{{"type":"user","parent_tool_use_id":"toolu_spawn","message":{{"content":[{{"type":"text","text":"{marker}"}}]}}}}"#
+            );
+            assert!(
+                !normalize_one(&frame)
+                    .iter()
+                    .any(|e| matches!(e, AgentEvent::Subagent { .. })),
+                "{marker} leaked as a steer"
+            );
+        }
+        // A genuine steer on the very same frame shape still arrives.
+        let real = r#"{"type":"user","parent_tool_use_id":"toolu_spawn","message":{"content":[{"type":"text","text":"Keep going."}]}}"#;
+        assert!(
+            normalize_one(real).iter().any(|e| matches!(
+                e,
+                AgentEvent::Subagent { parent_tool_use_id, event }
+                    if parent_tool_use_id == "toolu_spawn"
+                        && matches!(event.as_ref(), AgentEvent::UserMessage { text } if text == "Keep going.")
+            )),
+            "a real steer must still reach the subagent"
+        );
     }
 
     #[test]

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -220,7 +220,49 @@ impl ToolCall {
         };
         name == "Agent" || name.starts_with("Agent: ")
     }
+
+    /// The model a subagent SPAWN was given, when the spawn named one.
+    ///
+    /// Read off the spawn's own input rather than the session's picked model:
+    /// a spawn may override it per child (claude's `Agent` takes `model`, grok
+    /// `spawn_subagent` a `model_id`), and two chips spawned in one turn can
+    /// legitimately name different models. `None` means the spawn didn't say —
+    /// the child inherits the parent's model, which the chip already implies,
+    /// so nothing is rendered rather than guessing a name.
+    ///
+    /// Only ever answers for [`is_subagent_spawn`](Self::is_subagent_spawn)
+    /// calls: an ordinary tool with a stray `model` argument is not a spawn.
+    pub fn subagent_model(&self) -> Option<&str> {
+        if !self.is_subagent_spawn() {
+            return None;
+        }
+        let input = match self {
+            ToolCall::Unknown { input, .. } | ToolCall::Mcp { input, .. } => input.as_ref()?,
+            _ => return None,
+        };
+        SUBAGENT_MODEL_KEYS
+            .iter()
+            .find_map(|key| input.get(key).and_then(serde_json::Value::as_str))
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+    }
 }
+
+/// Spawn-input keys that carry a child model, in precedence order. Drivers
+/// disagree on the spelling, so the lookup is by key set, not by harness —
+/// a new adapter naming it any of these needs no code change here.
+pub const SUBAGENT_MODEL_KEYS: [&str; 4] = ["model", "modelId", "model_id", "subagent_model"];
+
+/// The spawn-input keys [`sanitize_tool_call`](crate::) must preserve so the
+/// chip can name the child's model. Deliberately tiny: everything else on a
+/// spawn's input (the whole prompt, most of all) stays host-local.
+pub const SUBAGENT_INPUT_KEEP: [&str; 5] = [
+    "model",
+    "modelId",
+    "model_id",
+    "subagent_model",
+    "subagent_type",
+];
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -400,6 +442,61 @@ mod tests {
         };
         let json = serde_json::to_string(&ev).unwrap();
         assert_eq!(serde_json::from_str::<AgentEvent>(&json).unwrap(), ev);
+    }
+
+    /// Drivers spell the key differently; the chip must not care which one
+    /// spawned the child. Non-spawns never answer, whatever they carry.
+    #[test]
+    fn subagent_model_reads_every_spelling_and_only_off_a_spawn() {
+        let spawn = |input: serde_json::Value| ToolCall::Unknown {
+            name: "Agent: scan".into(),
+            input: Some(input),
+        };
+        for key in SUBAGENT_MODEL_KEYS {
+            let call = spawn(serde_json::json!({ key: "haiku" }));
+            assert_eq!(call.subagent_model(), Some("haiku"), "key {key}");
+        }
+        // An MCP-shaped spawn (cursor routes its `task` through MCP) too.
+        assert_eq!(
+            ToolCall::Mcp {
+                server: "s".into(),
+                tool: "Agent: scan".into(),
+                input: Some(serde_json::json!({ "model": "sonnet" })),
+            }
+            .subagent_model(),
+            Some("sonnet")
+        );
+        // Not a spawn: the name gate wins over the key.
+        assert_eq!(
+            ToolCall::Unknown {
+                name: "Bash".into(),
+                input: Some(serde_json::json!({ "model": "haiku" })),
+            }
+            .subagent_model(),
+            None
+        );
+        // A spawn that named nothing usable inherits — nothing to render.
+        assert_eq!(
+            spawn(serde_json::json!({ "model": " " })).subagent_model(),
+            None
+        );
+        assert_eq!(
+            spawn(serde_json::json!({ "prompt": "x" })).subagent_model(),
+            None
+        );
+        assert_eq!(
+            ToolCall::Unknown {
+                name: "Agent".into(),
+                input: None
+            }
+            .subagent_model(),
+            None
+        );
+        // Non-string values are not names.
+        assert_eq!(
+            spawn(serde_json::json!({ "model": 5 })).subagent_model(),
+            None
+        );
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -4449,6 +4449,30 @@ fn chip_header_row(
                 })
                 .child(SharedString::from(detail)),
         )
+        .when_some(tool.call.subagent_model(), |row, model| {
+            // Which model the child runs on, when the spawn named one.
+            //
+            // In the trailing slot rather than suffixed onto the detail: the
+            // detail is the truncating slot, and the model is exactly what a
+            // reader scanning a fan-out of spawns wants left once the
+            // descriptions are cut.
+            //
+            // Bare faint text, NOT a filled pill: the tiles either side of it
+            // are AFFORDANCES (the spinner means running, the arrow opens the
+            // subagent), so giving a passive label the same chrome made the
+            // trailing edge read as three buttons — the loudest thing in the
+            // row was the one thing you cannot click.
+            row.child(
+                div()
+                    .flex_none()
+                    .h(px(18.0))
+                    .flex()
+                    .items_center()
+                    .text_size(px(11.0))
+                    .text_color(theme.text_faint)
+                    .child(SharedString::from(model.to_owned())),
+            )
+        })
         .when(running, |row| {
             // The sidebar working-row spinner, in the chip's trailing slot —
             // paint-local (fixed footprint), so it never moves the layout.


### PR DESCRIPTION

<img width="897" height="506" alt="image" src="https://github.com/user-attachments/assets/6daab5f7-34ad-4c9c-b9d8-62270bb52062" />


Two things, one about subagent spawn chips.

## The chip now says which model the child runs on

A fan-out of spawns rendered identically whether the children were `haiku` or `opus`. The only way to find out was to open each subagent tab.

The model was already on the wire — a spawn's input carries it whenever the call named one (claude's `Agent` takes `model`, grok's `spawn_subagent` a `model_id`). What was missing:

- `ToolCall::subagent_model()` reads it off the call, gated on the existing `is_subagent_spawn` genus so an ordinary tool with a stray `model` argument is never mistaken for a spawn. Four key spellings, since drivers disagree on it.
- `sanitize_tool_call` was dropping every `Unknown`/`Mcp` input wholesale, which is what had stranded the model host-side. It now keeps a whitelist of two short identifiers, for spawns only. The prompt still never leaves the host's run journal.
- The chip renders it in the trailing slot as bare faint text — not suffixed onto the description (that's the truncating slot, and it's exactly what gets cut in the fan-out this is for), and not a filled pill (the tiles either side are affordances; giving a passive label the same chrome made the loudest thing in the row the one thing you can't click).

A spawn that named no model renders nothing — the child inherits the parent's, which the chip already implies.

## Killing a subagent left its chip spinning forever

The CLI puts two frames on the child feed when a subagent is stopped, in this order:

```
done{interrupted}                       <- the chip settles
user "[Request interrupted by user]"    <- the chip goes back to running
```

A tagged user frame means "the parent steered its subagent" — it announces more work, and is therefore the one event allowed past the fold's no-regress guard onto a settled chip. The interruption marker announces the opposite, and nothing follows it, so the chip the `done` had just settled spun for the rest of the session.

It's filtered now, one line up from where `<system-reminder>` injections were already filtered: CLI bookkeeping riding a user frame is not conversation. Prefix-matched, since the CLI ships at least two spellings.

## Testing

Ran against a live claude session: spawned two haiku subagents, confirmed both chips read `haiku`, then killed them and confirmed both settle instead of spinning.

New tests cover all four model-key spellings, MCP-shaped spawns, non-spawn rejection, the prompt still being stripped, sanitize idempotency, both interruption-marker spellings, and — importantly — that a real steer on the identical frame shape still gets through.

One pre-existing failure on this tree, unrelated and present on a clean checkout: `shell_env::unix::tests::falls_back_when_interactive_attempt_hangs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789858872&installation_model_id=425430&pr_number=193&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F193&signature=fbdd549135686365d602db306fe072c2638ffc81826ae887bfff03c72298a875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->