### PR TITLE
opencode: picker offers only connected providers' models; dedupe doubled error chips

### DIFF
--- a/crates/harness/examples/opencode_models_probe.rs
+++ b/crates/harness/examples/opencode_models_probe.rs
@@ -1,0 +1,32 @@
+//! Live probe: opencode model discovery through the native driver — boots
+//! `opencode serve`, reads `GET /provider`, prints the picker catalog
+//! (connected providers only). Needs `opencode` on PATH (or
+//! OPENCODE_EXECUTABLE); no provider auth required (the anonymous Zen tier
+//! always connects).
+//!
+//!     cargo run -p zeron-harness --example opencode_models_probe
+
+use zeron_harness::{Harness, OpencodeHarness};
+
+#[tokio::main]
+async fn main() {
+    let start = std::time::Instant::now();
+    match OpencodeHarness::new().models().await {
+        Ok(models) => {
+            for m in &models {
+                eprintln!(
+                    "{:40} {:28} {:?} {:?}",
+                    m.id,
+                    m.label,
+                    m.description.as_deref().unwrap_or(""),
+                    m.reasoning_levels
+                );
+            }
+            eprintln!("--- {} models in {:?}", models.len(), start.elapsed());
+        }
+        Err(e) => {
+            eprintln!("discovery failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/harness/src/opencode/mod.rs
+++ b/crates/harness/src/opencode/mod.rs
@@ -621,7 +621,20 @@ fn truncate_body(body: &str) -> String {
 
 /// `GET /provider` → picker models: `{providerID}/{modelID}` ids, effort
 /// ladder from the model's reasoning variants.
+///
+/// Filtered to CONNECTED providers: `all` is the entire models.dev catalog
+/// (measured live: 194 providers / 7,203 models, nearly all needing an API
+/// key the user hasn't set) — offering it verbatim made the picker slow to
+/// open, slow to scroll, and full of models every run of which fails with
+/// "Model not found" (field report, v0.2.21). `connected` names exactly
+/// the usable set (credentialed + config-declared + the anonymous Zen
+/// tier). An absent/empty `connected` (older server) falls back to `all`.
 fn models_from_providers(providers: &Value) -> Vec<Model> {
+    let connected: std::collections::HashSet<&str> = providers
+        .get("connected")
+        .and_then(Value::as_array)
+        .map(|list| list.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
     let list = providers
         .get("all")
         .and_then(Value::as_array)
@@ -632,6 +645,9 @@ fn models_from_providers(providers: &Value) -> Vec<Model> {
         let Some(provider_id) = provider.get("id").and_then(Value::as_str) else {
             continue;
         };
+        if !connected.is_empty() && !connected.contains(provider_id) {
+            continue;
+        }
         let provider_name = provider
             .get("name")
             .and_then(Value::as_str)
@@ -1599,8 +1615,17 @@ async fn handle_bus_event(ctx: BusCtx<'_>) -> BusOutcome {
                         name.to_owned()
                     }
                 });
+            // opencode emits the same failure twice (once bare, once wrapped
+            // with an exception-name/stack prefix) — one chip per distinct
+            // failure: dedupe when either first line contains the other.
+            let first = |m: &str| m.lines().next().unwrap_or(m).trim().to_owned();
+            let line = first(&message);
+            let duplicate = turn.error.as_deref().is_some_and(|prev| {
+                let prev = first(prev);
+                !line.is_empty() && (prev.contains(&line) || line.contains(&prev))
+            });
             turn.error = Some(message.clone());
-            if !send(event_tx, AgentEvent::Error { message }).await {
+            if !duplicate && !send(event_tx, AgentEvent::Error { message }).await {
                 return BusOutcome::ConsumerGone;
             }
             BusOutcome::Continue

--- a/crates/harness/src/opencode/tests.rs
+++ b/crates/harness/src/opencode/tests.rs
@@ -26,7 +26,9 @@ fn models_map_provider_catalog_with_variant_ladders() {
         "connected": ["anthropic"],
     });
     let models = models_from_providers(&providers);
-    assert_eq!(models.len(), 3);
+    // `connected` filters: the full catalog is 194 providers / 7k models of
+    // which the user can run almost none (v0.2.21 field report).
+    assert_eq!(models.len(), 2);
     let opus = models
         .iter()
         .find(|m| m.id == "anthropic/claude-opus-5")
@@ -47,7 +49,29 @@ fn models_map_provider_catalog_with_variant_ladders() {
         .find(|m| m.id == "anthropic/claude-haiku-4-5")
         .expect("haiku");
     assert!(haiku.reasoning_levels.is_empty());
-    assert!(models.iter().any(|m| m.id == "opencode/big-pickle"));
+    assert!(
+        !models.iter().any(|m| m.id == "opencode/big-pickle"),
+        "unconnected providers stay out of the picker"
+    );
+}
+
+#[test]
+fn missing_connected_list_falls_back_to_the_full_catalog() {
+    let providers = json!({
+        "all": [
+            {"id": "a", "models": {"m1": {}}},
+            {"id": "b", "models": {"m2": {}}},
+        ],
+    });
+    assert_eq!(models_from_providers(&providers).len(), 2);
+    let providers = json!({
+        "all": [
+            {"id": "a", "models": {"m1": {}}},
+            {"id": "b", "models": {"m2": {}}},
+        ],
+        "connected": [],
+    });
+    assert_eq!(models_from_providers(&providers).len(), 2);
 }
 
 #[test]

--- a/crates/harness/tests/opencode.rs
+++ b/crates/harness/tests/opencode.rs
@@ -616,6 +616,21 @@ async fn session_error_with_no_content_settles_errored() {
         &ev,
         AgentEvent::Error { message } if message.contains("no credentials")
     ));
+    // opencode re-emits the same failure with an exception-name prefix and a
+    // stack — that must NOT mint a second chip (field report: every failure
+    // rendered twice).
+    fake.emit(json!({
+        "type": "session.error",
+        "properties": { "sessionID": "ses_test", "error": {
+            "name": "UnknownError",
+            "data": { "message": "ProviderAuthError: no credentials for anthropic\n    at stack" },
+        }},
+    }));
+    let quiet = tokio::time::timeout(Duration::from_millis(400), stream.next()).await;
+    assert!(
+        quiet.is_err(),
+        "duplicate error must not mint a second chip"
+    );
     idle(&fake, "ses_test");
     let events = drain_to_done(&mut stream).await;
     assert!(matches!(
@@ -835,11 +850,19 @@ async fn first_prompt_waits_for_the_live_event_subscription() {
 async fn models_discover_from_the_provider_catalog() {
     let fake = FakeOpencode::start().await;
     fake.set_providers(json!({
-        "all": [{
-            "id": "opencode",
-            "name": "OpenCode Zen",
-            "models": { "big-pickle": { "name": "Big Pickle" } },
-        }],
+        "all": [
+            {
+                "id": "opencode",
+                "name": "OpenCode Zen",
+                "models": { "big-pickle": { "name": "Big Pickle" } },
+            },
+            {
+                "id": "catalog-only",
+                "name": "Needs A Key",
+                "models": { "locked": { "name": "Locked" } },
+            },
+        ],
+        "connected": ["opencode"],
     }));
     let harness = harness(&fake);
     let models = harness.models().await.expect("models");


### PR DESCRIPTION
Field report on v0.2.21: the opencode model picker was laggy to open, laggy to scroll, and offered models that fail with "Model not found".

## Root cause

`GET /provider`'s `all` is the **entire models.dev catalog** — measured live: **194 providers / 7,203 models**, nearly all requiring an API key the user hasn't configured. v0.2.21 mapped it verbatim into the picker: the lag *was* the list, and almost every entry was un-runnable.

## Fix

- Discovery filters to the response's `connected` list — exactly the usable set (credentialed providers, config-declared ones, and the anonymous OpenCode Zen tier). Absent/empty `connected` (older servers) falls back to the full catalog. On this rig: **7 models instead of 7,203**, and the picker opens/scrolls instantly.
- Bonus from the same screenshot: opencode emits each provider failure **twice** on the bus (bare + exception-name/stack-wrapped), so failed turns rendered two identical error chips. Consecutive `session.error`s whose first lines contain each other now dedupe to one chip (regression-tested).
- New live probe: `cargo run -p zeron-harness --example opencode_models_probe` prints the discovered catalog + timing.

## After

Real opencode 1.18.21, zero credentials configured — the picker shows the seven models that actually run (the anonymous Zen tier), nothing else:

<img src="https://github.com/user-attachments/assets/490f1659-a3c2-4e01-b943-f0c3683c3977" width="850">

All 157 harness tests green (picker-filter unit tests updated, fallback + dedupe coverage added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790021016&installation_model_id=425430&pr_number=205&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F205&signature=0460607c5447f1b7ceb436f6acf67b8f5d2da7766785e80c736a3b7a1d880c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->