### PR TITLE
Preserve transcript viewport across chat switches

### DIFF
--- a/crates/ui/src/rail.rs
+++ b/crates/ui/src/rail.rs
@@ -249,6 +249,7 @@ impl Transcript {
     ///   measurement correcting the estimate just re-enters the timeline;
     /// - once the target row is measured the glide is pixel-exact.
     pub fn scroll_to_row(&mut self, target: usize, cx: &mut Context<Self>) {
+        self.begin_scroll_navigation();
         if motion::reduced_motion(cx) {
             self.list_state().scroll_to(ListOffset {
                 item_ix: target,

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -618,6 +618,10 @@ pub struct AppState {
     pub spaces_synced: bool,
     /// Joined transcript of the selected chat (continuations folded engine-side).
     pub transcript: Vec<SessionMessageEntry>,
+    /// The selected chat's opening `WatchDocMessages` reset has landed. An
+    /// empty transcript is otherwise indistinguishable from the pre-replay
+    /// gap after selection, where optimistic echoes may already be visible.
+    pub transcript_replayed: bool,
     /// Optimistic user echoes per chat id, shown until the doc frame carrying
     /// the same message id arrives (client-minted ids make dedup exact).
     echoes: HashMap<String, Vec<SessionMessageEntry>>,
@@ -678,6 +682,7 @@ impl AppState {
             selected_device: None,
             selected_chat: None,
             transcript: Vec::new(),
+            transcript_replayed: false,
             echoes: HashMap::new(),
             pending_sends: HashMap::new(),
             upload_progress: None,
@@ -749,6 +754,7 @@ impl AppState {
             // Selected chat vanished (deleted elsewhere): drop selection + transcript.
             self.selected_chat = None;
             self.transcript.clear();
+            self.transcript_replayed = false;
             self.transcript_task = None;
         }
     }
@@ -910,6 +916,7 @@ impl AppState {
             echoes.retain(|echo| !entries.iter().any(|e| e.id == echo.id));
         }
         self.transcript = entries;
+        self.transcript_replayed = true;
         self.ack_pending_send_from_transcript();
     }
 
@@ -919,7 +926,11 @@ impl AppState {
         &mut self,
         frame: TranscriptFrame,
     ) -> Result<(), TranscriptDesync> {
+        let is_reset = matches!(&frame, TranscriptFrame::Reset { .. });
         zeron_doc::apply_transcript_frame(&mut self.transcript, frame)?;
+        if is_reset {
+            self.transcript_replayed = true;
+        }
         if let Some(chat_id) = self.selected_chat.as_deref()
             && let Some(echoes) = self.echoes.get_mut(chat_id)
         {
@@ -1328,6 +1339,7 @@ impl AppState {
         self.chats_synced = false;
         self.spaces_synced = false;
         self.transcript.clear();
+        self.transcript_replayed = false;
         self.echoes.clear();
         self.pending_sends.clear();
         self.upload_progress = None;
@@ -1486,6 +1498,7 @@ impl AppState {
         self.selected_chat = chat_id.clone();
         self.auto_selected = true;
         self.transcript.clear();
+        self.transcript_replayed = false;
         self.transcript_task = None;
         if let Some(id) = chat_id.as_deref() {
             // A chat implies its project (or the lack of one); `select_chat(None)`
@@ -3007,6 +3020,27 @@ mod tests {
             },
         );
         assert!(state.pending_echoes().is_empty());
+    }
+
+    #[test]
+    fn transcript_replay_barrier_requires_the_opening_reset() {
+        let mut state = AppState::new();
+        assert!(!state.transcript_replayed);
+
+        state
+            .apply_transcript_frame(TranscriptFrame::Delta {
+                upsert: Vec::new(),
+                append: Vec::new(),
+                remove: Vec::new(),
+                count: 0,
+            })
+            .expect("empty delta");
+        assert!(!state.transcript_replayed);
+
+        state
+            .apply_transcript_frame(TranscriptFrame::Reset { reset: Vec::new() })
+            .expect("empty reset");
+        assert!(state.transcript_replayed);
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -26,7 +26,7 @@
 //! whole turn is already visible, so there is nothing to scroll to.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::ops::Range;
 use std::rc::Rc;
 use std::sync::{Arc, Weak};
@@ -61,6 +61,8 @@ pub const STICK_THRESHOLD_PX: f32 = 70.0;
 pub const OVERDRAW_PX: f32 = 320.0;
 /// Show the scroll-to-bottom button beyond this distance from the end.
 pub const SCROLL_BUTTON_THRESHOLD_PX: f32 = 320.0;
+/// Bound session-local viewport memory independently of total chat history.
+const MAX_SAVED_VIEWPORTS: usize = 256;
 /// Text-selection edge scrolling runs only during a drag. A 24 ms cadence is
 /// smooth enough to track text while avoiding a permanent animation-frame loop
 /// on low-end devices.
@@ -1464,8 +1466,9 @@ struct FoldState {
 /// hard-tracks the pad's stale bottom on every commit — rig-traced). Wheel
 /// input releases the hold, leaving the reservation as plain scrollable
 /// space. The anchor retires once the reply overflows the reservation (pad
-/// ~0, height-neutral) and on explicit navigation / chat switches (revisits
-/// start at the bottom).
+/// ~0, height-neutral). Chat switches snapshot its runway with the viewport
+/// and restore it released, so revisiting never resumes hidden auto-follow.
+#[derive(Clone, Debug)]
 struct OwnTurnAnchor {
     chat_id: String,
     message_id: SharedString,
@@ -1479,6 +1482,219 @@ struct OwnTurnAnchor {
     /// position absolutely after every layout (glue- and lag-proof — the
     /// exact mechanism the shipped first-send anchor used).
     positioned: bool,
+    /// A fresh send may install the anchor one notification before its echo.
+    /// Once the prompt has appeared, its later disappearance is terminal
+    /// (failed echo or removed entry) and the runway must retire.
+    seen_prompt: bool,
+}
+
+impl OwnTurnAnchor {
+    fn released_for_restore(mut self) -> Self {
+        self.held = false;
+        self.positioned = false;
+        self.seen_prompt = true;
+        self
+    }
+
+    fn observe_prompt(&mut self, exists: bool) -> bool {
+        if exists {
+            self.seen_prompt = true;
+        }
+        exists || !self.seen_prompt
+    }
+}
+
+/// A stable per-chat viewport anchor. Row identity is preferred over its old
+/// index because async replay can insert or remove rows while a chat is away.
+#[derive(Clone, Debug)]
+struct ViewportAnchor {
+    row_id: SharedString,
+    entry_id: SharedString,
+    fallback_ix: usize,
+    offset_in_row: Pixels,
+}
+
+impl ViewportAnchor {
+    fn capture(rows: &[Row], scroll_top: ListOffset) -> Option<Self> {
+        let fallback_ix = scroll_top.item_ix.min(rows.len().checked_sub(1)?);
+        let row = &rows[fallback_ix];
+        Some(Self {
+            row_id: row.id.clone(),
+            entry_id: row.entry_id.clone(),
+            fallback_ix,
+            offset_in_row: scroll_top.offset_in_item,
+        })
+    }
+
+    fn resolve_exact(&self, rows: &[Row]) -> Option<ListOffset> {
+        let item_ix = rows.iter().position(|row| row.id == self.row_id)?;
+        Some(ListOffset {
+            item_ix,
+            offset_in_item: self.offset_in_row,
+        })
+    }
+
+    fn resolve(&self, rows: &[Row]) -> Option<ListOffset> {
+        if let Some(offset) = self.resolve_exact(rows) {
+            return Some(offset);
+        }
+
+        // A row can disappear when a streaming block is reshaped. Stay in the
+        // same message entry, choosing the surviving row nearest the old
+        // location; the intra-row offset is no longer meaningful in that case.
+        let item_ix = rows
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| row.entry_id == self.entry_id)
+            .min_by_key(|(ix, _)| ix.abs_diff(self.fallback_ix))
+            .map(|(ix, _)| ix)
+            .unwrap_or_else(|| self.fallback_ix.min(rows.len().saturating_sub(1)));
+        (!rows.is_empty()).then_some(ListOffset {
+            item_ix,
+            offset_in_item: px(0.0),
+        })
+    }
+}
+
+/// Session-local viewport state. Chats that were following their tail keep
+/// following it; only user-owned viewports restore a concrete row anchor.
+#[derive(Clone, Debug)]
+enum SavedViewport {
+    FollowTail,
+    Anchored {
+        anchor: ViewportAnchor,
+        distance_from_bottom: f32,
+        /// Preserve the runway that made a short active turn scrollable.
+        /// Navigation releases its automatic hold, so revisiting restores the
+        /// viewport without immediately following new output to the bottom.
+        own_turn: Option<OwnTurnAnchor>,
+    },
+}
+
+struct RestoredViewport {
+    offset: ListOffset,
+    distance_from_bottom: f32,
+    own_turn: Option<OwnTurnAnchor>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ViewportFinalizeToken {
+    generation: u64,
+    layout_revision: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TranscriptReplayState {
+    Pending,
+    Empty,
+    Populated,
+}
+
+impl TranscriptReplayState {
+    fn authoritative_empty(self) -> bool {
+        self == Self::Empty
+    }
+
+    fn allows_fallback(self) -> bool {
+        self == Self::Populated
+    }
+}
+
+impl ViewportFinalizeToken {
+    fn still_current(self, generation: u64) -> bool {
+        self.generation == generation
+    }
+
+    fn layout_settled(self, layout_revision: u64) -> bool {
+        self.layout_revision == layout_revision
+    }
+}
+
+impl SavedViewport {
+    fn capture(
+        rows: &[Row],
+        scroll_top: ListOffset,
+        pinned: bool,
+        distance_from_bottom: f32,
+        own_turn: Option<&OwnTurnAnchor>,
+    ) -> Option<Self> {
+        if rows.is_empty() {
+            return None;
+        }
+        if pinned {
+            return Some(Self::FollowTail);
+        }
+        Some(Self::Anchored {
+            anchor: ViewportAnchor::capture(rows, scroll_top)?,
+            distance_from_bottom,
+            own_turn: own_turn.cloned(),
+        })
+    }
+
+    /// Before the opening reset arrives, rows may contain only optimistic
+    /// echoes. In that gap an exact row is safe, but entry/index fallbacks
+    /// would mistake an unrelated echo for the authoritative transcript.
+    fn resolve(&self, rows: &[Row], allow_fallback: bool) -> Option<RestoredViewport> {
+        let Self::Anchored {
+            anchor,
+            distance_from_bottom,
+            own_turn,
+        } = self
+        else {
+            return None;
+        };
+        let offset = if allow_fallback {
+            anchor.resolve(rows)?
+        } else {
+            anchor.resolve_exact(rows)?
+        };
+        let own_turn = own_turn
+            .clone()
+            .filter(|turn| {
+                rows.iter()
+                    .any(|row| row.turn_start && row.entry_id == turn.message_id)
+            })
+            .map(OwnTurnAnchor::released_for_restore);
+        Some(RestoredViewport {
+            offset,
+            distance_from_bottom: *distance_from_bottom,
+            own_turn,
+        })
+    }
+}
+
+#[derive(Default)]
+struct SavedViewportCache {
+    by_chat: HashMap<String, SavedViewport>,
+    recency: VecDeque<String>,
+}
+
+impl SavedViewportCache {
+    fn insert(&mut self, chat_id: String, viewport: SavedViewport) {
+        if self.by_chat.contains_key(&chat_id) {
+            self.recency.retain(|candidate| candidate != &chat_id);
+        }
+        self.recency.push_back(chat_id.clone());
+        self.by_chat.insert(chat_id, viewport);
+        while self.by_chat.len() > MAX_SAVED_VIEWPORTS {
+            let Some(evicted) = self.recency.pop_front() else {
+                break;
+            };
+            self.by_chat.remove(&evicted);
+        }
+    }
+
+    fn get_cloned_and_touch(&mut self, chat_id: &str) -> Option<SavedViewport> {
+        let viewport = self.by_chat.get(chat_id).cloned()?;
+        self.recency.retain(|candidate| candidate != chat_id);
+        self.recency.push_back(chat_id.to_string());
+        Some(viewport)
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.by_chat.len()
+    }
 }
 
 pub struct Transcript {
@@ -1496,6 +1712,23 @@ pub struct Transcript {
     /// only then may the working trailer render — a frozen snapshot must
     /// never spin, whatever its entries claim.
     doc_live: bool,
+    /// Memory-only viewport state for primary chats visited in this window.
+    /// A transcript instance is shared across tabs, so the active ListState is
+    /// reset on every attach and cannot retain these positions by itself.
+    saved_viewports: SavedViewportCache,
+    /// An anchored viewport waiting for the selected chat's async replay.
+    pending_viewport: Option<SavedViewport>,
+    /// Generation of the selected chat, guarding post-layout restoration
+    /// callbacks across rapid A→B→A navigation.
+    viewport_generation: u64,
+    /// A restored item anchor needs one post-layout refresh of distance-based
+    /// UI state; programmatic list scrolling never invokes `handle_scroll`.
+    viewport_finalize_pending: bool,
+    viewport_finalize_scheduled: bool,
+    /// Bumped whenever sync or own-turn logic invalidates measured rows. The
+    /// post-restore finalizer waits until one layout completes without another
+    /// invalidation, avoiding a stale jump-button decision.
+    viewport_layout_revision: u64,
     /// One-shot "open at the latest content" for UNPINNED (frozen) override
     /// instances: rows land ASYNC after the tab opens (watch replay / blob
     /// fetch), so the end-scroll fires on the first non-empty sync, then
@@ -1705,6 +1938,12 @@ impl Transcript {
             land_end_pending: doc_override.is_some() && !follow,
             doc_live: doc_override.is_some() && follow,
             doc_override,
+            saved_viewports: SavedViewportCache::default(),
+            pending_viewport: None,
+            viewport_generation: 0,
+            viewport_finalize_pending: false,
+            viewport_finalize_scheduled: false,
+            viewport_layout_revision: 0,
             row_cache: HashMap::new(),
             live_parsers: HashMap::new(),
             tree_cache: HashMap::new(),
@@ -1793,17 +2032,118 @@ impl Transcript {
         &self.list
     }
 
+    /// Snapshot the outgoing primary chat before its rows and ListState are
+    /// reset. Empty rows never overwrite an older snapshot: during a rapid
+    /// A→B→A switch, B's replay may not have arrived before leaving it again.
+    fn remember_current_viewport(&mut self) {
+        // Rows can already contain optimistic echoes while an older snapshot
+        // is still waiting for the authoritative replay. Leaving again in
+        // that window must preserve the older snapshot, not replace it with
+        // the partial echo-only viewport.
+        if self.pending_viewport.is_some() {
+            return;
+        }
+        let Some(chat_id) = self.chat_id.clone() else {
+            return;
+        };
+        let distance_from_bottom = if self.pinned {
+            0.0
+        } else {
+            self.distance_from_bottom()
+        };
+        let Some(viewport) = SavedViewport::capture(
+            &self.rows,
+            self.list.logical_scroll_top(),
+            self.pinned,
+            distance_from_bottom,
+            self.own_turn.as_ref(),
+        ) else {
+            return;
+        };
+        self.saved_viewports.insert(chat_id, viewport);
+    }
+
+    /// Restore an exact optimistic row while replay is pending, enable stable
+    /// fallbacks only after a populated reset, and retire snapshots proven
+    /// absent by an empty reset. `scroll_to` remains valid while the virtual
+    /// list measures restored rows on the following layout pass.
+    fn restore_pending_viewport(&mut self, replay: TranscriptReplayState) -> bool {
+        if self.pending_viewport.is_none() {
+            return false;
+        }
+        if !self.rows.is_empty()
+            && let Some(restored) = self
+                .pending_viewport
+                .as_ref()
+                .and_then(|saved| saved.resolve(&self.rows, replay.allows_fallback()))
+        {
+            self.pending_viewport = None;
+            self.list.scroll_to(restored.offset);
+            self.own_turn = restored.own_turn;
+            self.own_turn_kick = self.own_turn.is_some();
+            self.own_turn_last_tick = None;
+            if self.own_turn.is_some() {
+                // Replay readiness can change while echo rows stay identical,
+                // so the no-diff path may install a runway without splicing.
+                self.remeasure_last_row();
+            }
+            self.last_scroll_distance = restored.distance_from_bottom;
+            self.show_jump_button = restored.distance_from_bottom > SCROLL_BUTTON_THRESHOLD_PX;
+            self.viewport_finalize_pending = true;
+            return true;
+        }
+
+        if !replay.authoritative_empty() {
+            return false;
+        }
+        // The reset's document rows, not the combined rows, define
+        // authoritative emptiness. A matching optimistic row above remains
+        // valid, but an unrelated echo must never become an index fallback
+        // for old history.
+        self.discard_pending_viewport();
+        if self.own_turn.is_none() {
+            self.pinned = true;
+            self.last_scroll_distance = 0.0;
+            self.show_jump_button = false;
+            self.list.scroll_to_end();
+        }
+        true
+    }
+
+    /// Explicit user/navigation intent supersedes a replay-delayed restore.
+    /// Replace its cache entry with tail-follow until current rows can be
+    /// snapshotted normally on the next chat switch.
+    pub(crate) fn discard_pending_viewport(&mut self) {
+        if self.pending_viewport.take().is_some()
+            && let Some(chat_id) = self.chat_id.clone()
+        {
+            self.saved_viewports
+                .insert(chat_id, SavedViewport::FollowTail);
+        }
+    }
+
     pub(crate) fn state_entity(&self) -> &Entity<AppState> {
         &self.state
     }
 
-    /// Replace the transcript's scroll animation task (rail click / jump).
-    pub(crate) fn set_scroll_task(&mut self, task: Task<()>) {
+    /// Hand viewport ownership to explicit rail/navigation input before its
+    /// reduced-motion or animated branch moves the list.
+    pub(crate) fn begin_scroll_navigation(&mut self) {
+        self.discard_pending_viewport();
         // Rail navigation within the session RELEASES the hold but keeps the
         // runway (user spec: only leaving and revisiting the session clears
         // it) — scrolling back down re-arms the hold like any restick.
         self.release_own_turn_hold();
         self.pinned = false;
+        self.spring.reset();
+        self.spring_last_tick = None;
+        self.spring_settled_at = None;
+        self.spring_kick = false;
+        self.scroll_anim = None;
+    }
+
+    /// Store the animation after [`Self::begin_scroll_navigation`].
+    pub(crate) fn set_scroll_task(&mut self, task: Task<()>) {
         self.scroll_anim = Some(task);
     }
 
@@ -1816,9 +2156,10 @@ impl Transcript {
         self.own_turn_last_tick = None;
     }
 
-    fn remeasure_last_row(&self) {
+    fn remeasure_last_row(&mut self) {
         if let Some(last) = self.rows.len().checked_sub(1) {
             self.list.remeasure_items(last..last + 1);
+            self.viewport_layout_revision = self.viewport_layout_revision.wrapping_add(1);
         }
     }
 
@@ -1845,6 +2186,7 @@ impl Transcript {
         let this = cx.weak_entity();
         cx.defer(move |cx| {
             this.update(cx, |this: &mut Transcript, cx| {
+                this.discard_pending_viewport();
                 // Wheel/touch while a runway lives: input owns the viewport,
                 // and the BOTTOM PIN must stay out of it entirely. Escaping
                 // releases the hold (the reservation stays behind as plain
@@ -2013,6 +2355,7 @@ impl Transcript {
         // successive virtualized rows.
         render::update_drag_at(position);
         self.scroll_anim = None;
+        self.discard_pending_viewport();
         self.release_own_turn_hold();
         self.pinned = false;
         self.spring.reset();
@@ -2032,6 +2375,7 @@ impl Transcript {
     /// bottom lands the prompt at the top. Replacing a still-held previous
     /// anchor collapses its pad into the same glide — one continuous motion.
     pub fn on_own_send(&mut self, chat_id: String, message_id: String, cx: &mut Context<Self>) {
+        self.discard_pending_viewport();
         self.pinned = false;
         self.show_jump_button = false;
         self.spring.reset();
@@ -2045,12 +2389,17 @@ impl Transcript {
         // CONCRETE visible item first; the pad then reads as scrollable
         // distance for the glide to cover.
         self.materialize_scroll_anchor();
+        let seen_prompt = self
+            .rows
+            .iter()
+            .any(|row| row.turn_start && row.entry_id == message_id.as_str());
         self.own_turn = Some(OwnTurnAnchor {
             chat_id,
             message_id: SharedString::from(message_id),
             runway: 0.0,
             held: true,
             positioned: false,
+            seen_prompt,
         });
         self.own_turn_last_tick = None;
         self.own_turn_kick = true;
@@ -2098,6 +2447,35 @@ impl Transcript {
             .position(|row| row.turn_start && row.entry_id == anchor.message_id)
     }
 
+    fn reconcile_own_turn_prompt(&mut self) {
+        let Some(message_id) = self
+            .own_turn
+            .as_ref()
+            .map(|anchor| anchor.message_id.clone())
+        else {
+            return;
+        };
+        let exists = self
+            .rows
+            .iter()
+            .any(|row| row.turn_start && row.entry_id == message_id);
+        let keep = self
+            .own_turn
+            .as_mut()
+            .is_some_and(|anchor| anchor.observe_prompt(exists));
+        if keep {
+            return;
+        }
+
+        self.own_turn = None;
+        self.own_turn_kick = false;
+        self.own_turn_last_tick = None;
+        self.remeasure_last_row();
+        self.last_scroll_distance = self.distance_from_bottom();
+        self.show_jump_button = self.last_scroll_distance > SCROLL_BUTTON_THRESHOLD_PX;
+        self.viewport_finalize_pending = true;
+    }
+
     /// One post-layout own-turn step: size the reservation pad. Pure layout —
     /// all motion is the ordinary bottom pin (see [`OwnTurnAnchor`]).
     fn step_own_turn(&mut self, cx: &mut Context<Self>) {
@@ -2113,6 +2491,9 @@ impl Transcript {
             // The optimistic echo may arrive on the next state notification.
             return;
         };
+        if let Some(anchor) = self.own_turn.as_mut() {
+            anchor.seen_prompt = true;
+        }
         let viewport = self.list.viewport_bounds();
         let viewport_height = f32::from(viewport.size.height);
         if viewport_height <= 0.0 {
@@ -2380,6 +2761,7 @@ impl Transcript {
 
     /// The scroll-to-bottom pill's click: glide back to the end and re-pin.
     pub fn jump_to_bottom(&mut self, cx: &mut Context<Self>) {
+        self.discard_pending_viewport();
         // With a live runway, "bottom" IS the held position (the reservation
         // makes prompt-at-top and pad-bottom the same place): re-arm the hold
         // and glide back instead of destroying the runway (user spec — only
@@ -2492,7 +2874,7 @@ impl Transcript {
 
     /// Rebuild rows from app state; splice minimal ranges into the list.
     fn sync(&mut self, cx: &mut Context<Self>) {
-        let (selected, entries, echoes) = {
+        let (selected, entries, echoes, replay) = {
             let s = self.state.read(cx);
             match &self.doc_override {
                 // Pinned to a subagent doc: `selected` equals `chat_id` by
@@ -2502,17 +2884,35 @@ impl Transcript {
                     Some(doc_id.clone()),
                     s.sub_transcript(doc_id).to_vec(),
                     Vec::new(),
+                    TranscriptReplayState::Populated,
                 ),
-                None => (
-                    s.selected_chat.clone(),
-                    s.transcript.clone(),
-                    s.pending_echoes().to_vec(),
-                ),
+                None => {
+                    let replay = if !s.transcript_replayed {
+                        TranscriptReplayState::Pending
+                    } else if s.transcript.is_empty() {
+                        TranscriptReplayState::Empty
+                    } else {
+                        TranscriptReplayState::Populated
+                    };
+                    (
+                        s.selected_chat.clone(),
+                        s.transcript.clone(),
+                        s.pending_echoes().to_vec(),
+                        replay,
+                    )
+                }
             }
         };
 
         let attached = selected != self.chat_id;
         if attached {
+            // Read the incoming snapshot before inserting the outgoing one:
+            // a full bounded cache may evict its oldest entry, which can be
+            // exactly the chat the user is reopening.
+            let saved_viewport = selected
+                .as_ref()
+                .and_then(|chat_id| self.saved_viewports.get_cloned_and_touch(chat_id));
+            self.remember_current_viewport();
             let keep_own_turn = self
                 .own_turn
                 .as_ref()
@@ -2520,6 +2920,7 @@ impl Transcript {
             if !keep_own_turn {
                 self.own_turn = None;
                 self.own_turn_kick = false;
+                self.own_turn_last_tick = None;
             }
             self.chat_id = selected;
             self.rows.clear();
@@ -2531,14 +2932,45 @@ impl Transcript {
             self.render_cache.borrow_mut().clear();
             self.highlights.entries.clear();
             self.list.reset(0);
-            // A kept own-turn hold (send-created chat) owns the viewport;
-            // otherwise the fresh attach pins to the bottom.
-            self.pinned = self.own_turn.is_none();
+            self.pending_viewport = None;
+            self.viewport_generation = self.viewport_generation.wrapping_add(1);
+            self.viewport_finalize_pending = false;
+            if self.own_turn.is_some() {
+                // A kept own-turn hold (send-created chat) owns the viewport.
+                self.pinned = false;
+                self.last_scroll_distance = 0.0;
+                self.show_jump_button = false;
+            } else if let Some(SavedViewport::Anchored {
+                anchor,
+                distance_from_bottom,
+                own_turn,
+            }) = saved_viewport
+            {
+                // Keep a possible runway pending until replay confirms that
+                // its optimistic prompt still exists. Installing it on this
+                // empty attach frame can leave a failed send's stale anchor
+                // intercepting scroll-to-bottom forever.
+                self.pinned = false;
+                self.last_scroll_distance = distance_from_bottom;
+                self.show_jump_button = distance_from_bottom > SCROLL_BUTTON_THRESHOLD_PX;
+                self.pending_viewport = Some(SavedViewport::Anchored {
+                    anchor,
+                    distance_from_bottom,
+                    own_turn,
+                });
+            } else {
+                // New chats and chats that were following their tail retain
+                // the existing open-at-bottom behavior.
+                self.pinned = true;
+                self.last_scroll_distance = 0.0;
+                self.show_jump_button = false;
+            }
             self.spring.reset();
             self.spring_last_tick = None;
             self.spring_settled_at = None;
             self.spring_kick = false;
-            self.show_jump_button = false;
+            self.scroll_anim = None;
+            self.stop_selection_scroll();
         }
 
         let mut new_rows: Vec<Row> = Vec::new();
@@ -2588,6 +3020,13 @@ impl Transcript {
             None => {
                 self.rows = new_rows;
                 self.refresh_protected_attachments(cx);
+                self.reconcile_own_turn_prompt();
+                // Replay readiness is independent of row content: an empty
+                // reset (or one identical to optimistic rows) still resolves
+                // or retires the pending viewport.
+                if self.restore_pending_viewport(replay) {
+                    cx.notify();
+                }
                 return;
             }
             Some((old_range, count)) => {
@@ -2613,10 +3052,13 @@ impl Transcript {
                 } else {
                     self.list.splice(old_range, count);
                 }
+                self.viewport_layout_revision = self.viewport_layout_revision.wrapping_add(1);
             }
         }
         self.rows = new_rows;
         self.refresh_protected_attachments(cx);
+        self.reconcile_own_turn_prompt();
+        self.restore_pending_viewport(replay);
         if self.land_end_pending && !self.rows.is_empty() {
             // First content for an unpinned override tab: land at the end.
             // `scroll_to_end` is ITEM-anchored (past-the-end offset that the
@@ -4779,6 +5221,39 @@ impl Render for Transcript {
                     .ok();
             });
         }
+        // Programmatic `scroll_to` does not invoke the list's user-scroll
+        // handler. Refresh distance-derived state once layout has measured the
+        // replay, guarded so a stale A callback cannot mutate B (or a newer A).
+        if self.viewport_finalize_pending && !self.viewport_finalize_scheduled {
+            self.viewport_finalize_scheduled = true;
+            let token = ViewportFinalizeToken {
+                generation: self.viewport_generation,
+                layout_revision: self.viewport_layout_revision,
+            };
+            let entity = cx.weak_entity();
+            window.on_next_frame(move |_, cx| {
+                entity
+                    .update(cx, |this: &mut Transcript, cx| {
+                        this.viewport_finalize_scheduled = false;
+                        if !token.still_current(this.viewport_generation) {
+                            if this.viewport_finalize_pending {
+                                cx.notify();
+                            }
+                            return;
+                        }
+                        let distance = this.distance_from_bottom();
+                        this.last_scroll_distance = distance;
+                        this.show_jump_button = distance > SCROLL_BUTTON_THRESHOLD_PX
+                            && !this.pinned
+                            && !this.own_turn.as_ref().is_some_and(|turn| turn.held);
+                        if token.layout_settled(this.viewport_layout_revision) {
+                            this.viewport_finalize_pending = false;
+                        }
+                        cx.notify();
+                    })
+                    .ok();
+            });
+        }
         let rail = self.render_rail(cx);
         // The scroll-to-bottom pill is rendered by the SHELL (conversation
         // region overlay): it must float just above the composer and paint
@@ -5064,6 +5539,263 @@ mod tests {
         // over with no height jump).
         assert_eq!(own_turn_reservation(usable, 700.0), 0.0);
         assert_eq!(own_turn_reservation(usable, 1_200.0), 0.0);
+    }
+
+    fn viewport_row(id: &str, entry_id: &str) -> Row {
+        Row {
+            id: id.into(),
+            version: 0,
+            turn_start: true,
+            kind: RowKind::ErrorChip {
+                message: SharedString::default(),
+            },
+            entry_id: entry_id.into(),
+            timestamp: None,
+        }
+    }
+
+    #[test]
+    fn viewport_anchor_tracks_a_stable_row_across_replay() {
+        let rows = vec![
+            viewport_row("a", "entry-a"),
+            viewport_row("b", "entry-b"),
+            viewport_row("c", "entry-c"),
+        ];
+        let anchor = ViewportAnchor::capture(
+            &rows,
+            ListOffset {
+                item_ix: 1,
+                offset_in_item: px(23.0),
+            },
+        )
+        .expect("visible row");
+
+        let replay = vec![
+            viewport_row("new", "entry-new"),
+            viewport_row("a", "entry-a"),
+            viewport_row("b", "entry-b"),
+            viewport_row("c", "entry-c"),
+        ];
+        let restored = anchor.resolve(&replay).expect("restored row");
+        assert_eq!(restored.item_ix, 2);
+        assert_eq!(restored.offset_in_item, px(23.0));
+    }
+
+    #[test]
+    fn viewport_anchor_has_entry_and_index_fallbacks() {
+        let rows = vec![
+            viewport_row("a", "entry-a"),
+            viewport_row("b", "entry-b"),
+            viewport_row("old-block", "entry-c"),
+        ];
+        let anchor = ViewportAnchor::capture(
+            &rows,
+            ListOffset {
+                item_ix: 2,
+                offset_in_item: px(31.0),
+            },
+        )
+        .expect("visible row");
+
+        let reshaped = vec![
+            viewport_row("a", "entry-a"),
+            viewport_row("b", "entry-b"),
+            viewport_row("inserted", "entry-new"),
+            viewport_row("new-block", "entry-c"),
+        ];
+        let same_entry = anchor.resolve(&reshaped).expect("entry fallback");
+        assert_eq!(same_entry.item_ix, 3);
+        assert_eq!(same_entry.offset_in_item, px(0.0));
+
+        let entry_removed = vec![viewport_row("a", "entry-a"), viewport_row("b", "entry-b")];
+        let clamped = anchor.resolve(&entry_removed).expect("index fallback");
+        assert_eq!(clamped.item_ix, 1);
+        assert_eq!(clamped.offset_in_item, px(0.0));
+    }
+
+    #[test]
+    fn optimistic_echo_cannot_consume_a_historical_viewport_before_replay() {
+        let history = vec![viewport_row("historical", "historical-entry")];
+        let saved = SavedViewport::capture(&history, ListOffset::default(), false, 480.0, None)
+            .expect("historical viewport");
+        let echo_only = vec![viewport_row("echo", "echo-entry")];
+
+        assert!(
+            saved.resolve(&echo_only, false).is_none(),
+            "an unrelated echo is not an authoritative index fallback"
+        );
+        assert_eq!(
+            saved
+                .resolve(&echo_only, true)
+                .expect("populated replay may use an index fallback")
+                .offset
+                .item_ix,
+            0
+        );
+        assert!(TranscriptReplayState::Empty.authoritative_empty());
+        assert!(!TranscriptReplayState::Empty.allows_fallback());
+        assert!(!TranscriptReplayState::Pending.allows_fallback());
+        assert!(TranscriptReplayState::Populated.allows_fallback());
+
+        let echo_viewport =
+            SavedViewport::capture(&echo_only, ListOffset::default(), false, 0.0, None)
+                .expect("echo viewport");
+        assert!(
+            echo_viewport.resolve(&echo_only, false).is_some(),
+            "the exact optimistic row is safe before replay"
+        );
+    }
+
+    #[test]
+    fn saved_viewport_preserves_and_releases_an_active_turn_runway() {
+        let rows = vec![viewport_row("prompt", "prompt")];
+        let own_turn = OwnTurnAnchor {
+            chat_id: "chat-a".into(),
+            message_id: "prompt".into(),
+            runway: 640.0,
+            held: true,
+            positioned: true,
+            seen_prompt: true,
+        };
+        let saved = SavedViewport::capture(
+            &rows,
+            ListOffset {
+                item_ix: 0,
+                offset_in_item: px(0.0),
+            },
+            false,
+            0.0,
+            Some(&own_turn),
+        )
+        .expect("active chat viewport");
+        let SavedViewport::Anchored {
+            own_turn: Some(saved_turn),
+            ..
+        } = &saved
+        else {
+            panic!("an active turn must keep its runway with the viewport");
+        };
+        assert_eq!(saved_turn.runway, 640.0);
+        assert!(saved_turn.held);
+        assert!(saved_turn.positioned);
+
+        let restored = saved
+            .resolve(&rows, false)
+            .expect("exact queued echo survives an empty replay");
+        let restored_turn = restored.own_turn.expect("valid restored runway");
+        assert_eq!(restored_turn.runway, 640.0);
+        assert!(!restored_turn.held);
+        assert!(!restored_turn.positioned);
+        assert!(restored_turn.seen_prompt);
+
+        let list_state = ListState::new(rows.len(), ListAlignment::Bottom, px(0.0));
+        list_state.reset(0);
+        list_state.splice(0..0, rows.len());
+        list_state.scroll_to(restored.offset);
+        assert_eq!(list_state.logical_scroll_top().item_ix, 0);
+        assert_eq!(list_state.logical_scroll_top().offset_in_item, px(0.0));
+
+        assert!(
+            SavedViewport::capture(&[], ListOffset::default(), false, 0.0, Some(&own_turn))
+                .is_none(),
+            "an empty rapid-switch replay must not overwrite the older snapshot"
+        );
+    }
+
+    #[test]
+    fn own_turn_waits_for_its_first_echo_then_retires_if_it_disappears() {
+        let mut turn = OwnTurnAnchor {
+            chat_id: "chat-a".into(),
+            message_id: "prompt".into(),
+            runway: 0.0,
+            held: true,
+            positioned: false,
+            seen_prompt: false,
+        };
+
+        assert!(turn.observe_prompt(false), "fresh send waits one state gap");
+        assert!(turn.observe_prompt(true), "echo activates the runway");
+        assert!(turn.seen_prompt);
+        assert!(
+            !turn.observe_prompt(false),
+            "failed echo retires the activated runway"
+        );
+    }
+
+    #[test]
+    fn restored_viewport_discards_a_failed_optimistic_turn() {
+        let outgoing = vec![viewport_row("prompt", "prompt")];
+        let own_turn = OwnTurnAnchor {
+            chat_id: "chat-a".into(),
+            message_id: "prompt".into(),
+            runway: 640.0,
+            held: true,
+            positioned: true,
+            seen_prompt: true,
+        };
+        let saved = SavedViewport::capture(
+            &outgoing,
+            ListOffset::default(),
+            false,
+            420.0,
+            Some(&own_turn),
+        )
+        .expect("outgoing viewport");
+
+        // The failed echo vanished while A was hidden. The ordinary viewport
+        // still restores by index, but no stale runway may intercept jump.
+        let replay = vec![viewport_row("older", "older")];
+        let restored = saved.resolve(&replay, true).expect("index fallback");
+        assert!(restored.own_turn.is_none());
+        assert_eq!(restored.offset.item_ix, 0);
+        assert_eq!(restored.distance_from_bottom, 420.0);
+    }
+
+    #[test]
+    fn pinned_viewports_follow_tail_and_the_cache_is_bounded() {
+        let rows = vec![viewport_row("row", "entry")];
+        let pinned = SavedViewport::capture(&rows, ListOffset::default(), true, 999.0, None)
+            .expect("pinned viewport");
+        assert!(matches!(pinned, SavedViewport::FollowTail));
+
+        let mut cache = SavedViewportCache::default();
+        for ix in 0..MAX_SAVED_VIEWPORTS + 8 {
+            cache.insert(format!("chat-{ix}"), SavedViewport::FollowTail);
+        }
+        assert_eq!(cache.len(), MAX_SAVED_VIEWPORTS);
+        assert!(cache.get_cloned_and_touch("chat-0").is_none());
+        assert!(
+            cache
+                .get_cloned_and_touch(&format!("chat-{}", MAX_SAVED_VIEWPORTS + 7))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn reopening_the_oldest_cached_chat_protects_it_from_the_next_eviction() {
+        let mut cache = SavedViewportCache::default();
+        for ix in 0..MAX_SAVED_VIEWPORTS {
+            cache.insert(format!("chat-{ix}"), SavedViewport::FollowTail);
+        }
+
+        assert!(cache.get_cloned_and_touch("chat-0").is_some());
+        cache.insert("outgoing-new".into(), SavedViewport::FollowTail);
+
+        assert!(cache.by_chat.contains_key("chat-0"));
+        assert!(!cache.by_chat.contains_key("chat-1"));
+        assert!(cache.by_chat.contains_key("outgoing-new"));
+    }
+
+    #[test]
+    fn viewport_finalization_waits_for_current_generation_and_stable_layout() {
+        let token = ViewportFinalizeToken {
+            generation: 7,
+            layout_revision: 11,
+        };
+        assert!(token.still_current(7));
+        assert!(!token.still_current(8));
+        assert!(token.layout_settled(11));
+        assert!(!token.layout_settled(12));
     }
 
     fn parse(_: &str, text: &str) -> Arc<BlockTree> {

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -5686,6 +5686,7 @@ mod tests {
             },
             entry_id: entry_id.into(),
             timestamp: None,
+            copy_text: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Preserve each chat's transcript viewport when switching between conversations, preventing the UI from unexpectedly jumping back to the bottom.

This works for existing chats with replayed history, new chats with optimistic messages, and chats that are actively streaming.

## Problem

The transcript list is shared across chat tabs and resets whenever a different chat is attached.

Because transcript replay and layout measurement happen asynchronously, the list could lose the user-owned scroll position and re-engage bottom-follow behavior. This caused chats to jump to the bottom after tab switches or while the active turn changed the transcript geometry.

## Changes

- Add session-local viewport restoration for primary chats.
- Store up to 256 viewport snapshots using bounded LRU eviction.
- Anchor restoration to stable row and entry identifiers instead of relying only on row indexes.
- Distinguish pending, empty, and populated transcript replay states.
- Delay fallback restoration until the authoritative transcript reset arrives.
- Guard deferred restoration with chat-generation and layout-revision tokens.
- Preserve active-turn runway state when switching away from a streaming chat.
- Retire stale runway state when an optimistic prompt disappears after a failed send.
- Cancel pending restoration when the user explicitly scrolls or navigates.
- Hand viewport ownership to rail navigation consistently in animated and reduced-motion modes.
- Recalculate distance-based viewport state after the restored layout has stabilized.

## Behavior

- Chats that were following the tail continue following the tail.
- Chats where the user had scrolled upward restore the previous visible content.
- Returning to a cached chat marks it as the most recently used viewport.
- Subagent transcripts do not consume entries from the primary chat viewport cache.
- Viewport state remains memory-only and is not persisted across application restarts.

## Performance

The cache stores only small viewport anchors and metadata, not transcript contents.

Streaming adds no permanent polling loop. Layout finalization runs only while restoration or active-turn geometry is unsettled, and the cache is capped at 256 primary chats.

## Testing

- Added coverage for stable row restoration across transcript replay.
- Added entry and row-index fallback coverage.
- Added pending replay and optimistic echo coverage.
- Added active-turn runway restoration and failed-send cleanup coverage.
- Added LRU capacity and recency coverage.
- Added stale generation and unstable layout finalization coverage.
- Added rail navigation coverage for direct and animated scrolling.
- `cargo test -p zeron-ui --lib` (498 passed)
- `rustfmt --edition 2024 --check crates/ui/src/rail.rs crates/ui/src/state.rs crates/ui/src/transcript.rs`
- `git diff --check`

## Formatting note

The repository-wide `cargo fmt --check` currently reports pre-existing formatting differences outside the files changed by this PR. The three modified files pass an isolated `rustfmt --check`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789868707&installation_model_id=425430&pr_number=195&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F195&signature=cd9846bd986b80e3ef40cd4b7f71d777a5e713f8683acbd4faaee44a5af1ccf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->