### PR TITLE
Forward jump slots to the open model menu

### DIFF
--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -839,6 +839,21 @@ impl Pickers {
 
     /// Capture knob (`ZERON_OPEN_DIALOG=model`): open the combined
     /// harness/model menu programmatically.
+    /// A jump-slot press while the model menu is open. The shell's session
+    /// bindings (Mod+1…9) win the dispatch race — gpui runs a matched
+    /// binding before any key handler — so the shell forwards the slot here
+    /// instead of going quiet and eating the very chips the rows advertise
+    /// (macOS field report: "cmd shortcuts do nothing in the model
+    /// selector"). Returns whether the menu was open and the slot consumed.
+    pub fn jump_model_slot(&mut self, slot: usize, cx: &mut Context<Self>) -> bool {
+        if self.open_kind() != Some(PickerKind::HarnessModel) {
+            return false;
+        }
+        self.activate_model_index(slot, cx);
+        cx.notify();
+        true
+    }
+
     pub fn open_model_menu(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.open_kind() != Some(PickerKind::HarnessModel) {
             self.toggle(PickerKind::HarnessModel, window, cx);

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -7455,9 +7455,16 @@ impl Render for Shell {
             }))
             // A jump routes back to chat itself, so Settings is not a dead
             // spot — the same call a click on that sidebar row makes. But an
-            // open picker/palette owns the keyboard: no jumping underneath it.
+            // open picker/palette owns the keyboard: no jumping underneath
+            // it. The MODEL menu advertises these same slots on its rows and
+            // this matched binding beats its key handler to the dispatch —
+            // forward the slot instead of eating it.
             .on_action(cx.listener(|this, jump: &JumpSession, _, cx| {
-                if !this.overlay_owns_keyboard(cx) {
+                let pickers = this.composer.read(cx).pickers().clone();
+                let handled = pickers.update(cx, |pickers, cx| {
+                    pickers.jump_model_slot(jump.0, cx)
+                });
+                if !handled && !this.overlay_owns_keyboard(cx) {
                     this.jump_to_session(jump.0, cx)
                 }
             }))


### PR DESCRIPTION
The model picker's rows advertise ⌘1–⌘9 chips, but pressing them did nothing (macOS field report): the shell's session-jump bindings from #208 win gpui's dispatch race — a matched binding runs before any `on_key_down` — and the `JumpSession` handler goes quiet under any open overlay, eating the keystroke before the picker's own ⌘N handler can see it.

The handler now forwards the slot to the model menu when it is the open overlay (`Pickers::jump_model_slot`, same path as clicking the row); other overlays keep the quiet treatment, and plain session jumps are unchanged.

Verified in the headless rig: with the picker open, Ctrl+2 (Linux primary) activates row 2 and closes the menu — previously a no-op. `zeron-ui`: 556 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790236546&installation_model_id=425430&pr_number=224&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F224&signature=80357134192d054494557cf8cdefceba1edd4245b88547dcc6c0c0c0f92677b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->