### PR TITLE
feat(ui): add synchronized scrolling to diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9376,6 +9376,7 @@ dependencies = [
  "tracing",
  "ttf-parser",
  "unicode-segmentation",
+ "unicode-width",
  "uuid",
  "zeron-doc",
  "zeron-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ portable-pty = "0.8"
 alacritty_terminal = "0.26"
 pulldown-cmark = "0.12"
 unicode-segmentation = "1"
+unicode-width = "0.2"
 fontdb = "0.23"
 ttf-parser = "0.25.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -27,6 +27,7 @@ pulldown-cmark.workspace = true
 alacritty_terminal.workspace = true
 base64 = "0.22"
 unicode-segmentation.workspace = true
+unicode-width.workspace = true
 fontdb.workspace = true
 ttf-parser.workspace = true
 uuid.workspace = true

--- a/crates/ui/assets/icons/wrap-text.svg
+++ b/crates/ui/assets/icons/wrap-text.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 6H20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M4 10H17C18.6569 10 20 11.3431 20 13C20 14.6569 18.6569 16 17 16H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 13L9 16L12 19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M4 20H7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -38,6 +38,7 @@ use gpui::{
     AnyElement, App, Context, Entity, FocusHandle, Focusable as _, ListAlignment, ListState,
     SharedString, Subscription, Task, Window, div, font, list, prelude::*, px,
 };
+use unicode_width::UnicodeWidthChar as _;
 
 use zeron_proto::{Chat, CheckoutDiff, GitHistoryCommit};
 use zeron_rpc::methods;
@@ -79,6 +80,11 @@ pub const SPLIT_MARKER_WIDTH: f32 = 18.0;
 /// Hairline between the two split columns.
 pub const SPLIT_DIVIDER_WIDTH: f32 = 1.0;
 const DIFF_TEXT_SIZE: f32 = 12.0;
+const DIFF_TAB_SIZE: usize = 4;
+const UNIFIED_CODE_PADDING_LEFT: f32 = 12.0;
+const SPLIT_CODE_PADDING_LEFT: f32 = 6.0;
+/// Breathing room after the widest source line when scrolled fully right.
+const CODE_PADDING_RIGHT: f32 = 24.0;
 
 /// How the diff is laid out. Persisted in `ui-settings.json` (`diffSplit`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -258,6 +264,93 @@ impl FileDiff {
 pub fn gutter_width(file: &FileDiff) -> f32 {
     let digits = file.max_line.max(1).ilog10() + 1;
     (digits as f32 * 6.6 + 8.0 + 6.0).max(GUTTER_WIDTH)
+}
+
+/// Width inputs that are independent of the active window's font metrics.
+/// They are computed once with the parsed patch, off the render path.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct DiffHorizontalGeometry {
+    max_code_columns: usize,
+    max_gutter_width: f32,
+}
+
+impl DiffHorizontalGeometry {
+    fn from_files(files: &[FileDiff]) -> Self {
+        let max_code_columns = files
+            .iter()
+            .flat_map(|file| &file.hunks)
+            .flat_map(|hunk| &hunk.lines)
+            .map(|line| visual_columns(&line.text))
+            .max()
+            .unwrap_or(0);
+        let max_gutter_width = files.iter().map(gutter_width).fold(GUTTER_WIDTH, f32::max);
+        Self {
+            max_code_columns,
+            max_gutter_width,
+        }
+    }
+
+    fn resolve(self, theme: &Theme, window: &Window) -> DiffHorizontalMetrics {
+        let mono = font(theme.font_mono.clone());
+        let font_id = window.text_system().resolve_font(&mono);
+        let column_width = window
+            .text_system()
+            .ch_advance(font_id, px(DIFF_TEXT_SIZE))
+            .unwrap_or(px(DIFF_TEXT_SIZE * 0.6))
+            .as_f32();
+        DiffHorizontalMetrics {
+            max_text_width: self.max_code_columns as f32 * column_width,
+            max_gutter_width: self.max_gutter_width,
+        }
+    }
+}
+
+/// Count terminal-style display columns, including tab stops and wide
+/// Unicode glyphs. Syntax runs only recolour the shared mono font, so this is
+/// the stable width input for every virtualized row.
+fn visual_columns(text: &str) -> usize {
+    text.chars().fold(0usize, |columns, ch| {
+        if ch == '\t' {
+            columns + (DIFF_TAB_SIZE - columns % DIFF_TAB_SIZE)
+        } else {
+            columns + ch.width().unwrap_or(0)
+        }
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct DiffHorizontalMetrics {
+    max_text_width: f32,
+    max_gutter_width: f32,
+}
+
+impl DiffHorizontalMetrics {
+    /// Compensating for the file-local gutter keeps every unified code
+    /// viewport's effective scroll range identical.
+    fn unified_content_width(self, gutter_width: f32) -> f32 {
+        self.max_text_width
+            + UNIFIED_CODE_PADDING_LEFT
+            + CODE_PADDING_RIGHT
+            + 2.0 * (self.max_gutter_width - gutter_width)
+    }
+
+    /// Split has one gutter per half. Both halves use this same extent so old
+    /// and new remain synchronized even when one side is a filler.
+    fn split_content_width(self, gutter_width: f32) -> f32 {
+        self.max_text_width
+            + SPLIT_CODE_PADDING_LEFT
+            + CODE_PADDING_RIGHT
+            + (self.max_gutter_width - gutter_width)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum DiffCodeWidth {
+    /// Inline tool diffs keep their existing local clipping behavior.
+    Clipped,
+    /// Changes rows expose a stable intrinsic code width. Commit 2 connects
+    /// these viewports to the shared horizontal scroll state.
+    Scrollable(DiffHorizontalMetrics),
 }
 
 fn strip_git_prefix(path: &str) -> &str {
@@ -1025,6 +1118,7 @@ struct ParsedDiff {
     additions: u32,
     deletions: u32,
     file_count: usize,
+    horizontal_geometry: DiffHorizontalGeometry,
     files: Arc<Vec<FileDiff>>,
 }
 
@@ -1997,6 +2091,7 @@ impl Changes {
                 } else {
                     files.len()
                 };
+                let horizontal_geometry = DiffHorizontalGeometry::from_files(&files);
                 changes.folds.clear();
                 changes.highlights.clear();
                 let staged = changes.staged_comments(cx);
@@ -2025,6 +2120,7 @@ impl Changes {
                     additions,
                     deletions,
                     file_count,
+                    horizontal_geometry,
                     files: Arc::new(files),
                 });
                 cx.notify();
@@ -2737,12 +2833,7 @@ impl Changes {
 
     // ---- rendering ----
 
-    fn render_row(
-        &mut self,
-        ix: usize,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
+    fn render_row(&mut self, ix: usize, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         let Some(parsed) = &self.parsed else {
             return gpui::Empty.into_any_element();
         };
@@ -2752,6 +2843,8 @@ impl Changes {
             return gpui::Empty.into_any_element();
         };
         let theme = Theme::of(cx).clone();
+        let code_width =
+            DiffCodeWidth::Scrollable(parsed.horizontal_geometry.resolve(&theme, window));
         match row {
             DiffRow::FileHeader { file } => {
                 let Some(file_diff) = files.get(file as usize) else {
@@ -2799,7 +2892,7 @@ impl Changes {
                     .map(|highlights| highlights.spans(line))
                     .unwrap_or(&[]);
                 let gutter_px = gutter_width(file_diff);
-                let row = diff_line_row(line, spans, &theme, gutter_px);
+                let row = diff_line_row(line, spans, &theme, gutter_px, code_width);
                 let Some((side, line_no)) = line_anchor(line) else {
                     return row;
                 };
@@ -2874,7 +2967,7 @@ impl Changes {
                             .clone()
                             .unwrap_or_else(|| line_runs(line, highlight.as_deref(), &theme));
                         let number = if old { line.old_no } else { line.new_no };
-                        split_line_cell(line, number, runs, &theme, gutter_px)
+                        split_line_cell(line, number, runs, &theme, gutter_px, code_width)
                     })
                 };
                 // The left column is inert. It shows the pre-change file, and
@@ -2955,7 +3048,8 @@ impl Changes {
                 // Only the revealable slice is built — the tween never pays
                 // for lines it cannot show.
                 let cap = from.max(to).min(FOLD_TWEEN_MAX_PX);
-                let body = render_file_body_upto(file_diff, highlight, &theme, cap, self.mode);
+                let body =
+                    render_file_body_upto(file_diff, highlight, &theme, cap, self.mode, code_width);
                 let clipped = div().w_full().overflow_hidden().child(body);
                 if fold.animating() {
                     clipped
@@ -3730,6 +3824,31 @@ fn hunk_header_row(header: &str, theme: &Theme) -> AnyElement {
         .into_any_element()
 }
 
+/// The only part of a diff row allowed to exceed its viewport. The outer
+/// element keeps row chrome fixed; the inner element owns the intrinsic code
+/// width that commit 2 will move with a shared scroll handle.
+fn code_text_viewport(
+    text: String,
+    runs: Vec<gpui::TextRun>,
+    theme: &Theme,
+    padding_left: f32,
+    content_width: Option<f32>,
+) -> AnyElement {
+    let content = div()
+        .when_some(content_width, |el, width| el.w(px(width)).flex_none())
+        .pl(px(padding_left))
+        .font_family(theme.font_mono.clone())
+        .text_size(px(DIFF_TEXT_SIZE))
+        .whitespace_nowrap()
+        .child(gpui::StyledText::new(text).with_runs(runs));
+    div()
+        .flex_1()
+        .min_w_0()
+        .overflow_hidden()
+        .child(content)
+        .into_any_element()
+}
+
 /// One +/−/context/meta diff line: coloured accent bar, dual line-number
 /// gutters (`gutter_px` wide — see [`gutter_width`]), marker column, and
 /// paint-only syntax runs.
@@ -3738,6 +3857,7 @@ fn diff_line_row(
     spans: &[zeron_syntax::HighlightSpan],
     theme: &Theme,
     gutter_px: f32,
+    code_width: DiffCodeWidth,
 ) -> AnyElement {
     if line.kind == LineKind::Meta {
         return meta_line_row(
@@ -3798,6 +3918,10 @@ fn diff_line_row(
         theme.text.opacity(0.92),
         theme,
     );
+    let content_width = match code_width {
+        DiffCodeWidth::Clipped => None,
+        DiffCodeWidth::Scrollable(metrics) => Some(metrics.unified_content_width(gutter_px)),
+    };
     div()
         .h(px(DIFF_LINE_HEIGHT))
         .w_full()
@@ -3842,17 +3966,13 @@ fn diff_line_row(
                 .font_family(theme.font_mono.clone())
                 .child(SharedString::from(marker)),
         )
-        .child(
-            div()
-                .flex_1()
-                .min_w_0()
-                .overflow_hidden()
-                .pl(px(12.0))
-                .font_family(theme.font_mono.clone())
-                .text_size(px(DIFF_TEXT_SIZE))
-                .whitespace_nowrap()
-                .child(gpui::StyledText::new(line.text.clone()).with_runs(runs)),
-        )
+        .child(code_text_viewport(
+            line.text.clone(),
+            runs,
+            theme,
+            UNIFIED_CODE_PADDING_LEFT,
+            content_width,
+        ))
         .into_any_element()
 }
 
@@ -3904,6 +4024,7 @@ fn split_line_cell(
     runs: Vec<gpui::TextRun>,
     theme: &Theme,
     gutter_px: f32,
+    code_width: DiffCodeWidth,
 ) -> gpui::Div {
     let mut add_bg = add_color(theme);
     add_bg.a = 0.055;
@@ -3931,6 +4052,10 @@ fn split_line_cell(
             None,
             theme.text_faint.opacity(0.8),
         ),
+    };
+    let content_width = match code_width {
+        DiffCodeWidth::Clipped => None,
+        DiffCodeWidth::Scrollable(metrics) => Some(metrics.split_content_width(gutter_px)),
     };
     div()
         .flex_1()
@@ -3973,17 +4098,13 @@ fn split_line_cell(
                 .font_family(theme.font_mono.clone())
                 .child(SharedString::from(marker)),
         )
-        .child(
-            div()
-                .flex_1()
-                .min_w_0()
-                .overflow_hidden()
-                .pl(px(6.0))
-                .font_family(theme.font_mono.clone())
-                .text_size(px(DIFF_TEXT_SIZE))
-                .whitespace_nowrap()
-                .child(gpui::StyledText::new(line.text.clone()).with_runs(runs)),
-        )
+        .child(code_text_viewport(
+            line.text.clone(),
+            runs,
+            theme,
+            SPLIT_CODE_PADDING_LEFT,
+            content_width,
+        ))
 }
 
 /// The empty half of a one-sided split row — a pure-insert row has no old
@@ -4306,7 +4427,13 @@ pub(crate) fn render_file_body_with_syntax(
                 .as_deref()
                 .map(|highlights| highlights.spans(line))
                 .unwrap_or(&[]);
-            children.push(diff_line_row(line, spans, theme, gutter_px));
+            children.push(diff_line_row(
+                line,
+                spans,
+                theme,
+                gutter_px,
+                DiffCodeWidth::Clipped,
+            ));
         }
     }
     div()
@@ -4325,6 +4452,7 @@ fn render_file_body_upto(
     theme: &Theme,
     max_px: f32,
     mode: DiffMode,
+    code_width: DiffCodeWidth,
 ) -> AnyElement {
     let mut children: Vec<AnyElement> = Vec::new();
     let mut y = 0.0f32;
@@ -4356,7 +4484,13 @@ fn render_file_body_upto(
                         if y >= max_px {
                             break 'build;
                         }
-                        children.push(diff_line_row(line, spans_for(line), theme, gutter_px));
+                        children.push(diff_line_row(
+                            line,
+                            spans_for(line),
+                            theme,
+                            gutter_px,
+                            code_width,
+                        ));
                         y += DIFF_LINE_HEIGHT;
                     }
                 }
@@ -4378,6 +4512,7 @@ fn render_file_body_upto(
                                 line_runs(line, highlight.as_deref(), theme),
                                 theme,
                                 gutter_px,
+                                code_width,
                             )
                             .into_any_element(),
                             None => split_filler().into_any_element(),
@@ -5173,6 +5308,38 @@ rename to new_name.rs
         let mut file = files[0].clone();
         truncate_file_lines(&mut file, 3);
         assert_eq!(file.max_line, 2);
+    }
+
+    #[test]
+    fn horizontal_geometry_counts_tabs_and_unicode_columns() {
+        assert_eq!(visual_columns("ab\tc"), 5);
+        assert_eq!(visual_columns("界"), 2);
+        assert_eq!(visual_columns("e\u{301}"), 1);
+
+        let files = parse_patch("diff --git a/x b/x\n@@ -1 +1 @@\n-old\n+ab\t界\n");
+        let geometry = DiffHorizontalGeometry::from_files(&files);
+        assert_eq!(geometry.max_code_columns, 6);
+        assert_eq!(geometry.max_gutter_width, GUTTER_WIDTH);
+    }
+
+    #[test]
+    fn horizontal_content_width_compensates_for_local_gutters() {
+        let metrics = DiffHorizontalMetrics {
+            max_text_width: 240.0,
+            max_gutter_width: 52.0,
+        };
+        let narrow = 36.0;
+        let wide = 52.0;
+
+        let unified_total = |gutter| {
+            ACCENT_BAR_WIDTH + 2.0 * gutter + MARKER_WIDTH + metrics.unified_content_width(gutter)
+        };
+        assert_eq!(unified_total(narrow), unified_total(wide));
+
+        let split_total = |gutter| {
+            ACCENT_BAR_WIDTH + gutter + SPLIT_MARKER_WIDTH + metrics.split_content_width(gutter)
+        };
+        assert_eq!(split_total(narrow), split_total(wide));
     }
 
     #[test]

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -11,9 +11,9 @@
 //!   hunk header, and diff line is its own row (the flat model Zed's editor
 //!   uses for its project diff: only the visible slice materializes, and a
 //!   collapsed file's body rows are removed from the list outright, not
-//!   hidden); each section collapses with a 180 ms height tween on a
+//!   hidden); nowrap sections collapse with a 180 ms height tween on a
 //!   clipped stand-in row (analytic heights, capped to what the clip can
-//!   reveal) and a 200 ms chevron transition;
+//!   reveal), while variable-height wrapped sections settle immediately;
 //! - syntax highlight reuses the markdown tokenizer per diff line, computed
 //!   time-sliced on the background executor and applied as paint-only run
 //!   colors (layout never changes);
@@ -28,6 +28,9 @@
 //!   Its left column is inert: notes are cited against the post-change file,
 //!   so only the right column takes a `+` (already-staged old-side notes
 //!   still show their cards).
+//! - long-line wrapping is a persisted toolbar choice. It only changes the
+//!   code plane: gutters, comment affordances, and sticky headers stay fixed,
+//!   while the virtual list measures each logical row's resulting height.
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -110,18 +113,6 @@ impl DiffMode {
             Self::Unified => Self::Split,
             Self::Split => Self::Unified,
         }
-    }
-}
-
-/// Read-modify-write `ui-settings.json` for just the split-diff key — a fresh
-/// load, for the reason [`crate::appearance`] documents: the shell holds its
-/// own `UiSettings` and saves it debounced, so writing a cached snapshot from
-/// here would roll back a pane resize made seconds earlier.
-fn persist_split(split: bool, data_dir: &std::path::Path) {
-    let mut settings = crate::settings::UiSettings::load(data_dir);
-    settings.diff_split = split;
-    if let Err(err) = settings.save(data_dir) {
-        tracing::warn!(error = %err, "could not persist diff layout");
     }
 }
 
@@ -350,6 +341,8 @@ enum DiffCodeWidth {
     Clipped,
     /// Changes rows expose a stable intrinsic code width.
     Scrollable(DiffHorizontalMetrics),
+    /// Changes rows consume their viewport width and grow vertically.
+    Wrapped,
 }
 
 #[derive(Clone)]
@@ -1154,7 +1147,8 @@ struct ParsedDiff {
 /// its own row (Zed's editor draws exactly the visible line range the same
 /// way): scrolling a 10k-line file materializes ~50 line rows per frame, not
 /// one 10k-line element, and a collapsed file contributes no body rows at
-/// all. Heights are the analytic constants above — no measurement.
+/// all. Nowrap heights use the analytic constants above; wrapped line rows
+/// are measured by the list at the current pane width.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiffRow {
     FileHeader {
@@ -1548,6 +1542,8 @@ pub struct Changes {
     scope: DiffScope,
     /// Unified or side-by-side (toolbar toggle, persisted per user).
     mode: DiffMode,
+    /// Wrap long source lines instead of exposing the horizontal code plane.
+    wrap_lines: bool,
     /// Comparison ref for [`DiffScope::Branch`] — preset to the repo's
     /// default branch once the branch list lands.
     base_ref: Option<String>,
@@ -1586,19 +1582,34 @@ pub enum ChangesEvent {
 
 impl gpui::EventEmitter<ChangesEvent> for Changes {}
 
+struct DiffHeaderTooltip(&'static str);
+
+impl Render for DiffHeaderTooltip {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = Theme::of(cx);
+        div()
+            .px(px(8.0))
+            .py(px(6.0))
+            .rounded(px(6.0))
+            .border_1()
+            .border_color(theme.border_strong)
+            .bg(theme.surface_raised)
+            .shadow_md()
+            .text_size(px(11.0))
+            .text_color(theme.text)
+            .child(self.0)
+    }
+}
+
 impl Changes {
     pub fn new(state: Entity<AppState>, cx: &mut Context<Self>) -> Self {
         let observe = cx.observe(&state, |this: &mut Self, _, cx| this.sync(cx));
-        let mode = DiffMode::from_split(
-            state
-                .read(cx)
-                .data_dir
-                .as_deref()
-                .is_some_and(|dir| crate::settings::UiSettings::load(dir).diff_split),
-        );
+        let settings = crate::settings::current(cx);
+        let mode = DiffMode::from_split(settings.diff_split);
         Self {
             state,
             mode,
+            wrap_lines: settings.diff_wrap,
             diffs: Vec::new(),
             started: false,
             error: None,
@@ -2208,6 +2219,29 @@ impl Changes {
         let Some(file) = parsed.files.get(file_ix) else {
             return;
         };
+        if self.wrap_lines {
+            let collapsed = !self
+                .folds
+                .get(&file.path)
+                .is_some_and(|fold| fold.collapsed);
+            let body = if collapsed {
+                Vec::new()
+            } else {
+                body_rows(
+                    file_ix as u32,
+                    file,
+                    &self.comments_for(&file.path, cx),
+                    self.draft_anchor_in(&file.path),
+                    self.mode,
+                )
+            };
+            let fold = self.folds.entry(file.path.clone()).or_default();
+            fold.collapsed = collapsed;
+            fold.toggled_at = None;
+            self.replace_file_body(file_ix, body);
+            cx.notify();
+            return;
+        }
         let expanded_height = body_height_with(
             file,
             &self.comments_for(&file.path, cx),
@@ -2382,15 +2416,40 @@ impl Changes {
     fn toggle_mode(&mut self, cx: &mut Context<Self>) {
         self.mode = self.mode.toggled();
         reset_horizontal_scroll(&self.horizontal_scroll);
-        if let Some(dir) = self.state.read(cx).data_dir.clone() {
-            let split = self.mode.is_split();
-            cx.background_executor()
-                .spawn(async move { persist_split(split, &dir) })
-                .detach();
-        }
+        let split = self.mode.is_split();
+        crate::settings::update(crate::settings::SavePolicy::Immediate, cx, |settings| {
+            settings.diff_split = split;
+        });
         // A draft's `+` sits in a column that may not exist after the swap.
         self.hover = None;
         self.reflatten(cx);
+    }
+
+    fn toggle_wrap(&mut self, cx: &mut Context<Self>) {
+        self.wrap_lines = !self.wrap_lines;
+        reset_horizontal_scroll(&self.horizontal_scroll);
+        let wrap = self.wrap_lines;
+        crate::settings::update(crate::settings::SavePolicy::Immediate, cx, |settings| {
+            settings.diff_wrap = wrap;
+        });
+
+        // A folding stand-in has an analytic fixed-line height. Settle it
+        // before switching to variable-height rows; steady rows can then be
+        // measured by the virtual list at the current pane width.
+        let folding = self
+            .rows
+            .iter()
+            .any(|row| matches!(row, DiffRow::FoldingBody { .. }));
+        if folding {
+            self.fold_settle = None;
+            for fold in self.folds.values_mut() {
+                fold.toggled_at = None;
+            }
+            self.reflatten(cx);
+        } else {
+            self.list.remeasure();
+            cx.notify();
+        }
     }
 
     fn reflatten(&mut self, cx: &mut Context<Self>) {
@@ -2875,8 +2934,11 @@ impl Changes {
             return gpui::Empty.into_any_element();
         };
         let theme = Theme::of(cx).clone();
-        let code_width =
-            DiffCodeWidth::Scrollable(parsed.horizontal_geometry.resolve(&theme, window));
+        let code_width = if self.wrap_lines {
+            DiffCodeWidth::Wrapped
+        } else {
+            DiffCodeWidth::Scrollable(parsed.horizontal_geometry.resolve(&theme, window))
+        };
         let code_scroll = DiffCodeScrollContext {
             handle: self.horizontal_scroll.clone(),
             prefix: SharedString::from(format!("changes-code-row-{ix}")),
@@ -3055,7 +3117,7 @@ impl Changes {
                     (Some(cell), None) => cell.into_any_element(),
                     (None, _) => split_filler().into_any_element(),
                 };
-                split_row(left, right).into_any_element()
+                split_row(left, right, self.wrap_lines).into_any_element()
             }
             DiffRow::CommentCard { file, card } => {
                 let Some(file_diff) = files.get(file as usize) else {
@@ -3393,6 +3455,22 @@ impl Changes {
         .into_any_element()
     }
 
+    fn wrap_toggle(&self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+        Self::header_toggle(
+            "changes-wrap",
+            crate::icons::WRAP_TEXT,
+            self.wrap_lines,
+            theme,
+        )
+        .on_click(cx.listener(|this, _, _, cx| {
+            cx.stop_propagation();
+            this.toggle_wrap(cx);
+        }))
+        .tooltip(|_, cx| cx.new(|_| DiffHeaderTooltip("Wrap long lines")).into())
+        .tooltip_show_delay(Duration::from_millis(350))
+        .into_any_element()
+    }
+
     /// The pane-header controls: scope dropdown, `{branch} → {base ⌄}` ref
     /// selector (branch scope), fold-all. Rendered BY THE SHELL inside the
     /// session titlebar's trailing section (the band above the pane) — the
@@ -3436,6 +3514,7 @@ impl Changes {
                         .child(SharedString::from(commit.subject.clone())),
                 )
                 .child(self.split_toggle(&theme, cx))
+                .child(self.wrap_toggle(&theme, cx))
                 .child(
                     Self::header_button("changes-fold-all", crate::icons::FOLD_VERTICAL, &theme)
                         .on_click(cx.listener(|this, _, _, cx| {
@@ -3531,6 +3610,7 @@ impl Changes {
                 .items_center()
                 .gap(px(2.0))
                 .child(self.split_toggle(&theme, cx))
+                .child(self.wrap_toggle(&theme, cx))
                 .child(
                     Self::header_button("changes-fold-all", crate::icons::FOLD_VERTICAL, &theme)
                         .on_click(cx.listener(|this, _, _, cx| {
@@ -3897,9 +3977,11 @@ fn code_text_viewport(
     theme: &Theme,
     padding_left: f32,
     content_width: Option<f32>,
+    wrapped: bool,
     scroll: Option<DiffCodeScroll>,
 ) -> AnyElement {
     let content = div()
+        .when(wrapped, |el| el.w_full().min_w_0())
         .when_some(content_width, |el, width| {
             // Keep every tracked row's scroll extent identical. The width
             // already includes shaping slack on the right, so clipping here
@@ -3909,9 +3991,24 @@ fn code_text_viewport(
         .pl(px(padding_left))
         .font_family(theme.font_mono.clone())
         .text_size(px(DIFF_TEXT_SIZE))
-        .whitespace_nowrap()
+        .line_height(px(DIFF_LINE_HEIGHT))
+        .map(|el| {
+            if wrapped {
+                el.whitespace_normal()
+            } else {
+                el.whitespace_nowrap()
+            }
+        })
         .child(gpui::StyledText::new(text).with_runs(runs));
-    let viewport = div().flex_1().min_w_0().overflow_hidden().child(content);
+    let viewport = div()
+        .flex_1()
+        .min_w_0()
+        .min_h(px(DIFF_LINE_HEIGHT))
+        .overflow_hidden()
+        .child(content);
+    if wrapped {
+        return viewport.into_any_element();
+    }
     match scroll {
         Some(scroll) => {
             let mut viewport = viewport
@@ -3981,6 +4078,7 @@ fn diff_line_row(
             .flex_none()
             .font_family(theme.font_mono.clone())
             .text_size(px(11.0))
+            .line_height(px(DIFF_LINE_HEIGHT))
             .text_color(color)
             .flex()
             .justify_end()
@@ -4000,21 +4098,29 @@ fn diff_line_row(
     let content_width = match code_width {
         DiffCodeWidth::Clipped => None,
         DiffCodeWidth::Scrollable(metrics) => Some(metrics.unified_content_width(gutter_px)),
+        DiffCodeWidth::Wrapped => None,
     };
+    let wrapped = matches!(code_width, DiffCodeWidth::Wrapped);
     div()
-        .h(px(DIFF_LINE_HEIGHT))
+        .map(|el| {
+            if wrapped {
+                el.min_h(px(DIFF_LINE_HEIGHT))
+            } else {
+                el.h(px(DIFF_LINE_HEIGHT))
+            }
+        })
         .w_full()
         .flex_none()
         .flex()
         .flex_row()
-        .items_center()
+        .items_start()
         .when_some(row_bg, |el, bg| el.bg(bg))
         // Accent bar: solid colour on +/− rows, invisible spacer on
         // context rows so columns always align.
         .child(
             div()
                 .w(px(ACCENT_BAR_WIDTH))
-                .h_full()
+                .self_stretch()
                 .flex_none()
                 .when_some(accent, |el, color| el.bg(color)),
         )
@@ -4041,6 +4147,7 @@ fn diff_line_row(
                 .flex()
                 .justify_center()
                 .text_size(px(DIFF_TEXT_SIZE))
+                .line_height(px(DIFF_LINE_HEIGHT))
                 .text_color(marker_color)
                 .font_family(theme.font_mono.clone())
                 .child(SharedString::from(marker)),
@@ -4051,6 +4158,7 @@ fn diff_line_row(
             theme,
             UNIFIED_CODE_PADDING_LEFT,
             content_width,
+            wrapped,
             scroll,
         ))
         .into_any_element()
@@ -4137,20 +4245,22 @@ fn split_line_cell(
     let content_width = match code_width {
         DiffCodeWidth::Clipped => None,
         DiffCodeWidth::Scrollable(metrics) => Some(metrics.split_content_width(gutter_px)),
+        DiffCodeWidth::Wrapped => None,
     };
+    let wrapped = matches!(code_width, DiffCodeWidth::Wrapped);
     div()
         .flex_1()
         .min_w_0()
-        .h_full()
+        .self_stretch()
         .overflow_hidden()
         .flex()
         .flex_row()
-        .items_center()
+        .items_start()
         .when_some(row_bg, |el, bg| el.bg(bg))
         .child(
             div()
                 .w(px(ACCENT_BAR_WIDTH))
-                .h_full()
+                .self_stretch()
                 .flex_none()
                 .when_some(accent, |el, color| el.bg(color)),
         )
@@ -4160,6 +4270,7 @@ fn split_line_cell(
                 .flex_none()
                 .font_family(theme.font_mono.clone())
                 .text_size(px(11.0))
+                .line_height(px(DIFF_LINE_HEIGHT))
                 .text_color(number_color)
                 .flex()
                 .justify_end()
@@ -4175,6 +4286,7 @@ fn split_line_cell(
                 .flex()
                 .justify_center()
                 .text_size(px(DIFF_TEXT_SIZE))
+                .line_height(px(DIFF_LINE_HEIGHT))
                 .text_color(marker_color)
                 .font_family(theme.font_mono.clone())
                 .child(SharedString::from(marker)),
@@ -4185,6 +4297,7 @@ fn split_line_cell(
             theme,
             SPLIT_CODE_PADDING_LEFT,
             content_width,
+            wrapped,
             scroll,
         ))
 }
@@ -4196,14 +4309,20 @@ fn split_filler() -> gpui::Div {
     div()
         .flex_1()
         .min_w_0()
-        .h_full()
+        .self_stretch()
         .bg(crate::theme::ink(0.03))
 }
 
 /// Compose the two halves with the centre hairline.
-fn split_row(left: AnyElement, right: AnyElement) -> gpui::Div {
+fn split_row(left: AnyElement, right: AnyElement, wrapped: bool) -> gpui::Div {
     div()
-        .h(px(DIFF_LINE_HEIGHT))
+        .map(|el| {
+            if wrapped {
+                el.min_h(px(DIFF_LINE_HEIGHT))
+            } else {
+                el.h(px(DIFF_LINE_HEIGHT))
+            }
+        })
         .w_full()
         .flex_none()
         .flex()
@@ -4213,7 +4332,7 @@ fn split_row(left: AnyElement, right: AnyElement) -> gpui::Div {
         .child(
             div()
                 .w(px(SPLIT_DIVIDER_WIDTH))
-                .h_full()
+                .self_stretch()
                 .flex_none()
                 .bg(crate::theme::hairline(0.06)),
         )
@@ -4541,6 +4660,7 @@ fn render_file_body_upto(
     let mut children: Vec<AnyElement> = Vec::new();
     let mut y = 0.0f32;
     let gutter_px = gutter_width(file);
+    let wrapped = matches!(code_width, DiffCodeWidth::Wrapped);
     let spans_for = |line: &DiffLine| {
         highlight
             .as_deref()
@@ -4624,9 +4744,8 @@ fn render_file_body_upto(
                                 theme,
                                 2.0 * (ACCENT_BAR_WIDTH + gutter_px),
                             ),
-                            None => {
-                                split_row(cell(left, true), cell(right, false)).into_any_element()
-                            }
+                            None => split_row(cell(left, true), cell(right, false), wrapped)
+                                .into_any_element(),
                         });
                         y += DIFF_LINE_HEIGHT;
                     }

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -348,9 +348,33 @@ impl DiffHorizontalMetrics {
 enum DiffCodeWidth {
     /// Inline tool diffs keep their existing local clipping behavior.
     Clipped,
-    /// Changes rows expose a stable intrinsic code width. Commit 2 connects
-    /// these viewports to the shared horizontal scroll state.
+    /// Changes rows expose a stable intrinsic code width.
     Scrollable(DiffHorizontalMetrics),
+}
+
+#[derive(Clone)]
+struct DiffCodeScroll {
+    handle: gpui::ScrollHandle,
+    id: SharedString,
+}
+
+#[derive(Clone)]
+struct DiffCodeScrollContext {
+    handle: gpui::ScrollHandle,
+    prefix: SharedString,
+}
+
+impl DiffCodeScrollContext {
+    fn slot(&self, suffix: impl std::fmt::Display) -> DiffCodeScroll {
+        DiffCodeScroll {
+            handle: self.handle.clone(),
+            id: SharedString::from(format!("{}-{suffix}", self.prefix)),
+        }
+    }
+}
+
+fn reset_horizontal_scroll(handle: &gpui::ScrollHandle) {
+    handle.set_offset(gpui::Point::default());
 }
 
 fn strip_git_prefix(path: &str) -> &str {
@@ -1517,6 +1541,9 @@ pub struct Changes {
     /// once their tween window elapses.
     fold_settle: Option<Task<()>>,
     list: ListState,
+    /// Shared by every code viewport; row chrome stays outside these tracked
+    /// scrollers so virtualization never moves gutters or headers on x.
+    horizontal_scroll: gpui::ScrollHandle,
     /// What the pane diffs against (toolbar dropdown).
     scope: DiffScope,
     /// Unified or side-by-side (toolbar toggle, persisted per user).
@@ -1587,6 +1614,7 @@ impl Changes {
             // Rows are single lines now — a deep overdraw is cheap and keeps
             // fast wheel flicks from outrunning measurement.
             list: ListState::new(0, ListAlignment::Top, px(1024.0)),
+            horizontal_scroll: gpui::ScrollHandle::new(),
             scope: DiffScope::default(),
             base_ref: None,
             branches: Vec::new(),
@@ -1962,6 +1990,7 @@ impl Changes {
     fn set_scope(&mut self, scope: DiffScope, cx: &mut Context<Self>) {
         if self.scope != scope {
             self.scope = scope;
+            reset_horizontal_scroll(&self.horizontal_scroll);
             if scope == DiffScope::History {
                 self.history_pane(cx)
                     .update(cx, |history, cx| history.ensure_loaded(cx));
@@ -2055,6 +2084,7 @@ impl Changes {
         self.ensure_scoped(cx);
         let Some(diff) = self.active_diff(cx) else {
             if self.parsed.take().is_some() {
+                reset_horizontal_scroll(&self.horizontal_scroll);
                 self.rows.clear();
                 self.row_ranges.clear();
                 self.list.reset(0);
@@ -2114,6 +2144,7 @@ impl Changes {
                     .reset_with_uniform_height(rows.len(), px(DIFF_LINE_HEIGHT));
                 changes.rows = rows;
                 changes.row_ranges = ranges;
+                reset_horizontal_scroll(&changes.horizontal_scroll);
                 changes.parsed = Some(ParsedDiff {
                     key,
                     truncated,
@@ -2350,6 +2381,7 @@ impl Changes {
     /// indices do not survive the re-pairing).
     fn toggle_mode(&mut self, cx: &mut Context<Self>) {
         self.mode = self.mode.toggled();
+        reset_horizontal_scroll(&self.horizontal_scroll);
         if let Some(dir) = self.state.read(cx).data_dir.clone() {
             let split = self.mode.is_split();
             cx.background_executor()
@@ -2845,6 +2877,10 @@ impl Changes {
         let theme = Theme::of(cx).clone();
         let code_width =
             DiffCodeWidth::Scrollable(parsed.horizontal_geometry.resolve(&theme, window));
+        let code_scroll = DiffCodeScrollContext {
+            handle: self.horizontal_scroll.clone(),
+            prefix: SharedString::from(format!("changes-code-row-{ix}")),
+        };
         match row {
             DiffRow::FileHeader { file } => {
                 let Some(file_diff) = files.get(file as usize) else {
@@ -2892,7 +2928,14 @@ impl Changes {
                     .map(|highlights| highlights.spans(line))
                     .unwrap_or(&[]);
                 let gutter_px = gutter_width(file_diff);
-                let row = diff_line_row(line, spans, &theme, gutter_px, code_width);
+                let row = diff_line_row(
+                    line,
+                    spans,
+                    &theme,
+                    gutter_px,
+                    code_width,
+                    Some(code_scroll.slot("unified")),
+                );
                 let Some((side, line_no)) = line_anchor(line) else {
                     return row;
                 };
@@ -2967,7 +3010,15 @@ impl Changes {
                             .clone()
                             .unwrap_or_else(|| line_runs(line, highlight.as_deref(), &theme));
                         let number = if old { line.old_no } else { line.new_no };
-                        split_line_cell(line, number, runs, &theme, gutter_px, code_width)
+                        split_line_cell(
+                            line,
+                            number,
+                            runs,
+                            &theme,
+                            gutter_px,
+                            code_width,
+                            Some(code_scroll.slot(if old { "old" } else { "new" })),
+                        )
                     })
                 };
                 // The left column is inert. It shows the pre-change file, and
@@ -3048,8 +3099,21 @@ impl Changes {
                 // Only the revealable slice is built — the tween never pays
                 // for lines it cannot show.
                 let cap = from.max(to).min(FOLD_TWEEN_MAX_PX);
-                let body =
-                    render_file_body_upto(file_diff, highlight, &theme, cap, self.mode, code_width);
+                let body = render_file_body_upto(
+                    file_diff,
+                    highlight,
+                    &theme,
+                    cap,
+                    self.mode,
+                    code_width,
+                    Some(DiffCodeScrollContext {
+                        handle: self.horizontal_scroll.clone(),
+                        prefix: SharedString::from(format!(
+                            "changes-fold-code-{file}-{}",
+                            fold.epoch
+                        )),
+                    }),
+                );
                 let clipped = div().w_full().overflow_hidden().child(body);
                 if fold.animating() {
                     clipped
@@ -3826,27 +3890,41 @@ fn hunk_header_row(header: &str, theme: &Theme) -> AnyElement {
 
 /// The only part of a diff row allowed to exceed its viewport. The outer
 /// element keeps row chrome fixed; the inner element owns the intrinsic code
-/// width that commit 2 will move with a shared scroll handle.
+/// width and is the only plane moved by the shared horizontal scroll handle.
 fn code_text_viewport(
     text: String,
     runs: Vec<gpui::TextRun>,
     theme: &Theme,
     padding_left: f32,
     content_width: Option<f32>,
+    scroll: Option<DiffCodeScroll>,
 ) -> AnyElement {
     let content = div()
-        .when_some(content_width, |el, width| el.w(px(width)).flex_none())
+        .when_some(content_width, |el, width| {
+            // Keep every tracked row's scroll extent identical. The width
+            // already includes shaping slack on the right, so clipping here
+            // only prevents a child from redefining the shared maximum.
+            el.w(px(width)).flex_none().overflow_hidden()
+        })
         .pl(px(padding_left))
         .font_family(theme.font_mono.clone())
         .text_size(px(DIFF_TEXT_SIZE))
         .whitespace_nowrap()
         .child(gpui::StyledText::new(text).with_runs(runs));
-    div()
-        .flex_1()
-        .min_w_0()
-        .overflow_hidden()
-        .child(content)
-        .into_any_element()
+    let viewport = div().flex_1().min_w_0().overflow_hidden().child(content);
+    match scroll {
+        Some(scroll) => {
+            let mut viewport = viewport
+                .id(scroll.id)
+                .overflow_x_scroll()
+                .track_scroll(&scroll.handle);
+            // Without this GPUI maps a vertical-only wheel delta onto x for
+            // an x-only scroller, starving the virtualized list underneath.
+            viewport.style().restrict_scroll_to_axis = Some(true);
+            viewport.into_any_element()
+        }
+        None => viewport.into_any_element(),
+    }
 }
 
 /// One +/−/context/meta diff line: coloured accent bar, dual line-number
@@ -3858,6 +3936,7 @@ fn diff_line_row(
     theme: &Theme,
     gutter_px: f32,
     code_width: DiffCodeWidth,
+    scroll: Option<DiffCodeScroll>,
 ) -> AnyElement {
     if line.kind == LineKind::Meta {
         return meta_line_row(
@@ -3972,6 +4051,7 @@ fn diff_line_row(
             theme,
             UNIFIED_CODE_PADDING_LEFT,
             content_width,
+            scroll,
         ))
         .into_any_element()
 }
@@ -4025,6 +4105,7 @@ fn split_line_cell(
     theme: &Theme,
     gutter_px: f32,
     code_width: DiffCodeWidth,
+    scroll: Option<DiffCodeScroll>,
 ) -> gpui::Div {
     let mut add_bg = add_color(theme);
     add_bg.a = 0.055;
@@ -4104,6 +4185,7 @@ fn split_line_cell(
             theme,
             SPLIT_CODE_PADDING_LEFT,
             content_width,
+            scroll,
         ))
 }
 
@@ -4433,6 +4515,7 @@ pub(crate) fn render_file_body_with_syntax(
                 theme,
                 gutter_px,
                 DiffCodeWidth::Clipped,
+                None,
             ));
         }
     }
@@ -4453,6 +4536,7 @@ fn render_file_body_upto(
     max_px: f32,
     mode: DiffMode,
     code_width: DiffCodeWidth,
+    scroll: Option<DiffCodeScrollContext>,
 ) -> AnyElement {
     let mut children: Vec<AnyElement> = Vec::new();
     let mut y = 0.0f32;
@@ -4472,7 +4556,7 @@ fn render_file_body_upto(
             children.push(notice_row(notice, theme));
             y += NOTICE_HEIGHT;
         }
-        for hunk in &file.hunks {
+        for (hunk_ix, hunk) in file.hunks.iter().enumerate() {
             if y >= max_px {
                 break 'build;
             }
@@ -4480,7 +4564,7 @@ fn render_file_body_upto(
             y += HUNK_HEADER_HEIGHT;
             match mode {
                 DiffMode::Unified => {
-                    for line in &hunk.lines {
+                    for (line_ix, line) in hunk.lines.iter().enumerate() {
                         if y >= max_px {
                             break 'build;
                         }
@@ -4490,6 +4574,9 @@ fn render_file_body_upto(
                             theme,
                             gutter_px,
                             code_width,
+                            scroll
+                                .as_ref()
+                                .map(|scroll| scroll.slot(format_args!("{hunk_ix}-{line_ix}"))),
                         ));
                         y += DIFF_LINE_HEIGHT;
                     }
@@ -4499,7 +4586,10 @@ fn render_file_body_upto(
                     // arm breaks out of a lazy walk, so the split arm must not
                     // materialize the whole hunk first.
                     let budget = ((max_px - y) / DIFF_LINE_HEIGHT).ceil().max(0.0) as usize;
-                    for (left, right) in split_pairs_upto(&hunk.lines, budget) {
+                    for (pair_ix, (left, right)) in split_pairs_upto(&hunk.lines, budget)
+                        .into_iter()
+                        .enumerate()
+                    {
                         if y >= max_px {
                             break 'build;
                         }
@@ -4513,6 +4603,12 @@ fn render_file_body_upto(
                                 theme,
                                 gutter_px,
                                 code_width,
+                                scroll.as_ref().map(|scroll| {
+                                    scroll.slot(format_args!(
+                                        "{hunk_ix}-{pair_ix}-{}",
+                                        if old { "old" } else { "new" }
+                                    ))
+                                }),
                             )
                             .into_any_element(),
                             None => split_filler().into_any_element(),
@@ -5340,6 +5436,31 @@ rename to new_name.rs
             ACCENT_BAR_WIDTH + gutter + SPLIT_MARKER_WIDTH + metrics.split_content_width(gutter)
         };
         assert_eq!(split_total(narrow), split_total(wide));
+    }
+
+    #[test]
+    fn horizontal_scroll_reset_returns_to_origin() {
+        let handle = gpui::ScrollHandle::new();
+        handle.set_offset(gpui::Point::new(px(-120.0), px(-18.0)));
+
+        reset_horizontal_scroll(&handle);
+
+        assert_eq!(handle.offset(), gpui::Point::default());
+    }
+
+    #[test]
+    fn horizontal_scroll_slots_share_offset_but_keep_unique_ids() {
+        let context = DiffCodeScrollContext {
+            handle: gpui::ScrollHandle::new(),
+            prefix: "row-7".into(),
+        };
+        let old = context.slot("old");
+        let new = context.slot("new");
+
+        old.handle.set_offset(gpui::Point::new(px(-96.0), px(0.0)));
+
+        assert_eq!(new.handle.offset(), old.handle.offset());
+        assert_ne!(old.id, new.id);
     }
 
     #[test]

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -98,6 +98,8 @@ icon_assets![
     // The changes pane's unified/split toggle: a rounded frame halved by a
     // centre rule (Solar Linear weight).
     (SPLIT_COLUMNS, "split-columns"),
+    // The changes pane's long-line wrapping toggle.
+    (WRAP_TEXT, "wrap-text"),
     (ALT_ARROW_LEFT, "alt-arrow-left"),
     (ALT_ARROW_RIGHT, "alt-arrow-right"),
     (SMARTPHONE, "smartphone"),

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -255,6 +255,8 @@ pub struct UiSettings {
     pub theme_selection: zeron_theme::ThemeSelection,
     /// Changes pane: side-by-side diffs instead of the unified stack.
     pub diff_split: bool,
+    /// Changes pane: wrap long source lines instead of scrolling horizontally.
+    pub diff_wrap: bool,
     /// Interactive identity overlay; imported themes default to their own accent.
     pub accent: zeron_theme::AccentSelection,
     /// Glass policy, independent from the selected appearance, theme, and accent.
@@ -294,6 +296,7 @@ impl Default for UiSettings {
             ui_font_size: crate::typography::UiFontSize::default(),
             theme_selection: zeron_theme::ThemeSelection::default(),
             diff_split: false,
+            diff_wrap: false,
             accent: zeron_theme::AccentSelection::default(),
             surface: zeron_theme::SurfacePreference::default(),
             legacy_accent_color: None,
@@ -799,11 +802,14 @@ mod tests {
                 dark: "catppuccin-mocha".into(),
             },
             diff_split: true,
+            diff_wrap: true,
             accent: zeron_theme::AccentSelection::Preset(zeron_theme::AccentPreset::Cyan),
             surface: zeron_theme::SurfacePreference::Frosted,
             legacy_accent_color: None,
         };
         settings.save(dir.path()).unwrap();
+        let json = std::fs::read_to_string(UiSettings::path(dir.path())).unwrap();
+        assert!(json.contains(r#""diffWrap": true"#));
         assert_eq!(UiSettings::load(dir.path()), settings);
     }
 
@@ -909,6 +915,7 @@ mod tests {
         );
         assert_eq!(loaded.sidebar_width, 300.0);
         assert!(!loaded.sound_enabled);
+        assert!(!loaded.diff_wrap);
         assert_eq!(
             loaded.ui_font_size,
             crate::typography::UiFontSize::default()


### PR DESCRIPTION
## Summary

- scroll only the source-code plane horizontally while keeping file headers, sticky headers, hunk headers, gutters, markers, comment controls, and row chrome fixed
- share one stable horizontal offset across virtualized unified rows, both split panes, and fold animations while leaving inline transcript diffs clipped
- account for tabs, Unicode display width, and per-file gutter widths when computing the shared scroll range
- add a persisted toolbar toggle for wrapping long diff lines; wrapped rows are remeasured by the virtualized list and bypass horizontal scrolling
- keep the scope to native horizontal scrolling gestures, without adding custom diff scrollbars or changing the existing model-picker scrollbar implementation

## Scrollbar decision

Custom diff scrollbars were removed because the virtualized list exposes only the materialized viewport, so their thumbs could not reliably represent how much content remained below. Solving that cleanly requires GPUI to expose virtual-content extent and scroll metrics; until then, the diff keeps native scrolling and avoids presenting inaccurate scrollbar state.

## Testing

- `cargo test -p zeron-ui` (579 passed)
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790356577&installation_model_id=425430&pr_number=227&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F227&signature=22d9cbaf879a24211bc2d546bfe07f31713da5d84b813f41352e31fc4760cd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->