### PR TITLE
Build Linux releases against the oldest glibc we support (fixes load failure on Ubuntu 22.04)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,21 @@ permissions:
 
 jobs:
   linux:
+    # Build on the OLDEST Ubuntu we support, not the newest. A dynamically
+    # linked glibc binary carries a hard version floor equal to the glibc it
+    # was built against, and ld.so refuses to load it on anything older — so
+    # whatever runner is named here silently becomes the minimum supported
+    # distro. Building on 24.04 (glibc 2.39) made the tarballs unloadable on
+    # 22.04 (glibc 2.35), which is in standard support until 2027 and is what
+    # most cloud images still ship. glibc is backward compatible, so a 22.04
+    # build runs fine on 24.04+. Only bump this to intentionally drop 22.04
+    # (scripts/package-linux.sh asserts the floor and will fail if you do).
     strategy:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-24.04 # x86_64
-          - runner: ubuntu-24.04-arm # aarch64
+          - runner: ubuntu-22.04 # x86_64
+          - runner: ubuntu-22.04-arm # aarch64
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/edge/src/install.sh
+++ b/edge/src/install.sh
@@ -3,14 +3,16 @@
 #
 #   curl -fsSL https://zeron.sh/install.sh | sh
 #
-# Installs the self-contained native binary (no runtime deps) to
-# ~/.zeron/app, puts `zeron` on PATH, and runs it as a local-only
-# systemd user service that survives reboots. Signing in is optional and
-# enables sync after a restart. Re-running
-# upgrades in place; ~/.zeron state is preserved.
+# Installs the native binary to ~/.zeron/app, puts `zeron` on PATH, and runs it
+# as a local-only systemd user service that survives reboots. Signing in is
+# optional and enables sync after a restart. Re-running upgrades in place;
+# ~/.zeron state is preserved.
 #
 # The binary ships with production endpoints baked in: no ZERON_EDGE_URL or
 # client-id configuration needed. Overrides (if any) go in ~/.zeron/env.
+#
+# It does need a couple of system libraries (libxkbcommon-x11, libxcb) that
+# minimal server images omit — see the preflight check below.
 set -eu
 
 BASE="${ZERON_BASE_URL:-https://zeron.sh}"
@@ -56,6 +58,66 @@ else
   curl -fSL --progress-bar "$BASE/releases/$file" -o "$tmp/$file"
   mkdir -p "$dest"
   tar -xzf "$tmp/$file" -C "$dest" --strip-components=1
+fi
+
+# --- preflight: system libraries ---------------------------------------------
+# The binary is not fully self-contained: gpui links libxkbcommon-x11 and libxcb
+# as hard DT_NEEDED entries, so *every* subcommand fails to load without them --
+# including `zeron headless`, `login` and `status`, none of which open a window.
+# Minimal server and cloud images generally don't ship them. Check here, before
+# systemd is pointed at the binary, so the failure names the missing package
+# instead of surfacing as a restart loop in `systemctl --user status zeron`.
+#
+# This runs before `current` is repointed below: on an upgrade, a binary that
+# cannot load must not displace the version that is running fine.
+if command -v ldd >/dev/null 2>&1; then
+  ldd_out="$(ldd "$dest/zeron" 2>&1 || true)"
+
+  # glibc older than the one the release was built against: the loader reports a
+  # version it cannot satisfy, and nothing the user installs can fix it.
+  glibc_want="$(printf '%s\n' "$ldd_out" \
+    | sed -n "s/.*version .\(GLIBC_[0-9.]*\). not found.*/\1/p" | head -1)"
+  if [ -n "$glibc_want" ]; then
+    echo "" >&2
+    echo "zeron install: this build requires $glibc_want, newer than the glibc on" >&2
+    echo "  this system ($(ldd --version 2>/dev/null | head -1))." >&2
+    echo "" >&2
+    echo "  The published binary is too new for this distro -- this is a packaging" >&2
+    echo "  bug, not something you can install your way out of. Please report it:" >&2
+    echo "  https://github.com/zeronsh/comet/issues" >&2
+    exit 1
+  fi
+
+  missing="$(printf '%s\n' "$ldd_out" | awk '/=> not found/ { print $1 }' | sort -u)"
+  if [ -n "$missing" ]; then
+    if command -v apt-get >/dev/null 2>&1; then
+      hint="sudo apt-get install -y libxkbcommon-x11-0 libxcb1"
+    elif command -v dnf >/dev/null 2>&1; then
+      hint="sudo dnf install -y libxkbcommon-x11 libxcb"
+    elif command -v pacman >/dev/null 2>&1; then
+      hint="sudo pacman -S --needed libxkbcommon-x11 libxcb"
+    elif command -v zypper >/dev/null 2>&1; then
+      hint="sudo zypper install -y libxkbcommon-x11-0 libxcb1"
+    elif command -v apk >/dev/null 2>&1; then
+      hint="sudo apk add libxkbcommon libxcb"
+    else
+      hint=""
+    fi
+    echo "" >&2
+    echo "zeron install: missing system libraries:" >&2
+    printf '  %s\n' $missing >&2
+    if [ -n "$hint" ]; then
+      echo "" >&2
+      echo "  install them with:" >&2
+      echo "    $hint" >&2
+      echo "" >&2
+      echo "  then re-run this installer." >&2
+    else
+      echo "" >&2
+      echo "  install the packages providing them, then re-run this installer." >&2
+    fi
+    exit 1
+  fi
 fi
 
 ln -sfn "$dest" "$app_root/current"

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -27,6 +27,31 @@ else
   BIN="$ROOT/target/debug/zeron"
 fi
 
+# --- glibc floor guard -------------------------------------------------------
+# A dynamically linked glibc binary hard-fails at load on any glibc older than
+# the one it was built against, so the build host's glibc silently becomes the
+# minimum Ubuntu we support. Assert the floor here instead of learning it from
+# a user's "cannot open shared object file" report.
+#
+# Note this is about the *version reference* recorded in .gnu.version_r, not
+# about whether the program really needs the newer glibc: Rust std emits a
+# weak, runtime-detected reference to pidfd_spawnp/pidfd_getpid (glibc 2.39)
+# whenever it is built against 2.39 headers, and ld.so validates every entry in
+# .gnu.version_r regardless of the symbols being weak. Building on 22.04 keeps
+# the reference from being emitted at all.
+GLIBC_MAX="${GLIBC_MAX:-2.35}" # Ubuntu 22.04 (standard support until 2027)
+needed="$(readelf -V "$BIN" | sed -n '/Version needs/,$p' \
+  | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sort -Vu | tail -1)"
+if [[ -n "$needed" && "$(printf '%s\nGLIBC_%s\n' "$needed" "$GLIBC_MAX" | sort -V | tail -1)" != "GLIBC_$GLIBC_MAX" ]]; then
+  echo "package-linux.sh: binary requires $needed but the floor is GLIBC_$GLIBC_MAX." >&2
+  echo "  It will not load on any system older than $needed. Symbols pulling it in:" >&2
+  objdump -T "$BIN" | grep -F "($needed)" | sed 's/^/    /' >&2
+  echo "  Fix: build on the oldest supported runner (see .github/workflows/release.yml)," >&2
+  echo "  or raise GLIBC_MAX to intentionally drop older distros." >&2
+  exit 1
+fi
+echo "glibc floor ok: requires ${needed:-none} (max allowed GLIBC_$GLIBC_MAX)"
+
 rm -rf "$STAGE" "$TARBALL"
 mkdir -p "$STAGE"
 install -m 755 "$BIN" "$STAGE/zeron"


### PR DESCRIPTION
## What's broken

The published Linux tarballs don't load on Ubuntu 22.04. On a stock 22.04.5 cloud image (glibc 2.35), a fresh `curl -fsSL https://zeron.sh/install.sh | sh` of 0.2.19 gives:

```
$ zeron login
zeron: error while loading shared libraries: libxkbcommon-x11.so.0:
       cannot open shared object file: No such file or directory
```

and once that library is installed, the real blocker appears:

```
$ ldd ~/.zeron/app/0.2.19/zeron
zeron: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

Two separate bugs. 22.04 is in standard support until 2027 and is what most cloud images still ship, so this is every headless install on a slightly older host.

## Bug 1 — the GLIBC_2.39 floor is spurious

The linux release job runs on `ubuntu-24.04`, whose glibc is 2.39. A dynamically linked glibc binary carries a hard version floor equal to the glibc it was built against, so the release runner's image silently sets the minimum supported distro.

Nothing in the program actually needs glibc 2.39. The only two symbols that pull it in are *weak*:

```
$ objdump -T zeron | grep GLIBC_2.39
  w  DF *UND*  (GLIBC_2.39) pidfd_spawnp
  w  DF *UND*  (GLIBC_2.39) pidfd_getpid
```

Those are Rust std's runtime-detected pidfd fast path for `Command::spawn` — std null-checks both and falls back to `fork`/`exec`. The floor comes purely from building against 2.39 headers, which emits a **non-weak** `GLIBC_2.39` entry in `.gnu.version_r`, and `ld.so` validates every entry there regardless of whether any symbol still references it:

```
$ readelf -V zeron
  0x0020: Version: 1  File: libc.so.6  Cnt: 23
  ...
  0x01e0:   Name: GLIBC_2.39  Flags: none  Version: 25
                              ^^^^^^^^^^^ not WEAK -> ld.so hard-fails
```

**Fix:** build on the oldest Ubuntu we support (`ubuntu-22.04` / `ubuntu-22.04-arm`). glibc is backward compatible, so a 22.04 build still runs on 24.04+ — the floor only ever needs to be as new as the oldest target.

`scripts/package-linux.sh` now also asserts the floor (`GLIBC_MAX`, default 2.35) and fails the build with the offending symbols named, so a future runner bump can't silently reintroduce this.

## Bug 2 — the binary isn't self-contained, and install.sh says it is

`install.sh` opens with *"Installs the self-contained native binary (no runtime deps)"*, but gpui links the X11/xkb libraries as hard `DT_NEEDED` entries:

```
$ readelf -d zeron | grep NEEDED
 (NEEDED)  Shared library: [libxcb.so.1]
 (NEEDED)  Shared library: [libxkbcommon.so.0]
 (NEEDED)  Shared library: [libxkbcommon-x11.so.0]
 ...
```

So *every* subcommand fails to load without them — including `headless`, `login` and `status`, none of which open a window — and minimal server images don't ship them. Under the systemd unit the installer writes, this surfaces as a restart loop rather than a legible error.

`install.sh` now preflights the dynamic loader and names the package to install, with hints for apt/dnf/pacman/zypper/apk, plus a distinct message for the "distro too old" case that no package install can fix. The check runs **before** `current` is repointed, so a broken download can't displace a working install on upgrade. The header comment is corrected.

## Verification

Done on the affected platform — Ubuntu 22.04.5, glibc 2.35, x86_64:

- **Full workspace builds on jammy** with the exact dep list already in `release.yml` (every package name resolves on 22.04; `apt-get install` rc=0), Rust stable 1.98, `cargo build -p zeron` → rc=0.
- **The resulting binary's ceiling is `GLIBC_2.35`** — no 2.39 entry in `.gnu.version_r` at all, confirming std simply doesn't emit the pidfd reference when built against 2.35 headers. `ldd` resolves everything.
- **`scripts/package-linux.sh` runs end to end** and produces `zeron-0.2.19-linux-x86_64.tar.gz`: `glibc floor ok: requires GLIBC_2.35 (max allowed GLIBC_2.35)`.
- **The guard's failure path works**: run with `GLIBC_MAX=2.34` it aborts with exit 1 and names the symbol (`hypotf`). Run against the *shipped* 0.2.19 binary it reports `requires GLIBC_2.39` and names `pidfd_spawnp` / `pidfd_getpid` — i.e. it would have caught this release.
- **install.sh preflight** tested against real loader output for all three branches: the glibc-too-old case, a missing-soname case, and a clean binary (passes silently).

Local verification was a debug build, since profile doesn't affect symbol versioning. The release-profile runner change gets exercised by CI on the next tag.

## Notes for reviewers

- I don't have push access, so this comes from a fork.
- `ubuntu-22.04` and `ubuntu-22.04-arm` are both current, non-deprecated GitHub-hosted labels ([runner-images](https://github.com/actions/runner-images#available-images)).
- If you'd rather keep a modern runner, `cargo-zigbuild --target x86_64-unknown-linux-gnu.2.35` pins the floor explicitly — I didn't go that way because it changes the toolchain for a C-heavy dependency tree (wgpu/gpui/freetype), and building on the older runner needs no new tooling. The floor guard is useful either way.
- Longer term, `dlopen`-ing the X11/xkb libs from the gpui backend would make `zeron headless` genuinely dependency-free on a server. That's a bigger change than this PR, so the preflight just fails loudly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789901293&installation_model_id=425430&pr_number=197&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F197&signature=bef0d769f9efa2c81e44603509b55812e086e73c1377baadb83ba0c5477fb061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->