### PR TITLE
Add horizontal scrolling and fit toggle to chat code blocks

### DIFF
--- a/crates/ui/assets/icons/wrap-text.svg
+++ b/crates/ui/assets/icons/wrap-text.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 6H20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M4 10H17C18.6569 10 20 11.3431 20 13C20 14.6569 18.6569 16 17 16H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 13L9 16L12 19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M4 20H7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -98,6 +98,8 @@ icon_assets![
     // The changes pane's unified/split toggle: a rounded frame halved by a
     // centre rule (Solar Linear weight).
     (SPLIT_COLUMNS, "split-columns"),
+    // Agent Markdown fences: fit/wrap long lines to the available width.
+    (WRAP_TEXT, "wrap-text"),
     (ALT_ARROW_LEFT, "alt-arrow-left"),
     (ALT_ARROW_RIGHT, "alt-arrow-right"),
     (SMARTPHONE, "smartphone"),

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -83,8 +83,9 @@ pub struct RenderOptions {
     /// (previews outside the transcript).
     pub copy: Option<CopyUi>,
     /// Agent-transcript-only fence layout controls and tracked horizontal
-    /// scroll state. `None` keeps non-chat Markdown surfaces unchanged.
-    pub code: Option<CodeUi>,
+    /// scroll state, keyed by the same element discriminator passed to
+    /// [`render_block`]. `None` keeps non-chat Markdown surfaces unchanged.
+    pub code: Option<HashMap<usize, CodeUi>>,
 }
 
 /// Copy-button wiring for one row's code blocks: the handler writes the code
@@ -260,6 +261,43 @@ pub fn render_tree(
         .into_any_element()
 }
 
+fn quote_child_ix(ix: usize, child_ix: usize) -> usize {
+    ix * 100 + child_ix
+}
+
+fn list_child_ix(ix: usize, item_ix: usize, child_ix: usize) -> usize {
+    ix * 100 + item_ix * 10 + child_ix
+}
+
+/// Element discriminators for every code block below `block`. Transcript rows
+/// use this to provision one independent scroll handle per nested fence before
+/// the renderer recursively reaches it.
+pub(crate) fn code_block_indices(block: &Block, ix: usize) -> Vec<usize> {
+    fn collect(block: &Block, ix: usize, out: &mut Vec<usize>) {
+        match block {
+            Block::CodeBlock { .. } => out.push(ix),
+            Block::BlockQuote { children } => {
+                for (child_ix, child) in children.iter().enumerate() {
+                    collect(child, quote_child_ix(ix, child_ix), out);
+                }
+            }
+            Block::List { items, .. } => {
+                for (item_ix, item) in items.iter().enumerate() {
+                    for (child_ix, child) in item.iter().enumerate() {
+                        collect(child, list_child_ix(ix, item_ix, child_ix), out);
+                    }
+                }
+            }
+            Block::Paragraph { .. } | Block::Heading { .. } | Block::Table { .. } | Block::Rule => {
+            }
+        }
+    }
+
+    let mut indices = Vec::new();
+    collect(block, ix, &mut indices);
+    indices
+}
+
 /// Render one block (top-level or nested). `top_ix` is the enclosing top-level
 /// block index (cache invalidation scope); `ix` the per-element discriminator.
 #[allow(clippy::too_many_arguments)]
@@ -312,7 +350,15 @@ pub fn render_block(
             .gap(px(8.0))
             .text_color(theme.text_muted)
             .children(children.iter().enumerate().map(|(ci, child)| {
-                render_block(child, top_ix, ix * 100 + ci, opts, theme, window, None)
+                render_block(
+                    child,
+                    top_ix,
+                    quote_child_ix(ix, ci),
+                    opts,
+                    theme,
+                    window,
+                    None,
+                )
             }))
             .into_any_element(),
         Block::List {
@@ -363,7 +409,7 @@ pub fn render_block(
                             render_block(
                                 child,
                                 top_ix,
-                                ix * 100 + item_ix * 10 + ci,
+                                list_child_ix(ix, item_ix, ci),
                                 opts,
                                 theme,
                                 window,
@@ -1153,7 +1199,7 @@ fn render_code_block(
         None => Vec::new(),
     };
     let scroll_id: SharedString = format!("{}-code{ix}", opts.row_key).into();
-    let code_ui = opts.code.clone();
+    let code_ui = opts.code.as_ref().and_then(|code| code.get(&ix)).cloned();
     let fit_content = code_ui.as_ref().is_some_and(|ui| ui.fit_content);
 
     // Header actions stay in normal header flow so Fit and Copy never overlap.
@@ -1495,7 +1541,19 @@ pub fn runs_for_syntax_line_with_plain(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::markdown::parser::InlineStyle;
+    use crate::markdown::parser::{InlineStyle, parse_full};
+
+    #[test]
+    fn code_block_indices_include_nested_quotes_and_lists() {
+        let quoted = parse_full("> ```rust\n> let x = 1;\n> ```\n");
+        assert_eq!(code_block_indices(&quoted.blocks[0].block, 0), vec![0]);
+
+        let listed = parse_full("- Result:\n\n  ```json\n  {\"ok\":true}\n  ```\n");
+        assert_eq!(code_block_indices(&listed.blocks[0].block, 0), vec![1]);
+
+        let top_level = parse_full("paragraph\n\n```text\nvalue\n```\n");
+        assert_eq!(code_block_indices(&top_level.blocks[1].block, 1), vec![1]);
+    }
 
     /// Model GPUI's upstream affinity at a soft-wrap boundary: byte 5 is
     /// reported at the end of row 0, while byte 6 is after the first glyph on

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -15,9 +15,9 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use gpui::{
-    AnyElement, BorderStyle, Bounds, FontStyle, FontWeight, Hsla, InteractiveText, SharedString,
-    StyledText, TextRun, UnderlineStyle, Window, canvas, div, font, point, prelude::*, px, quad,
-    size,
+    AnyElement, BorderStyle, Bounds, Context, FontStyle, FontWeight, Hsla, InteractiveText, Render,
+    SharedString, StyledText, TextRun, UnderlineStyle, Window, canvas, div, font, point,
+    prelude::*, px, quad, size,
 };
 use zeron_syntax::{HighlightKind, HighlightSpan, HighlightedDocument};
 
@@ -36,6 +36,9 @@ pub const CODE_TEXT_SIZE: f32 = 12.5;
 pub const CODE_LINE_HEIGHT: f32 = 18.0;
 pub const CODE_PADDING_X: f32 = 12.0;
 pub const CODE_PADDING_Y: f32 = 10.0;
+const CODE_HEADER_HEIGHT: f32 = 28.0;
+const CODE_ACTION_SIZE: f32 = 22.0;
+const CODE_SCROLLBAR_HIT_HEIGHT: f32 = 10.0;
 
 // Table metrics — a port of mugen-markdown 0.6.2's `TableBlock` under zeron's
 // resolved md theme. The design is frameless ("flat hairline"): 1px horizontal
@@ -79,6 +82,9 @@ pub struct RenderOptions {
     /// Code-block copy-button plumbing (round 9): `None` renders no button
     /// (previews outside the transcript).
     pub copy: Option<CopyUi>,
+    /// Agent-transcript-only fence layout controls and tracked horizontal
+    /// scroll state. `None` keeps non-chat Markdown surfaces unchanged.
+    pub code: Option<CodeUi>,
 }
 
 /// Copy-button wiring for one row's code blocks: the handler writes the code
@@ -90,6 +96,65 @@ pub struct CopyUi {
     pub copied_ix: Option<usize>,
 }
 
+type HoverHandler = Rc<dyn Fn(bool, &mut Window, &mut gpui::App)>;
+type PointerHandler = Rc<dyn Fn(gpui::Pixels, &mut Window, &mut gpui::App)>;
+type ReleaseHandler = Rc<dyn Fn(&mut Window, &mut gpui::App)>;
+
+/// Transcript-owned interaction for the one fenced block represented by a
+/// virtualized Markdown row. The renderer owns only layout/chrome; callbacks
+/// keep durable preference and mutable scroll state in [`crate::transcript`].
+#[derive(Clone)]
+pub struct CodeUi {
+    pub key: SharedString,
+    pub fit_content: bool,
+    pub scroll: gpui::ScrollHandle,
+    pub scrollbar: Option<CodeScrollbarUi>,
+    pub toggle_fit: Rc<dyn Fn(&mut Window, &mut gpui::App)>,
+    pub viewport_hover: HoverHandler,
+    pub drag_move: PointerHandler,
+}
+
+#[derive(Clone)]
+pub struct CodeScrollbarUi {
+    pub metrics: crate::popover::HorizontalScrollbarMetrics,
+    pub active: bool,
+    pub hover: HoverHandler,
+    pub press: PointerHandler,
+    pub release: ReleaseHandler,
+}
+
+#[derive(Clone)]
+struct CodeScrollbarDrag {
+    key: SharedString,
+}
+
+struct CodeScrollbarDragGhost;
+
+impl Render for CodeScrollbarDragGhost {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        gpui::Empty
+    }
+}
+
+struct CodeBlockTooltip(&'static str);
+
+impl Render for CodeBlockTooltip {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = Theme::of(cx);
+        div()
+            .px(px(8.0))
+            .py(px(6.0))
+            .rounded(px(6.0))
+            .border_1()
+            .border_color(theme.border_strong)
+            .bg(theme.surface_raised)
+            .shadow_md()
+            .text_size(px(11.0))
+            .text_color(theme.text)
+            .child(self.0)
+    }
+}
+
 impl RenderOptions {
     /// Options for a completed (non-streaming) row — no veil, no cache.
     pub fn settled(row_key: SharedString) -> Self {
@@ -99,6 +164,7 @@ impl RenderOptions {
             cache: None,
             now: Instant::now(),
             copy: None,
+            code: None,
         }
     }
 }
@@ -1087,11 +1153,12 @@ fn render_code_block(
         None => Vec::new(),
     };
     let scroll_id: SharedString = format!("{}-code{ix}", opts.row_key).into();
-    // Copy affordance (round 9; no source counterpart — the original block is
-    // header + body only): a small ghost button in the block's top-right,
-    // absolutely overlaid so clicking / the "Copied" flash never shifts
-    // layout. Sits centered in the header when there is one, floats over the
-    // first code line otherwise.
+    let code_ui = opts.code.clone();
+    let fit_content = code_ui.as_ref().is_some_and(|ui| ui.fit_content);
+
+    // Header actions stay in normal header flow so Fit and Copy never overlap.
+    // The feedback label may widen Copy, but the fixed header height keeps the
+    // virtual row stable.
     let copy_button = opts.copy.clone().map(|copy| {
         let copied = copy.copied_ix == Some(ix);
         let code_text: SharedString = code.to_string().into();
@@ -1099,10 +1166,7 @@ fn render_code_block(
         let fade_key = format!("{}-copy{ix}", opts.row_key);
         div()
             .id(SharedString::from(fade_key.clone()))
-            .absolute()
-            .top(px(3.0))
-            .right(px(5.0))
-            .h(px(20.0))
+            .h(px(CODE_ACTION_SIZE))
             .px(px(6.0))
             .rounded(px(5.0))
             .flex()
@@ -1120,7 +1184,10 @@ fn render_code_block(
             .on_hover(crate::motion::hover_listener(fade_key))
             .text_size(px(10.5))
             .text_color(theme.text_muted)
-            .on_click(move |_, window, cx| handler(ix, code_text.clone(), window, cx))
+            .on_click(move |_, window, cx| {
+                cx.stop_propagation();
+                handler(ix, code_text.clone(), window, cx);
+            })
             .child(
                 crate::icons::icon(if copied {
                     crate::icons::CHECK
@@ -1132,7 +1199,216 @@ fn render_code_block(
             )
             .when(copied, |el| el.child(SharedString::from("Copied")))
     });
-    div()
+
+    let fit_button = code_ui.as_ref().map(|ui| {
+        let toggle = ui.toggle_fit.clone();
+        let fade_key = format!("{}-fit{ix}", opts.row_key);
+        let base = if fit_content {
+            crate::theme::ink(0.09)
+        } else {
+            gpui::transparent_black()
+        };
+        let hover = crate::theme::ink(if fit_content { 0.13 } else { 0.08 });
+        div()
+            .id(SharedString::from(fade_key.clone()))
+            .size(px(CODE_ACTION_SIZE))
+            .rounded(px(6.0))
+            .flex()
+            .items_center()
+            .justify_center()
+            .cursor_pointer()
+            .bg(crate::motion::hover_blend(&fade_key, base, hover))
+            .on_hover(crate::motion::hover_listener(fade_key))
+            .on_click(move |_, window, cx| {
+                cx.stop_propagation();
+                toggle(window, cx);
+            })
+            .tooltip(move |_, cx| {
+                cx.new(move |_| {
+                    CodeBlockTooltip(if fit_content {
+                        "Use horizontal scrolling"
+                    } else {
+                        "Fit content"
+                    })
+                })
+                .into()
+            })
+            .child(
+                crate::icons::icon(crate::icons::WRAP_TEXT)
+                    .size(px(13.0))
+                    .text_color(theme.text_muted),
+            )
+    });
+
+    let show_header = language.is_some() || copy_button.is_some() || fit_button.is_some();
+    let header = show_header.then(|| {
+        div()
+            .h(px(CODE_HEADER_HEIGHT))
+            .pl(px(CODE_PADDING_X))
+            .pr(px(5.0))
+            .border_b_1()
+            .border_color(theme.border)
+            .bg(crate::theme::ink(0.02))
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_between()
+            .child(
+                div()
+                    .min_w_0()
+                    .text_size(px(11.0))
+                    .text_color(theme.text_muted)
+                    .children(language.map(|lang| SharedString::from(lang.to_string()))),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap(px(2.0))
+                    .children(fit_button)
+                    .children(copy_button),
+            )
+    });
+
+    let lines = div()
+        .map(|el| {
+            if fit_content {
+                el.w_full().min_w_0()
+            } else {
+                el.min_w_full().flex_none()
+            }
+        })
+        .px(px(CODE_PADDING_X))
+        .py(px(CODE_PADDING_Y))
+        .font_family(theme.font_mono.clone())
+        .text_size(px(CODE_TEXT_SIZE))
+        .line_height(px(CODE_LINE_HEIGHT))
+        .map(|el| {
+            if fit_content {
+                el.whitespace_normal()
+            } else {
+                el.whitespace_nowrap()
+            }
+        })
+        .flex()
+        .flex_col()
+        .children((0..cached.lines.len()).scan(0usize, move |off, li| {
+            let (line, runs) = &cached.lines[li];
+            let start = *off;
+            *off = start + line.len() + 1; // +1 for the '\n'
+            let local = slice_spans(&veil_spans, start, start + line.len());
+            let runs = apply_veil(runs.clone(), &local);
+            Some(
+                div()
+                    .map(|el| {
+                        if fit_content {
+                            el.w_full().min_w_0().min_h(px(CODE_LINE_HEIGHT))
+                        } else {
+                            el.h(px(CODE_LINE_HEIGHT)).flex_none()
+                        }
+                    })
+                    .child(StyledText::new(line.clone()).with_runs(runs)),
+            )
+        }));
+
+    let body: AnyElement = if let Some(ui) = code_ui.as_ref() {
+        if fit_content {
+            div()
+                .w_full()
+                .min_w_0()
+                .overflow_hidden()
+                .child(lines)
+                .into_any_element()
+        } else {
+            let mut scroller = div()
+                .id(scroll_id)
+                .w_full()
+                .min_w_0()
+                .flex()
+                .overflow_x_scroll()
+                .track_scroll(&ui.scroll)
+                .child(lines);
+            // A vertical wheel over code must keep bubbling to the transcript;
+            // only a true horizontal gesture moves this local viewport.
+            scroller.style().restrict_scroll_to_axis = Some(true);
+            scroller.into_any_element()
+        }
+    } else {
+        // Non-transcript previews keep their existing native scroll behavior.
+        div()
+            .id(scroll_id)
+            .w_full()
+            .overflow_x_scroll()
+            .child(lines)
+            .into_any_element()
+    };
+
+    let scrollbar = (!fit_content)
+        .then(|| code_ui.as_ref())
+        .flatten()
+        .and_then(|ui| {
+            let bar = ui.scrollbar.as_ref()?;
+            let metrics = bar.metrics;
+            let hover = bar.hover.clone();
+            let press = bar.press.clone();
+            let release_up = bar.release.clone();
+            let release_out = bar.release.clone();
+            let thumb_height = if bar.active {
+                crate::popover::MENU_SCROLLBAR_HOVER_THUMB_WIDTH
+            } else {
+                crate::popover::MENU_SCROLLBAR_THUMB_WIDTH
+            };
+            Some(
+                div()
+                    .id(SharedString::from(format!("{}-scrollbar", ui.key)))
+                    .absolute()
+                    .left(px(0.0))
+                    .right(px(0.0))
+                    .bottom(px(0.0))
+                    .h(px(CODE_SCROLLBAR_HIT_HEIGHT))
+                    .on_hover(move |hovered, window, cx| hover(*hovered, window, cx))
+                    .on_mouse_down(gpui::MouseButton::Left, move |event, window, cx| {
+                        press(event.position.x, window, cx);
+                    })
+                    .on_drag(
+                        CodeScrollbarDrag {
+                            key: ui.key.clone(),
+                        },
+                        |_, _, _, cx| {
+                            cx.stop_propagation();
+                            cx.new(|_| CodeScrollbarDragGhost)
+                        },
+                    )
+                    .on_mouse_up(gpui::MouseButton::Left, move |_, window, cx| {
+                        release_up(window, cx)
+                    })
+                    .on_mouse_up_out(gpui::MouseButton::Left, move |_, window, cx| {
+                        release_out(window, cx)
+                    })
+                    .child(
+                        div()
+                            .absolute()
+                            .left(px(
+                                crate::popover::MENU_SCROLLBAR_TRACK_INSET + metrics.thumb_left
+                            ))
+                            .bottom(px(2.0))
+                            .w(px(metrics.thumb_width))
+                            .h(px(thumb_height))
+                            .rounded(px(thumb_height / 2.0))
+                            .bg(theme
+                                .text_faint
+                                .opacity(if bar.active { 0.68 } else { 0.5 })),
+                    ),
+            )
+        });
+
+    let mut block = div()
+        .id(SharedString::from(format!(
+            "{}-code-frame{ix}",
+            opts.row_key
+        )))
         .rounded(px(10.0))
         // Faint white wash over the near-black panel ≈ #101010 (zeron's code
         // surface), with the hairline border.
@@ -1141,49 +1417,27 @@ fn render_code_block(
         .border_color(theme.border)
         .overflow_hidden()
         .relative()
-        .when_some(language, |el, lang| {
-            el.child(
-                div()
-                    .px(px(CODE_PADDING_X))
-                    .py(px(5.0))
-                    .border_b_1()
-                    .border_color(theme.border)
-                    // A whisper of tone separation between header and body.
-                    .bg(crate::theme::ink(0.02))
-                    .text_size(px(11.0))
-                    .text_color(theme.text_muted)
-                    .child(SharedString::from(lang.to_string())),
-            )
-        })
-        .child(
-            div()
-                .id(scroll_id)
-                .overflow_x_scroll()
-                .px(px(CODE_PADDING_X))
-                .py(px(CODE_PADDING_Y))
-                .font_family(theme.font_mono.clone())
-                .text_size(px(CODE_TEXT_SIZE))
-                .line_height(px(CODE_LINE_HEIGHT))
-                .whitespace_nowrap()
-                .flex()
-                .flex_col()
-                .children((0..cached.lines.len()).scan(0usize, move |off, li| {
-                    let (line, runs) = &cached.lines[li];
-                    let start = *off;
-                    *off = start + line.len() + 1; // +1 for the '\n'
-                    let local = slice_spans(&veil_spans, start, start + line.len());
-                    let runs = apply_veil(runs.clone(), &local);
-                    Some(
-                        div()
-                            .h(px(CODE_LINE_HEIGHT))
-                            .flex_none()
-                            .child(StyledText::new(line.clone()).with_runs(runs)),
-                    )
-                })),
-        )
-        // Overlay LAST so it paints above the header/body.
-        .children(copy_button)
-        .into_any_element()
+        .children(header)
+        .child(div().w_full().relative().child(body).children(scrollbar));
+    if let Some(ui) = code_ui {
+        let viewport_hover = ui.viewport_hover.clone();
+        let drag_move = ui.drag_move.clone();
+        let drag_key = ui.key;
+        block = block
+            .on_hover(move |hovered, window, cx| viewport_hover(*hovered, window, cx))
+            .on_drag_move(
+                move |event: &gpui::DragMoveEvent<CodeScrollbarDrag>, window, cx| {
+                    let Some(drag) = event.dragged_item().downcast_ref::<CodeScrollbarDrag>()
+                    else {
+                        return;
+                    };
+                    if drag.key == drag_key {
+                        drag_move(event.event.position.x, window, cx);
+                    }
+                },
+            );
+    }
+    block.into_any_element()
 }
 
 /// Paint color for a token class — the soft syntax palette (round 9: the

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -1372,6 +1372,155 @@ impl MenuScrollbarState {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Horizontal floating scrollbar — the same quiet rail used by menus, rotated
+// for local code planes. Kept separate from `MenuScrollbarState` so a code
+// fence can own one state per stable block while existing menu callers retain
+// their vertical API.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HorizontalScrollbarMetrics {
+    pub track_width: f32,
+    pub thumb_left: f32,
+    pub thumb_width: f32,
+    pub max_scroll: f32,
+}
+
+impl HorizontalScrollbarMetrics {
+    pub fn travel(self) -> f32 {
+        (self.track_width - self.thumb_width).max(0.0)
+    }
+
+    pub fn from_viewport(
+        viewport_width: f32,
+        max_scroll: f32,
+        current_scroll: f32,
+    ) -> Option<Self> {
+        let max_scroll = max_scroll.max(0.0);
+        if viewport_width <= 0.0 || max_scroll <= 0.0 {
+            return None;
+        }
+        let track_width = (viewport_width - MENU_SCROLLBAR_TRACK_INSET * 2.0).max(0.0);
+        if track_width <= 0.0 {
+            return None;
+        }
+        let content_width = viewport_width + max_scroll;
+        let thumb_width = (track_width * viewport_width / content_width)
+            .max(MENU_SCROLLBAR_MIN_THUMB)
+            .min(track_width);
+        let current_scroll = current_scroll.clamp(0.0, max_scroll);
+        let travel = (track_width - thumb_width).max(0.0);
+        Some(Self {
+            track_width,
+            thumb_left: travel * current_scroll / max_scroll,
+            thumb_width,
+            max_scroll,
+        })
+    }
+}
+
+/// Hover/drag state for one horizontal code viewport. Geometry comes from the
+/// same tracked [`gpui::ScrollHandle`] that moves the code, so the thumb always
+/// represents the block's real local overflow (virtual transcript height is
+/// irrelevant here).
+#[derive(Default)]
+pub struct HorizontalScrollbarState {
+    viewport_hovered: bool,
+    bar_hovered: bool,
+    grab: Option<f32>,
+}
+
+impl HorizontalScrollbarState {
+    pub fn metrics(&self, scroll: &gpui::ScrollHandle) -> Option<HorizontalScrollbarMetrics> {
+        let bounds = scroll.bounds();
+        let max_scroll = f32::from(scroll.max_offset().x).max(0.0);
+        let current_scroll = (-f32::from(scroll.offset().x)).clamp(0.0, max_scroll);
+        HorizontalScrollbarMetrics::from_viewport(
+            f32::from(bounds.size.width),
+            max_scroll,
+            current_scroll,
+        )
+    }
+
+    pub fn visible(&self) -> bool {
+        self.viewport_hovered || self.grab.is_some()
+    }
+
+    pub fn active(&self) -> bool {
+        self.bar_hovered || self.grab.is_some()
+    }
+
+    pub fn set_viewport_hovered(&mut self, hovered: bool) -> bool {
+        if self.viewport_hovered == hovered {
+            return false;
+        }
+        self.viewport_hovered = hovered;
+        if !hovered && self.grab.is_none() {
+            self.bar_hovered = false;
+        }
+        true
+    }
+
+    pub fn set_bar_hovered(&mut self, hovered: bool) -> bool {
+        let active = hovered || self.grab.is_some();
+        if self.bar_hovered == active {
+            return false;
+        }
+        self.bar_hovered = active;
+        true
+    }
+
+    pub fn begin_press(&mut self, scroll: &gpui::ScrollHandle, pointer_x: Pixels) -> bool {
+        let Some(metrics) = self.metrics(scroll) else {
+            return false;
+        };
+        let pointer_in_track = self.pointer_in_track(scroll, pointer_x);
+        let grab_offset = if (metrics.thumb_left..=metrics.thumb_left + metrics.thumb_width)
+            .contains(&pointer_in_track)
+        {
+            pointer_in_track - metrics.thumb_left
+        } else {
+            metrics.thumb_width / 2.0
+        };
+        self.grab = Some(grab_offset);
+        self.drag_to(scroll, pointer_x);
+        true
+    }
+
+    pub fn drag_to(&self, scroll: &gpui::ScrollHandle, pointer_x: Pixels) -> bool {
+        let Some(grab_offset) = self.grab else {
+            return false;
+        };
+        let Some(metrics) = self.metrics(scroll) else {
+            return false;
+        };
+        let thumb_left =
+            (self.pointer_in_track(scroll, pointer_x) - grab_offset).clamp(0.0, metrics.travel());
+        let scroll_to = if metrics.travel() <= 0.0 {
+            0.0
+        } else {
+            thumb_left / metrics.travel() * metrics.max_scroll
+        };
+        let offset = scroll.offset();
+        scroll.set_offset(gpui::Point::new(px(-scroll_to), offset.y));
+        true
+    }
+
+    pub fn end_press(&mut self) -> bool {
+        self.grab = None;
+        if !self.viewport_hovered && self.bar_hovered {
+            self.bar_hovered = false;
+            return true;
+        }
+        false
+    }
+
+    fn pointer_in_track(&self, scroll: &gpui::ScrollHandle, pointer_x: Pixels) -> f32 {
+        f32::from(pointer_x - scroll.bounds().left()) - MENU_SCROLLBAR_TRACK_INSET
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1520,5 +1669,27 @@ mod tests {
         // Negative offsets clamp to the top.
         let m = MenuScrollbarMetrics::from_viewport(100.0, 9900.0, -3.0).unwrap();
         assert_eq!(m.thumb_top, 0.0);
+    }
+
+    #[test]
+    fn horizontal_scrollbar_metrics_match_the_vertical_treatment() {
+        let m = HorizontalScrollbarMetrics::from_viewport(300.0, 300.0, 150.0).unwrap();
+        assert_eq!(m.track_width, 292.0);
+        assert_eq!(m.thumb_width, 146.0);
+        assert_eq!(m.travel(), 146.0);
+        assert_eq!(m.thumb_left, 73.0);
+        assert_eq!(m.max_scroll, 300.0);
+    }
+
+    #[test]
+    fn horizontal_scrollbar_hides_without_overflow_and_clamps_position() {
+        assert_eq!(
+            HorizontalScrollbarMetrics::from_viewport(300.0, 0.0, 0.0),
+            None
+        );
+        let m = HorizontalScrollbarMetrics::from_viewport(100.0, 9900.0, 99_999.0).unwrap();
+        assert_eq!(m.thumb_left, 92.0 - MENU_SCROLLBAR_MIN_THUMB);
+        let m = HorizontalScrollbarMetrics::from_viewport(100.0, 9900.0, -3.0).unwrap();
+        assert_eq!(m.thumb_left, 0.0);
     }
 }

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -255,6 +255,9 @@ pub struct UiSettings {
     pub theme_selection: zeron_theme::ThemeSelection,
     /// Changes pane: side-by-side diffs instead of the unified stack.
     pub diff_split: bool,
+    /// Agent-sent Markdown fences: wrap long lines to the chat width instead
+    /// of exposing their horizontal scroll plane.
+    pub code_fences_fit_content: bool,
     /// Interactive identity overlay; imported themes default to their own accent.
     pub accent: zeron_theme::AccentSelection,
     /// Glass policy, independent from the selected appearance, theme, and accent.
@@ -294,6 +297,7 @@ impl Default for UiSettings {
             ui_font_size: crate::typography::UiFontSize::default(),
             theme_selection: zeron_theme::ThemeSelection::default(),
             diff_split: false,
+            code_fences_fit_content: false,
             accent: zeron_theme::AccentSelection::default(),
             surface: zeron_theme::SurfacePreference::default(),
             legacy_accent_color: None,
@@ -799,12 +803,15 @@ mod tests {
                 dark: "catppuccin-mocha".into(),
             },
             diff_split: true,
+            code_fences_fit_content: true,
             accent: zeron_theme::AccentSelection::Preset(zeron_theme::AccentPreset::Cyan),
             surface: zeron_theme::SurfacePreference::Frosted,
             legacy_accent_color: None,
         };
         settings.save(dir.path()).unwrap();
         assert_eq!(UiSettings::load(dir.path()), settings);
+        let json = std::fs::read_to_string(UiSettings::path(dir.path())).unwrap();
+        assert!(json.contains(r#""codeFencesFitContent": true"#));
     }
 
     #[test]
@@ -963,6 +970,7 @@ mod tests {
         let loaded = UiSettings::load(dir.path());
         assert_eq!(loaded.sidebar_width, SIDEBAR_MAX);
         assert_eq!(loaded.right_pane_width, RIGHT_PANE_MIN);
+        assert!(!loaded.code_fences_fit_content);
     }
 
     #[test]

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -68,6 +68,10 @@ pub struct SettingsStore {
     data_dir: PathBuf,
     revision: u64,
     saved_revision: u64,
+    /// In-process invalidation token for transcript code-fence layout. Unlike
+    /// the persisted revision, this advances only when the global Fit choice
+    /// changes, including a change back to its previous value.
+    code_fences_generation: u64,
     save_task: Option<Task<()>>,
 }
 
@@ -82,6 +86,20 @@ impl SettingsStore {
         self.saved_revision = self.saved_revision.max(revision);
         self.saved_revision == self.revision
     }
+
+    fn update_current(&mut self, mutate: impl FnOnce(&mut UiSettings)) -> bool {
+        let before = self.current.clone();
+        mutate(&mut self.current);
+        self.current = self.current.clone().clamped();
+        if self.current == before {
+            return false;
+        }
+        if self.current.code_fences_fit_content != before.code_fences_fit_content {
+            self.code_fences_generation = self.code_fences_generation.wrapping_add(1);
+        }
+        self.revision = self.revision.wrapping_add(1);
+        true
+    }
 }
 
 pub fn init(settings: UiSettings, data_dir: impl Into<PathBuf>, cx: &mut App) {
@@ -90,6 +108,7 @@ pub fn init(settings: UiSettings, data_dir: impl Into<PathBuf>, cx: &mut App) {
         data_dir: data_dir.into(),
         revision: 0,
         saved_revision: 0,
+        code_fences_generation: 0,
         save_task: None,
     });
 }
@@ -101,18 +120,22 @@ pub fn current(cx: &App) -> UiSettings {
         .unwrap_or_default()
 }
 
+/// Monotonic id of the global code-fence layout choice. Every transcript
+/// compares this during render so inactive subagent tabs can observe all mode
+/// transitions when they next become visible.
+pub fn code_fences_generation(cx: &App) -> u64 {
+    cx.try_global::<SettingsStore>()
+        .map(|store| store.code_fences_generation)
+        .unwrap_or_default()
+}
+
 pub fn update(policy: SavePolicy, cx: &mut App, mutate: impl FnOnce(&mut UiSettings)) -> bool {
-    let Some(store) = cx.try_global::<SettingsStore>() else {
-        return false;
-    };
-    let before = store.current.clone();
-    let store = cx.global_mut::<SettingsStore>();
-    mutate(&mut store.current);
-    store.current = store.current.clone().clamped();
-    if store.current == before {
+    if !cx.has_global::<SettingsStore>() {
         return false;
     }
-    store.revision = store.revision.wrapping_add(1);
+    if !cx.global_mut::<SettingsStore>().update_current(mutate) {
+        return false;
+    }
     schedule(policy, cx);
     true
 }
@@ -822,6 +845,7 @@ mod tests {
             data_dir: dir.path().to_path_buf(),
             revision: 0,
             saved_revision: 0,
+            code_fences_generation: 0,
             save_task: None,
         };
 
@@ -843,6 +867,30 @@ mod tests {
             reloaded.ui_font_family,
             crate::typography::UiFontFamily::Installed("Arial".into())
         );
+    }
+
+    #[test]
+    fn code_fence_generation_tracks_every_mode_transition_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = SettingsStore {
+            current: UiSettings::default(),
+            data_dir: dir.path().to_path_buf(),
+            revision: 0,
+            saved_revision: 0,
+            code_fences_generation: 0,
+            save_task: None,
+        };
+
+        assert!(store.update_current(|settings| settings.sidebar_width = 300.0));
+        assert_eq!(store.code_fences_generation, 0);
+
+        assert!(store.update_current(|settings| settings.code_fences_fit_content = true));
+        assert_eq!(store.code_fences_generation, 1);
+        assert!(store.update_current(|settings| settings.code_fences_fit_content = false));
+        assert_eq!(store.code_fences_generation, 2);
+
+        assert!(!store.update_current(|settings| settings.code_fences_fit_content = false));
+        assert_eq!(store.code_fences_generation, 2);
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -26,7 +26,7 @@
 //! whole turn is already visible, so there is nothing to scroll to.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ops::Range;
 use std::rc::Rc;
 use std::sync::{Arc, Weak};
@@ -35,8 +35,8 @@ use std::time::{Duration, Instant};
 use gpui::{
     AnyElement, BorderStyle, Bounds, ClipboardItem, Context, Entity, ListAlignment, ListOffset,
     ListScrollEvent, ListState, MouseButton, MouseMoveEvent, MouseUpEvent, ObjectFit, Pixels,
-    Point, SharedString, StyledImage as _, StyledText, Subscription, Task, TextRun, Window, canvas,
-    div, img, list, prelude::*, px, quad,
+    Point, ScrollHandle, SharedString, StyledImage as _, StyledText, Subscription, Task, TextRun,
+    Window, canvas, div, img, list, prelude::*, px, quad,
 };
 
 use zeron_doc::{MessagePart, MessageRole, MessageStatus, SessionMessageEntry, SubagentStatus};
@@ -2125,6 +2125,12 @@ struct SavedViewportCache {
     recency: VecDeque<String>,
 }
 
+#[derive(Default)]
+struct CodeFenceRuntime {
+    scroll: ScrollHandle,
+    scrollbar: crate::popover::HorizontalScrollbarState,
+}
+
 impl SavedViewportCache {
     fn insert(&mut self, chat_id: String, viewport: SavedViewport) {
         if self.by_chat.contains_key(&chat_id) {
@@ -2277,6 +2283,11 @@ pub struct Transcript {
     /// the companion task after ~1.2s.
     copied_code: Option<(SharedString, usize)>,
     copied_clear: Option<Task<()>>,
+    /// Per-visible-fence horizontal offsets and scrollbar hover/drag state.
+    /// Keys use the transcript's stable row identity, so streaming → settled
+    /// rerenders keep their local scroll position without leaking state for
+    /// blocks no longer present in the selected chat.
+    code_fences: HashMap<SharedString, CodeFenceRuntime>,
     /// Entry whose hover action is showing transient copied-check feedback.
     copied_message: Option<SharedString>,
     copied_message_clear: Option<Task<()>>,
@@ -2439,6 +2450,7 @@ impl Transcript {
             hovered_entry: None,
             copied_code: None,
             copied_clear: None,
+            code_fences: HashMap::new(),
             copied_message: None,
             copied_message_clear: None,
             attachment_preview: None,
@@ -3449,6 +3461,26 @@ impl Transcript {
             new_rows.extend(self.rows_for(echo, true));
         }
 
+        // Runtime scroll handles follow the stable code rows exactly. A live
+        // block keeps its handle through completion; deleted/reindexed tail
+        // blocks and the previous chat cannot accumulate stale handles.
+        let active_code_fences: HashSet<SharedString> = new_rows
+            .iter()
+            .filter_map(|row| match &row.kind {
+                RowKind::Markdown { tree, block_ix } | RowKind::LiveMarkdown { tree, block_ix }
+                    if tree
+                        .blocks
+                        .get(*block_ix)
+                        .is_some_and(|top| matches!(&top.block, Block::CodeBlock { .. })) =>
+                {
+                    Some(format!("{}#code{block_ix}", row.id).into())
+                }
+                _ => None,
+            })
+            .collect();
+        self.code_fences
+            .retain(|key, _| active_code_fences.contains(key));
+
         // Text already streamed before this (re)attach is the veil BASELINE:
         // its rows' veils seed instead of fading (render creates them from
         // this set), so only post-switch appends animate. Captured from the
@@ -4244,17 +4276,20 @@ impl Transcript {
                 column.into_any_element()
             }
             RowKind::Markdown { tree, block_ix } => {
+                let Some(top) = tree.blocks.get(*block_ix) else {
+                    return gpui::Empty.into_any_element();
+                };
+                let code = matches!(&top.block, Block::CodeBlock { .. })
+                    .then(|| self.code_ui_for(&row.id, *block_ix, cx));
                 let opts = RenderOptions {
                     row_key: row.id.clone(),
                     veil: None,
                     cache: (!render_cache_disabled()).then(|| self.render_cache.clone()),
                     now: Instant::now(),
                     copy: Some(self.copy_ui_for(&row.id, cx)),
+                    code,
                 };
                 let highlight = self.code_highlight_for(&row.id, tree, Some(*block_ix), cx);
-                let Some(top) = tree.blocks.get(*block_ix) else {
-                    return gpui::Empty.into_any_element();
-                };
                 render::render_block(
                     &top.block,
                     *block_ix,
@@ -4269,6 +4304,11 @@ impl Transcript {
                 )
             }
             RowKind::LiveMarkdown { tree, block_ix } => {
+                let Some(top) = tree.blocks.get(*block_ix) else {
+                    return gpui::Empty.into_any_element();
+                };
+                let code = matches!(&top.block, Block::CodeBlock { .. })
+                    .then(|| self.code_ui_for(&row.id, *block_ix, cx));
                 // Per-appended-chunk fade veil (opacity only — layout commits
                 // instantly). Reduced motion renders with no veil at all.
                 // Baseline rows (text already streamed when the transcript
@@ -4292,11 +4332,9 @@ impl Transcript {
                     cache: (!render_cache_disabled()).then(|| self.render_cache.clone()),
                     now: Instant::now(),
                     copy: Some(self.copy_ui_for(&row.id, cx)),
+                    code,
                 };
                 let highlight = self.code_highlight_for(&row.id, tree, Some(*block_ix), cx);
-                let Some(top) = tree.blocks.get(*block_ix) else {
-                    return gpui::Empty.into_any_element();
-                };
                 let timer = frame_stats_enabled().then(Instant::now);
                 let el = render::render_block(
                     &top.block,
@@ -4513,6 +4551,149 @@ impl Transcript {
                     .ok();
             });
         render::CopyUi { handler, copied_ix }
+    }
+
+    /// Interactive layout/scroll plumbing for one agent Markdown fence. The
+    /// persisted Fit choice is global, while each block retains only its own
+    /// ephemeral horizontal offset and hover/drag state.
+    fn code_ui_for(
+        &mut self,
+        row_id: &SharedString,
+        block_ix: usize,
+        cx: &mut Context<Self>,
+    ) -> render::CodeUi {
+        let key: SharedString = format!("{row_id}#code{block_ix}").into();
+        let runtime = self.code_fences.entry(key.clone()).or_default();
+        let scroll = runtime.scroll.clone();
+        let fit_content = crate::settings::current(cx).code_fences_fit_content;
+        let scrollbar = (!fit_content)
+            .then(|| runtime.scrollbar.metrics(&scroll))
+            .flatten()
+            .filter(|_| runtime.scrollbar.visible())
+            .map(|metrics| render::CodeScrollbarUi {
+                metrics,
+                active: runtime.scrollbar.active(),
+                hover: {
+                    let entity = cx.weak_entity();
+                    let key = key.clone();
+                    Rc::new(move |hovered, _window, cx| {
+                        entity
+                            .update(cx, |this, cx| {
+                                let Some(runtime) = this.code_fences.get_mut(&key) else {
+                                    return;
+                                };
+                                if runtime.scrollbar.set_bar_hovered(hovered) {
+                                    cx.notify();
+                                }
+                            })
+                            .ok();
+                    })
+                },
+                press: {
+                    let entity = cx.weak_entity();
+                    let key = key.clone();
+                    Rc::new(move |pointer_x, _window, cx| {
+                        entity
+                            .update(cx, |this, cx| {
+                                let Some(runtime) = this.code_fences.get_mut(&key) else {
+                                    return;
+                                };
+                                let scroll = runtime.scroll.clone();
+                                if runtime.scrollbar.begin_press(&scroll, pointer_x) {
+                                    cx.stop_propagation();
+                                    cx.notify();
+                                }
+                            })
+                            .ok();
+                    })
+                },
+                release: {
+                    let entity = cx.weak_entity();
+                    let key = key.clone();
+                    Rc::new(move |_window, cx| {
+                        entity
+                            .update(cx, |this, cx| {
+                                let Some(runtime) = this.code_fences.get_mut(&key) else {
+                                    return;
+                                };
+                                runtime.scrollbar.end_press();
+                                cx.notify();
+                            })
+                            .ok();
+                    })
+                },
+            });
+
+        render::CodeUi {
+            key: key.clone(),
+            fit_content,
+            scroll,
+            scrollbar,
+            toggle_fit: {
+                let entity = cx.weak_entity();
+                Rc::new(move |_window, cx| {
+                    entity
+                        .update(cx, |this, cx| {
+                            let fit = !crate::settings::current(cx).code_fences_fit_content;
+                            crate::settings::update(
+                                crate::settings::SavePolicy::Immediate,
+                                cx,
+                                |settings| settings.code_fences_fit_content = fit,
+                            );
+                            // Horizontal positions are not a preference. A
+                            // mode change starts every block at its left edge.
+                            for runtime in this.code_fences.values() {
+                                runtime.scroll.set_offset(Point::default());
+                            }
+                            // Fit changes every code row from analytic to
+                            // measured height (or back), so invalidate all
+                            // virtual-list measurements in one anchored pass.
+                            this.list.remeasure();
+                            if this.pinned {
+                                this.wake_spring();
+                            }
+                            if this.own_turn.is_some() {
+                                this.own_turn_kick = true;
+                            }
+                            cx.notify();
+                            cx.refresh_windows();
+                        })
+                        .ok();
+                })
+            },
+            viewport_hover: {
+                let entity = cx.weak_entity();
+                let key = key.clone();
+                Rc::new(move |hovered, _window, cx| {
+                    entity
+                        .update(cx, |this, cx| {
+                            let Some(runtime) = this.code_fences.get_mut(&key) else {
+                                return;
+                            };
+                            if runtime.scrollbar.set_viewport_hovered(hovered) {
+                                cx.notify();
+                            }
+                        })
+                        .ok();
+                })
+            },
+            drag_move: {
+                let entity = cx.weak_entity();
+                Rc::new(move |pointer_x, _window, cx| {
+                    entity
+                        .update(cx, |this, cx| {
+                            let Some(runtime) = this.code_fences.get_mut(&key) else {
+                                return;
+                            };
+                            let scroll = runtime.scroll.clone();
+                            if runtime.scrollbar.drag_to(&scroll, pointer_x) {
+                                cx.notify();
+                            }
+                        })
+                        .ok();
+                })
+            },
+        }
     }
 
     /// Request highlights for the code blocks of a tree. `only` limits to one

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2230,6 +2230,10 @@ pub struct Transcript {
     /// Family and size changes can alter prose wrapping without changing row
     /// identity, so the virtual list must explicitly discard cached heights.
     typography_generation: u32,
+    /// Last global code-fence layout generation applied to this transcript.
+    /// Each instance owns separate scroll handles and list measurements, so
+    /// every one must reset itself after a global Fit-mode transition.
+    code_fences_generation: u64,
     highlights: HighlightStore,
     show_jump_button: bool,
     /// Distance from the bottom at the last observation (wheel event or spring
@@ -2428,6 +2432,7 @@ impl Transcript {
             veil_attach_pending: true,
             render_cache: Rc::new(RefCell::new(RenderCache::default())),
             typography_generation: crate::typography::generation(cx),
+            code_fences_generation: crate::settings::code_fences_generation(cx),
             highlights: HighlightStore::default(),
             show_jump_button: false,
             last_scroll_distance: 0.0,
@@ -4631,35 +4636,16 @@ impl Transcript {
             scroll,
             scrollbar,
             toggle_fit: {
-                let entity = cx.weak_entity();
                 Rc::new(move |_window, cx| {
-                    entity
-                        .update(cx, |this, cx| {
-                            let fit = !crate::settings::current(cx).code_fences_fit_content;
-                            crate::settings::update(
-                                crate::settings::SavePolicy::Immediate,
-                                cx,
-                                |settings| settings.code_fences_fit_content = fit,
-                            );
-                            // Horizontal positions are not a preference. A
-                            // mode change starts every block at its left edge.
-                            for runtime in this.code_fences.values() {
-                                runtime.scroll.set_offset(Point::default());
-                            }
-                            // Fit changes every code row from analytic to
-                            // measured height (or back), so invalidate all
-                            // virtual-list measurements in one anchored pass.
-                            this.list.remeasure();
-                            if this.pinned {
-                                this.wake_spring();
-                            }
-                            if this.own_turn.is_some() {
-                                this.own_turn_kick = true;
-                            }
-                            cx.notify();
-                            cx.refresh_windows();
-                        })
-                        .ok();
+                    let fit = !crate::settings::current(cx).code_fences_fit_content;
+                    crate::settings::update(
+                        crate::settings::SavePolicy::Immediate,
+                        cx,
+                        |settings| settings.code_fences_fit_content = fit,
+                    );
+                    // Every Transcript observes the generation change during
+                    // its next render and resets its own local runtime state.
+                    cx.refresh_windows();
                 })
             },
             viewport_hover: {
@@ -6019,6 +6005,24 @@ fn entry_fingerprint(entry: &SessionMessageEntry, pending: bool) -> u64 {
 
 impl Render for Transcript {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let code_fences_generation = crate::settings::code_fences_generation(cx);
+        if self.code_fences_generation != code_fences_generation {
+            self.code_fences_generation = code_fences_generation;
+            // Horizontal positions are ephemeral. Reset every block owned by
+            // this Transcript even when the toggle originated in another one.
+            for runtime in self.code_fences.values() {
+                runtime.scroll.set_offset(Point::default());
+            }
+            // Fit changes every code row from analytic to measured height (or
+            // back), including virtual rows outside the current viewport.
+            self.list.remeasure();
+            if self.pinned {
+                self.wake_spring();
+            }
+            if self.own_turn.is_some() {
+                self.own_turn_kick = true;
+            }
+        }
         let typography_generation = crate::typography::generation(cx);
         if self.typography_generation != typography_generation {
             self.typography_generation = typography_generation;

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -3466,16 +3466,19 @@ impl Transcript {
         // blocks and the previous chat cannot accumulate stale handles.
         let active_code_fences: HashSet<SharedString> = new_rows
             .iter()
-            .filter_map(|row| match &row.kind {
-                RowKind::Markdown { tree, block_ix } | RowKind::LiveMarkdown { tree, block_ix }
-                    if tree
-                        .blocks
+            .flat_map(|row| match &row.kind {
+                RowKind::Markdown { tree, block_ix } | RowKind::LiveMarkdown { tree, block_ix } => {
+                    tree.blocks
                         .get(*block_ix)
-                        .is_some_and(|top| matches!(&top.block, Block::CodeBlock { .. })) =>
-                {
-                    Some(format!("{}#code{block_ix}", row.id).into())
+                        .map(|top| {
+                            render::code_block_indices(&top.block, *block_ix)
+                                .into_iter()
+                                .map(|ix| format!("{}#code{ix}", row.id).into())
+                                .collect()
+                        })
+                        .unwrap_or_default()
                 }
-                _ => None,
+                _ => Vec::new(),
             })
             .collect();
         self.code_fences
@@ -4279,8 +4282,7 @@ impl Transcript {
                 let Some(top) = tree.blocks.get(*block_ix) else {
                     return gpui::Empty.into_any_element();
                 };
-                let code = matches!(&top.block, Block::CodeBlock { .. })
-                    .then(|| self.code_ui_for(&row.id, *block_ix, cx));
+                let code = self.code_uis_for(&row.id, &top.block, *block_ix, cx);
                 let opts = RenderOptions {
                     row_key: row.id.clone(),
                     veil: None,
@@ -4307,8 +4309,7 @@ impl Transcript {
                 let Some(top) = tree.blocks.get(*block_ix) else {
                     return gpui::Empty.into_any_element();
                 };
-                let code = matches!(&top.block, Block::CodeBlock { .. })
-                    .then(|| self.code_ui_for(&row.id, *block_ix, cx));
+                let code = self.code_uis_for(&row.id, &top.block, *block_ix, cx);
                 // Per-appended-chunk fade veil (opacity only — layout commits
                 // instantly). Reduced motion renders with no veil at all.
                 // Baseline rows (text already streamed when the transcript
@@ -4694,6 +4695,24 @@ impl Transcript {
                 })
             },
         }
+    }
+
+    /// Provision independent interaction state for every fence nested below
+    /// one virtualized Markdown row (top-level, quoted, or listed).
+    fn code_uis_for(
+        &mut self,
+        row_id: &SharedString,
+        block: &Block,
+        block_ix: usize,
+        cx: &mut Context<Self>,
+    ) -> Option<HashMap<usize, render::CodeUi>> {
+        let indices = render::code_block_indices(block, block_ix);
+        (!indices.is_empty()).then(|| {
+            indices
+                .into_iter()
+                .map(|ix| (ix, self.code_ui_for(row_id, ix, cx)))
+                .collect()
+        })
     }
 
     /// Request highlights for the code blocks of a tree. `only` limits to one


### PR DESCRIPTION
## Summary

- give agent-authored Markdown code fences stable horizontal scrolling with an on-hover, draggable scrollbar
- add a **Fit content** action beside Copy that toggles wrapped and horizontally scrollable layouts
- persist the last selected layout globally so users do not need to toggle every code block
- keep non-transcript Markdown previews unchanged

## Implementation notes

- code-fence scroll handles use stable transcript row identities and survive streaming-to-settled rendering
- toggling Fit resets transient horizontal offsets and remeasures the virtualized transcript while preserving its anchor behavior
- the scrollbar is hidden when content fits or wrapping is enabled, and vertical wheel gestures continue bubbling to the transcript
- this is independent from #227, which covers diff scrolling

## Test plan

- `cargo check -p zeron-ui --all-targets`
- `cargo test -p zeron-ui` (577 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791082340&installation_model_id=425430&pr_number=244&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F244&signature=d265874b68c0a0488e6ec5c4df1afdc7fbb312ee39fd051006db23ac2f23c5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->