### PR TITLE
Composer model/traits chips truncate instead of overlapping the send button

### DIFF
--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -2202,11 +2202,15 @@ impl Pickers {
             })
             // The effort half of the combined model+effort chip (and the space
             // chip's "@ device" tag): muted, no icon — one button, two tones.
-            // `tint` overrides the muted tone (the offline warning).
+            // `tint` overrides the muted tone (the offline warning). Under row
+            // pressure the suffix yields FIRST (large shrink factor) so the
+            // model name — the run's identity — truncates last.
             .when_some(suffix, |el, (suffix, tint)| {
                 el.child(
                     div()
-                        .flex_none()
+                        .flex_shrink(1000.0)
+                        .min_w_0()
+                        .truncate()
                         .text_color(tint.unwrap_or(theme.text_muted.opacity(0.7)))
                         .child(suffix),
                 )
@@ -4057,7 +4061,12 @@ impl Render for Pickers {
             .flex()
             .flex_row()
             .items_center()
-            .flex_none()
+            // Shrinkable under row pressure, like the footer chips: the chip's
+            // own `min_w_0().truncate()` label/suffix only engage when this
+            // cluster is allowed to give up width — `flex_none` here let the
+            // labels paint over the attach/send buttons at narrow widths
+            // instead of truncating (user report).
+            .min_w_0()
             .gap(px(4.0))
             // End-anchored: the menu's right edge sits flush with the chip's
             // right edge (user request), same as the footer's ref popover.


### PR DESCRIPTION
Fixes the composer's combined model+traits chip painting over the attach and send buttons at narrow composer widths (user report screenshot), while preserving the one-chip design (bright model name + muted traits suffix).

## Cause

The chip cluster (`right` in `Pickers::render`) was `flex_none`, so it refused to give up width under row pressure. The chip's label already carries the standard `min_w_0().truncate()` treatment (same as the footer chips), but that only engages once the flex container is allowed to shrink — instead the cluster overflowed and painted over the attach/send buttons. The traits suffix was also `flex_none`, so it could never truncate at all.

## Fix

- `min_w_0` on the cluster (mirroring the footer chips' "shrinkable under row pressure" arrangement); the fixed-size attach/send buttons stay `flex_none` and hold their spots.
- The traits suffix becomes a truncating container with a large `flex_shrink` factor, so under pressure it yields **first** — the model name (the run's identity) truncates last.

## Before / after

~260px composer — before, "High · 200K" runs under the paperclip into the send button; after, the suffix yields and the model name stays whole:

| Before | After |
| --- | --- |
| ![before-260](https://github.com/user-attachments/assets/a35f87f7-fea5-495c-9c1e-1b8b6eb4c561) | ![after-260](https://github.com/user-attachments/assets/fdbc3f9e-c05d-408f-b925-4387402b5803) |

~220px — before, the suffix runs off past the send button; after, the suffix has fully yielded and the model name itself ellipsizes:

| Before | After |
| --- | --- |
| ![before-220](https://github.com/user-attachments/assets/dc37c846-e38b-49f0-8dae-549acc3e5118) | ![after-220](https://github.com/user-attachments/assets/26398ecd-7cee-4a1f-b294-dc5cef81a0da) |

Mid-squeeze (~310px) the suffix ellipsizes gracefully ("High · 2…"):

![after-310](https://github.com/user-attachments/assets/56ac5b71-0b02-47df-9961-c4707d4a88cf)

Wide composer is unchanged — the combined chip reads exactly as designed:

![after-500](https://github.com/user-attachments/assets/b731fa9b-f527-4d2a-9c51-2bc4cfee6994)

Captured on the headless rig with a long-labelled mock model (`ZERON_HARNESS=mock`); `cargo test -p zeron-ui` 575/575 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)