### PR TITLE
Fix unbounded memory growth while scrolling/switching sessions: mimalloc v3 → v2, macOS-only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,10 +91,14 @@ uuid = { version = "1", features = ["v4", "serde"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 
 # misc
-# Global allocator for the binaries: returns freed pages to the OS. System
-# malloc (macOS libmalloc especially) retains the churn high-water mark as
-# permanent RSS - measured as the top residency cause in docs/memory-plan.md.
-mimalloc = "0.1"
+# Global allocator on macOS only: libmalloc retains the churn high-water mark
+# as permanent RSS - measured as the top residency cause in
+# docs/memory-plan.md. Pinned to mimalloc v2: the crate's default (v3.3.2)
+# has the same watermark pathology itself - transient streaming/render churn
+# became permanent RSS (~6x glibc growth, daemon at 908MB for 7.3MB of docs,
+# no idle recovery). Linux stays on glibc, which measured flat on the same
+# workloads.
+mimalloc = { version = "0.1", features = ["v2"] }
 anyhow = "1"
 tempfile = "3"
 thiserror = "2"

--- a/apps/zeron/Cargo.toml
+++ b/apps/zeron/Cargo.toml
@@ -16,12 +16,16 @@ zeron-ui.workspace = true
 zeron-update.workspace = true
 tokio.workspace = true
 clap.workspace = true
-mimalloc.workspace = true
 anyhow.workspace = true
 libc.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+# The custom allocator is macOS-only (see main.rs): glibc measured flat on the
+# same streaming/scroll workloads, so Linux keeps the system allocator.
+[target.'cfg(target_os = "macos")'.dependencies]
+mimalloc.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/apps/zeron/src/main.rs
+++ b/apps/zeron/src/main.rs
@@ -90,9 +90,13 @@ fn workos_client_id_from_env(edge_token: &Option<String>) -> Option<String> {
     }
 }
 
-/// mimalloc: system malloc (macOS libmalloc especially) never returns the
-/// streaming churn's high-water pages, so transient allocation became
-/// permanent RSS (docs/memory-plan.md §1).
+/// mimalloc, macOS only: libmalloc never returns the streaming churn's
+/// high-water pages, so transient allocation became permanent RSS
+/// (docs/memory-plan.md §1). Pinned to mimalloc v2 in the workspace manifest —
+/// the crate's default v3 has the same pathology (churn retained as permanent
+/// RSS, ~6x glibc's growth on identical workloads, no idle recovery). Linux
+/// measured flat on glibc, so it keeps the system allocator.
+#[cfg(target_os = "macos")]
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/docs/memory-plan.md
+++ b/docs/memory-plan.md
@@ -129,6 +129,18 @@ dial-lock hygiene. Verified: full workspace suite green; 20-chat run shows the
 LRU evicting (8×), post-cap growth slope halved, and RSS recovering at idle —
 which the baseline never did. Cold-open stayed on the measured ~62ms path.
 
+**Allocator revision (2026-09-03):** the phase-1 mimalloc adoption itself
+became the top residency cause — `mimalloc = "0.1"` had drifted onto crate
+0.1.52, whose bundled default is mimalloc **v3.3.2**, and v3 retains the
+streaming/render churn as permanent RSS instead of returning it (measured on
+Linux: daemon at 908MB for 7.3MB of docs after six streamed chats, no idle
+recovery; glibc control flat on identical workloads; the ratchet surfaced as
+"memory grows unbounded when scrolling/switching sessions"). Fix: mimalloc is
+now macOS-only (the libmalloc watermark it was adopted for) and pinned to the
+crate's `v2` feature (mimalloc 2.3.2, ~half of v3's retention); Linux runs the
+system allocator. Purge knobs (`MIMALLOC_PURGE_DELAY=0`,
+`MIMALLOC_ABANDONED_PAGE_PURGE=1`) measurably do NOT rescue v3.
+
 Known follow-ups: GPU atlas tiles for raw-bytes images still free only on
 window close (needs a small gpui-fork patch exposing a drop path for
 `ImageSource::Image`); UI-side full-transcript clone per frame


### PR DESCRIPTION
## Memory grows unbounded when scrolling sessions and switching between them

Debugged wing's report end-to-end on a headless rig (sway + seeded mock daemon + scripted wheel-scroll and Ctrl+1-6 session cycling, RSS sampled from `/proc`). **It is not a heap leak.** The transcript's row/tree/render/highlight caches all clear on chat switch, and heaptrack on a system-allocator build shows the churn is freed: peak heap **13.5MB**, genuinely leaked **1.46MB**, on a workload whose RSS climbed by hundreds of MB.

The ratchet is the allocator. `mimalloc = "0.1"` (adopted by the memory plan, 0ed1b1d, to fix the macOS libmalloc watermark) has drifted onto crate 0.1.52, whose `libmimalloc-sys` bundles **mimalloc v3.3.2 by default** — and v3 has the very pathology mimalloc was brought in to cure: it retains the app's transient allocation churn (~47k allocs/s while a session streams; every scroll/switch frame adds more) as permanent RSS and never returns it. Scrolling and switching are exactly what generate frames, so that's when memory climbs — and it never comes back down. Worst observed: a daemon serving six streamed chats at **908MB with 7.3MB of docs on disk**, flat at idle, while a glibc control stayed at ~50-90MB on identical workloads. `MIMALLOC_PURGE_DELAY=0` and `MIMALLOC_ABANDONED_PAGE_PURGE=1` measurably do not rescue v3.

## The fix

- Pin the crate's **`v2` feature** (mimalloc 2.3.2) — roughly half of v3's retention in every scenario.
- Register the global allocator **only on macOS** (the libmalloc watermark it exists for, `docs/memory-plan.md` §1); the dependency moves to a `cfg(target_os = "macos")` target table. **Linux returns to glibc**, which measured flat on every scenario.

## Before / after (Linux, debug build, identical scripted runs)

| Scenario | Before (mimalloc v3, main) | After (this PR) |
|---|---|---|
| Daemon, 1 streaming session, 90s | 77 → **139MB** (+62MB) | 42 → **51MB** (+9MB) |
| Daemon, 6 streaming sessions, 180s | 83 → **134MB**, no recovery after 2min idle | 44 → **58MB**, flat |
| App, 60s cycling Ctrl+1-6 across streaming sessions | 239 → **248MB** (+9MB) | 207 → **209MB** (+2MB) |
| App, 120s continuous scrolling (static transcripts) + 30s idle | 262 → 262MB | 216 → 216MB |
| App idle baseline, identical state | **~50MB higher** than glibc | = glibc |

Supporting A/Bs from the diagnosis: allocator-only comparison on one streaming chat, daemon RSS +90s — glibc **+9.5MB** (true content growth per heaptrack) / mimalloc v2 **+30MB** / mimalloc v3 **+60MB**. The longer/richer interaction script (150s of switching + scrolling against streaming sessions) ratcheted the v3 app **+23MB with no idle recovery** vs glibc **+5MB then flat**. Where the growth is real content (the streamed transcript itself), before and after grow alike — the delta is pure allocator retention.

macOS keeps mimalloc (v2): libmalloc's own watermark behavior is documented in the plan as the original top residency cause, so dropping the custom allocator there would trade one ratchet for the other. v2 is the widely-deployed line; v3's retention regressions are what this PR removes. Worth a quick Activity Monitor sanity pass on a Mac before release.

## Verification

- Full workspace suite: **1206 passed, 0 real failures** (`interrupt_unblocks_a_run_awaiting_input` timed out once under full parallel load — passes 3/3 in isolation and 17/17 on a clean rerun of the e2e binary; it asserts on a 10s wall-clock wait, unrelated to allocation).
- `cargo fmt -p zeron --check` clean; Linux binary confirmed mimalloc-free via `nm` (0 `mi_*` symbols vs 6 before); `Cargo.lock` unchanged (features aren't recorded in the lock).
- App boots, streams, scrolls, and switches sessions normally in the headed rig under the new binary (scenarios C/D above ran on it).

## Follow-ups (out of scope here)

- `doc_host` LRU `resident_estimate = snapshot_bytes × 6` badly underestimates **live-streaming** docs (~10MB real heap per 90s of streaming vs ~1MB snapshot; reopened docs are only ~3MB, so the estimate is fine for those). The 80MB budget can hold much more real memory than budgeted while sessions stream.
- The churn itself (per-tick re-serialize + per-frame re-render) is what feeds any allocator's watermark — memory-plan phase-3 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791013860&installation_model_id=425430&pr_number=241&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F241&signature=6fd70385da1406c1e7bcd4211fabc5143cfd2e54f1b765aae8d97d0a64c42d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->