### PR TITLE
Thinking rides the tool-group accordion (same fold, same tween)

### DIFF
--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -296,6 +296,13 @@ pub struct ToolItem {
     /// per-delta header rewrites read as noise). Never rendered; still
     /// fingerprinted so an old doc's chips re-splice correctly.
     pub subagent_tail: Option<SharedString>,
+    /// A REASONING part riding the tool group as a chip (user request: the
+    /// thought process belongs inside the combined "Ran N commands"
+    /// accordion, opening/closing with the same tween). Synthesized in
+    /// [`rows_for_entry`] — never comes from a doc tool part. The thought
+    /// text is the `detail`; `resolved == false` means it is still
+    /// streaming (the chip then defaults open).
+    pub is_thought: bool,
 }
 
 /// Subagent spawn chips — [`ToolCall::is_subagent_spawn`], the shared genus
@@ -325,6 +332,97 @@ fn is_spawn_link(item: &ToolItem) -> bool {
 /// render as their own always-open row.
 fn tool_group_collapses(tools: &[ToolItem]) -> bool {
     tools.iter().any(|t| !is_agent_tool(t))
+}
+
+/// Column budget for soft-wrapping thought text into detail lines. The
+/// detail body is preformatted (no element wrapping), so the wrap happens
+/// here — conservative enough to fit the card at typical transcript widths.
+const THOUGHT_WRAP_COLS: usize = 96;
+
+/// Soft-wrap a thought's prose at word boundaries into detail lines.
+/// Overlong single words hard-split at the column budget.
+fn wrap_thought_lines(text: &str) -> Vec<SharedString> {
+    let mut lines: Vec<SharedString> = Vec::new();
+    for paragraph in text.lines() {
+        let paragraph = paragraph.trim_end();
+        if paragraph.is_empty() {
+            if !lines.is_empty() {
+                lines.push(SharedString::default());
+            }
+            continue;
+        }
+        let mut current = String::new();
+        for word in paragraph.split_whitespace() {
+            if !current.is_empty()
+                && current.chars().count() + 1 + word.chars().count() > THOUGHT_WRAP_COLS
+            {
+                lines.push(SharedString::from(std::mem::take(&mut current)));
+            }
+            if word.chars().count() > THOUGHT_WRAP_COLS {
+                // Hard-split a pathological token.
+                let mut chunk = String::new();
+                for c in word.chars() {
+                    chunk.push(c);
+                    if chunk.chars().count() == THOUGHT_WRAP_COLS {
+                        lines.push(SharedString::from(std::mem::take(&mut chunk)));
+                    }
+                }
+                current = chunk;
+                continue;
+            }
+            if current.is_empty() {
+                current = word.to_owned();
+            } else {
+                current.push(' ');
+                current.push_str(word);
+            }
+        }
+        if !current.is_empty() {
+            lines.push(SharedString::from(current));
+        }
+    }
+    while lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+    lines
+}
+
+/// A reasoning part as a tool-group chip: "Thought process" header over the
+/// wrapped thought text as an output-style detail (analytic height — the
+/// group's fold tween needs it). Capped like tool outputs, with the counted
+/// tail. `live` = the part is still streaming (chip defaults open).
+fn thought_item(text: &str, live: bool) -> ToolItem {
+    let mut lines = wrap_thought_lines(text);
+    let truncated_by = lines.len().saturating_sub(OUTPUT_DETAIL_MAX_LINES);
+    if truncated_by > 0 {
+        // Keep the TAIL while streaming (the fresh thinking is the signal);
+        // settled thoughts keep the head like tool outputs do.
+        if live {
+            lines.drain(..truncated_by);
+        } else {
+            lines.truncate(OUTPUT_DETAIL_MAX_LINES);
+        }
+    }
+    ToolItem {
+        call: ToolCall::Unknown {
+            name: "Thought process".into(),
+            input: None,
+        },
+        is_error: false,
+        resolved: !live,
+        detail: Some(Arc::new(ToolDetail::Output {
+            lines,
+            truncated_by,
+        })),
+        invocation: None,
+        output_ref: None,
+        output_bytes: None,
+        diff_ref: None,
+        subagent_ref: None,
+        subagent_status: None,
+        subagent_tail: None,
+        is_thought: true,
+    }
 }
 
 /// A chip's expandable detail payload.
@@ -606,14 +704,6 @@ pub enum RowKind {
         tools: Arc<Vec<ToolItem>>,
         auto_open: bool,
     },
-    /// A reasoning part: collapsible "Thinking" block. Auto-open while it is
-    /// streaming (the live tail of a working reply), collapsed once settled —
-    /// a user toggle overrides either way (same follow-the-rule contract as
-    /// tool groups).
-    Thinking {
-        text: SharedString,
-        streaming: bool,
-    },
     InputChip {
         /// First question's header (chat-view.tsx `InputChip`: the resolved
         /// chip shows it; unresolved shows "Awaiting your answer…" — which
@@ -883,6 +973,7 @@ pub fn rows_for_entry(
                     subagent_ref: subagent_ref.clone().map(SharedString::from),
                     subagent_status: *subagent_status,
                     subagent_tail: subagent_tail.clone().map(SharedString::from),
+                    is_thought: false,
                 };
                 // Agent chips don't share a fold with ordinary tools: flush
                 // whenever the genus flips so each group is uniform.
@@ -890,6 +981,30 @@ pub fn rows_for_entry(
                     .first()
                     .is_some_and(|head| is_agent_tool(head) != is_agent_tool(&item))
                 {
+                    flush_group(
+                        &mut rows,
+                        &mut pending_group,
+                        &mut group_ix,
+                        group_last_part_ix,
+                    );
+                }
+                pending_group.push(item);
+                group_last_part_ix = part_ix;
+            }
+            // Thinking rides the SAME accordion as the tools around it
+            // (user request) — a thought chip in the group, not its own row.
+            MessagePart::Reasoning { id: _, text } => {
+                if text.trim().is_empty() {
+                    continue;
+                }
+                // Live only while it is the tail of a streaming reply — once
+                // text or a tool follows, the thought is finished even though
+                // the entry still streams.
+                let live = streaming && part_ix == last_part_ix;
+                let item = thought_item(text, live);
+                // Thoughts join ordinary tool groups; agent (spawn-link)
+                // groups stay pure, exactly like the tool genus rule.
+                if pending_group.first().is_some_and(is_agent_tool) {
                     flush_group(
                         &mut rows,
                         &mut pending_group,
@@ -908,27 +1023,6 @@ pub fn rows_for_entry(
                     group_last_part_ix,
                 );
                 match other {
-                    MessagePart::Reasoning { id: part_id, text } => {
-                        if text.trim().is_empty() {
-                            continue;
-                        }
-                        // Live only while it is the tail of a streaming reply —
-                        // once text or a tool follows, the thought is finished
-                        // even though the entry still streams.
-                        let live = streaming && part_ix == last_part_ix;
-                        rows.push(Row {
-                            id: format!("{}#{}", entry.id, part_id).into(),
-                            version: fnv1a(text.as_bytes()) << 1 | live as u64,
-                            turn_start: false,
-                            kind: RowKind::Thinking {
-                                text: text.clone().into(),
-                                streaming: live,
-                            },
-                            entry_id: entry_id.clone(),
-                            timestamp: None,
-                            copy_text: None,
-                        });
-                    }
                     MessagePart::Text { id: part_id, text } => {
                         if text.trim().is_empty() {
                             continue;
@@ -1015,8 +1109,9 @@ pub fn rows_for_entry(
                             copy_text: None,
                         });
                     }
-                    // Tools are grouped by the outer arm; nothing reaches here.
-                    MessagePart::Tool { .. } => {}
+                    // Tools and thoughts are grouped by the outer arms;
+                    // nothing reaches here.
+                    MessagePart::Tool { .. } | MessagePart::Reasoning { .. } => {}
                 }
             }
         }
@@ -1174,15 +1269,9 @@ pub fn top_gap_for(prev: Option<&Row>, row: &Row) -> f32 {
     });
     if same_part_markdown {
         render::MD_BLOCK_GAP
-    } else if matches!(
-        row.kind,
-        RowKind::ToolGroup { .. } | RowKind::Thinking { .. }
-    ) || prev.is_some_and(|row| {
-        matches!(
-            row.kind,
-            RowKind::ToolGroup { .. } | RowKind::Thinking { .. }
-        )
-    }) {
+    } else if matches!(row.kind, RowKind::ToolGroup { .. })
+        || prev.is_some_and(|row| matches!(row.kind, RowKind::ToolGroup { .. }))
+    {
         Theme::SPACE_MD
     } else {
         Theme::SPACE_SM
@@ -1218,8 +1307,28 @@ pub fn diff_rows(old: &[Row], new: &[Row]) -> Option<(Range<usize>, usize)> {
 /// The rule lives in `zeron_proto::view` so the terminal viewport reports the
 /// same summary; this only adapts the row model's [`ToolItem`] to it.
 pub fn tool_group_summary(tools: &[ToolItem]) -> String {
-    let pairs: Vec<(ToolCall, bool)> = tools.iter().map(|t| (t.call.clone(), t.is_error)).collect();
-    zeron_proto::view::tool_group_summary(&pairs)
+    let pairs: Vec<(ToolCall, bool)> = tools
+        .iter()
+        .filter(|t| !t.is_thought)
+        .map(|t| (t.call.clone(), t.is_error))
+        .collect();
+    let thoughts = tools.iter().filter(|t| t.is_thought).count();
+    // The shared summary answers "used 0 tools" for an empty set — a
+    // thought-only group must not inherit that.
+    let base = if pairs.is_empty() {
+        String::new()
+    } else {
+        zeron_proto::view::tool_group_summary(&pairs)
+    };
+    // Thought chips ride the group (they are UI-synthesized, so the shared
+    // view summary never sees them): name them on the collapsed line.
+    match (base.is_empty(), thoughts) {
+        (_, 0) => base,
+        (true, 1) => "Thought process".into(),
+        (true, n) => format!("Thought {n} times"),
+        (false, 1) => format!("Thought · {base}"),
+        (false, n) => format!("Thought {n} times · {base}"),
+    }
 }
 
 // `single_line` and the per-kind chip label/detail are shared with the terminal
@@ -3941,9 +4050,6 @@ impl Transcript {
             RowKind::ToolGroup { tools, auto_open } => {
                 self.render_tool_group(&row.id, tools, *auto_open, &theme, cx)
             }
-            RowKind::Thinking { text, streaming } => {
-                self.render_thinking(&row.id, text.clone(), *streaming, &theme, cx)
-            }
             RowKind::InputChip { header, resolved } => {
                 input_chip(header.clone(), *resolved, &theme)
             }
@@ -4314,8 +4420,13 @@ impl Transcript {
             .iter()
             .zip(&invocations)
             .zip(&detail_folds)
-            .map(|((detail, invocation), fold)| {
-                (detail.is_some() || invocation.is_some()) && fold.open.unwrap_or(false)
+            .zip(tools.iter())
+            .map(|(((detail, invocation), fold), tool)| {
+                // A STREAMING thought chip defaults open (the live thinking
+                // is the point); settled chips default closed. A user toggle
+                // overrides either way.
+                let default_open = tool.is_thought && !tool.resolved;
+                (detail.is_some() || invocation.is_some()) && fold.open.unwrap_or(default_open)
             })
             .collect();
         let detail_highlights: Vec<Option<Arc<crate::changes::DiffHighlights>>> = details
@@ -4638,99 +4749,6 @@ impl Transcript {
             .when(collapses, |el| el.child(header))
             .child(body)
             .into_any_element()
-    }
-
-    /// The thinking block: the tool-group header recipe (chevron tile +
-    /// quiet 12px label) over a dimmed plain-text body along the guide rail.
-    /// Open follows the streaming rule until the user toggles; no tween —
-    /// the body mounts/unmounts at intrinsic height (thinking bodies have no
-    /// analytic height, and the block usually opens/closes off-screen at the
-    /// live tail anyway).
-    fn render_thinking(
-        &mut self,
-        row_id: &SharedString,
-        text: SharedString,
-        streaming: bool,
-        theme: &Theme,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
-        let fold = self.folds.get(row_id).copied().unwrap_or_default();
-        let open = fold.open.unwrap_or(streaming);
-        let label: SharedString = if streaming {
-            "Thinking…".into()
-        } else {
-            "Thought process".into()
-        };
-        let toggle_id = row_id.clone();
-        let header = div()
-            .id(SharedString::from(format!("{row_id}-hdr")))
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap(px(8.0))
-            .px(px(4.0))
-            .h(px(26.0))
-            .cursor_pointer()
-            .text_size(px(12.0))
-            .line_height(px(18.0))
-            .text_color(theme.text_muted)
-            .hover(|s| s.text_color(theme.text))
-            .on_click(cx.listener(move |this, _, _, cx| {
-                this.toggle_fold(toggle_id.clone(), 0.0, streaming);
-                cx.notify();
-            }))
-            .child(
-                div()
-                    .size(px(18.0))
-                    .flex_none()
-                    .rounded(px(5.0))
-                    .bg(crate::theme::ink(0.06))
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .text_size(px(10.0))
-                    .text_color(theme.text_muted.opacity(0.7))
-                    .child(SharedString::from(if open { "▾" } else { "▸" })),
-            )
-            .child(
-                div()
-                    .min_w_0()
-                    .h(px(18.0))
-                    .flex()
-                    .items_center()
-                    .truncate()
-                    .child(label),
-            );
-
-        let mut column = div().flex().flex_col().child(header);
-        if open {
-            column = column.child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .child(
-                        // The tool groups' guide rail, so the open body reads
-                        // as "inside the fold".
-                        div()
-                            .ml(px(12.0))
-                            .w(px(1.0))
-                            .flex_none()
-                            .bg(crate::theme::ink(0.08)),
-                    )
-                    .child(
-                        div()
-                            .min_w_0()
-                            .flex_1()
-                            .pl(px(14.0))
-                            .py(px(6.0))
-                            .text_size(px(13.0))
-                            .line_height(px(20.0))
-                            .text_color(theme.text_muted)
-                            .child(text),
-                    ),
-            );
-        }
-        column.into_any_element()
     }
 }
 
@@ -5079,7 +5097,11 @@ fn chip_header_row(
     view: gpui::EntityId,
     cx: &mut gpui::App,
 ) -> gpui::Div {
-    let (label, detail) = tool_chip_content(&tool.call);
+    let (label, detail) = if tool.is_thought {
+        ("Thought process", String::new())
+    } else {
+        tool_chip_content(&tool.call)
+    };
     let running = tool.subagent_ref.is_some()
         && matches!(tool.subagent_status, Some(SubagentStatus::Running));
     let failed = tool.is_error
@@ -5113,9 +5135,13 @@ fn chip_header_row(
                 .items_center()
                 .justify_center()
                 .child(
-                    crate::icons::icon(tool_icon_path(&tool.call))
-                        .size(px(12.0))
-                        .text_color(theme.text_muted),
+                    crate::icons::icon(if tool.is_thought {
+                        crate::icons::CHAT_ROUND_LINE
+                    } else {
+                        tool_icon_path(&tool.call)
+                    })
+                    .size(px(12.0))
+                    .text_color(theme.text_muted),
                 ),
         )
         .child(
@@ -6088,6 +6114,113 @@ mod tests {
         }
     }
 
+    fn reasoning_part(id: &str, text: &str) -> MessagePart {
+        MessagePart::Reasoning {
+            id: id.into(),
+            text: text.into(),
+        }
+    }
+
+    #[test]
+    fn reasoning_joins_the_tool_group_accordion() {
+        // Thought → tool → thought → tool folds into ONE group row (user
+        // request: the thought process lives inside the combined accordion),
+        // and the collapsed summary names the thinking.
+        let entry = assistant(
+            "a1",
+            MessageStatus::Complete,
+            vec![
+                reasoning_part("r0", "planning the first step"),
+                tool_part("t1", "ls"),
+                reasoning_part("r2", "now the second step"),
+                tool_part("t3", "pwd"),
+            ],
+        );
+        let rows = rows_for_entry(&entry, false, &mut parse);
+        assert_eq!(rows.len(), 1, "one combined accordion row");
+        let RowKind::ToolGroup { tools, .. } = &rows[0].kind else {
+            panic!("expected a tool group");
+        };
+        assert_eq!(tools.len(), 4);
+        assert!(tools[0].is_thought && tools[2].is_thought);
+        assert!(!tools[1].is_thought && !tools[3].is_thought);
+        // Thought chips carry their text as an output-style detail with an
+        // ANALYTIC height, so the group's fold tween covers them.
+        assert!(matches!(
+            tools[0].detail.as_deref(),
+            Some(ToolDetail::Output { lines, .. }) if !lines.is_empty()
+        ));
+        let summary = tool_group_summary(&tools);
+        assert!(summary.starts_with("Thought 2 times"), "{summary}");
+        assert!(summary.contains("2 commands"), "{summary}");
+
+        // A lone thought is still an accordion (with the group tween), named
+        // plainly.
+        let entry = assistant(
+            "a2",
+            MessageStatus::Complete,
+            vec![reasoning_part("r0", "just thinking")],
+        );
+        let rows = rows_for_entry(&entry, false, &mut parse);
+        assert_eq!(rows.len(), 1);
+        let RowKind::ToolGroup { tools, .. } = &rows[0].kind else {
+            panic!("expected a tool group");
+        };
+        assert_eq!(tool_group_summary(&tools), "Thought process");
+
+        // Empty reasoning renders nothing.
+        let entry = assistant(
+            "a3",
+            MessageStatus::Complete,
+            vec![reasoning_part("r0", "   ")],
+        );
+        assert!(rows_for_entry(&entry, false, &mut parse).is_empty());
+    }
+
+    #[test]
+    fn live_thought_streams_open_and_settles_closed() {
+        let entry = assistant(
+            "a1",
+            MessageStatus::Streaming,
+            vec![reasoning_part("r0", "thinking hard")],
+        );
+        let rows = rows_for_entry(&entry, false, &mut parse);
+        let RowKind::ToolGroup { tools, auto_open } = &rows[0].kind else {
+            panic!("expected a tool group");
+        };
+        // The live tail auto-opens the group; the chip itself is unresolved
+        // (defaults open) until the part stops being the tail.
+        assert!(*auto_open);
+        assert!(!tools[0].resolved);
+
+        let entry = assistant(
+            "a2",
+            MessageStatus::Streaming,
+            vec![
+                reasoning_part("r0", "thinking hard"),
+                text_part("t1", "answer"),
+            ],
+        );
+        let rows = rows_for_entry(&entry, false, &mut parse);
+        let RowKind::ToolGroup { tools, .. } = &rows[0].kind else {
+            panic!("expected a tool group");
+        };
+        assert!(tools[0].resolved, "a followed thought is settled");
+    }
+
+    #[test]
+    fn thought_wrap_is_word_aware_and_bounded() {
+        let lines = wrap_thought_lines("one two three");
+        assert_eq!(lines.len(), 1);
+        let long = "word ".repeat(200);
+        let lines = wrap_thought_lines(&long);
+        assert!(lines.iter().all(|l| l.chars().count() <= THOUGHT_WRAP_COLS));
+        assert!(lines.len() > 5);
+        let pathological = "x".repeat(300);
+        let lines = wrap_thought_lines(&pathological);
+        assert!(lines.iter().all(|l| l.chars().count() <= THOUGHT_WRAP_COLS));
+    }
+
     fn tool_part(id: &str, command: &str) -> MessagePart {
         MessagePart::Tool {
             id: id.into(),
@@ -6637,6 +6770,7 @@ mod tests {
             subagent_ref: None,
             subagent_status: None,
             subagent_tail: None,
+            is_thought: false,
         };
         let edit = |p: &str| ToolItem {
             call: ToolCall::EditFile {
@@ -6654,6 +6788,7 @@ mod tests {
             subagent_ref: None,
             subagent_status: None,
             subagent_tail: None,
+            is_thought: false,
         };
         let tools = vec![
             exec("ls"),
@@ -6687,6 +6822,7 @@ mod tests {
                 subagent_ref: None,
                 subagent_status: None,
                 subagent_tail: None,
+                is_thought: false,
             },
             ToolItem {
                 call: ToolCall::Glob {
@@ -6702,6 +6838,7 @@ mod tests {
                 subagent_ref: None,
                 subagent_status: None,
                 subagent_tail: None,
+                is_thought: false,
             },
             ToolItem {
                 call: ToolCall::WebSearch { query: "q".into() },
@@ -6715,6 +6852,7 @@ mod tests {
                 subagent_ref: None,
                 subagent_status: None,
                 subagent_tail: None,
+                is_thought: false,
             },
         ];
         assert_eq!(tool_group_summary(&tools), "Read 1 file · searched 2 times");


### PR DESCRIPTION
Field follow-up on the thinking feature (#202): the standalone "Thought process" row didn't animate like the other transcript accordions, and thinking should live **inside** the combined "Ran N commands" fold rather than as its own row between groups.

## What changed

Reasoning parts now become **thought chips inside the tool group itself** — `thought → tool → thought → tool` folds into one accordion row. A thought chip is a synthesized `ToolItem` whose text is an output-style, line-based detail (soft-wrapped at word boundaries, capped like tool outputs — a streaming thought keeps the tail since the fresh thinking is the signal). Because line-based details have **analytic heights**, the group's existing 200ms fold tween covers thoughts with zero new animation code — the smoothness ask is satisfied by construction, since it's now literally the same accordion.

- A live thought chip defaults open (and the group auto-opens as the live tail); it settles closed once text or a tool follows. User toggles override either way via the existing per-chip fold state.
- The collapsed summary names the thinking: "Thought process" for a thought-only group, "Thought 3 times · Ran 2 commands" when mixed. Agent/spawn chip groups stay pure (same rule as the tool genus split).
- `RowKind::Thinking`, its bespoke renderer, and its spacing special-case are deleted.

## Live (real opencode + scripted provider)

Mid-turn — the combined accordion auto-open: settled thought collapsed, the Run chip, and the **streaming** thought open with its text growing, all inside one group:

<img src="https://github.com/user-attachments/assets/00f05c42-3820-4f73-ba27-49cff814ab7d" width="850">

Settled — the whole turn folds to one quiet line:

<img src="https://github.com/user-attachments/assets/64e2e031-a12d-4100-a438-557d134e01f4" width="850">

All 507 UI tests green (new coverage: reasoning+tools group into one row with the right summary, lone thoughts still fold, live-open/settled-closed defaults, word-aware wrap bounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790064216&installation_model_id=425430&pr_number=209&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F209&signature=d5115074aea8390e187fb5ae43164ddc5b9558351a7762ab33db3b55f7400c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->