### PR TITLE
Restore Tree-sitter query coverage for derived languages

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,7 +1,6 @@
 # Third-party notices
 
-Zeron bundles the following syntax-highlighting components. Their parsers and
-queries are consumed from the pinned Rust crates listed in `Cargo.lock`.
+Zeron bundles the following syntax-highlighting components. Unless noted otherwise, their parsers and queries are consumed from the pinned Rust crates listed in `Cargo.lock`. The Kotlin highlight query is maintained as Zeron source code and is not attributed to the grammar crate.
 
 | Component | Version | License | Source |
 | --- | --- | --- | --- |
@@ -11,7 +10,8 @@ queries are consumed from the pinned Rust crates listed in `Cargo.lock`.
 | Tree-sitter JavaScript grammar and queries | 0.25.0 | MIT | https://github.com/tree-sitter/tree-sitter-javascript |
 | Tree-sitter TypeScript grammar and queries | 0.23.2 | MIT | https://github.com/tree-sitter/tree-sitter-typescript |
 | Tree-sitter Python, Go, JSON, Bash, HTML, CSS, C, C++, C#, Java, Ruby and PHP grammars and queries | pinned in `Cargo.lock` | MIT | https://github.com/tree-sitter |
-| Tree-sitter TOML, Markdown, YAML, Kotlin, Swift, SQL, Lua, Nix, Make and Containerfile grammars and queries | pinned in `Cargo.lock` | MIT-compatible; see each crate | Crate repositories recorded in `Cargo.lock` |
+| Tree-sitter TOML, Markdown, YAML, Swift, SQL, Lua, Nix, Make and Containerfile grammars and queries | pinned in `Cargo.lock` | MIT-compatible; see each crate | Crate repositories recorded in `Cargo.lock` |
+| Tree-sitter Kotlin grammar | 1.1.0 | MIT | https://github.com/tree-sitter-grammars/tree-sitter-kotlin |
 
 The full Zeron distribution remains licensed under the terms in `LICENSE`.
 

--- a/crates/syntax/queries/kotlin/highlights.scm
+++ b/crates/syntax/queries/kotlin/highlights.scm
@@ -1,0 +1,266 @@
+; Comments
+
+[
+  (line_comment)
+  (block_comment)
+  (shebang)
+] @comment
+
+; Literals
+
+[
+  (string_literal)
+  (multiline_string_literal)
+  (character_literal)
+] @string
+
+(escape_sequence) @string.escape
+
+[
+  (number_literal)
+  (float_literal)
+] @number
+
+; Keep the generic identifier capture before structural refinements. Tree-sitter
+; resolves later matching patterns for the same range as the more specific role.
+(identifier) @variable
+
+((identifier) @boolean
+  (#any-of? @boolean "true" "false"))
+
+((identifier) @constant
+  (#eq? @constant "null"))
+
+; Declarations and references
+
+(class_declaration
+  name: (identifier) @type)
+
+(object_declaration
+  name: (identifier) @type)
+
+(companion_object
+  name: (identifier) @type)
+
+(type_alias
+  type: (identifier) @type)
+
+(type_parameter
+  (identifier) @type)
+
+(user_type
+  (identifier) @type)
+
+((user_type
+  (identifier) @type.builtin)
+  (#any-of? @type.builtin
+    "Any" "Boolean" "Byte" "Char" "Double" "Float" "Int" "Long"
+    "Nothing" "Short" "String" "Unit" "UByte" "UInt" "ULong" "UShort"))
+
+(function_declaration
+  name: (identifier) @function)
+
+(call_expression
+  (identifier) @function.call
+  .
+  (value_arguments))
+
+(call_expression
+  (navigation_expression
+    (identifier) @function.call)
+  .
+  (value_arguments))
+
+((call_expression
+  (identifier) @constructor
+  .
+  (value_arguments))
+  (#match? @constructor "^[A-Z]"))
+
+(constructor_invocation
+  (user_type
+    (identifier) @constructor))
+
+(parameter
+  (identifier) @variable.parameter)
+
+(class_parameter
+  (identifier) @variable.parameter)
+
+(lambda_parameters
+  (variable_declaration
+    (identifier) @variable.parameter))
+
+(catch_block
+  (identifier) @variable.parameter)
+
+(setter
+  (identifier) @variable.parameter)
+
+(class_parameter
+  ["val" "var"]
+  (identifier) @property)
+
+(class_body
+  (property_declaration
+    (variable_declaration
+      (identifier) @property)))
+
+(value_argument
+  (identifier) @property
+  "=")
+
+(property_declaration
+  (modifiers
+    (property_modifier))
+  (variable_declaration
+    (identifier) @constant))
+
+(enum_entry
+  (identifier) @constant)
+
+; Annotations and labels
+
+(annotation
+  "@" @punctuation.special)
+
+(annotation
+  (constructor_invocation
+    (user_type
+      (identifier) @attribute)))
+
+(label) @label
+
+[
+  (this_expression)
+  (super_expression)
+] @variable.builtin
+
+; Keywords and modifiers
+
+[
+  "package"
+  "import"
+  "as"
+  "class"
+  "interface"
+  "object"
+  "companion"
+  "fun"
+  "val"
+  "var"
+  "typealias"
+  "constructor"
+  "init"
+  "return"
+  "return@"
+  "throw"
+  "if"
+  "else"
+  "when"
+  "for"
+  "while"
+  "do"
+  "try"
+  "catch"
+  "finally"
+  "in"
+  "!in"
+  "is"
+  "!is"
+  "by"
+  "where"
+  "dynamic"
+  "abstract"
+  "actual"
+  "annotation"
+  "const"
+  "crossinline"
+  "data"
+  "enum"
+  "expect"
+  "external"
+  "final"
+  "infix"
+  "inline"
+  "inner"
+  "internal"
+  "lateinit"
+  "noinline"
+  "open"
+  "operator"
+  "override"
+  "private"
+  "protected"
+  "public"
+  "sealed"
+  "suspend"
+  "tailrec"
+  "value"
+  "vararg"
+] @keyword
+
+(reification_modifier) @keyword
+
+; Operators
+
+[
+  "!"
+  "!!"
+  "!="
+  "!=="
+  "%"
+  "%="
+  "&"
+  "&&"
+  "*"
+  "*="
+  "+"
+  "++"
+  "+="
+  "-"
+  "--"
+  "-="
+  "->"
+  "/"
+  "/="
+  ".."
+  "..<"
+  "<"
+  "<="
+  "="
+  "=="
+  "==="
+  ">"
+  ">="
+  "?:"
+  "||"
+  "as?"
+] @operator
+
+; Punctuation
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  ","
+  "."
+  "?."
+  ":"
+  "::"
+  ";"
+  "?"
+] @punctuation.delimiter
+
+[
+  "$"
+  "${"
+  "@"
+] @punctuation.special

--- a/crates/syntax/queries/kotlin/highlights.scm
+++ b/crates/syntax/queries/kotlin/highlights.scm
@@ -61,21 +61,15 @@
   name: (identifier) @function)
 
 (call_expression
-  (identifier) @function.call
   .
-  (value_arguments))
+  (identifier) @function.call)
 
 (call_expression
+  .
   (navigation_expression
-    (identifier) @function.call)
-  .
-  (value_arguments))
-
-((call_expression
-  (identifier) @constructor
-  .
-  (value_arguments))
-  (#match? @constructor "^[A-Z]"))
+    (_)
+    .
+    (identifier) @function.call))
 
 (constructor_invocation
   (user_type
@@ -106,6 +100,11 @@
     (variable_declaration
       (identifier) @property)))
 
+(source_file
+  (property_declaration
+    (variable_declaration
+      (identifier) @property)))
+
 (value_argument
   (identifier) @property
   "=")
@@ -128,6 +127,10 @@
   (constructor_invocation
     (user_type
       (identifier) @attribute)))
+
+(annotation
+  (user_type
+    (identifier) @attribute))
 
 (label) @label
 

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -312,7 +312,10 @@ pub fn highlight_with_limits(
 
     let mut primary_configuration = configuration(language)?;
     primary_configuration.configure(CAPTURE_NAMES);
-    let injected = if matches!(language, LanguageId::Html | LanguageId::Markdown) {
+    let injected = if matches!(
+        language,
+        LanguageId::Html | LanguageId::Markdown | LanguageId::Dockerfile
+    ) {
         injected_languages(language)
             .into_iter()
             .filter_map(|language| {
@@ -372,6 +375,7 @@ fn injected_languages(parent: LanguageId) -> Vec<LanguageId> {
             Rust, JavaScript, Jsx, TypeScript, Tsx, Python, Go, Json, Jsonc, Bash, Toml, Html, Css,
             Yaml, C, Cpp, CSharp, Java, Kotlin, Swift, Ruby, Php, Sql, Lua, Dockerfile, Nix, Make,
         ],
+        Dockerfile => vec![Bash, Json, Yaml, Toml],
         _ => Vec::new(),
     }
 }
@@ -413,42 +417,70 @@ fn make_configuration(
         .map_err(|error| HighlightError::Parser(error.to_string()))
 }
 
+fn javascript_family_highlights(language: LanguageId) -> String {
+    use LanguageId::*;
+
+    let queries = match language {
+        JavaScript => &[tree_sitter_javascript::HIGHLIGHT_QUERY][..],
+        Jsx => &[
+            tree_sitter_javascript::HIGHLIGHT_QUERY,
+            tree_sitter_javascript::JSX_HIGHLIGHT_QUERY,
+        ][..],
+        TypeScript => &[
+            tree_sitter_javascript::HIGHLIGHT_QUERY,
+            tree_sitter_typescript::HIGHLIGHTS_QUERY,
+        ][..],
+        Tsx => &[
+            tree_sitter_javascript::HIGHLIGHT_QUERY,
+            tree_sitter_javascript::JSX_HIGHLIGHT_QUERY,
+            tree_sitter_typescript::HIGHLIGHTS_QUERY,
+        ][..],
+        _ => unreachable!("JavaScript query composition requires a JavaScript-family language"),
+    };
+    queries.join("\n")
+}
+
+fn javascript_family_configuration(
+    language: LanguageId,
+) -> Result<HighlightConfiguration, HighlightError> {
+    use LanguageId::*;
+
+    let highlights = javascript_family_highlights(language);
+    let (grammar, name, injections, locals) = match language {
+        JavaScript => (
+            tree_sitter_javascript::LANGUAGE.into(),
+            "javascript",
+            tree_sitter_javascript::INJECTIONS_QUERY,
+            tree_sitter_javascript::LOCALS_QUERY,
+        ),
+        Jsx => (
+            tree_sitter_javascript::LANGUAGE.into(),
+            "jsx",
+            tree_sitter_javascript::INJECTIONS_QUERY,
+            tree_sitter_javascript::LOCALS_QUERY,
+        ),
+        TypeScript => (
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            "typescript",
+            "",
+            tree_sitter_typescript::LOCALS_QUERY,
+        ),
+        Tsx => (
+            tree_sitter_typescript::LANGUAGE_TSX.into(),
+            "tsx",
+            "",
+            tree_sitter_typescript::LOCALS_QUERY,
+        ),
+        _ => unreachable!("JavaScript configuration requires a JavaScript-family language"),
+    };
+    make_configuration(grammar, name, &highlights, injections, locals)
+}
+
 fn configuration(language: LanguageId) -> Result<HighlightConfiguration, HighlightError> {
     use LanguageId::*;
     match language {
         Rust => rust_configuration(),
-        JavaScript => make_configuration(
-            tree_sitter_javascript::LANGUAGE.into(),
-            "javascript",
-            tree_sitter_javascript::HIGHLIGHT_QUERY,
-            tree_sitter_javascript::INJECTIONS_QUERY,
-            tree_sitter_javascript::LOCALS_QUERY,
-        ),
-        Jsx => make_configuration(
-            tree_sitter_javascript::LANGUAGE.into(),
-            "jsx",
-            &format!(
-                "{}\n{}",
-                tree_sitter_javascript::HIGHLIGHT_QUERY,
-                tree_sitter_javascript::JSX_HIGHLIGHT_QUERY
-            ),
-            tree_sitter_javascript::INJECTIONS_QUERY,
-            tree_sitter_javascript::LOCALS_QUERY,
-        ),
-        TypeScript => make_configuration(
-            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-            "typescript",
-            tree_sitter_typescript::HIGHLIGHTS_QUERY,
-            "",
-            tree_sitter_typescript::LOCALS_QUERY,
-        ),
-        Tsx => make_configuration(
-            tree_sitter_typescript::LANGUAGE_TSX.into(),
-            "tsx",
-            tree_sitter_typescript::HIGHLIGHTS_QUERY,
-            "",
-            tree_sitter_typescript::LOCALS_QUERY,
-        ),
+        JavaScript | Jsx | TypeScript | Tsx => javascript_family_configuration(language),
         Python => make_configuration(
             tree_sitter_python::LANGUAGE.into(),
             "python",
@@ -547,7 +579,7 @@ fn configuration(language: LanguageId) -> Result<HighlightConfiguration, Highlig
         Kotlin => make_configuration(
             tree_sitter_kotlin_ng::LANGUAGE.into(),
             "kotlin",
-            "[(line_comment) (block_comment)] @comment [(string_literal) (multiline_string_literal)] @string [(number_literal) (float_literal)] @number",
+            include_str!("../queries/kotlin/highlights.scm"),
             "",
             "",
         ),
@@ -604,7 +636,7 @@ fn configuration(language: LanguageId) -> Result<HighlightConfiguration, Highlig
             tree_sitter_containerfile::LANGUAGE.into(),
             "dockerfile",
             tree_sitter_containerfile::HIGHLIGHTS_QUERY,
-            "",
+            tree_sitter_containerfile::INJECTIONS_QUERY,
             "",
         ),
     }
@@ -1011,7 +1043,7 @@ fn build(value: usize) -> Widget {
     }
 
     #[test]
-    fn every_registered_grammar_loads_and_highlights_a_fixture() {
+    fn every_registered_grammar_and_query_loads_for_the_bundled_abi() {
         let fixtures = [
             (LanguageId::JavaScript, "app.js", "const value = call(42);"),
             (
@@ -1082,6 +1114,23 @@ fn build(value: usize) -> Widget {
             assert!(
                 document.lines.iter().flatten().next().is_some(),
                 "{language:?} fixture has no structural spans"
+            );
+        }
+    }
+
+    #[test]
+    fn affected_composed_and_project_queries_load_for_pinned_grammars() {
+        for language in [
+            LanguageId::TypeScript,
+            LanguageId::Tsx,
+            LanguageId::Kotlin,
+            LanguageId::Dockerfile,
+        ] {
+            let configuration = configuration(language)
+                .unwrap_or_else(|error| panic!("{language:?} query failed to load: {error}"));
+            assert!(
+                !configuration.names().is_empty(),
+                "{language:?} query has no captures"
             );
         }
     }

--- a/crates/syntax/tests/quality.rs
+++ b/crates/syntax/tests/quality.rs
@@ -141,7 +141,9 @@ fn kotlin_project_query_covers_structural_roles() {
 
 // Structural Kotlin fixture
 @Deprecated("old")
-data class Greeter(private val prefix: String) {
+@Marker
+open class Parent
+data class Greeter(private val prefix: String) : Parent() {
     val version: Int = 1
 
     suspend fun greet(name: String, enabled: Boolean): String {
@@ -153,6 +155,14 @@ data class Greeter(private val prefix: String) {
 val greeter = Greeter("Hello")
 val enabled = true
 val missing = null
+
+fun exercise(receiver: Greeter) {
+    genericCall<String>()
+    lambdaCall { value -> value }
+    receiver.genericMethod<String>()
+    receiver.lambdaMethod { value -> value }
+    Uppercase()
+}
 "#;
     assert_fragments(
         source,
@@ -161,9 +171,11 @@ val missing = null
             ("package", HighlightKind::Keyword),
             ("// Structural Kotlin fixture", HighlightKind::Comment),
             ("Deprecated", HighlightKind::Attribute),
+            ("Marker", HighlightKind::Attribute),
             ("data", HighlightKind::Keyword),
             ("Greeter", HighlightKind::Type),
-            ("Greeter", HighlightKind::Constructor),
+            ("Greeter", HighlightKind::Function),
+            ("Parent", HighlightKind::Constructor),
             ("prefix", HighlightKind::Property),
             ("String", HighlightKind::TypeBuiltin),
             ("version", HighlightKind::Property),
@@ -178,13 +190,29 @@ val missing = null
             ("\"$prefix, $name\"", HighlightKind::String),
             ("true", HighlightKind::Boolean),
             ("null", HighlightKind::Constant),
+            ("greeter", HighlightKind::Property),
+            ("genericCall", HighlightKind::Function),
+            ("lambdaCall", HighlightKind::Function),
+            ("genericMethod", HighlightKind::Function),
+            ("lambdaMethod", HighlightKind::Function),
+            ("Uppercase", HighlightKind::Function),
             ("(", HighlightKind::Punctuation),
         ],
+    );
+    assert!(
+        !fragments(source, "src/Greeter.kt")
+            .contains(&("Uppercase".into(), HighlightKind::Constructor)),
+        "capitalized function calls must not be guessed to be constructors"
+    );
+    assert!(
+        !fragments(source, "src/Greeter.kt")
+            .contains(&("receiver".into(), HighlightKind::Function)),
+        "only the terminal navigation member is a function call"
     );
 }
 
 #[test]
-fn dockerfile_uses_bounded_shell_and_json_injections() {
+fn dockerfile_uses_bounded_shell_and_structured_data_injections() {
     let source = r#"FROM alpine
 ENV NAME=World
 RUN echo "hello $NAME" && printf '%s\n' "$NAME"
@@ -193,6 +221,12 @@ touch /tmp/ready
 SCRIPT
 COPY <<EOF config.json
 {"enabled": true}
+EOF
+COPY <<EOF config.yaml
+yaml_enabled: true
+EOF
+COPY <<EOF config.toml
+toml_enabled = true
 EOF
 COPY <<EOF config.xml
 <root />
@@ -209,6 +243,8 @@ EOF
             ("'%s\\n'", HighlightKind::String),
             ("touch", HighlightKind::Function),
             ("true", HighlightKind::Constant),
+            ("yaml_enabled", HighlightKind::Property),
+            ("toml_enabled = true", HighlightKind::Property),
             ("<root />", HighlightKind::String),
         ],
     );

--- a/crates/syntax/tests/quality.rs
+++ b/crates/syntax/tests/quality.rs
@@ -1,23 +1,56 @@
 use std::time::Instant;
 
-use zeron_syntax::{HighlightKind, HighlightRequest, highlight};
+use zeron_syntax::{HighlightKind, HighlightRequest, HighlightedDocument, highlight};
 
-fn snapshot(source: &str, path: &str) -> Vec<String> {
-    let document = highlight(HighlightRequest {
+fn document(source: &str, path: &str) -> HighlightedDocument {
+    highlight(HighlightRequest {
         source,
         path: Some(path),
         fence_tag: None,
     })
-    .unwrap();
+    .unwrap()
+}
+
+fn fragments(source: &str, path: &str) -> Vec<(String, HighlightKind)> {
+    let document = document(source, path);
     source
         .lines()
         .zip(document.lines)
         .flat_map(|(line, spans)| {
             spans
                 .into_iter()
-                .map(move |span| format!("{:?}:{}", span.kind, &line[span.range]))
+                .map(move |span| (line[span.range].to_owned(), span.kind))
         })
         .collect()
+}
+
+fn assert_fragments(source: &str, path: &str, expected: &[(&str, HighlightKind)]) {
+    let fragments = fragments(source, path);
+    for &(text, kind) in expected {
+        assert!(
+            fragments
+                .iter()
+                .any(|fragment| fragment == &(text.into(), kind)),
+            "missing {text:?} as {kind:?} in {path}: {fragments:#?}"
+        );
+    }
+}
+
+fn assert_valid_document(source: &str, path: &str) {
+    let document = document(source, path);
+    assert_eq!(document.lines.len(), source.lines().count().max(1));
+    for (line, spans) in source.lines().zip(document.lines) {
+        assert!(
+            spans
+                .windows(2)
+                .all(|pair| pair[0].range.end <= pair[1].range.start),
+            "overlapping spans in {path}: {spans:?}"
+        );
+        for span in spans {
+            assert!(line.is_char_boundary(span.range.start));
+            assert!(line.is_char_boundary(span.range.end));
+        }
+    }
 }
 
 #[test]
@@ -29,24 +62,178 @@ fn build(value: usize) -> Widget {
     let label = format!("item-{value}");
     Widget { field: 42 }
 }"#;
-    let spans = snapshot(source, "src/lib.rs");
-    for expected in [
-        "Keyword:use",
-        "Constructor:Path",
-        "Comment:// quiet comment",
-        "Type:Widget",
-        "Property:field",
-        "TypeBuiltin:usize",
-        "Function:build",
-        "Parameter:value",
-        "Macro:format!",
-        "String:\"item-{value}\"",
-        "Number:42",
+    assert_fragments(
+        source,
+        "src/lib.rs",
+        &[
+            ("use", HighlightKind::Keyword),
+            ("Path", HighlightKind::Constructor),
+            ("// quiet comment", HighlightKind::Comment),
+            ("Widget", HighlightKind::Type),
+            ("field", HighlightKind::Property),
+            ("usize", HighlightKind::TypeBuiltin),
+            ("build", HighlightKind::Function),
+            ("value", HighlightKind::Parameter),
+            ("format!", HighlightKind::Macro),
+            ("\"item-{value}\"", HighlightKind::String),
+            ("42", HighlightKind::Number),
+        ],
+    );
+}
+
+#[test]
+fn typescript_composes_javascript_and_typescript_roles() {
+    let source = r#"import type { Widget } from "./widget";
+export function derive<T>(name: string, input: Widget): Promise<T> {
+    const kind = input.kind;
+    if (kind === "ready") {
+        const result = parse<T>(`${name}:${kind}`, 42);
+        return result;
+    }
+    throw new Error("bad");
+}"#;
+    assert_fragments(
+        source,
+        "src/derive.ts",
+        &[
+            ("import", HighlightKind::Keyword),
+            ("derive", HighlightKind::Function),
+            ("name", HighlightKind::Parameter),
+            ("string", HighlightKind::TypeBuiltin),
+            ("Widget", HighlightKind::Type),
+            ("kind", HighlightKind::Property),
+            ("parse", HighlightKind::Function),
+            ("`${name}:${kind}`", HighlightKind::String),
+            ("42", HighlightKind::Number),
+            ("===", HighlightKind::Operator),
+            ("(", HighlightKind::Punctuation),
+            ("result", HighlightKind::Variable),
+        ],
+    );
+}
+
+#[test]
+fn tsx_composes_javascript_jsx_and_typescript_roles() {
+    let source = r#"type Props = { id: string; title: string };
+export function card(props: Props): JSX.Element {
+    return <main id={props.id} data-kind={props.title}>{props.title}</main>;
+}"#;
+    assert_fragments(
+        source,
+        "src/card.tsx",
+        &[
+            ("type", HighlightKind::Keyword),
+            ("card", HighlightKind::Function),
+            ("props", HighlightKind::Parameter),
+            ("Props", HighlightKind::Type),
+            ("string", HighlightKind::TypeBuiltin),
+            ("main", HighlightKind::Tag),
+            ("id", HighlightKind::Attribute),
+            ("data-kind", HighlightKind::Attribute),
+            ("title", HighlightKind::Property),
+        ],
+    );
+}
+
+#[test]
+fn kotlin_project_query_covers_structural_roles() {
+    let source = r#"package demo
+
+// Structural Kotlin fixture
+@Deprecated("old")
+data class Greeter(private val prefix: String) {
+    val version: Int = 1
+
+    suspend fun greet(name: String, enabled: Boolean): String {
+        if (enabled && version > 0) println("$prefix, $name")
+        return prefix
+    }
+}
+
+val greeter = Greeter("Hello")
+val enabled = true
+val missing = null
+"#;
+    assert_fragments(
+        source,
+        "src/Greeter.kt",
+        &[
+            ("package", HighlightKind::Keyword),
+            ("// Structural Kotlin fixture", HighlightKind::Comment),
+            ("Deprecated", HighlightKind::Attribute),
+            ("data", HighlightKind::Keyword),
+            ("Greeter", HighlightKind::Type),
+            ("Greeter", HighlightKind::Constructor),
+            ("prefix", HighlightKind::Property),
+            ("String", HighlightKind::TypeBuiltin),
+            ("version", HighlightKind::Property),
+            ("Int", HighlightKind::TypeBuiltin),
+            ("1", HighlightKind::Number),
+            ("suspend", HighlightKind::Keyword),
+            ("greet", HighlightKind::Function),
+            ("name", HighlightKind::Parameter),
+            ("Boolean", HighlightKind::TypeBuiltin),
+            ("&&", HighlightKind::Operator),
+            ("println", HighlightKind::Function),
+            ("\"$prefix, $name\"", HighlightKind::String),
+            ("true", HighlightKind::Boolean),
+            ("null", HighlightKind::Constant),
+            ("(", HighlightKind::Punctuation),
+        ],
+    );
+}
+
+#[test]
+fn dockerfile_uses_bounded_shell_and_json_injections() {
+    let source = r#"FROM alpine
+ENV NAME=World
+RUN echo "hello $NAME" && printf '%s\n' "$NAME"
+RUN <<SCRIPT
+touch /tmp/ready
+SCRIPT
+COPY <<EOF config.json
+{"enabled": true}
+EOF
+COPY <<EOF config.xml
+<root />
+EOF
+"#;
+    assert_fragments(
+        source,
+        "Dockerfile",
+        &[
+            ("FROM", HighlightKind::Keyword),
+            ("NAME", HighlightKind::Property),
+            ("echo", HighlightKind::Function),
+            ("&&", HighlightKind::Operator),
+            ("'%s\\n'", HighlightKind::String),
+            ("touch", HighlightKind::Function),
+            ("true", HighlightKind::Constant),
+            ("<root />", HighlightKind::String),
+        ],
+    );
+    assert!(
+        !fragments(source, "Dockerfile")
+            .iter()
+            .any(|(text, kind)| text == "root" && *kind == HighlightKind::Tag),
+        "unsupported XML heredocs must remain parent-highlighted"
+    );
+    assert_valid_document(source, "Dockerfile");
+}
+
+#[test]
+fn affected_languages_keep_utf8_boundaries_for_incomplete_code() {
+    for (path, source) in [
+        (
+            "src/broken.ts",
+            "export function café(name: string) {\n const label = `héllo ${name\n if (name ===",
+        ),
+        (
+            "src/Broken.kt",
+            "fun café(name: String) {\n val label = \"héllo $name\n if (name ==",
+        ),
     ] {
-        assert!(
-            spans.iter().any(|span| span == expected),
-            "missing {expected}: {spans:#?}"
-        );
+        assert_valid_document(source, path);
     }
 }
 
@@ -102,16 +289,12 @@ fn benchmark_small_medium_large_and_incomplete_documents() {
 
 #[test]
 fn reference_contains_expected_visual_roles() {
-    let spans = snapshot("fn call() { let value = 42; }", "main.rs");
+    let spans = fragments("fn call() { let value = 42; }", "main.rs");
     for kind in [
         HighlightKind::Keyword,
         HighlightKind::Function,
         HighlightKind::Number,
     ] {
-        assert!(
-            spans
-                .iter()
-                .any(|span| span.starts_with(&format!("{kind:?}:")))
-        );
+        assert!(spans.iter().any(|(_, actual)| *actual == kind));
     }
 }

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -5397,13 +5397,13 @@ rename to new_name.rs
 
     #[test]
     fn full_diff_highlights_map_old_new_and_context_by_source_line() {
-        let old_source = "fn old() {\n    let value = 1;\n}\n";
-        let new_source = "fn new() {\n    let value = 2;\n}\n";
+        let old_source = "export function old(value: string) {\n    return value.trim();\n}\n";
+        let new_source = "export function new(value: string) {\n    return value.trim();\n}\n";
         let parse = |source| {
             Arc::new(
                 zeron_syntax::highlight(zeron_syntax::HighlightRequest {
                     source,
-                    path: Some("src/lib.rs"),
+                    path: Some("src/derive.ts"),
                     fence_tag: None,
                 })
                 .unwrap(),
@@ -5417,19 +5417,19 @@ rename to new_name.rs
             kind: LineKind::Del,
             old_no: Some(1),
             new_no: None,
-            text: "fn old() {".into(),
+            text: "export function old(value: string) {".into(),
         };
         let added = DiffLine {
             kind: LineKind::Add,
             old_no: None,
             new_no: Some(1),
-            text: "fn new() {".into(),
+            text: "export function new(value: string) {".into(),
         };
         let context = DiffLine {
             kind: LineKind::Context,
             old_no: Some(2),
             new_no: Some(2),
-            text: "    let value = 2;".into(),
+            text: "    return value.trim();".into(),
         };
         assert_eq!(
             highlights.source_ref(&deleted),

--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -5467,6 +5467,72 @@ rename to new_name.rs
     }
 
     #[test]
+    fn split_line_runs_use_affected_old_and_new_documents() {
+        let theme = Theme::dark();
+        for (path, source, required) in [
+            (
+                "src/card.tsx",
+                "const view: JSX.Element = <main id=\"app\" />;",
+                zeron_syntax::HighlightKind::Tag,
+            ),
+            (
+                "src/Greeter.kt",
+                "fun greet(name: String) = println(name)",
+                zeron_syntax::HighlightKind::Function,
+            ),
+            (
+                "Dockerfile",
+                "RUN echo \"hello\"",
+                zeron_syntax::HighlightKind::Function,
+            ),
+        ] {
+            let document = Arc::new(
+                zeron_syntax::highlight(zeron_syntax::HighlightRequest {
+                    source,
+                    path: Some(path),
+                    fence_tag: None,
+                })
+                .unwrap(),
+            );
+            let highlights = DiffHighlights {
+                old: Some(document.clone()),
+                new: Some(document),
+            };
+            for line in [
+                DiffLine {
+                    kind: LineKind::Del,
+                    old_no: Some(1),
+                    new_no: None,
+                    text: source.into(),
+                },
+                DiffLine {
+                    kind: LineKind::Add,
+                    old_no: None,
+                    new_no: Some(1),
+                    text: source.into(),
+                },
+            ] {
+                assert!(
+                    highlights
+                        .spans(&line)
+                        .iter()
+                        .any(|span| span.kind == required),
+                    "missing {required:?} for {path} on {:?}",
+                    line.kind
+                );
+                let runs = line_runs(&line, Some(&highlights), &theme);
+                assert_eq!(runs.iter().map(|run| run.len).sum::<usize>(), source.len());
+                assert!(
+                    runs.iter()
+                        .any(|run| run.color == render::token_color(required, &theme)),
+                    "split runs dropped {required:?} for {path} on {:?}",
+                    line.kind
+                );
+            }
+        }
+    }
+
+    #[test]
     fn excerpt_parses_old_and_new_hunks_as_separate_documents() {
         let file = FileDiff {
             path: "src/lib.rs".into(),

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -1328,24 +1328,74 @@ mod tests {
     }
 
     #[test]
-    fn composed_typescript_roles_flow_through_markdown_paint_only() {
-        let line = "export function derive(name: string) { return call(name); }";
-        let document = zeron_syntax::highlight(zeron_syntax::HighlightRequest {
-            source: line,
-            path: None,
-            fence_tag: Some("typescript"),
-        })
-        .unwrap();
-        for theme in [Theme::dark(), Theme::light()] {
-            let mono = font(theme.font_mono.clone());
-            let runs = runs_for_syntax_line(line, &document.lines[0], &mono, &theme);
-            assert_eq!(runs.iter().map(|run| run.len).sum::<usize>(), line.len());
-            assert!(runs.iter().all(|run| run.font == mono));
-            let colors = runs.iter().map(|run| run.color).collect::<Vec<_>>();
-            assert!(colors.contains(&theme.syntax.keyword));
-            assert!(colors.contains(&theme.syntax.function));
-            assert!(colors.contains(&theme.syntax.parameter));
-            assert!(colors.contains(&theme.syntax.type_builtin));
+    fn affected_language_roles_flow_through_markdown_paint_only() {
+        let cases: &[(&str, &str, &[HighlightKind])] = &[
+            (
+                "typescript",
+                "export function derive(name: string) { return call(name); }",
+                &[
+                    HighlightKind::Keyword,
+                    HighlightKind::Function,
+                    HighlightKind::Parameter,
+                    HighlightKind::TypeBuiltin,
+                ],
+            ),
+            (
+                "tsx",
+                "function card(props: Props): JSX.Element { return <main id={props.id} />; }",
+                &[
+                    HighlightKind::Tag,
+                    HighlightKind::Attribute,
+                    HighlightKind::Type,
+                ],
+            ),
+            (
+                "kotlin",
+                "fun greet(name: String) = println(name)",
+                &[
+                    HighlightKind::Keyword,
+                    HighlightKind::Function,
+                    HighlightKind::Parameter,
+                    HighlightKind::TypeBuiltin,
+                ],
+            ),
+            (
+                "dockerfile",
+                "RUN echo \"hello\"",
+                &[
+                    HighlightKind::Keyword,
+                    HighlightKind::Function,
+                    HighlightKind::String,
+                ],
+            ),
+        ];
+        for &(fence_tag, line, required) in cases {
+            let document = zeron_syntax::highlight(zeron_syntax::HighlightRequest {
+                source: line,
+                path: None,
+                fence_tag: Some(fence_tag),
+            })
+            .unwrap();
+            let kinds = document.lines[0]
+                .iter()
+                .map(|span| span.kind)
+                .collect::<Vec<_>>();
+            for &kind in required {
+                assert!(kinds.contains(&kind), "missing {kind:?} for {fence_tag}");
+            }
+            for theme in [Theme::dark(), Theme::light()] {
+                let mono = font(theme.font_mono.clone());
+                let runs = runs_for_syntax_line(line, &document.lines[0], &mono, &theme);
+                assert_eq!(runs.iter().map(|run| run.len).sum::<usize>(), line.len());
+                assert!(runs.iter().all(|run| run.font == mono));
+                let colors = runs.iter().map(|run| run.color).collect::<Vec<_>>();
+                for &kind in required {
+                    assert!(
+                        colors.contains(&token_color(kind, &theme)),
+                        "missing {kind:?} color for {fence_tag}"
+                    );
+                }
+            }
         }
     }
 

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -1328,6 +1328,28 @@ mod tests {
     }
 
     #[test]
+    fn composed_typescript_roles_flow_through_markdown_paint_only() {
+        let line = "export function derive(name: string) { return call(name); }";
+        let document = zeron_syntax::highlight(zeron_syntax::HighlightRequest {
+            source: line,
+            path: None,
+            fence_tag: Some("typescript"),
+        })
+        .unwrap();
+        for theme in [Theme::dark(), Theme::light()] {
+            let mono = font(theme.font_mono.clone());
+            let runs = runs_for_syntax_line(line, &document.lines[0], &mono, &theme);
+            assert_eq!(runs.iter().map(|run| run.len).sum::<usize>(), line.len());
+            assert!(runs.iter().all(|run| run.font == mono));
+            let colors = runs.iter().map(|run| run.color).collect::<Vec<_>>();
+            assert!(colors.contains(&theme.syntax.keyword));
+            assert!(colors.contains(&theme.syntax.function));
+            assert!(colors.contains(&theme.syntax.parameter));
+            assert!(colors.contains(&theme.syntax.type_builtin));
+        }
+    }
+
+    #[test]
     fn code_line_runs_with_no_tokens_are_one_plain_run() {
         let theme = Theme::dark();
         let mono = font(theme.font_mono.clone());

--- a/docs/syntax-highlighting.md
+++ b/docs/syntax-highlighting.md
@@ -1,34 +1,23 @@
 # Syntax highlighting
 
-Desktop syntax highlighting lives in the pure `zeron-syntax` crate. It detects
-languages, runs pinned Tree-sitter grammars and queries, and returns sorted,
-non-overlapping UTF-8 byte spans relative to each source line. The UI resolves
-those neutral `HighlightKind` values through `Theme::syntax`; parser code never
-depends on GPUI or colors.
+Desktop syntax highlighting lives in the pure `zeron-syntax` crate. It detects languages, runs pinned Tree-sitter grammars and queries, and returns sorted, non-overlapping UTF-8 byte spans relative to each source line. The UI resolves those neutral `HighlightKind` values through `Theme::syntax`; parser code never depends on GPUI or colors.
 
-Markdown fences and tool diffs parse complete documents on GPUI's background
-executor. Changes first parses separate old/new hunk excerpts, then lazily asks
-the checkout host for checksum-bound complete sources. Deleted lines use the old
-document; added and context lines prefer the new document. A stale checksum or
-any visible-line mismatch discards the full result atomically.
+Markdown fences and tool diffs parse complete documents on GPUI's background executor. Changes first parses separate old/new hunk excerpts, then lazily asks the checkout host for checksum-bound complete sources. Deleted lines use the old document; added and context lines prefer the new document. A stale checksum or any visible-line mismatch discards the full result atomically.
+
+## Query composition and ownership
+
+Derived grammars must explicitly compose every compatible base and extension query in base-to-extension order. JavaScript uses the JavaScript query, JSX adds the JSX extension, TypeScript adds the TypeScript extension to JavaScript, and TSX combines all three. Query extensions must not be treated as standalone highlight definitions.
+
+Kotlin uses `crates/syntax/queries/kotlin/highlights.scm`, a project-owned query written for the AST of the pinned `tree-sitter-kotlin-ng` version. Changes to that grammar require compiling the query and rerunning the token-to-`HighlightKind` quality fixtures before updating the pin.
+
+Injection registries are closed per parent language. Containerfile/Dockerfile accepts only the bundled Bash, JSON, YAML, and TOML children advertised by its upstream injection query; unsupported names such as XML and `comment` remain parent-highlighted or plain. Markdown and HTML keep their own independent child registries.
 
 ## Adding a grammar
 
-1. Review the parser, generated sources, and queries' licenses. Pin an exact
-   crate version in `crates/syntax/Cargo.toml` and add it to
-   `THIRD_PARTY_NOTICES.md`.
-2. Add aliases, extensions, exact filenames, and any unambiguous shebang to the
-   central registry in `crates/syntax/src/lib.rs`.
-3. Add its `HighlightConfiguration` using official compatible queries. Map new
-   capture vocabulary to an existing `HighlightKind`; never expose capture names
-   to the theme.
-4. Add a minimal distinctive fixture to the query-load table. If the language
-   supports injections, register only known child parsers and keep unknown
-   injected languages plain.
-5. Run `cargo test -p zeron-syntax`, UI Markdown/Changes tests, the ignored
-   diagnostic benchmark when parser cost changes, and the workspace checks.
+1. Review the parser, generated sources, and queries' licenses. Pin an exact crate version in `crates/syntax/Cargo.toml` and add it to `THIRD_PARTY_NOTICES.md`.
+2. Add aliases, extensions, exact filenames, and any unambiguous shebang to the central registry in `crates/syntax/src/lib.rs`.
+3. Add its `HighlightConfiguration` using official compatible queries or a clearly documented project-owned query. Compose inherited queries explicitly, map new capture vocabulary to an existing `HighlightKind`, and never expose capture names to the theme.
+4. Add a minimal distinctive fixture to the ABI/query-load table and token-to-role fixtures for visual quality. If the language supports injections, register only known child parsers and keep unknown injected languages plain.
+5. Run `cargo test -p zeron-syntax`, UI Markdown/Changes tests, the ignored diagnostic benchmark when parser cost changes, and the workspace checks.
 
-Do not add language-specific parsing to a renderer. Unknown languages, binaries,
-oversized sources, incompatible queries, and parse failures must remain plain.
-Highlighting changes foreground color only—never font, weight, style, wrapping,
-height, or scroll geometry.
+Do not add language-specific parsing to a renderer. Unknown languages, binaries, oversized sources, incompatible queries, and parse failures must remain plain. Highlighting changes foreground color only—never font, weight, style, wrapping, height, or scroll geometry.


### PR DESCRIPTION
## Summary

- compose TypeScript and TSX highlighting queries with their inherited language coverage
- add structural Kotlin highlighting for declarations, calls, annotations, properties, and constructor invocations
- bound Dockerfile heredoc injections and cover shell, JSON, YAML, TOML, and XML payloads
- add token-to-HighlightKind regressions for the shared Markdown and Changes consumers, including split diffs

## Testing

- cargo test -p zeron-syntax
- cargo clippy -p zeron-syntax --all-targets -- -D warnings
- cargo test -p zeron-ui markdown
- cargo test -p zeron-ui changes
- rustfmt --edition 2024 --check crates/syntax/tests/quality.rs crates/ui/src/markdown/render.rs crates/ui/src/changes.rs
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790544378&installation_model_id=425430&pr_number=230&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F230&signature=d3d9b82a2cd6650f24e176ebdab6b986730c68e784bec33f0a109972a678cb35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->