### PR TITLE
Chat rows survive configs from newer peers; iOS learns opencode

### DIFF
--- a/apps/ios/Zeron/Models/HarnessCatalog.swift
+++ b/apps/ios/Zeron/Models/HarnessCatalog.swift
@@ -38,6 +38,7 @@ enum HarnessCatalog {
         "hermes": "Hermes",
         "pi": "Pi",
         "cursor": "Cursor",
+        "opencode": "OpenCode",
         "mock": "Mock",
     ]
 
@@ -71,6 +72,19 @@ enum HarnessCatalog {
                 ModelInfo(id: "default", label: "pi default",
                           description: "Runs the model configured in pi (`pi` settings)",
                           reasoningLevels: ["minimal", "low", "medium", "high", "xhigh", "max"]),
+            ]
+        case "opencode":
+            // Static fallback only — a reachable host answers `listModels`
+            // with its live discovery (connected providers). The anonymous
+            // OpenCode Zen tier is always available, so these always run.
+            return [
+                ModelInfo(id: "opencode/big-pickle", label: "Big Pickle",
+                          description: "OpenCode Zen's flagship coding model", reasoningLevels: []),
+                ModelInfo(id: "opencode/mimo-v2.5-free", label: "MiMo V2.5 Free",
+                          description: "Free tier on OpenCode Zen", reasoningLevels: []),
+                ModelInfo(id: "opencode/hy3-free", label: "Hy3 Free",
+                          description: "Free tier on OpenCode Zen",
+                          reasoningLevels: ["low", "medium", "high"]),
             ]
         case "codex":
             return [

--- a/apps/ios/Zeron/Theme/BrandMarks.swift
+++ b/apps/ios/Zeron/Theme/BrandMarks.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 enum BrandMark {
-    case claude, openai, cursor, grok, hermes, pi
+    case claude, openai, cursor, grok, hermes, pi, opencode
 
     var viewBox: CGSize {
         switch self {
@@ -17,6 +17,7 @@ enum BrandMark {
         case .grok: return CGSize(width: 16, height: 16)
         case .hermes: return CGSize(width: 24, height: 24)
         case .pi: return CGSize(width: 800, height: 800)
+        case .opencode: return CGSize(width: 24, height: 30)
         }
     }
 
@@ -24,7 +25,7 @@ enum BrandMark {
     /// asset says so or the mark's holes fill in solid.
     var evenOddFill: Bool {
         switch self {
-        case .hermes, .pi: return true
+        case .hermes, .pi, .opencode: return true
         default: return false
         }
     }
@@ -43,6 +44,11 @@ enum BrandMark {
             return HermesMarkData.pathData
         case .pi:
             return "M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65ZM517.36 400H634.72V634.72H517.36Z"
+        case .opencode:
+            // opencode-mark.svg's frame (the desktop asset's second path is a
+            // 45%-opacity inner fill this single-path renderer skips — the
+            // mark reads identically at glyph sizes).
+            return "M24 0H0V30H24V0ZM18 6H6V24H18V6Z"
         }
     }
 
@@ -53,6 +59,7 @@ enum BrandMark {
         case "grok": return .grok
         case "hermes": return .hermes
         case "pi": return .pi
+        case "opencode": return .opencode
         default: return .claude  // claude-code + mock share the mark, like the desktop
         }
     }

--- a/crates/doc/src/registry/tests.rs
+++ b/crates/doc/src/registry/tests.rs
@@ -368,6 +368,54 @@ fn rows_round_trip_and_upsert_refreshes() {
 }
 
 #[test]
+fn future_harness_chat_rows_stay_visible_without_their_config() {
+    // Field incident: a pre-v0.2.10 client received rows whose
+    // config.harness said "opencode" — a variant it didn't have — and
+    // dropped the WHOLE row ("skipping malformed registry row"), so new
+    // sessions silently never appeared in that device's sidebar. Unknown
+    // config values must cost the config, not the row.
+    let mut ws = RegistryDoc::new("dev-a");
+    ws.upsert_chat(&chat("chat-1", "dev-a")).unwrap();
+    let fields: std::collections::BTreeMap<String, serde_json::Value> = [
+        ("id".to_owned(), json!("chat-2")),
+        ("deviceId".to_owned(), json!("dev-b")),
+        ("createdAt".to_owned(), json!(1_000)),
+        (
+            "config".to_owned(),
+            json!({
+                "harness": "harness-from-the-future",
+                "model": "novel/model",
+                "sandbox": "workspace-write",
+            }),
+        ),
+    ]
+    .into_iter()
+    .collect();
+    ws.apply_rows(
+        7,
+        vec![RegistryRow {
+            kind: "chats".into(),
+            id: "chat-2".into(),
+            seq: 7,
+            deleted: false,
+            del_hlc: None,
+            fields,
+            clocks: Default::default(),
+        }],
+    );
+
+    let chats = ws.read_chats().unwrap();
+    assert_eq!(chats.len(), 2, "the future-harness row must not vanish");
+    let newcomer = chats.iter().find(|c| c.id == "chat-2").expect("visible");
+    assert_eq!(
+        newcomer.config, None,
+        "unknown config degrades, row survives"
+    );
+    // The well-formed sibling keeps its config untouched.
+    assert!(chats.iter().any(|c| c.id == "chat-1" && c.config.is_some()));
+}
+
+#[test]
 fn field_mutators_round_trip() {
     let mut ws = RegistryDoc::new("dev-a");
     ws.upsert_device(&device("dev-a", "laptop")).unwrap();

--- a/crates/doc/src/workspace.rs
+++ b/crates/doc/src/workspace.rs
@@ -631,7 +631,13 @@ pub(crate) struct RawChat {
     branch: Option<String>,
     #[serde(default)]
     checkout_id: Option<String>,
-    #[serde(default)]
+    /// LENIENT: a config this build can't decode (a harness/reasoning/sandbox
+    /// id from a NEWER peer — field incident: pre-v0.2.10 laptops dropped
+    /// every `"opencode"` chat row wholesale, so new sessions silently never
+    /// appeared in the sidebar) degrades to `None` instead of failing the
+    /// row. The chat stays visible and selectable with generic defaults;
+    /// up-to-date devices still see the real config.
+    #[serde(default, deserialize_with = "lenient_chat_config")]
     config: Option<ChatConfig>,
     #[serde(default)]
     last_message_preview: Option<String>,
@@ -649,6 +655,24 @@ pub(crate) struct RawChat {
     last_seen_at: Option<i64>,
     #[serde(default)]
     room_gen: Option<u32>,
+}
+
+/// Decode a chat row's `config` leniently: unknown enum values (a newer
+/// peer's harness id, reasoning level or sandbox mode) cost the CONFIG, not
+/// the row. Mirrors the transcript salvage rule: a missing field must cost
+/// at most what the field carried.
+fn lenient_chat_config<'de, D>(deserializer: D) -> Result<Option<ChatConfig>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|value| match serde_json::from_value::<ChatConfig>(value) {
+        Ok(config) => Some(config),
+        Err(err) => {
+            tracing::warn!(error = %err, "chat config from a newer peer; showing the row without it");
+            None
+        }
+    }))
 }
 
 impl From<RawChat> for Chat {


### PR DESCRIPTION
Field report (multi-device): new sessions never appear in the work laptop's sidebar (old ones keep updating), and on iOS opencode sessions wear the claude mark and open showing claude with Fable selected.

## Root cause — one skew, two surfaces

The fleet learned a harness id the other surfaces don't know. `HarnessId::Opencode` shipped in **v0.2.10**; every chat row created with it since carries `config.harness: "opencode"`.

- **Desktop (the laptop)**: the typed row decode (`read_kind` → `RawChat`) **skips any row it can't parse** — and `ChatConfig.harness` is a closed enum. A build older than v0.2.10 therefore drops every opencode chat row wholesale, logging only `skipping malformed registry row`. Old (claude) rows still decode, so their status keeps updating — exactly the reported asymmetry. → **The immediate remedy for the laptop is updating the app there** (`curl -fsSL https://zeron.sh/install.sh | sh`); it's running something older than v0.2.10 (Aug 18).
- **iOS**: rows sync fine (harness is a plain string there), but `HarnessCatalog`/`BrandMark` had no `"opencode"` entry — the `default:` arms answer with the claude mark and the claude model list, hence "claude with Fable" on open.

## Fix

- **Desktop, forward-compat for all future skew**: the chat row's `config` now decodes leniently — an unknown harness/reasoning/sandbox value costs the *config* (the row renders and is selectable with generic defaults, and up-to-date devices still see the real config), never the row. Same rule as transcript salvage: a missing field costs at most what the field carried. Regression test constructs a row from a "harness-from-the-future" peer and asserts it stays visible with `config: None` while its well-formed sibling keeps its config.
- **iOS**: added the OpenCode label, the brand mark (the desktop `opencode-mark.svg` frame path, even-odd fill), and a static model fallback (the anonymous Zen tier — a reachable host still answers `listModels` with its live connected-provider discovery). ⚠️ Swift changes are unbuilt here (Linux box) — needs a quick mac build + TestFlight pass.

All doc + engine suites green (83 + 160 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790067315&installation_model_id=425430&pr_number=210&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F210&signature=9c31e209e12d680de36937bad0b7ddf51ad1f7ce8092c3f0f326412cadfa41ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->