### PR TITLE
Orphan sweep waits for server truth; unreadable HTTP ack retries

### DIFF
--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -1210,6 +1210,7 @@ impl RpcService for EngineRpc {
                 fn room_json(s: &zeron_sync::RoomStatsSnapshot) -> serde_json::Value {
                     serde_json::json!({
                         "connected": s.connected,
+                        "synced": s.synced,
                         "lastPushedMs": s.last_pushed_ms,
                         "lastAckMs": s.last_ack_ms,
                         "rejoins": s.rejoins,

--- a/crates/engine/src/spaces.rs
+++ b/crates/engine/src/spaces.rs
@@ -17,7 +17,10 @@
 //! The repair tick also runs the orphan sweep: a chat created concurrently
 //! with a `deleteSpace` on another device can sync in after the cascade ran,
 //! leaving a dangling `spaceId`. The HOST device deletes its own such chats
-//! (writer discipline — we never touch other devices' rows).
+//! (writer discipline — we never touch other devices' rows). The sweep only
+//! runs once the registry has applied a server state this boot
+//! ([`WorkspaceHost::registry_synced`]): on an un-synced replica a missing
+//! space row means "we haven't heard yet", not "deleted".
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -248,6 +251,14 @@ async fn check_space(inner: &Arc<SpacesSyncInner>, space_id: &str, path: &Path) 
 /// Host-side repair: delete OUR chats whose `spaceId` dangles (create-vs-delete
 /// race). Chats hosted by other devices are left alone.
 fn sweep_orphans(inner: &Arc<SpacesSyncInner>) {
+    // NEVER sweep off a replica that hasn't heard from the server this boot:
+    // a gapped/pre-heal/offline-at-boot view is missing rows, and "space row
+    // absent" on it is not evidence the space was deleted — sweeping there
+    // globally destroys live chats (2026-08-23 missing-sessions audit).
+    if !inner.workspace.registry_synced() {
+        tracing::debug!("spaces: orphan sweep skipped (registry not yet synced this boot)");
+        return;
+    }
     let spaces = inner.workspace.watch_spaces().borrow().clone();
     let live: std::collections::HashSet<&str> = spaces.iter().map(|s| s.id.as_str()).collect();
     let chats = inner.workspace.watch_chats().borrow().clone();

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -549,6 +549,22 @@ impl WorkspaceHost {
             .is_some_and(|room| room.stats().connected)
     }
 
+    /// True once this replica has applied a server state this process (WS
+    /// hello answer or HTTPS pull) — or when no edge is configured at all
+    /// (local-only: the local table IS the whole truth). Destructive repair
+    /// (the orphan sweep) gates on this: a replica that has not heard from
+    /// the server this boot may be arbitrarily behind (gapped cursor,
+    /// pre-heal, offline at boot), and "row absent locally" on such a view
+    /// is not evidence of deletion.
+    pub fn registry_synced(&self) -> bool {
+        if self.inner.config.edge.is_none() {
+            return true;
+        }
+        lock(&self.inner.room)
+            .as_ref()
+            .is_some_and(|room| room.stats().synced)
+    }
+
     /// Probe the registry room's liveness NOW (window-focus sweep). Probes are
     /// deadline-checked in the client: an unanswered probe tears the session
     /// down for a fresh socket, so a deaf-receiving room (2026-08-04 incident)

--- a/crates/sync/src/registry.rs
+++ b/crates/sync/src/registry.rs
@@ -243,6 +243,9 @@ async fn pump(
 #[derive(Default)]
 struct Stats {
     connected: std::sync::atomic::AtomicBool,
+    /// Latched once a server state applies this process (hello or HTTPS
+    /// pull) — never cleared by disconnects; see `RoomStatsSnapshot::synced`.
+    synced: std::sync::atomic::AtomicBool,
     last_pushed_ms: std::sync::atomic::AtomicI64,
     last_ack_ms: std::sync::atomic::AtomicI64,
     rejoins: std::sync::atomic::AtomicU64,
@@ -276,6 +279,7 @@ impl Stats {
         use std::sync::atomic::Ordering::Relaxed;
         RoomStatsSnapshot {
             connected: self.connected.load(Relaxed),
+            synced: self.synced.load(Relaxed),
             last_pushed_ms: self.last_pushed_ms.load(Relaxed),
             last_ack_ms: self.last_ack_ms.load(Relaxed),
             rejoins: self.rejoins.load(Relaxed),
@@ -768,6 +772,7 @@ impl Actor {
             }
         }
         self.stats.connected.store(true, Relaxed);
+        self.stats.synced.store(true, Relaxed);
         self.stats.last_pushed_ms.store(epoch_ms(), Relaxed);
         self.stats.retry_at_ms.store(0, Relaxed);
         *lock(&self.stats.last_failure) = None;
@@ -888,11 +893,27 @@ impl Actor {
                     serde_json::json!({ "batch": batch.batch, "ops": batch.ops }).to_string();
                 match transport.push(body).await {
                     Ok(ack) => {
-                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&ack) {
-                            if let (Some(b), Some(seq)) = (v["batch"].as_str(), v["seq"].as_u64()) {
-                                lock(&doc).ack_batch(b, seq);
+                        let parsed = serde_json::from_str::<serde_json::Value>(&ack)
+                            .ok()
+                            .and_then(|v| {
+                                Some((v["batch"].as_str()?.to_owned(), v["seq"].as_u64()?))
+                            });
+                        match parsed {
+                            Some((b, seq)) => {
+                                lock(&doc).ack_batch(&b, seq);
                                 stats.last_ack_ms.store(epoch_ms(), Relaxed);
                                 let _ = events.send(RegistryEvent::Applied);
+                            }
+                            None => {
+                                // An unreadable ack must count as a FAILED
+                                // push: swallowing it left the batch marked
+                                // in-flight, and on a pure-HTTPS device no
+                                // socket disconnect ever comes along to
+                                // un-mark it — the write was stranded until
+                                // process restart.
+                                tracing::warn!("registry: http push ack unreadable; will retry");
+                                push_failed = true;
+                                break;
                             }
                         }
                     }
@@ -933,6 +954,7 @@ impl Actor {
                                 map.insert(device, (at, now));
                             }
                             drop(map);
+                            stats.synced.store(true, Relaxed);
                             stats.last_pushed_ms.store(epoch_ms(), Relaxed);
                             let _ = events.send(RegistryEvent::Applied);
                         }

--- a/crates/sync/src/types.rs
+++ b/crates/sync/src/types.rs
@@ -50,6 +50,11 @@ impl UrlProvider for StaticUrl {
 pub struct RoomStatsSnapshot {
     /// A join is currently established.
     pub connected: bool,
+    /// A server state has been APPLIED this process (WS hello answer or
+    /// HTTPS pull) — the local replica has heard authoritative truth at
+    /// least once this boot. Destructive repair (the orphan sweep) gates on
+    /// this: before it, "row absent locally" is not evidence of deletion.
+    pub synced: bool,
     /// Epoch ms of the last SERVER-PUSHED frame (broadcast, backfill,
     /// join answer) — 0 = never. The deaf-socket tell: fresh acks + stale
     /// pushes.

--- a/crates/sync/tests/registry_client.rs
+++ b/crates/sync/tests/registry_client.rs
@@ -335,6 +335,7 @@ async fn probe_answers_and_stats_flow() {
         .expect("connects");
     let before = client.stats();
     assert!(before.connected);
+    assert!(before.synced, "hello state apply latches synced");
     client.probe();
     let events = client.events();
     tokio::time::sleep(Duration::from_millis(200)).await;
@@ -483,4 +484,82 @@ async fn applied_events_fire_for_republish() {
     assert_eq!(event, RegistryEvent::Applied);
     client_a.shutdown().await;
     client_b.shutdown().await;
+}
+
+/// HTTPS-transport seam for the pure-offline tests below: pulls answer with
+/// an empty delta; the FIRST push ack comes back unreadable (a captive
+/// portal / proxy interposing on the response body), later pushes ack
+/// properly. The regression: an unreadable ack used to be silently ignored,
+/// leaving the batch marked in-flight — and with no socket session there is
+/// no disconnect to un-mark it, so the write was stranded until restart.
+struct FlakyAckTransport {
+    push_calls: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl zeron_sync::registry::RegistryTransport for FlakyAckTransport {
+    fn fetch(
+        &self,
+        _since: u64,
+    ) -> futures::future::BoxFuture<'static, Result<String, zeron_sync::SyncError>> {
+        Box::pin(async {
+            Ok(r#"{"seq":0,"full":false,"gcFloor":0,"rows":[],"presence":{}}"#.to_string())
+        })
+    }
+
+    fn push(
+        &self,
+        body: String,
+    ) -> futures::future::BoxFuture<'static, Result<String, zeron_sync::SyncError>> {
+        let call = self
+            .push_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Box::pin(async move {
+            if call == 0 {
+                return Ok("<html>proxy login required</html>".to_string());
+            }
+            let v: serde_json::Value = serde_json::from_str(&body).expect("push body is json");
+            let batch = v["batch"].as_str().expect("batch id").to_owned();
+            Ok(format!(r#"{{"batch":"{batch}","seq":1,"applied":1}}"#))
+        })
+    }
+}
+
+#[tokio::test]
+async fn unreadable_http_ack_retries_instead_of_stranding_the_batch() {
+    let push_calls = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let doc = new_doc("dev-a");
+    {
+        let mut d = doc.lock().unwrap();
+        d.upsert_chat(&chat("chat-1", "dev-a")).unwrap();
+        assert_eq!(d.pending_len(), 1);
+    }
+    // The WS side never connects (dead port): every sync runs over HTTPS.
+    let client = RegistryClient::connect_via_transport(
+        Arc::new(zeron_sync::StaticUrl("ws://127.0.0.1:1/ws".into())),
+        doc.clone(),
+        "dev-a",
+        zeron_sync::RegistryTuning::default(),
+        Arc::new(FlakyAckTransport {
+            push_calls: push_calls.clone(),
+        }),
+    )
+    .await
+    .expect("transport clients construct immediately");
+
+    // Cycle 1 push gets the unreadable ack; the batch must become pushable
+    // again so a later cycle (here: the next dial backoff) retries and the
+    // proper ack clears it.
+    wait_until(|| doc.lock().unwrap().pending_len() == 0).await;
+    assert!(
+        push_calls.load(std::sync::atomic::Ordering::SeqCst) >= 2,
+        "the stranded batch must be re-pushed after the unreadable ack"
+    );
+
+    // The empty pulls also latched the synced flag — server truth has been
+    // heard this process even though no socket ever joined.
+    let stats = client.stats();
+    assert!(stats.synced, "HTTP pull apply must latch synced");
+    assert!(!stats.connected, "no WS session ever joined");
+
+    client.shutdown().await;
 }


### PR DESCRIPTION
Follow-up hardening from the missing-sessions audit (the v0.2.26 / #211 incident). Both defects were found while auditing why incident-window sessions stayed invisible on one device; neither caused that incident, but both are loaded guns of the same caliber.

## 1. Orphan sweep can no longer run ahead of server truth

`sweep_orphans` (spaces.rs repair tick) deletes this device's chats whose `spaceId` doesn't resolve — judged against the **local** replica. On a replica that hasn't heard from the server this boot (gapped cursor pre-#211, mid-heal, offline at boot), a missing space row means "not received yet", not "deleted" — but the sweep's `delete_chat` is a global, permanent write that syncs everywhere.

Fix: a `synced` latch on the registry client, set the moment a server state applies this process (WS hello answer **or** HTTPS pull — whichever transport wins), exposed as `WorkspaceHost::registry_synced()`. The sweep returns early until it's true. Hosts with no edge configured are exempt: their local table is the whole truth. The latch also rides `RoomStatsSnapshot`/SyncStatus, so `zeron sync` now shows whether a device has actually heard authoritative state this boot.

## 2. Unreadable HTTP push ack no longer strands the batch

`spawn_offline_sync` parsed the push ack with `if let Ok(v) … if let (Some, Some)` and **silently ignored** anything else (captive-portal HTML, proxy interference). `take_pushable` had already marked the batch in-flight, and on a pure-HTTPS device no socket disconnect ever arrives to un-mark it — the write was stranded until process restart. An unreadable ack now counts as a failed push: `mark_disconnected` runs, the batch becomes pushable again, and the next cycle retries it. (Server-rejected pushes are unaffected — non-2xx already surfaced as `Err`.)

## Tests

- `unreadable_http_ack_retries_instead_of_stranding_the_batch` — pure-HTTPS client (dead WS port), first ack is proxy HTML: asserts the batch re-pushes and drains, and that HTTP pulls latch `synced` while `connected` stays false. Under the old code the batch stayed in-flight forever and the test times out.
- `probe_answers_and_stats_flow` now asserts the WS hello latches `synced`.
- Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790073800&installation_model_id=425430&pr_number=212&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F212&signature=1c5ac85508199de2844cc475d0df15666f5508bee44acf957bf0bbad3c8e1a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->