### PR TITLE
fix(ui): full-width scrollable composer completion popups

### DIFF
--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -2203,13 +2203,6 @@ impl ComposerInput {
         self.point_for_display_index(self.projection.raw_to_display(index))
     }
 
-    fn visible_point_for_index(&self, index: usize) -> Option<Point<Pixels>> {
-        let point = self.point_for_index(index)?;
-        let height = self.last_bounds?.size.height;
-        let y = point.y - px(self.scroll_top);
-        (y >= px(0.0) && y + self.line_height <= height).then_some(gpui::point(point.x, y))
-    }
-
     /// Content-local point for a shaped projection byte index. The icon layer
     /// uses this to occupy its explicit projection slot without inventing a
     /// second coordinate system beside the custom text editor.
@@ -3274,6 +3267,11 @@ fn mention_token(text: &str, cursor: usize) -> Option<MentionToken> {
     })
 }
 
+/// Restart a popup's row stack at the top (fresh open / query / result set).
+fn reset_scroll_offset(scroll: &gpui::ScrollHandle) {
+    scroll.set_offset(gpui::Point::new(px(0.0), px(0.0)));
+}
+
 /// The `/` must open the input: slash commands are whole-prompt prefixes
 /// (`/compact`, `/goal ship it`), so only the first token triggers, and a
 /// query containing another `/` (a typed path) never does.
@@ -3393,6 +3391,14 @@ pub struct Composer {
     /// Advertised commands per harness (one `ListCommands` per harness per
     /// composer lifetime; the engine caches discovery on its side too).
     slash_cache: HashMap<HarnessId, Vec<SlashCommand>>,
+    /// Slash-popup row scroll — the stack overflows into a wheel/keyboard-
+    /// scrollable list once it outgrows the card.
+    slash_scroll: gpui::ScrollHandle,
+    /// File-mention popup row scroll (same treatment).
+    mention_scroll: gpui::ScrollHandle,
+    /// Shared scrollbar hover/drag state for both popups' floating rails —
+    /// they never show at once (mutually exclusive by token shape).
+    popup_bar: crate::popover::MenuScrollbarState,
     current_key: String,
     sending: bool,
     failure: Option<SharedString>,
@@ -3545,6 +3551,9 @@ impl Composer {
             slash_task: None,
             slash: SlashState::default(),
             slash_cache: HashMap::new(),
+            slash_scroll: gpui::ScrollHandle::new(),
+            mention_scroll: gpui::ScrollHandle::new(),
+            popup_bar: crate::popover::MenuScrollbarState::default(),
             current_key,
             sending: false,
             failure: None,
@@ -3898,6 +3907,8 @@ impl Composer {
         if !refining {
             self.mention.results.clear();
             self.mention.active = None;
+            // Fresh open: the row stack restarts at the top.
+            reset_scroll_offset(&self.mention_scroll);
         }
         self.mention.error = None;
         self.mention.loading = token.is_some();
@@ -3973,6 +3984,8 @@ impl Composer {
                             composer.mention.error = None;
                             composer.mention.active = (!results.is_empty()).then_some(0);
                             composer.mention.results = results;
+                            // New result set: the row stack restarts at the top.
+                            reset_scroll_offset(&composer.mention_scroll);
                         }
                         Err(err) => tracing::warn!(%err, "file mention response decode failed"),
                     },
@@ -3994,6 +4007,10 @@ impl Composer {
     fn move_mention(&mut self, delta: isize, cx: &mut Context<Self>) {
         self.mention.active =
             crate::popover::menu_step(self.mention.active, self.mention.results.len(), delta);
+        if let Some(active) = self.mention.active {
+            // Keep the keyboard cursor visible in the scrolled row stack.
+            self.mention_scroll.scroll_to_item(active);
+        }
         self.sync_mention_controls(cx);
         cx.notify();
     }
@@ -4039,6 +4056,9 @@ impl Composer {
             .w_full()
             .max_h(px(320.0))
             .overflow_hidden()
+            // GPUI dispatches this captured stream while the thumb is
+            // dragged, including when the pointer has left the popup.
+            .on_drag_move(cx.listener(Self::on_popup_bar_drag_move))
             .on_mouse_down_out(cx.listener(|this, _, _, cx| this.dismiss_mention(cx)));
         if self.mention.loading && self.mention.results.is_empty() {
             card = card.child(crate::popover::skeleton_rows(
@@ -4071,13 +4091,14 @@ impl Composer {
                     }),
             );
         } else {
+            let mut rows: Vec<gpui::AnyElement> = Vec::with_capacity(self.mention.results.len());
             for (ix, result) in self.mention.results.iter().enumerate() {
                 let selected = self.mention.active == Some(ix);
                 let (directory, name) = match result.path.rsplit_once('/') {
                     Some((directory, name)) => (directory.to_string(), name.to_string()),
                     None => (String::new(), result.path.clone()),
                 };
-                card = card.child(
+                rows.push(
                     crate::popover::menu_row(theme, selected, format!("file-mention-result-{ix}"))
                         .id(("file-mention-result", ix))
                         .on_click(cx.listener(move |this, _, _, cx| {
@@ -4120,9 +4141,34 @@ impl Composer {
                                             .child(directory),
                                     )
                                 }),
-                        ),
+                        )
+                        .into_any_element(),
                 );
             }
+            // Overflowing rows wheel-scroll inside a bounded viewport; the
+            // floating rail mirrors the model-list scrollbar treatment.
+            card = card.child(
+                div()
+                    .id("mention-scroll-host")
+                    .relative()
+                    .on_hover(cx.listener(Self::on_popup_list_hover))
+                    .child(
+                        div()
+                            .id("mention-list")
+                            .max_h(px(312.0))
+                            .flex()
+                            .flex_col()
+                            .overflow_y_scroll()
+                            .track_scroll(&self.mention_scroll)
+                            .children(rows),
+                    )
+                    .children(self.popup_scrollbar(
+                        "mention-scrollbar",
+                        &self.mention_scroll,
+                        theme,
+                        cx,
+                    )),
+            );
         }
         Some(crate::popover::full_width_menu_above(
             "file-mention-popup",
@@ -4131,11 +4177,8 @@ impl Composer {
         ))
     }
 
-    fn render_input_with_completion(&self, theme: &Theme, cx: &mut Context<Self>) -> gpui::Div {
-        div()
-            .relative()
-            .child(self.input.clone())
-            .children(self.render_slash_popup(theme, cx))
+    fn render_input_with_completion(&self) -> gpui::Div {
+        div().relative().child(self.input.clone())
     }
 
     // ---- slash commands ---------------------------------------------------
@@ -4244,6 +4287,8 @@ impl Composer {
         let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
         self.slash.filtered = crate::popover::filter_indices(&query, &names);
         self.slash.active = (!self.slash.filtered.is_empty()).then_some(0);
+        // A fresh query/reopen restarts the row stack at the top.
+        reset_scroll_offset(&self.slash_scroll);
         self.sync_mention_controls(cx);
         cx.notify();
     }
@@ -4251,6 +4296,10 @@ impl Composer {
     fn move_slash(&mut self, delta: isize, cx: &mut Context<Self>) {
         self.slash.active =
             crate::popover::menu_step(self.slash.active, self.slash.filtered.len(), delta);
+        if let Some(active) = self.slash.active {
+            // Keep the keyboard cursor visible in the scrolled row stack.
+            self.slash_scroll.scroll_to_item(active);
+        }
         self.sync_mention_controls(cx);
         cx.notify();
     }
@@ -4310,17 +4359,23 @@ impl Composer {
         theme: &Theme,
         cx: &mut Context<Self>,
     ) -> Option<gpui::AnyElement> {
-        let token = self.slash.token.as_ref()?;
+        // Only while a slash token is active.
+        self.slash.token.as_ref()?;
         let commands = self
             .slash
             .harness
             .and_then(|h| self.slash_cache.get(&h))
             .map(Vec::as_slice)
             .unwrap_or_default();
+        // Full pill width at the mention card's height budget — both composer
+        // completions share the same surface shape.
         let mut card = crate::popover::popover_card(theme)
-            .w(px(380.0))
-            .max_h(px(280.0))
+            .w_full()
+            .max_h(px(320.0))
             .overflow_hidden()
+            // GPUI dispatches this captured stream while the thumb is
+            // dragged, including when the pointer has left the popup.
+            .on_drag_move(cx.listener(Self::on_popup_bar_drag_move))
             .on_mouse_down_out(cx.listener(|this, _, _, cx| this.dismiss_slash(cx)));
         if self.slash.loading && commands.is_empty() {
             card = card.child(crate::popover::skeleton_rows(
@@ -4353,6 +4408,7 @@ impl Composer {
                     }),
             );
         } else {
+            let mut rows: Vec<gpui::AnyElement> = Vec::with_capacity(self.slash.filtered.len());
             for (row_ix, &cmd_ix) in self.slash.filtered.iter().enumerate() {
                 let Some(command) = commands.get(cmd_ix) else {
                     continue;
@@ -4368,7 +4424,7 @@ impl Composer {
                     }
                 }
                 let description: SharedString = description.into();
-                card = card.child(
+                rows.push(
                     crate::popover::menu_row(theme, selected, format!("slash-result-{row_ix}"))
                         .id(("slash-result", row_ix))
                         .on_click(cx.listener(move |this, _, _, cx| {
@@ -4404,20 +4460,146 @@ impl Composer {
                                         .text_color(theme.text_muted)
                                         .child(description),
                                 ),
-                        ),
+                        )
+                        .into_any_element(),
                 );
             }
+            // Overflowing rows wheel-scroll inside a bounded viewport; the
+            // floating rail mirrors the model-list scrollbar treatment.
+            card = card.child(
+                div()
+                    .id("slash-scroll-host")
+                    .relative()
+                    .on_hover(cx.listener(Self::on_popup_list_hover))
+                    .child(
+                        div()
+                            .id("slash-list")
+                            .max_h(px(312.0))
+                            .flex()
+                            .flex_col()
+                            .overflow_y_scroll()
+                            .track_scroll(&self.slash_scroll)
+                            .children(rows),
+                    )
+                    .children(self.popup_scrollbar(
+                        "slash-scrollbar",
+                        &self.slash_scroll,
+                        theme,
+                        cx,
+                    )),
+            );
         }
-        let anchor = self
-            .input
-            .read(cx)
-            .visible_point_for_index(token.range.start)?;
-        Some(crate::popover::anchored_menu_above_at(
+        // Full pill width above the composer, matching the file-mention popup.
+        Some(crate::popover::full_width_menu_above(
             "slash-popup",
-            anchor,
             card.into_any_element(),
             None,
         ))
+    }
+
+    /// The floating scrollbar rail for a composer popup's scroll host (the
+    /// model-list treatment). Callers pass the id and that popup's scroll
+    /// handle; the hover/drag interaction state is shared.
+    fn popup_scrollbar(
+        &self,
+        id: &'static str,
+        scroll: &gpui::ScrollHandle,
+        theme: &Theme,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        let metrics = self.popup_bar.metrics(scroll)?;
+        Some(
+            self.popup_bar
+                .render_rail(theme, metrics)?
+                .id(id)
+                .on_hover(cx.listener(Self::on_popup_bar_hover))
+                .on_mouse_down(
+                    gpui::MouseButton::Left,
+                    cx.listener(Self::on_popup_bar_mouse_down),
+                )
+                .on_drag(crate::popover::MenuScrollbarDrag, |_, _, _, cx| {
+                    cx.stop_propagation();
+                    cx.new(|_| crate::popover::MenuScrollbarDragGhost)
+                })
+                .on_mouse_up_out(
+                    gpui::MouseButton::Left,
+                    cx.listener(Self::on_popup_bar_mouse_up),
+                )
+                .on_mouse_up(
+                    gpui::MouseButton::Left,
+                    cx.listener(Self::on_popup_bar_mouse_up),
+                )
+                .into_any_element(),
+        )
+    }
+
+    /// The popup whose rows a scrollbar drag is moving — the tokens are
+    /// mutually exclusive, so at most one exists.
+    fn active_popup_scroll(&self) -> Option<gpui::ScrollHandle> {
+        if self.slash.token.is_some() {
+            Some(self.slash_scroll.clone())
+        } else if self.mention.token.is_some() {
+            Some(self.mention_scroll.clone())
+        } else {
+            None
+        }
+    }
+
+    fn on_popup_list_hover(
+        &mut self,
+        hovered: &bool,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.popup_bar.set_list_hovered(*hovered) {
+            cx.notify();
+        }
+    }
+
+    fn on_popup_bar_hover(&mut self, hovered: &bool, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.popup_bar.set_bar_hovered(*hovered) {
+            cx.notify();
+        }
+    }
+
+    fn on_popup_bar_mouse_down(
+        &mut self,
+        event: &gpui::MouseDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(scroll) = self.active_popup_scroll() else {
+            return;
+        };
+        if !self.popup_bar.begin_press(&scroll, event.position.y) {
+            return;
+        }
+        cx.stop_propagation();
+        cx.notify();
+    }
+
+    fn on_popup_bar_drag_move(
+        &mut self,
+        event: &gpui::DragMoveEvent<crate::popover::MenuScrollbarDrag>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(scroll) = self.active_popup_scroll() else {
+            return;
+        };
+        if self.popup_bar.drag_to(&scroll, event.event.position.y) {
+            cx.notify();
+        }
+    }
+
+    fn on_popup_bar_mouse_up(
+        &mut self,
+        _event: &gpui::MouseUpEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.popup_bar.end_press();
+        cx.notify();
     }
 
     fn on_state_changed(&mut self, cx: &mut Context<Self>) {
@@ -5984,7 +6166,7 @@ impl Render for Composer {
                         .px(px(16.0))
                         .pt(px(text_pt))
                         .pb(px(4.0))
-                        .child(self.render_input_with_completion(&theme, cx)),
+                        .child(self.render_input_with_completion()),
                 )
                 .child(
                     div()
@@ -6052,7 +6234,7 @@ impl Render for Composer {
                                 .pr(px(8.0))
                                 .relative()
                                 .top(px(-text_glide))
-                                .child(self.render_input_with_completion(&theme, cx)),
+                                .child(self.render_input_with_completion()),
                         )
                         .child(
                             div()
@@ -6094,7 +6276,10 @@ impl Render for Composer {
                     16.0,
                     motion::fade_quick("composer-input", body),
                 ))
-                .children(self.render_file_mention_popup(&theme, cx)),
+                // Both completion popups span the full pill width above it —
+                // the file-mention and slash tokens are mutually exclusive.
+                .children(self.render_file_mention_popup(&theme, cx))
+                .children(self.render_slash_popup(&theme, cx)),
         );
         // Branch/worktree toolbar under the pill (t3code BranchToolbar): the
         // checkout-kind selector + ref picker for new sessions, read-only

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -30,11 +30,6 @@ use zeron_rpc::methods;
 /// footer; a flat cap + "Showing X of Y refs" reads the same without
 /// pagination plumbing).
 const MAX_REF_ROWS: usize = 300;
-const MODEL_SCROLLBAR_TRACK_INSET: f32 = 4.0;
-const MODEL_SCROLLBAR_HIT_WIDTH: f32 = 10.0;
-const MODEL_SCROLLBAR_THUMB_WIDTH: f32 = 3.0;
-const MODEL_SCROLLBAR_HOVER_THUMB_WIDTH: f32 = 5.0;
-const MODEL_SCROLLBAR_MIN_THUMB: f32 = 24.0;
 
 use crate::composer::{ComposerInput, ComposerInputEvent};
 use crate::motion;
@@ -421,38 +416,6 @@ struct ModelRowData {
     model: Model,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct ModelScrollbarGrab {
-    grab_offset: f32,
-}
-
-/// Marker for GPUI's captured drag stream. The actual grab geometry stays in
-/// [`ModelScrollbarGrab`] so a track click can center the thumb first.
-struct ModelScrollbarDrag;
-
-/// Invisible drag preview: scrollbar drags manipulate the existing thumb.
-struct ModelScrollbarDragGhost;
-
-impl gpui::Render for ModelScrollbarDragGhost {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl gpui::IntoElement {
-        gpui::Empty
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-struct ModelScrollbarMetrics {
-    track_height: f32,
-    thumb_top: f32,
-    thumb_height: f32,
-    max_scroll: f32,
-}
-
-impl ModelScrollbarMetrics {
-    fn travel(self) -> f32 {
-        (self.track_height - self.thumb_height).max(0.0)
-    }
-}
-
 /// Which picker popover is open.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PickerKind {
@@ -507,11 +470,8 @@ pub struct Pickers {
     model_rows_cache: std::cell::RefCell<Option<(ModelRowsKey, std::sync::Arc<Vec<ModelRowData>>)>>,
     /// Bumped on every catalog/favorites mutation; invalidates the cache.
     catalog_rev: u64,
-    /// Drag state for the floating model-list scrollbar.
-    model_scrollbar_drag: Option<ModelScrollbarGrab>,
-    /// The scrollbar is an on-demand affordance for the model-list surface.
-    model_list_hovered: bool,
-    model_scrollbar_hovered: bool,
+    /// Hover/drag state of the floating model-list scrollbar.
+    model_bar: popover::MenuScrollbarState,
     /// Shared search / URL / name input, reused across popovers.
     search: Entity<ComposerInput>,
     /// One-shot mute for the next Edited event's highlight reset — armed by
@@ -669,9 +629,7 @@ impl Pickers {
             model_scroll: gpui::UniformListScrollHandle::new(),
             model_rows_cache: std::cell::RefCell::new(None),
             catalog_rev: 0,
-            model_scrollbar_drag: None,
-            model_list_hovered: false,
-            model_scrollbar_hovered: false,
+            model_bar: popover::MenuScrollbarState::default(),
             search,
             search_reset_muted: false,
             focus: cx.focus_handle(),
@@ -880,9 +838,7 @@ impl Pickers {
 
     /// Begin the exit animation (shared by every close path).
     fn animate_close(&mut self, cx: &mut Context<Self>) {
-        self.model_scrollbar_drag = None;
-        self.model_list_hovered = false;
-        self.model_scrollbar_hovered = false;
+        self.model_bar = popover::MenuScrollbarState::default();
         if self.open.begin_close() {
             popover::reap_popup(cx, |pickers: &mut Self| &mut pickers.open);
         }
@@ -2705,71 +2661,15 @@ impl Pickers {
         self.model_scroll.0.borrow().base_handle.clone()
     }
 
-    fn model_scrollbar_metrics(&self) -> Option<ModelScrollbarMetrics> {
-        let scroll = self.model_scroll_base();
-        let bounds = scroll.bounds();
-        let viewport_height = f32::from(bounds.size.height);
-        // GPUI stores the maximum as a positive distance; only the live
-        // scroll offset is negative while content moves upward.
-        let max_scroll = f32::from(scroll.max_offset().y).max(0.0);
-        if viewport_height <= 0.0 || max_scroll <= 0.0 {
-            return None;
-        }
-        let track_height = (viewport_height - MODEL_SCROLLBAR_TRACK_INSET * 2.0).max(0.0);
-        if track_height <= 0.0 {
-            return None;
-        }
-        let content_height = viewport_height + max_scroll;
-        let thumb_height = (track_height * viewport_height / content_height)
-            .max(MODEL_SCROLLBAR_MIN_THUMB)
-            .min(track_height);
-        let current_scroll = (-f32::from(scroll.offset().y)).clamp(0.0, max_scroll);
-        let travel = (track_height - thumb_height).max(0.0);
-        Some(ModelScrollbarMetrics {
-            track_height,
-            thumb_top: travel * current_scroll / max_scroll,
-            thumb_height,
-            max_scroll,
-        })
-    }
-
-    fn model_scrollbar_to_pointer(
-        &mut self,
-        pointer_y: gpui::Pixels,
-        grab_offset: f32,
-        cx: &mut Context<Self>,
-    ) {
-        let Some(metrics) = self.model_scrollbar_metrics() else {
-            return;
-        };
-        let scroll = self.model_scroll_base();
-        let bounds = scroll.bounds();
-        let pointer_in_track = f32::from(pointer_y - bounds.top()) - MODEL_SCROLLBAR_TRACK_INSET;
-        let thumb_top = (pointer_in_track - grab_offset).clamp(0.0, metrics.travel());
-        let scroll_to = if metrics.travel() <= 0.0 {
-            0.0
-        } else {
-            thumb_top / metrics.travel() * metrics.max_scroll
-        };
-        let offset = scroll.offset();
-        scroll.set_offset(gpui::Point::new(offset.x, px(-scroll_to)));
-        cx.notify();
-    }
-
     fn on_model_list_hover(
         &mut self,
         hovered: &bool,
         _window: &mut gpui::Window,
         cx: &mut Context<Self>,
     ) {
-        if self.model_list_hovered == *hovered {
-            return;
+        if self.model_bar.set_list_hovered(*hovered) {
+            cx.notify();
         }
-        self.model_list_hovered = *hovered;
-        if !*hovered && self.model_scrollbar_drag.is_none() {
-            self.model_scrollbar_hovered = false;
-        }
-        cx.notify();
     }
 
     fn on_model_scrollbar_hover(
@@ -2778,11 +2678,7 @@ impl Pickers {
         _window: &mut gpui::Window,
         cx: &mut Context<Self>,
     ) {
-        // Keep the active treatment while a captured drag travels outside the
-        // model list; the hover callback quite correctly turns false there.
-        let active = *hovered || self.model_scrollbar_drag.is_some();
-        if self.model_scrollbar_hovered != active {
-            self.model_scrollbar_hovered = active;
+        if self.model_bar.set_bar_hovered(*hovered) {
             cx.notify();
         }
     }
@@ -2793,35 +2689,25 @@ impl Pickers {
         window: &mut gpui::Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(metrics) = self.model_scrollbar_metrics() else {
+        let scroll = self.model_scroll_base();
+        if !self.model_bar.begin_press(&scroll, event.position.y) {
             return;
-        };
+        }
         window.focus(&self.focus, cx);
-        let bounds = self.model_scroll_base().bounds();
-        let pointer_in_track =
-            f32::from(event.position.y - bounds.top()) - MODEL_SCROLLBAR_TRACK_INSET;
-        let grab_offset = if (metrics.thumb_top..=metrics.thumb_top + metrics.thumb_height)
-            .contains(&pointer_in_track)
-        {
-            pointer_in_track - metrics.thumb_top
-        } else {
-            metrics.thumb_height / 2.0
-        };
-        self.model_scrollbar_drag = Some(ModelScrollbarGrab { grab_offset });
-        self.model_scrollbar_to_pointer(event.position.y, grab_offset, cx);
         cx.stop_propagation();
+        cx.notify();
     }
 
     fn on_model_scrollbar_drag_move(
         &mut self,
-        event: &gpui::DragMoveEvent<ModelScrollbarDrag>,
+        event: &gpui::DragMoveEvent<popover::MenuScrollbarDrag>,
         _window: &mut gpui::Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(drag) = self.model_scrollbar_drag else {
-            return;
-        };
-        self.model_scrollbar_to_pointer(event.event.position.y, drag.grab_offset, cx);
+        let scroll = self.model_scroll_base();
+        if self.model_bar.drag_to(&scroll, event.event.position.y) {
+            cx.notify();
+        }
     }
 
     fn on_model_scrollbar_mouse_up(
@@ -2830,10 +2716,7 @@ impl Pickers {
         _window: &mut gpui::Window,
         cx: &mut Context<Self>,
     ) {
-        self.model_scrollbar_drag = None;
-        if !self.model_list_hovered {
-            self.model_scrollbar_hovered = false;
-        }
+        self.model_bar.end_press();
         cx.notify();
     }
 
@@ -2842,33 +2725,19 @@ impl Pickers {
         theme: &Theme,
         cx: &mut Context<Self>,
     ) -> Option<gpui::AnyElement> {
-        let dragging = self.model_scrollbar_drag.is_some();
-        if !self.model_list_hovered && !dragging {
-            return None;
-        }
-        let metrics = self.model_scrollbar_metrics()?;
-        let active = self.model_scrollbar_hovered || dragging;
-        let thumb_width = if active {
-            MODEL_SCROLLBAR_HOVER_THUMB_WIDTH
-        } else {
-            MODEL_SCROLLBAR_THUMB_WIDTH
-        };
+        let metrics = self.model_bar.metrics(&self.model_scroll_base())?;
         Some(
-            div()
+            self.model_bar
+                .render_rail(theme, metrics)?
                 .id("model-scrollbar")
-                .absolute()
-                .top(px(0.0))
-                .bottom(px(0.0))
-                .right(px(0.0))
-                .w(px(MODEL_SCROLLBAR_HIT_WIDTH))
                 .on_hover(cx.listener(Self::on_model_scrollbar_hover))
                 .on_mouse_down(
                     gpui::MouseButton::Left,
                     cx.listener(Self::on_model_scrollbar_mouse_down),
                 )
-                .on_drag(ModelScrollbarDrag, |_, _, _, cx| {
+                .on_drag(popover::MenuScrollbarDrag, |_, _, _, cx| {
                     cx.stop_propagation();
-                    cx.new(|_| ModelScrollbarDragGhost)
+                    cx.new(|_| popover::MenuScrollbarDragGhost)
                 })
                 .on_mouse_up_out(
                     gpui::MouseButton::Left,
@@ -2877,18 +2746,6 @@ impl Pickers {
                 .on_mouse_up(
                     gpui::MouseButton::Left,
                     cx.listener(Self::on_model_scrollbar_mouse_up),
-                )
-                .child(
-                    div()
-                        .absolute()
-                        .top(px(MODEL_SCROLLBAR_TRACK_INSET + metrics.thumb_top))
-                        .right(px(2.0))
-                        // The thumb is an absolute child inside a fixed-width
-                        // hit rail, so hover expansion never reflows rows.
-                        .w(px(thumb_width))
-                        .h(px(metrics.thumb_height))
-                        .rounded(px(thumb_width / 2.0))
-                        .bg(theme.text_faint.opacity(if active { 0.68 } else { 0.5 })),
                 )
                 .into_any_element(),
         )

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -12,7 +12,8 @@
 //! feed them measurements/events.
 
 use gpui::{
-    Anchor, AnyElement, ElementId, IntoElement, Pixels, Point, SharedString, div, prelude::*, px,
+    Anchor, AnyElement, Context, Div, ElementId, IntoElement, Pixels, Point, SharedString, Window,
+    div, prelude::*, px,
 };
 
 use crate::motion::{self, ZERON_PULSE};
@@ -1036,6 +1037,240 @@ pub fn error_row(theme: &Theme, message: &str) -> gpui::Div {
         .child(gpui::SharedString::from(message.to_string()))
 }
 
+// ---------------------------------------------------------------------------
+// Floating menu scrollbar — the model-list treatment, shared
+// ---------------------------------------------------------------------------
+
+/// Track inset top/bottom; the thumb travels inside it.
+pub const MENU_SCROLLBAR_TRACK_INSET: f32 = 4.0;
+/// Invisible hit strip width on the right edge.
+pub const MENU_SCROLLBAR_HIT_WIDTH: f32 = 10.0;
+/// Resting thumb width.
+pub const MENU_SCROLLBAR_THUMB_WIDTH: f32 = 3.0;
+/// Thumb width while hovered/dragged.
+pub const MENU_SCROLLBAR_HOVER_THUMB_WIDTH: f32 = 5.0;
+/// Smallest readable thumb on very long lists.
+pub const MENU_SCROLLBAR_MIN_THUMB: f32 = 24.0;
+
+/// Geometry of the floating thumb for a scroll viewport at one instant.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MenuScrollbarMetrics {
+    pub track_height: f32,
+    pub thumb_top: f32,
+    pub thumb_height: f32,
+    pub max_scroll: f32,
+}
+
+impl MenuScrollbarMetrics {
+    /// Distance the thumb itself can travel.
+    pub fn travel(self) -> f32 {
+        (self.track_height - self.thumb_height).max(0.0)
+    }
+
+    /// Pure geometry from the viewport and scroll distances. `None` when the
+    /// content fits (`max_scroll <= 0`) or the viewport is too small to hold
+    /// a track.
+    pub fn from_viewport(
+        viewport_height: f32,
+        max_scroll: f32,
+        current_scroll: f32,
+    ) -> Option<Self> {
+        let max_scroll = max_scroll.max(0.0);
+        if viewport_height <= 0.0 || max_scroll <= 0.0 {
+            return None;
+        }
+        let track_height = (viewport_height - MENU_SCROLLBAR_TRACK_INSET * 2.0).max(0.0);
+        if track_height <= 0.0 {
+            return None;
+        }
+        let content_height = viewport_height + max_scroll;
+        let thumb_height = (track_height * viewport_height / content_height)
+            .max(MENU_SCROLLBAR_MIN_THUMB)
+            .min(track_height);
+        let current_scroll = current_scroll.clamp(0.0, max_scroll);
+        let travel = (track_height - thumb_height).max(0.0);
+        Some(Self {
+            track_height,
+            thumb_top: travel * current_scroll / max_scroll,
+            thumb_height,
+            max_scroll,
+        })
+    }
+}
+
+/// Marker for GPUI's captured drag stream. The actual grab geometry stays in
+/// [`MenuScrollbarState`] so a track click can center the thumb first.
+pub struct MenuScrollbarDrag;
+
+/// Invisible drag preview: scrollbar drags manipulate the existing thumb.
+pub struct MenuScrollbarDragGhost;
+
+impl gpui::Render for MenuScrollbarDragGhost {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl gpui::IntoElement {
+        gpui::Empty
+    }
+}
+
+/// Hover/drag interaction state for one floating scrollbar, owned by the view
+/// that renders the list. Event handlers stay on the view (they need its
+/// listeners) and delegate here; only one list surface owns a state at a
+/// time, so mutually exclusive popups may share one instance.
+#[derive(Default)]
+pub struct MenuScrollbarState {
+    list_hovered: bool,
+    bar_hovered: bool,
+    grab: Option<f32>,
+}
+
+impl MenuScrollbarState {
+    /// Metrics from any scroll handle's live bounds/offset — both
+    /// `ScrollHandle` and a virtualized list's base handle qualify. `None`
+    /// when the content fits.
+    pub fn metrics(&self, scroll: &gpui::ScrollHandle) -> Option<MenuScrollbarMetrics> {
+        let bounds = scroll.bounds();
+        // GPUI stores the maximum as a positive distance; only the live
+        // scroll offset is negative while content moves upward.
+        let max_scroll = f32::from(scroll.max_offset().y).max(0.0);
+        let current_scroll = (-f32::from(scroll.offset().y)).clamp(0.0, max_scroll);
+        MenuScrollbarMetrics::from_viewport(
+            f32::from(bounds.size.height),
+            max_scroll,
+            current_scroll,
+        )
+    }
+
+    /// Whether the rail paints at all — an on-demand affordance like the
+    /// model list's: hidden until the list is hovered or a drag holds it.
+    pub fn visible(&self) -> bool {
+        self.list_hovered || self.grab.is_some()
+    }
+
+    /// Whether the thumb carries the expanded/stronger treatment.
+    pub fn active(&self) -> bool {
+        self.bar_hovered || self.grab.is_some()
+    }
+
+    /// The pointer entered/left the LIST. Returns whether anything changed.
+    pub fn set_list_hovered(&mut self, hovered: bool) -> bool {
+        if self.list_hovered == hovered {
+            return false;
+        }
+        self.list_hovered = hovered;
+        if !hovered && self.grab.is_none() {
+            self.bar_hovered = false;
+        }
+        true
+    }
+
+    /// The pointer entered/left the RAIL. Keeps the active treatment while a
+    /// captured drag travels outside (the hover callback correctly turns
+    /// false there). Returns whether anything changed.
+    pub fn set_bar_hovered(&mut self, hovered: bool) -> bool {
+        let active = hovered || self.grab.is_some();
+        if self.bar_hovered == active {
+            return false;
+        }
+        self.bar_hovered = active;
+        true
+    }
+
+    /// A press landed on the rail: choose the grab point (pressing the thumb
+    /// keeps its relative position; pressing the track centers the thumb
+    /// under the pointer first), engage the drag, and scroll to the pointer.
+    /// `false` when there is nothing to scroll.
+    pub fn begin_press(&mut self, scroll: &gpui::ScrollHandle, pointer_y: Pixels) -> bool {
+        let Some(metrics) = self.metrics(scroll) else {
+            return false;
+        };
+        let pointer_in_track = self.pointer_in_track(scroll, pointer_y);
+        let grab_offset = if (metrics.thumb_top..=metrics.thumb_top + metrics.thumb_height)
+            .contains(&pointer_in_track)
+        {
+            pointer_in_track - metrics.thumb_top
+        } else {
+            metrics.thumb_height / 2.0
+        };
+        self.grab = Some(grab_offset);
+        self.drag_to(scroll, pointer_y);
+        true
+    }
+
+    /// Move an engaged drag to `pointer_y`. `false` when no drag is engaged
+    /// or the content stopped scrolling mid-drag.
+    pub fn drag_to(&self, scroll: &gpui::ScrollHandle, pointer_y: Pixels) -> bool {
+        let Some(grab_offset) = self.grab else {
+            return false;
+        };
+        let Some(metrics) = self.metrics(scroll) else {
+            return false;
+        };
+        let thumb_top =
+            (self.pointer_in_track(scroll, pointer_y) - grab_offset).clamp(0.0, metrics.travel());
+        let scroll_to = if metrics.travel() <= 0.0 {
+            0.0
+        } else {
+            thumb_top / metrics.travel() * metrics.max_scroll
+        };
+        let offset = scroll.offset();
+        scroll.set_offset(gpui::Point::new(offset.x, px(-scroll_to)));
+        true
+    }
+
+    /// The press ended anywhere: drop the drag; the rail stays armed only
+    /// while the list is still hovered. Returns whether anything changed.
+    pub fn end_press(&mut self) -> bool {
+        self.grab = None;
+        if !self.list_hovered && self.bar_hovered {
+            self.bar_hovered = false;
+            return true;
+        }
+        false
+    }
+
+    fn pointer_in_track(&self, scroll: &gpui::ScrollHandle, pointer_y: Pixels) -> f32 {
+        f32::from(pointer_y - scroll.bounds().top()) - MENU_SCROLLBAR_TRACK_INSET
+    }
+
+    /// The positioned rail visuals: a full-height hit strip on the right with
+    /// the thumb inside. Callers layer identity + their own listeners onto
+    /// the returned strip — `.id(...)` first (hover needs element state),
+    /// then `.on_hover`, `.on_mouse_down`,
+    /// `.on_drag(MenuScrollbarDrag, |_, _, _, cx| { cx.stop_propagation();
+    /// cx.new(|_| MenuScrollbarDragGhost) })`, `.on_mouse_up_out` /
+    /// `.on_mouse_up`. `None` while hidden or the content fits.
+    pub fn render_rail(&self, theme: &Theme, metrics: MenuScrollbarMetrics) -> Option<Div> {
+        if !self.visible() {
+            return None;
+        }
+        let active = self.active();
+        let thumb_width = if active {
+            MENU_SCROLLBAR_HOVER_THUMB_WIDTH
+        } else {
+            MENU_SCROLLBAR_THUMB_WIDTH
+        };
+        Some(
+            div()
+                .absolute()
+                .top(px(0.0))
+                .bottom(px(0.0))
+                .right(px(0.0))
+                .w(px(MENU_SCROLLBAR_HIT_WIDTH))
+                // The thumb is an absolute child inside a fixed-width hit
+                // rail, so hover expansion never reflows rows.
+                .child(
+                    div()
+                        .absolute()
+                        .top(px(MENU_SCROLLBAR_TRACK_INSET + metrics.thumb_top))
+                        .right(px(2.0))
+                        .w(px(thumb_width))
+                        .h(px(metrics.thumb_height))
+                        .rounded(px(thumb_width / 2.0))
+                        .bg(theme.text_faint.opacity(if active { 0.68 } else { 0.5 })),
+                ),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1146,5 +1381,43 @@ mod tests {
         assert_eq!(e.error(), Some("boom"));
         assert!(Loadable::<u32>::Loading.is_loading());
         assert_eq!(Loadable::<u32>::default(), Loadable::Idle);
+    }
+
+    #[test]
+    fn scrollbar_metrics_hidden_when_content_fits_or_viewport_tiny() {
+        // No overflow → no scrollbar.
+        assert_eq!(MenuScrollbarMetrics::from_viewport(300.0, 0.0, 0.0), None);
+        assert_eq!(MenuScrollbarMetrics::from_viewport(300.0, -5.0, 0.0), None);
+        // No viewport → no scrollbar.
+        assert_eq!(MenuScrollbarMetrics::from_viewport(0.0, 300.0, 0.0), None);
+        // Viewport smaller than two track insets → no track.
+        assert_eq!(MenuScrollbarMetrics::from_viewport(8.0, 300.0, 0.0), None);
+    }
+
+    #[test]
+    fn scrollbar_metrics_scales_thumb_to_content_ratio() {
+        let m = MenuScrollbarMetrics::from_viewport(300.0, 300.0, 150.0).unwrap();
+        // Track = 300 - 2*4; thumb = half the content (600) → 146.
+        assert_eq!(m.track_height, 292.0);
+        assert_eq!(m.thumb_height, 146.0);
+        assert_eq!(m.travel(), 146.0);
+        // Half-scrolled puts the thumb mid-track.
+        assert_eq!(m.thumb_top, 73.0);
+        assert_eq!(m.max_scroll, 300.0);
+    }
+
+    #[test]
+    fn scrollbar_metrics_clamps_min_thumb_and_position() {
+        let m = MenuScrollbarMetrics::from_viewport(100.0, 9900.0, 4950.0).unwrap();
+        // Raw ratio (92 * 100 / 10000 ≈ 0.92px) clamps to the readable minimum.
+        assert_eq!(m.thumb_height, MENU_SCROLLBAR_MIN_THUMB);
+        assert_eq!(m.travel(), 92.0 - MENU_SCROLLBAR_MIN_THUMB);
+        assert_eq!(m.thumb_top, (92.0 - MENU_SCROLLBAR_MIN_THUMB) / 2.0);
+        // Overscroll clamps to the bottom of the track.
+        let m = MenuScrollbarMetrics::from_viewport(100.0, 9900.0, 99_999.0).unwrap();
+        assert_eq!(m.thumb_top, 92.0 - MENU_SCROLLBAR_MIN_THUMB);
+        // Negative offsets clamp to the top.
+        let m = MenuScrollbarMetrics::from_viewport(100.0, 9900.0, -3.0).unwrap();
+        assert_eq!(m.thumb_top, 0.0);
     }
 }


### PR DESCRIPTION
## Problem

In the composer prompt input:

- The `/` slash-command popup opened as a **fixed 380px box** anchored at the caret token, while the `@` file-mention popup spanned the full composer width.
- Neither completion list scrolled — long command/file lists were simply clipped (`overflow_hidden` on a plain row stack).

## Fix

- **Slash popup** now opens full pill width above the composer (same mount/anchor as the file-mention popup, covering both expanded and compact layouts) and its rows wheel-scroll inside a bounded viewport.
- **File-mention popup** gets the same scroll treatment for consistency (confirmed desired).
- Both lists gained the **model-list's floating scrollbar**: thin right-rail thumb that expands on hover and supports click-to-jump + drag, hidden until the list is hovered or the content overflows.
- Arrow-key navigation keeps the active row visible via `scroll_to_item`; the scroll position resets on open/query change so stale offsets never show.

## Refactor

The model-picker's hand-rolled scrollbar (geometry, hover/drag state, ghost drag preview, thumb visuals) moved into `popover.rs` as shared primitives (`MenuScrollbarMetrics` + `MenuScrollbarState`, unit-tested), so the model picker, slash popup, and mention popup all use one implementation. Picker behavior is pixel-identical.

## Before

https://github.com/user-attachments/assets/7970415f-e80d-4448-998e-0042a2871a87

## After

https://github.com/user-attachments/assets/0c45a2a9-85ab-4e25-896c-200a70a789ad



## Testing

- `cargo test -p zeron-ui`: 521 passed (includes new scrollbar-metrics unit tests)
- `cargo check --workspace`, clippy clean on touched code, rustfmt clean
- Verified live in the running app: `/` with a 26-command catalog → full-width card, wheel/drag scrolling, keyboard-follow; `@` file search scrolls the same way; model-picker scrollbar regression pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790143398&installation_model_id=425430&pr_number=218&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F218&signature=3bda6b4155382d1371acee5f8023dd1ed8ff6d8925e89051aaa11436a955cada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

help me rewrite it to turn the before after video into a 2 col table layout for good visual representation for pr message