### PR TITLE
Add Daybreak Blue to the Codex model catalog

### DIFF
--- a/crates/harness/src/codex/catalog.rs
+++ b/crates/harness/src/codex/catalog.rs
@@ -113,19 +113,28 @@ fn service_tier() -> ModelOption {
     }
 }
 
-fn model(id: &str, label: &str, description: &str, ladder: &[ReasoningLevel]) -> Model {
+fn model(
+    id: &str,
+    label: &str,
+    description: &str,
+    ladder: &[ReasoningLevel],
+    options: Vec<ModelOption>,
+) -> Model {
     Model {
         id: id.into(),
         label: label.into(),
         description: (!description.is_empty()).then(|| description.into()),
         reasoning_levels: ladder.to_vec(),
-        options: vec![service_tier()],
+        options,
     }
 }
 
-/// The curated catalog: a snapshot of codex-cli 0.144's `model/list`, newest
-/// family first — efforts as the server reports them (gpt-5.6 goes up to
-/// `ultra`). Mirrors codex.ts's `CODEX_MODELS` fallback.
+/// The curated catalog: a snapshot of codex-cli 0.146's `model/list`, wire
+/// order (newest family first, Daybreak within the current-gen block) —
+/// efforts as the server reports them (gpt-5.6 goes up to `ultra`). Daybreak
+/// Blue reports NO service tiers, so it carries no trait — sending
+/// `serviceTier: priority` for it would be rejected. Mirrors codex.ts's
+/// `CODEX_MODELS` fallback.
 pub(crate) fn static_models() -> Vec<Model> {
     vec![
         model(
@@ -133,42 +142,56 @@ pub(crate) fn static_models() -> Vec<Model> {
             "GPT-5.6-Sol",
             "Frontier reasoning flagship",
             ULTRA_LADDER,
+            vec![service_tier()],
         ),
         model(
             "gpt-5.6-terra",
             "GPT-5.6-Terra",
             "Deep multi-step agentic work",
             ULTRA_LADDER,
+            vec![service_tier()],
         ),
         model(
             "gpt-5.6-luna",
             "GPT-5.6-Luna",
             "Fast frontier model",
             MAX_LADDER,
+            vec![service_tier()],
+        ),
+        model(
+            "gpt-daybreak-blue-latest",
+            "Daybreak Blue",
+            "Frontier model for defensive cybersecurity work",
+            ULTRA_LADDER,
+            Vec::new(),
         ),
         model(
             "gpt-5.5",
             "GPT-5.5",
             "Previous generation flagship",
             XHIGH_LADDER,
+            vec![service_tier()],
         ),
         model(
             "gpt-5.4",
             "GPT-5.4",
             "Reliable general coding",
             XHIGH_LADDER,
+            vec![service_tier()],
         ),
         model(
             "gpt-5.4-mini",
             "GPT-5.4-Mini",
             "Small, fast and capable",
             XHIGH_LADDER,
+            vec![service_tier()],
         ),
         model(
             "gpt-5.3-codex-spark",
             "GPT-5.3-Codex-Spark",
             "Ultra-fast lightweight coding",
             XHIGH_LADDER,
+            vec![service_tier()],
         ),
     ]
 }
@@ -190,13 +213,30 @@ mod tests {
     #[test]
     fn catalog_is_newest_first_with_service_tiers() {
         let models = static_models();
-        assert_eq!(models.len(), 7);
+        assert_eq!(models.len(), 8);
         assert_eq!(models[0].id, "gpt-5.6-sol");
         assert!(models[0].reasoning_levels.contains(&ReasoningLevel::Ultra));
-        assert!(!models[3].reasoning_levels.contains(&ReasoningLevel::Max));
+        assert!(!models[4].reasoning_levels.contains(&ReasoningLevel::Max));
         for m in &models {
             let tier = m.options.iter().find(|o| o.id == "serviceTier");
-            assert!(tier.is_some(), "{} missing serviceTier", m.id);
+            // Daybreak Blue reports no service tiers on the wire.
+            if m.id == "gpt-daybreak-blue-latest" {
+                assert!(tier.is_none(), "{} must not carry serviceTier", m.id);
+            } else {
+                assert!(tier.is_some(), "{} missing serviceTier", m.id);
+            }
         }
+    }
+
+    #[test]
+    fn daybreak_blue_rides_the_full_ultra_ladder() {
+        let models = static_models();
+        let daybreak = models
+            .iter()
+            .find(|m| m.id == "gpt-daybreak-blue-latest")
+            .expect("daybreak blue in catalog");
+        assert_eq!(daybreak.label, "Daybreak Blue");
+        assert!(daybreak.reasoning_levels.contains(&ReasoningLevel::Ultra));
+        assert!(daybreak.options.is_empty());
     }
 }

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -581,12 +581,13 @@ async fn missing_binary_is_not_installed() {
 #[tokio::test]
 async fn models_returns_curated_catalog() {
     let models = harness().models().await.expect("models");
-    assert_eq!(models.len(), 7);
+    assert_eq!(models.len(), 8);
     assert_eq!(models[0].id, "gpt-5.6-sol");
     assert!(models[0].reasoning_levels.contains(&ReasoningLevel::Ultra));
     assert!(
         models
             .iter()
+            .filter(|m| m.id != "gpt-daybreak-blue-latest")
             .all(|m| m.options.iter().any(|o| o.id == "serviceTier"))
     );
 


### PR DESCRIPTION
## Summary
Codex model discovery is **not automatic** — `CodexHarness::models` returns a curated snapshot (`crates/harness/src/codex/catalog.rs`); live `model/list` splicing remains a future seam. So Daybreak Blue, newly granted on the account, never appeared in the picker.

Verified the real model shape against codex-cli 0.146's app-server `model/list` on this machine (the account has access):

- id `gpt-daybreak-blue-latest`, displayName "Daybreak Blue", specialty `cyber`
- efforts low → ultra (same full ladder as Sol/Terra)
- **no service tiers** — unlike the rest of the current gen it advertises neither `serviceTiers` nor `additionalSpeedTiers`, so the row must not carry the Fast-tier trait
- listed after GPT-5.6-Luna in wire order

Changes:
- `model()` helper takes an options vec (mirroring the claude catalog's shape) instead of stamping `serviceTier` on every row
- Daybreak Blue added with the ultra ladder and no options; snapshot comment bumped 0.144 → 0.146
- Tests updated: catalog count 7 → 8, serviceTier assertions except Daybreak, new ladder/options test

## Testing
- `cargo test -p zeron-harness --lib codex` / `--lib models_` — all pass
- `cargo test -p zeron-harness --test codex models_returns_curated_catalog` — passes
- Touched files `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791072863&installation_model_id=425430&pr_number=243&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F243&signature=2f2629216c2c2d2e3d83522a9112f80cc3ec4eb1a9b9b891e8d7fca4256b8a7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->