### PR TITLE
Add Copy Path to the session context menu

### DIFF
--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -144,6 +144,23 @@ fn conversation_width(viewport: f32, sidebar: f32, right: f32) -> f32 {
     (viewport - sidebar - right).max(0.0)
 }
 
+/// The host-resolved checkout root for a chat, falling back to its current
+/// working directory when source context has not landed yet. Source context
+/// from a previous cwd must not make a retargeted chat copy the old checkout.
+fn chat_checkout_path(chat: &zeron_proto::Chat) -> Option<&str> {
+    let cwd = chat
+        .cwd
+        .as_deref()
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty() && std::path::Path::new(cwd).is_absolute())?;
+    chat.source_context
+        .as_ref()
+        .filter(|source| source.cwd.trim() == cwd)
+        .map(|source| source.repo_root.trim())
+        .filter(|root| !root.is_empty() && std::path::Path::new(root).is_absolute())
+        .or(Some(cwd))
+}
+
 fn titlebar_new_session_alpha(is_chat_route: bool, has_selected_chat: bool) -> f32 {
     if is_chat_route && has_selected_chat {
         1.0
@@ -2324,6 +2341,22 @@ impl Shell {
         if let Some(id) = id.filter(|id| !id.trim().is_empty()) {
             cx.write_to_clipboard(ClipboardItem::new_string(id));
             self.sidebar_notice = Some("Harness session ID copied".into());
+        }
+        self.close_chat_menu(cx);
+        cx.notify();
+    }
+
+    fn copy_chat_checkout_path(&mut self, chat_id: &str, cx: &mut Context<Self>) {
+        let path = self
+            .state
+            .read(cx)
+            .chats
+            .iter()
+            .find(|chat| chat.id == chat_id)
+            .and_then(chat_checkout_path)
+            .map(str::to_owned);
+        if let Some(path) = path {
+            cx.write_to_clipboard(ClipboardItem::new_string(path));
         }
         self.close_chat_menu(cx);
         cx.notify();
@@ -5243,9 +5276,11 @@ impl Shell {
                         .as_ref()
                         .and_then(|chat| chat.harness_session_id.as_deref())
                         .is_some_and(|id| !id.trim().is_empty());
+                    let has_checkout_path = chat.as_ref().and_then(chat_checkout_path).is_some();
                     let zeron_id = chat_id.clone();
                     let harness_id = chat_id.clone();
                     let session_chat_id = chat_id.clone();
+                    let path_chat_id = chat_id.clone();
                     menu.child(
                         popover::menu_row(&theme, false, format!("chat-copy-back-{chat_id}"))
                             .id("chat-copy-back")
@@ -5263,6 +5298,21 @@ impl Shell {
                             .child(SharedString::from("Back")),
                     )
                     .child(popover::menu_separator())
+                    .when(has_checkout_path, |menu| {
+                        menu.child(
+                            popover::menu_row(&theme, false, format!("chat-copy-path-{chat_id}"))
+                                .id("chat-copy-path")
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    this.copy_chat_checkout_path(&path_chat_id, cx)
+                                }))
+                                .child(
+                                    icon(icons::COPY)
+                                        .size(px(16.0))
+                                        .text_color(theme.text_muted),
+                                )
+                                .child(SharedString::from("Copy Path")),
+                        )
+                    })
                     .child(
                         popover::menu_row(&theme, false, format!("chat-copy-zeron-{chat_id}"))
                             .id("chat-copy-zeron")
@@ -7728,6 +7778,71 @@ impl Render for Shell {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn chat_with_checkout_path(
+        cwd: Option<&str>,
+        source: Option<(&str, &str)>,
+    ) -> zeron_proto::Chat {
+        zeron_proto::Chat {
+            id: "chat".into(),
+            device_id: "remote-device".into(),
+            title: None,
+            archived: false,
+            cwd: cwd.map(str::to_owned),
+            branch: None,
+            checkout_id: None,
+            source_context: source.map(|(source_cwd, repo_root)| {
+                zeron_proto::ConversationSourceContext {
+                    checkout_id: "checkout".into(),
+                    repo_root: repo_root.into(),
+                    cwd: source_cwd.into(),
+                    branch: "main".into(),
+                    head_sha: None,
+                    observed_at: chrono::Utc::now(),
+                }
+            }),
+            config: None,
+            last_message_preview: None,
+            last_message_at: None,
+            created_at: chrono::Utc::now(),
+            harness_session_id: None,
+            harness_session_cwd: None,
+            space_id: None,
+            last_seen_at: None,
+            room_gen: None,
+        }
+    }
+
+    #[test]
+    fn copy_path_prefers_the_matching_host_resolved_checkout_root() {
+        let chat = chat_with_checkout_path(
+            Some("/remote/repo/packages/app"),
+            Some(("/remote/repo/packages/app", "/remote/repo")),
+        );
+
+        assert_eq!(chat_checkout_path(&chat), Some("/remote/repo"));
+    }
+
+    #[test]
+    fn copy_path_falls_back_to_current_cwd_when_source_context_is_stale() {
+        let chat = chat_with_checkout_path(
+            Some("/remote/worktrees/new-checkout"),
+            Some(("/remote/repo", "/remote/repo")),
+        );
+
+        assert_eq!(
+            chat_checkout_path(&chat),
+            Some("/remote/worktrees/new-checkout")
+        );
+    }
+
+    #[test]
+    fn copy_path_is_unavailable_without_an_absolute_checkout_path() {
+        for cwd in [None, Some(""), Some("~"), Some(".")] {
+            let chat = chat_with_checkout_path(cwd, None);
+            assert_eq!(chat_checkout_path(&chat), None);
+        }
+    }
 
     #[test]
     fn every_default_shortcut_binds_on_this_platform() {


### PR DESCRIPTION
## Summary

- Add a Copy Path action to the desktop session context menu.
- Prefer the host-resolved Git checkout root when it matches the current working directory, with the current absolute working directory as a safe fallback.
- Support remote sessions by copying the path in the host device filesystem namespace without requiring an RPC.
- Hide the action when no absolute checkout path is available, including projectless sessions that use ~.

## UX note

Copy Path is intentionally silent: it writes to the clipboard and closes the menu without showing a confirmation banner. If you prefer it to not be silent, let me know. 

The existing copy items use sidebar_notice for confirmation. In normal use, those banners disappear only when the user clicks them; they do not currently have a timeout. The component also appears to have been designed primarily for error handling, as indicated by its persistent danger styling. A follow-up should consider giving these confirmation banners a timeout or introducing a dedicated transient success notification.

## Testing

- cargo test -p zeron-ui copy_path
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791090739&installation_model_id=425430&pr_number=245&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F245&signature=3c801251933654573ddfb17ac53cff0f77d29159d4d748263f9c8a9d9ad7ddb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->