### PR TITLE
Registry cursor can no longer jump over unapplied rows (missing-sessions incident)

### DIFF
--- a/apps/ios/Zeron/Sync/RegistryCore.swift
+++ b/apps/ios/Zeron/Sync/RegistryCore.swift
@@ -373,8 +373,13 @@ final class RegistryDoc {
 
     // MARK: Persistence ({rows, cursor, gcFloor, clock, pending} JSON blob)
 
+    /// Bump to force one full resync on next load (heals snapshots whose
+    /// cursor jumped past unapplied rows; mirrors the desktop epoch).
+    private static let currentResyncEpoch = 1
+
     private struct Persisted: Codable {
         var v: Int
+        var resyncEpoch: Int?
         var deviceId: String
         var serverSeq: UInt64
         var gcFloor: UInt64
@@ -384,7 +389,8 @@ final class RegistryDoc {
     }
 
     func toData() throws -> Data {
-        let state = Persisted(v: 1, deviceId: deviceId, serverSeq: serverSeq, gcFloor: gcFloor,
+        let state = Persisted(v: 1, resyncEpoch: Self.currentResyncEpoch,
+                              deviceId: deviceId, serverSeq: serverSeq, gcFloor: gcFloor,
                               clock: clock, rows: authoritative.values.flatMap(\.values),
                               pending: pending)
         return try JSONEncoder().encode(state)
@@ -396,7 +402,9 @@ final class RegistryDoc {
             throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "unknown registry snapshot version \(state.v)"))
         }
         let doc = RegistryDoc(deviceId: deviceId)
-        doc.serverSeq = state.serverSeq
+        // Pre-epoch snapshots may hide a jumped cursor: zero it once so the
+        // next hello returns full state. Rows are kept.
+        doc.serverSeq = (state.resyncEpoch ?? 0) < Self.currentResyncEpoch ? 0 : state.serverSeq
         doc.gcFloor = state.gcFloor
         doc.clock = state.clock
         doc.pending = state.pending
@@ -449,17 +457,25 @@ final class RegistryDoc {
     }
 
     /// Apply a `rows` broadcast (merged truth for the touched rows).
-    func applyRows(seq: UInt64, rows: [RegistryRow]) {
+    /// Returns false on a SEQ GAP — frames between the cursor and this batch
+    /// were missed: the rows still apply, but the cursor holds so the caller
+    /// resyncs (a fresh hello backfills the window). Advancing across a gap
+    /// makes the missed rows permanently invisible (desktop field incident).
+    func applyRows(seq: UInt64, rows: [RegistryRow]) -> Bool {
         generation += 1
         for row in rows { putAuthoritative(row) }
+        if seq > serverSeq + 1 { return false }
         if seq > serverSeq { serverSeq = seq }
+        return true
     }
 
-    /// Retire an acked batch; the ack's seq advances the cursor.
+    /// Retire an acked batch. Deliberately does NOT advance the cursor: the
+    /// ack's seq is OUR batch's position, and peers' batches may sit between
+    /// the cursor and it — jumping skipped them forever (desktop field
+    /// incident; the cursor advances only with actual row payloads).
     func ackBatch(_ batch: String, seq: UInt64) {
         let before = pending.count
         pending.removeAll { $0.batch == batch }
-        if seq > serverSeq { serverSeq = seq }
         if pending.count != before { generation += 1 }
     }
 

--- a/apps/ios/Zeron/Sync/WorkspaceStore.swift
+++ b/apps/ios/Zeron/Sync/WorkspaceStore.swift
@@ -227,7 +227,11 @@ final class WorkspaceStore {
                 restartChangeRequestStreams(resetUnsupported: true)
             }
         case .rows(let seq, let rows):
-            doc.applyRows(seq: seq, rows: rows)
+            // A false return = seq gap (missed frames): the rows applied but
+            // the cursor held, so the next reconnect's hello backfills the
+            // window instead of skipping it forever. iOS sockets churn on
+            // every suspension, so convergence is quick without forcing one.
+            _ = doc.applyRows(seq: seq, rows: rows)
             project()
             saver?.poke()
         case .ack(let batch, let seq, _):

--- a/crates/doc/src/registry.rs
+++ b/crates/doc/src/registry.rs
@@ -311,10 +311,21 @@ pub enum StateOutcome {
     Reseeded,
 }
 
+/// Bump to force every client ONE full resync on its next boot (persisted
+/// snapshots below this epoch zero their cursor on load). 1 = the
+/// cursor-jump healing (ack/gap fixes below).
+const CURRENT_RESYNC_EPOCH: u32 = 1;
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PersistedState {
     v: u32,
+    /// Cursor-integrity epoch: bumping [`CURRENT_RESYNC_EPOCH`] forces every
+    /// client one full resync on its first load after upgrading (heals
+    /// snapshots whose cursor jumped past unapplied rows). Additive —
+    /// pre-epoch snapshots default to 0.
+    #[serde(default)]
+    resync_epoch: u32,
     device_id: String,
     server_seq: u64,
     gc_floor: u64,
@@ -371,6 +382,8 @@ impl RegistryDoc {
 
     // ── persistence ─────────────────────────────────────────────────────────
 
+    // (see PersistedState::resync_epoch)
+
     pub fn to_bytes(&self) -> Result<Vec<u8>, DocError> {
         let rows = self
             .authoritative
@@ -379,6 +392,7 @@ impl RegistryDoc {
             .collect();
         let state = PersistedState {
             v: 1,
+            resync_epoch: CURRENT_RESYNC_EPOCH,
             device_id: self.device_id.clone(),
             server_seq: self.server_seq,
             gc_floor: self.gc_floor,
@@ -398,7 +412,17 @@ impl RegistryDoc {
             )));
         }
         let mut doc = Self::new(device_id);
-        doc.server_seq = state.server_seq;
+        // One-shot healing resync: snapshots from before a cursor-integrity
+        // fix may have a cursor that JUMPED past rows this replica never
+        // applied (the ack/gap bugs above) — those rows are invisible and no
+        // amount of ordinary syncing refetches them. Zeroing the cursor once
+        // forces the next hello/pull to return full state; local rows are
+        // kept (and local-only ones re-seed through apply_state's full path).
+        if state.resync_epoch < CURRENT_RESYNC_EPOCH {
+            doc.server_seq = 0;
+        } else {
+            doc.server_seq = state.server_seq;
+        }
         doc.gc_floor = state.gc_floor;
         doc.clock = state.clock;
         doc.pending = state.pending;
@@ -478,23 +502,42 @@ impl RegistryDoc {
     }
 
     /// Apply a `rows` broadcast (merged truth for the touched rows).
-    pub fn apply_rows(&mut self, seq: u64, rows: Vec<RegistryRow>) {
+    /// Apply one broadcast batch. Returns `false` on a SEQ GAP — frames
+    /// between the cursor and this batch were missed (a hibernating DO, a
+    /// half-dead socket): the rows still apply (fresh data), but the cursor
+    /// holds so the caller can resync (reconnect → hello/pull from the true
+    /// cursor backfills the window). Advancing across a gap made the missed
+    /// rows permanently invisible.
+    #[must_use]
+    pub fn apply_rows(&mut self, seq: u64, rows: Vec<RegistryRow>) -> bool {
         self.generation += 1;
         for row in rows {
             self.put_authoritative(row);
         }
+        if seq > self.server_seq + 1 {
+            return false;
+        }
         if seq > self.server_seq {
             self.server_seq = seq;
         }
+        true
     }
 
     /// Retire an acked batch; returns whether it existed.
-    pub fn ack_batch(&mut self, batch: &str, seq: u64) -> bool {
+    ///
+    /// Deliberately does NOT advance the sync cursor: the ack's `seq` is OUR
+    /// batch's position, and other devices' batches may sit between the
+    /// cursor and it. Jumping the cursor skipped those forever — on the
+    /// HTTPS transport the very next pull used the jumped cursor, so a
+    /// device that pushed anything (a seen-marker was enough) while behind
+    /// permanently missed every row its peers wrote since its last sync
+    /// (field incident: new sessions never appeared in a laptop's sidebar
+    /// while updates to already-known rows kept flowing). The cursor only
+    /// advances with actual row payloads (state/pull/contiguous broadcasts);
+    /// re-pulling our own batch is an idempotent LWW no-op.
+    pub fn ack_batch(&mut self, batch: &str, _seq: u64) -> bool {
         let before = self.pending.len();
         self.pending.retain(|b| b.batch != batch);
-        if seq > self.server_seq {
-            self.server_seq = seq;
-        }
         if self.pending.len() != before {
             self.generation += 1;
             true

--- a/crates/doc/src/registry/tests.rs
+++ b/crates/doc/src/registry/tests.rs
@@ -333,7 +333,7 @@ fn server_round(
         touched_all.extend(touched);
     }
     for doc in docs.iter_mut() {
-        doc.apply_rows(*seq, touched_all.clone());
+        let _ = doc.apply_rows(*seq, touched_all.clone());
     }
     for (i, batch) in acks {
         docs[i].ack_batch(&batch, *seq);
@@ -368,6 +368,91 @@ fn rows_round_trip_and_upsert_refreshes() {
 }
 
 #[test]
+fn own_push_ack_never_advances_the_cursor() {
+    // Field incident: on the HTTPS transport, push ran before pull in one
+    // cycle — the ack jumped the cursor to OUR batch's seq, and the pull
+    // then fetched "since" that jumped cursor, permanently skipping every
+    // batch other devices wrote in between (new sessions never appeared in
+    // a laptop's sidebar while updates to known rows kept flowing).
+    let mut ws = RegistryDoc::new("dev-a");
+    ws.apply_state(10, true, 0, Vec::new());
+    assert_eq!(ws.cursor(), 10);
+    ws.upsert_chat(&chat("chat-1", "dev-a")).unwrap();
+    let batch = ws.take_pushable().pop().expect("pending batch");
+    // The server assigns our batch seq 15 — batches 11..=14 belong to peers
+    // and have not reached us yet.
+    assert!(ws.ack_batch(&batch.batch, 15));
+    assert_eq!(
+        ws.cursor(),
+        10,
+        "the next pull must still fetch the peers' batches 11..=14"
+    );
+    assert_eq!(ws.pending_len(), 0, "the ack still retires the batch");
+}
+
+#[test]
+fn broadcast_seq_gap_applies_rows_but_holds_the_cursor() {
+    let mut ws = RegistryDoc::new("dev-a");
+    ws.apply_state(10, true, 0, Vec::new());
+    let row = |id: &str, seq: u64| RegistryRow {
+        kind: "chats".into(),
+        id: id.into(),
+        seq,
+        deleted: false,
+        del_hlc: None,
+        fields: [
+            ("id".to_owned(), json!(id)),
+            ("deviceId".to_owned(), json!("dev-b")),
+            ("createdAt".to_owned(), json!(1_000)),
+        ]
+        .into_iter()
+        .collect(),
+        clocks: Default::default(),
+    };
+    // Contiguous broadcast advances.
+    assert!(ws.apply_rows(11, vec![row("chat-a", 11)]));
+    assert_eq!(ws.cursor(), 11);
+    // A GAPPED broadcast (12..=14 were missed) applies its rows but must
+    // not advance — the caller resyncs and the reconnect hello backfills.
+    assert!(!ws.apply_rows(15, vec![row("chat-b", 15)]));
+    assert_eq!(ws.cursor(), 11, "cursor holds across the gap");
+    assert_eq!(ws.read_chats().unwrap().len(), 2, "fresh rows still apply");
+    // Idempotent replay of an already-seen batch is not a gap.
+    assert!(ws.apply_rows(11, vec![row("chat-a", 11)]));
+}
+
+#[test]
+fn pre_epoch_snapshots_resync_in_full_once() {
+    let mut ws = RegistryDoc::new("dev-a");
+    ws.apply_state(42, true, 0, Vec::new());
+    ws.upsert_chat(&chat("chat-1", "dev-a")).unwrap();
+    let bytes = ws.to_bytes().unwrap();
+
+    // A current-epoch snapshot keeps its cursor.
+    let restored = RegistryDoc::from_bytes(&bytes, "dev-a").unwrap();
+    assert_eq!(restored.cursor(), 42);
+    assert_eq!(restored.read_chats().unwrap().len(), 1);
+
+    // A snapshot from BEFORE the cursor-integrity fixes (no epoch field)
+    // may hide a jumped cursor: it zeroes on load so the next hello/pull is
+    // a full state, healing any invisible-row window. Rows are kept.
+    let mut v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    v.as_object_mut().unwrap().remove("resyncEpoch");
+    let old = serde_json::to_vec(&v).unwrap();
+    let healed = RegistryDoc::from_bytes(&old, "dev-a").unwrap();
+    assert_eq!(
+        healed.cursor(),
+        0,
+        "pre-epoch snapshot forces a full resync"
+    );
+    assert_eq!(
+        healed.read_chats().unwrap().len(),
+        1,
+        "rows survive the reset"
+    );
+}
+
+#[test]
 fn future_harness_chat_rows_stay_visible_without_their_config() {
     // Field incident: a pre-v0.2.10 client received rows whose
     // config.harness said "opencode" — a variant it didn't have — and
@@ -391,7 +476,7 @@ fn future_harness_chat_rows_stay_visible_without_their_config() {
     ]
     .into_iter()
     .collect();
-    ws.apply_rows(
+    let _ = ws.apply_rows(
         7,
         vec![RegistryRow {
             kind: "chats".into(),

--- a/crates/sync/src/registry.rs
+++ b/crates/sync/src/registry.rs
@@ -976,9 +976,16 @@ impl Actor {
         };
         match frame {
             ServerFrame::Rows { seq, rows } => {
-                lock(&self.doc).apply_rows(seq, rows);
+                let contiguous = lock(&self.doc).apply_rows(seq, rows);
                 self.stats.last_pushed_ms.store(epoch_ms(), Relaxed);
                 let _ = self.events.send(RegistryEvent::Applied);
+                if !contiguous {
+                    // Frames between the cursor and this batch were missed;
+                    // the cursor held. Reconnect — the fresh hello pulls the
+                    // whole gap from the true cursor.
+                    tracing::warn!(seq, "registry: broadcast seq gap; resyncing");
+                    return false;
+                }
             }
             ServerFrame::Ack { batch, seq, .. } => {
                 lock(&self.doc).ack_batch(&batch, seq);


### PR DESCRIPTION
Field incident, root-caused properly this time (the earlier stale-version theory was **wrong** — the affected laptop runs v0.2.24): new sessions created on one device never appear in another's sidebar, while status updates to already-known rows keep flowing. iOS shows the sessions.

## Verified against production data first

The "missing" chats and their space rows are **complete and correct in the registry** (checked via a read-only watch on this org: today's rows carry proper `config.harness: "opencode"` and valid `spaceId`s, and the space rows exist). The failure is purely on the reading device.

## The hole (deterministic, no packet loss required)

On the HTTPS transport — used exactly when a network strips WebSocket upgrades (#168's dual transport, shipped v0.2.12) — one sync cycle **pushes before it pulls**:

1. Device is behind at cursor `N`. Peers wrote batches `N+1..N+K-1` (the new sessions).
2. Device pushes any local write (a seen-marker suffices). The ack assigns it seq `N+K`, and `ack_batch` **jumped the cursor to `N+K`**.
3. The same cycle then pulls `since cursor()` = `N+K` → the peers' batches are never fetched. The cursor persists, so restarts/updates don't help. Rows touched later re-broadcast and self-heal — which is why statuses kept updating while creations stayed invisible.

On WS the ack is preceded by the peers' broadcasts on the same ordered socket, so it never bit there — the work laptop on a corporate network riding the HTTP path is the textbook victim.

## Fix

- **`ack_batch` no longer advances the cursor.** The ack's seq is our own batch's position; the cursor only moves with actual row payloads (state/pull/contiguous broadcasts). Re-pulling our own batch is an idempotent LWW no-op.
- **`apply_rows` guards contiguity**: a broadcast past a seq gap (hibernating DO, half-dead socket) applies its rows but *holds* the cursor and the client reconnects — the fresh hello backfills the whole window instead of skipping it forever.
- **Healing resync epoch**: snapshots persisted before this fix may already hide a jumped cursor, so the first load after upgrading zeroes the cursor once and pulls full state (rows kept; local-only rows re-seed through the existing full-state path). **Updating the laptop to this release heals it automatically.**
- **iOS mirrors all three** (its WS ordering masked the ack bug so far; gap-hold converges on the next natural reconnect). Swift unbuilt here — needs the usual mac pass.

Regression tests: own-push ack keeps the cursor at the pre-push seq (the exact incident); gapped broadcasts apply-but-hold with idempotent replays accepted; pre-epoch snapshots resync in full once with rows preserved. Full workspace suite: 1111 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790069446&installation_model_id=425430&pr_number=211&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F211&signature=986853d106221bb0cf8c1678e2a1ad341a95e16c4fea33324f90c3f08bec45f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->