### PR TITLE
Repoint gpui at zeronsh/zui (fork extracted to its own repo)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "schemars",
  "serde",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "anyhow",
  "log",
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4014,7 +4014,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4823,7 +4823,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "collections",
  "serde",
@@ -5664,7 +5664,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "derive_refineable",
 ]
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6568,7 +6568,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -7735,7 +7735,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "perf",
  "quote",
@@ -9438,7 +9438,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9455,7 +9455,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9466,7 +9466,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=0b18592c541a2692726cf5a14a2fb8badb7abfc3#0b18592c541a2692726cf5a14a2fb8badb7abfc3"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,34 +39,25 @@ loro = "1.13"
 # frames, cross-checked by its js_snapshots tests).
 loro-protocol = "0.3"
 
-# gpui — the wingleeio/zed fork: upstream f14fea9 + commits on
-# `comet/edge-fade-horizontal` (tip of `comet/line-wrap-closing-punctuation`
-# + 5d1f83d horizontal per-pixel EdgeFade for quads/images; rebase when bumping the
-# upstream rev): a6bf17c fixes BOTH wrap-rule copies (LineWrapper +
-# line_layout's shaped-text duplicate); 14baea0 adds the EdgeFade primitive
-# (Window::with_edge_fade — per-primitive scroll-edge fades for the glass
-# sidebar); a6c1ad5 adds BackdropBlur + horizontal EdgeFade + glass fixes;
-# 9b672fa bounds renderer GPU memory (region-sized backdrop blur scratch,
-# idle release of blur/path intermediates, instance pool shrink,
-# ZERON_GPU_STATS=1 diagnostics); b687328 adds ImageSource::evict (frees
-# sprite-atlas tiles — remove_asset alone leaked them, see
-# attachments::flush_evicted); ac135eb adds device memory to the stats line;
-# f596cde fixes destination alpha on transparent windows (Porter-Duff OVER,
-# not additive); 53518c0 merges the edge-fade line: per-edge fade bands +
-# per-pixel EdgeFade for quads/images (true fade-into-glass), and
-# object-fit Cover cropping via atlas-tile UVs so image corner radii hold;
-# 8a8954c switches the macOS blurred view to UnderWindowBackground (macOS 26
-# stopped vending CABackdropLayer for Selection — window blur went dead);
-# b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
-# Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/wingleeio/zed", rev = "e2ddcc6805f8c5088e62a60dfe517abcccd61a9a" }
-gpui_platform = { git = "https://github.com/wingleeio/zed", rev = "e2ddcc6805f8c5088e62a60dfe517abcccd61a9a", features = [
+# gpui — zeronsh/zui: our GPUI fork extracted from wingleeio/zed into a
+# standalone workspace (gpui + gpui_platform + gpui_tokio and their in-tree
+# dependency closure only — cargo no longer clones all of zed). Snapshot of
+# wingleeio/zed @ e2ddcc6 = upstream f14fea9 + the comet patch line
+# (line-wrap closing punctuation, EdgeFade per-edge bands + per-pixel
+# quad/image fades, BackdropBlur incl. the wgpu/Linux rasterization, GPU
+# memory bounding + ZERON_GPU_STATS=1, ImageSource::evict, transparent-window
+# destination alpha, macOS 26 UnderWindowBackground blur, object-fit Cover
+# via atlas-tile UVs). Full per-commit history: zui's README and this
+# comment's git history. Crate paths in zui match zed's layout, so upstream
+# zed patches still apply there unchanged.
+gpui = { git = "https://github.com/zeronsh/zui", rev = "0b18592c541a2692726cf5a14a2fb8badb7abfc3" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "0b18592c541a2692726cf5a14a2fb8badb7abfc3", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/wingleeio/zed", rev = "e2ddcc6805f8c5088e62a60dfe517abcccd61a9a" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "0b18592c541a2692726cf5a14a2fb8badb7abfc3" }
 
 # diffs
 similar = "2"


### PR DESCRIPTION
## What

Extracts our GPUI fork out of `wingleeio/zed` into a standalone repo, [zeronsh/zui](https://github.com/zeronsh/zui), and repoints comet's three git deps (`gpui`, `gpui_platform`, `gpui_tokio`) at it, pinned by rev as before.

## Why

- Cargo's git dependency fetch previously cloned the **entire zed repository** on every fresh checkout/CI build. zui contains only the 27 crates in gpui's in-tree dependency closure.
- The fork now reads as what it is — our UI framework — instead of a rev buried in a fork of zed.

## How it was extracted

- `zeronsh/zui@0b18592` is a snapshot of `wingleeio/zed @ e2ddcc6` (the exact rev previously pinned here); crate sources are **byte-identical**, so this PR is a pure re-plumb — no behavior change.
- Crate paths keep zed's layout (`crates/<name>`, `tooling/perf`) so upstream zed patches still apply there via `format-patch`/`apply` (documented in zui's README).
- zui's root manifest is pruned to the 130 workspace-dependency entries those crates use; unused `[patch.crates-io]` entries (livekit, webrtc, notify) dropped; Cargo.lock seeded from zed's and pruned by resolution.

## Verification

- `cargo check --workspace` and `cargo check --workspace --all-targets` green in zui, plus a targeted check of comet's exact `gpui_platform` feature set (`wayland,x11,font-kit,runtime_shaders`).
- In comet: `cargo check --workspace` green, full `cargo test --workspace` green (604 tests, 0 failures); `Cargo.lock` has zero remaining `wingleeio/zed` references.

Note: `path`, `zlog`, `ztracing` in the closure are GPL-3.0-or-later (unchanged from the zed fork — we already linked them); both license files are carried in zui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790252269&installation_model_id=425430&pr_number=226&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F226&signature=5f0c7996536527c7209bb8cccb633a67dd456f10b683477f7b8a5b3fbdb7ff8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->