### PR TITLE
Model pick keeps the picker open

### DIFF
--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -1335,7 +1335,9 @@ impl Pickers {
     }
 
     fn pick_model(&mut self, model_id: String, cx: &mut Context<Self>) {
-        self.animate_close(cx);
+        // The card stays open on a pick (user request): model and traits
+        // share one popover now, and adjusting the tray right after choosing
+        // a model is the expected flow. Esc, click-out, or the chip close it.
         if self.state.read(cx).selected_chat.is_some() {
             // Existing chat: persist to the chat row (Mutate setChatConfig) —
             // survives restarts and syncs; next runs in this chat use it.


### PR DESCRIPTION
Selecting a model no longer closes the model selector: model and traits share one card since #221, and picking a model then adjusting reasoning/options in the same dropdown is the expected flow. The selection ring and combined chip update live behind the open card; Esc, click-out, or the chip still dismiss it. Branch/checkout pickers keep close-on-pick.

Verified in the headless rig: pick Opus 5 → card stays open, chip reads "Opus 5 High · 200K · Off"; pick Medium in the same card → "Opus 5 Medium · 200K · Off"; Esc closes. `zeron-ui`: 556 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790248679&installation_model_id=425430&pr_number=225&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F225&signature=b7400ef46124f777ac511c6ddc71707f2e877a3f7b1f3559e8e61c6b6003414c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->