### PR TITLE
Add Fable 5.1 to the Claude model catalog

### DIFF
--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -3279,7 +3279,7 @@ mod tests {
         let models = models_from_session(&response, &crate::claude::catalog::static_models());
         assert_eq!(
             models.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
-            vec!["Opus 5", "Fable 5", "Sonnet 5", "Haiku 4.5"]
+            vec!["Opus 5", "Fable 5.1", "Sonnet 5", "Haiku 4.5"]
         );
         // The alias rows carry the catalog's per-model ladders.
         assert!(

--- a/crates/harness/src/claude/catalog.rs
+++ b/crates/harness/src/claude/catalog.rs
@@ -153,9 +153,16 @@ fn model(
 pub fn static_models() -> Vec<Model> {
     vec![
         model(
+            "claude-fable-5-1",
+            "Fable 5.1",
+            "Most intelligent model for building agents",
+            FULL_LADDER,
+            vec![context_window()],
+        ),
+        model(
             "claude-fable-5",
             "Fable 5",
-            "Most intelligent model for building agents",
+            "Previous generation Fable",
             FULL_LADDER,
             vec![context_window()],
         ),
@@ -229,6 +236,7 @@ mod tests {
     #[test]
     fn xhigh_family_matching() {
         assert!(supports_xhigh("claude-fable-5"));
+        assert!(supports_xhigh("claude-fable-5-1"));
         assert!(supports_xhigh("claude-opus-5"));
         assert!(supports_xhigh("claude-opus-5[1m]"));
         assert!(supports_xhigh("claude-opus-4-7-20260101"));


### PR DESCRIPTION
## Summary
Claude model discovery was missing Fable 5.1. The Claude catalog (`crates/harness/src/claude/catalog.rs`) is the curated list that both discovery-side enrichment (`models_from_session`) and the UI's display-side normalization (`normalize_model_rows`) read from.

- Add `claude-fable-5-1` ("Fable 5.1") as the new flagship row: full effort ladder through ultracode/ultrathink plus the 200K/1M context-window trait, same shape as Fable 5.
- `claude-fable-5` steps down to "Previous generation Fable".
- Because family-alias matching picks the first (flagship-ordered) row, the bare `fable` alias the Claude adapter advertises now enriches to "Fable 5.1" — updated the alias-enrichment test accordingly.
- `supports_xhigh` already covers the new id via the `fable-5` substring; added an assertion.

## Testing
- `cargo test -p zeron-harness --lib` — 91 passed (includes catalog + alias-enrichment tests)
- `cargo test -p zeron-ui --lib normalize` — passed (versioned ids match exactly, so `claude-fable-5[1m]` folding is unaffected)
- Touched files are `cargo fmt` clean (pre-existing unformatted hunks on main left alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791026028&installation_model_id=425430&pr_number=242&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F242&signature=8869d0c29544e3f977a73bf15bb786f29203519945916bbff5af546378fa832c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->