### PR TITLE
Add GPT-6 Astra to Codex model catalogs

### DIFF
--- a/apps/ios/Zeron/Composer/ComposerView.swift
+++ b/apps/ios/Zeron/Composer/ComposerView.swift
@@ -218,6 +218,7 @@ struct ComposerView: View {
     @State private var uploadError: String?
     @State private var showModelPicker = false
     @State private var showTraitPicker = false
+    @State private var showOptionPicker: ModelOptionInfo?
     /// Live catalog for the chat's harness from its space's device.
     @State private var catalogs: [String: [ModelInfo]] = [:]
 
@@ -228,13 +229,22 @@ struct ComposerView: View {
     }
 
     private var currentModel: ModelInfo {
-        models.first { $0.id == chat.config?.model } ?? HarnessCatalog.defaultModel(for: harness)
+        models.first { $0.id == chat.config?.model }
+            ?? models.first
+            ?? HarnessCatalog.defaultModel(for: harness)
     }
 
     private var currentReasoning: String? {
         guard !currentModel.reasoningLevels.isEmpty else { return nil }
         if let r = chat.config?.reasoning, currentModel.reasoningLevels.contains(r) { return r }
         return HarnessCatalog.defaultReasoning(for: currentModel)
+    }
+
+    private func currentChoice(for option: ModelOptionInfo) -> ModelOptionChoiceInfo {
+        HarnessCatalog.selectedChoice(
+            for: option,
+            selectedId: chat.config?.modelOptions[option.id]?.stringValue
+        )
     }
 
     var body: some View {
@@ -276,7 +286,7 @@ struct ComposerView: View {
                 sendEnabled: true,
                 showStop: runLive,
                 busy: uploading,
-                keepExpanded: showModelPicker || showTraitPicker,
+                keepExpanded: showModelPicker || showTraitPicker || showOptionPicker != nil,
                 onSend: send,
                 onStop: { store.sendInterrupt() },
                 attachments: attachments,
@@ -297,6 +307,11 @@ struct ComposerView: View {
                 if let currentReasoning {
                     ComposerChip(label: HarnessCatalog.reasoningLabel(currentReasoning)) {
                         showTraitPicker = true
+                    }
+                }
+                ForEach(currentModel.options) { option in
+                    ComposerChip(label: currentChoice(for: option).label) {
+                        showOptionPicker = option
                     }
                 }
             }
@@ -331,6 +346,12 @@ struct ComposerView: View {
                 levels: currentModel.reasoningLevels
             )
         }
+        .sheet(item: $showOptionPicker) { option in
+            ModelOptionPickerSheet(option: option, choiceId: Binding(
+                get: { currentChoice(for: option).id },
+                set: { writeOption(option: option, choiceId: $0) }
+            ))
+        }
         .task(id: "\(chat.id)/\(harness)") {
             guard let space = model.space(for: chat) else { return }
             catalogs[harness] = await model.listModels(space: space, harness: harness)
@@ -344,12 +365,37 @@ struct ComposerView: View {
     }
 
     /// Merge a model/effort change into the chat's config row (LWW; the host
-    /// picks it up on the next run dispatch). Copies preserve modelOptions.
+    /// picks it up on the next run dispatch). Compatible model options survive
+    /// edits; changing model prunes traits the destination does not advertise.
     private func writeConfig(model newModel: String?, reasoning newReasoning: String?) {
         var config = chat.config ?? ChatConfig(harness: harness, model: nil,
                                                reasoning: nil, sandbox: "workspace-write")
+        let changedModel = newModel != nil && newModel != config.model
         config.model = newModel
         config.reasoning = newReasoning
+        if changedModel, let newModel,
+           let target = models.first(where: { $0.id == newModel }) {
+            var compatible: [String: JSONValue] = [:]
+            for option in target.options {
+                guard let selected = config.modelOptions[option.id]?.stringValue,
+                      selected != option.defaultChoice,
+                      option.choices.contains(where: { $0.id == selected }) else { continue }
+                compatible[option.id] = .string(selected)
+            }
+            config.modelOptions = compatible
+        }
+        model.setChatConfig(chatId: chat.id, config: config)
+    }
+
+    private func writeOption(option: ModelOptionInfo, choiceId: String) {
+        var config = chat.config ?? ChatConfig(harness: harness, model: currentModel.id,
+                                               reasoning: currentReasoning,
+                                               sandbox: "workspace-write")
+        if choiceId == option.defaultChoice {
+            config.modelOptions.removeValue(forKey: option.id)
+        } else {
+            config.modelOptions[option.id] = .string(choiceId)
+        }
         model.setChatConfig(chatId: chat.id, config: config)
     }
 

--- a/apps/ios/Zeron/Models/HarnessCatalog.swift
+++ b/apps/ios/Zeron/Models/HarnessCatalog.swift
@@ -1,8 +1,8 @@
 // Harness + model catalogs — ports of crates/harness's curated static
-// catalogs (claude/catalog.rs, codex/catalog.rs). The desktop overlays these
-// on runtime discovery; the phone uses them directly for the pickers.
-// Defaults mirror pickers.rs: first catalog row, reasoning xhigh where the
-// ladder has it, else high.
+// catalogs (claude/catalog.rs, codex/catalog.rs). Desktop discovers at runtime;
+// the phone mirrors its run device's live catalog and falls back to these.
+// Defaults mirror pickers.rs: first catalog row, reasoning high where the
+// ladder has it, else medium/first.
 
 import Foundation
 
@@ -11,12 +11,35 @@ struct HarnessInfo: Identifiable, Hashable {
     let label: String
 }
 
+struct ModelOptionChoiceInfo: Identifiable, Hashable {
+    let id: String
+    let label: String
+}
+
+struct ModelOptionInfo: Identifiable, Hashable {
+    let id: String
+    let label: String
+    let choices: [ModelOptionChoiceInfo]
+    let defaultChoice: String
+}
+
 struct ModelInfo: Identifiable, Hashable {
     let id: String
     let label: String
     let description: String?
     /// Unified reasoning ladder, lowercase wire values. Empty = no efforts.
     let reasoningLevels: [String]
+    /// Harness-specific traits such as Codex Standard/Fast.
+    let options: [ModelOptionInfo]
+
+    init(id: String, label: String, description: String?, reasoningLevels: [String],
+         options: [ModelOptionInfo] = []) {
+        self.id = id
+        self.label = label
+        self.description = description
+        self.reasoningLevels = reasoningLevels
+        self.options = options
+    }
 }
 
 enum HarnessCatalog {
@@ -52,6 +75,12 @@ enum HarnessCatalog {
     private static let codexUltraLadder = ["low", "medium", "high", "xhigh", "max", "ultra"]
     private static let codexMaxLadder = ["low", "medium", "high", "xhigh", "max"]
     private static let codexXhighLadder = ["low", "medium", "high", "xhigh"]
+    private static let codexServiceTier = [
+        ModelOptionInfo(id: "serviceTier", label: "Service Tier", choices: [
+            ModelOptionChoiceInfo(id: "default", label: "Standard"),
+            ModelOptionChoiceInfo(id: "fast", label: "Fast"),
+        ], defaultChoice: "default"),
+    ]
 
     static func models(for harness: String) -> [ModelInfo] {
         switch harness {
@@ -98,20 +127,33 @@ enum HarnessCatalog {
             ]
         case "codex":
             return [
+                ModelInfo(id: "gpt-6-astra", label: "GPT-6-Astra",
+                          description: "Our most capable model for complex, demanding work.",
+                          reasoningLevels: codexUltraLadder, options: codexServiceTier),
                 ModelInfo(id: "gpt-5.6-sol", label: "GPT-5.6-Sol",
-                          description: "Frontier reasoning flagship", reasoningLevels: codexUltraLadder),
+                          description: "Frontier reasoning flagship", reasoningLevels: codexUltraLadder,
+                          options: codexServiceTier),
                 ModelInfo(id: "gpt-5.6-terra", label: "GPT-5.6-Terra",
-                          description: "Deep multi-step agentic work", reasoningLevels: codexUltraLadder),
+                          description: "Deep multi-step agentic work", reasoningLevels: codexUltraLadder,
+                          options: codexServiceTier),
                 ModelInfo(id: "gpt-5.6-luna", label: "GPT-5.6-Luna",
-                          description: "Fast frontier model", reasoningLevels: codexMaxLadder),
+                          description: "Fast frontier model", reasoningLevels: codexMaxLadder,
+                          options: codexServiceTier),
+                ModelInfo(id: "gpt-daybreak-blue-latest", label: "Daybreak Blue",
+                          description: "Frontier model for defensive cybersecurity work",
+                          reasoningLevels: codexUltraLadder),
                 ModelInfo(id: "gpt-5.5", label: "GPT-5.5",
-                          description: "Previous generation flagship", reasoningLevels: codexXhighLadder),
+                          description: "Previous generation flagship", reasoningLevels: codexXhighLadder,
+                          options: codexServiceTier),
                 ModelInfo(id: "gpt-5.4", label: "GPT-5.4",
-                          description: "Reliable general coding", reasoningLevels: codexXhighLadder),
+                          description: "Reliable general coding", reasoningLevels: codexXhighLadder,
+                          options: codexServiceTier),
                 ModelInfo(id: "gpt-5.4-mini", label: "GPT-5.4-Mini",
-                          description: "Small, fast and capable", reasoningLevels: codexXhighLadder),
+                          description: "Small, fast and capable", reasoningLevels: codexXhighLadder,
+                          options: codexServiceTier),
                 ModelInfo(id: "gpt-5.3-codex-spark", label: "GPT-5.3-Codex-Spark",
-                          description: "Ultra-fast lightweight coding", reasoningLevels: codexXhighLadder),
+                          description: "Ultra-fast lightweight coding", reasoningLevels: codexXhighLadder,
+                          options: codexServiceTier),
             ]
         default:  // claude-code (mock shares it)
             return [
@@ -135,10 +177,20 @@ enum HarnessCatalog {
         models(for: harness)[0]
     }
 
-    /// pickers.rs:126 — X-High when the ladder has it, else High.
+    /// pickers.rs — High when available, then Medium, then the first level.
     static func defaultReasoning(for model: ModelInfo) -> String? {
         if model.reasoningLevels.isEmpty { return nil }
-        return model.reasoningLevels.contains("xhigh") ? "xhigh" : "high"
+        if model.reasoningLevels.contains("high") { return "high" }
+        if model.reasoningLevels.contains("medium") { return "medium" }
+        return model.reasoningLevels.first
+    }
+
+    static func selectedChoice(for option: ModelOptionInfo,
+                               selectedId: String?) -> ModelOptionChoiceInfo {
+        option.choices.first { $0.id == selectedId }
+            ?? option.choices.first { $0.id == option.defaultChoice }
+            ?? option.choices.first
+            ?? ModelOptionChoiceInfo(id: option.defaultChoice, label: option.defaultChoice)
     }
 
     static func reasoningLabel(_ level: String) -> String {

--- a/apps/ios/Zeron/Sync/WorkspaceStore.swift
+++ b/apps/ios/Zeron/Sync/WorkspaceStore.swift
@@ -568,18 +568,39 @@ final class WorkspaceStore {
     }
 
     func listModels(deviceId: String, harness: String) async -> [ModelInfo]? {
+        struct WireChoice: Decodable {
+            var id: String
+            var label: String
+        }
+        struct WireOption: Decodable {
+            var id: String
+            var label: String
+            var choices: [WireChoice]
+            var defaultChoice: String
+        }
         struct WireModel: Decodable {
             var id: String
             var label: String
             var description: String?
             var reasoningLevels: [String]?
+            var options: [WireOption]?
         }
         let wire: [WireModel]? = try? await relay(for: deviceId)
             .call(method: "ListModels", params: ["harness": harness])
         return wire.map { models in
             models.map {
                 ModelInfo(id: $0.id, label: $0.label, description: $0.description,
-                          reasoningLevels: $0.reasoningLevels ?? [])
+                          reasoningLevels: $0.reasoningLevels ?? [],
+                          options: ($0.options ?? []).map { option in
+                              ModelOptionInfo(
+                                  id: option.id,
+                                  label: option.label,
+                                  choices: option.choices.map {
+                                      ModelOptionChoiceInfo(id: $0.id, label: $0.label)
+                                  },
+                                  defaultChoice: option.defaultChoice
+                              )
+                          })
             }
         }
     }

--- a/apps/ios/Zeron/Views/NewSessionView.swift
+++ b/apps/ios/Zeron/Views/NewSessionView.swift
@@ -21,6 +21,7 @@ struct NewSessionView: View {
     @State private var draft = ""
     @State private var showPicker = false
     @State private var showTraitPicker = false
+    @State private var showOptionPicker: ModelOptionInfo?
     @State private var showRefPicker = false
     @State private var showCheckoutPicker = false
     @State private var attachments: [StagedAttachment] = []
@@ -32,6 +33,7 @@ struct NewSessionView: View {
     @State private var liveHarnesses: [HarnessInfo]?
     /// Live per-harness catalogs from the space's device (static fallback).
     @State private var catalogs: [String: [ModelInfo]] = [:]
+    @State private var optionSelections: [String: String] = [:]
     @State private var refs: [RepoRef] = []
     @State private var selectedRef: String?
     @State private var checkoutKind: CheckoutKind = .local
@@ -61,6 +63,22 @@ struct NewSessionView: View {
         if selectedModel.reasoningLevels.isEmpty { return nil }
         if selectedModel.reasoningLevels.contains(storedReasoning) { return storedReasoning }
         return HarnessCatalog.defaultReasoning(for: selectedModel)
+    }
+
+    private func selectedChoice(for option: ModelOptionInfo) -> ModelOptionChoiceInfo {
+        HarnessCatalog.selectedChoice(for: option, selectedId: optionSelections[option.id])
+    }
+
+    /// Only non-default picks ride the run, matching the desktop picker.
+    private var resolvedModelOptions: [String: JSONValue] {
+        var result: [String: JSONValue] = [:]
+        for option in selectedModel.options {
+            let choice = selectedChoice(for: option)
+            if choice.id != option.defaultChoice {
+                result[option.id] = .string(choice.id)
+            }
+        }
+        return result
     }
 
     var body: some View {
@@ -187,6 +205,12 @@ struct NewSessionView: View {
                 set: { storedReasoning = $0 ?? "" }
             ), levels: selectedModel.reasoningLevels)
         }
+        .sheet(item: $showOptionPicker) { option in
+            ModelOptionPickerSheet(option: option, choiceId: Binding(
+                get: { selectedChoice(for: option).id },
+                set: { optionSelections[option.id] = $0 }
+            ))
+        }
         .photosPicker(isPresented: $showPhotoPicker, selection: $pickerItems,
                       maxSelectionCount: 8, matching: .images)
         .onChange(of: pickerItems) { _, items in
@@ -240,6 +264,12 @@ struct NewSessionView: View {
                     ComposerChip(label: HarnessCatalog.reasoningLabel(reasoning)) {
                         focused = false
                         showTraitPicker = true
+                    }
+                }
+                ForEach(selectedModel.options) { option in
+                    ComposerChip(label: selectedChoice(for: option).label) {
+                        focused = false
+                        showOptionPicker = option
                     }
                 }
             }
@@ -373,7 +403,8 @@ struct NewSessionView: View {
         let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         busy = true
         let config = ChatConfig(harness: harness, model: selectedModel.id,
-                                reasoning: reasoning, sandbox: "workspace-write")
+                                reasoning: reasoning, modelOptions: resolvedModelOptions,
+                                sandbox: "workspace-write")
         Task { @MainActor in
             var cwd: String?
             let branch = selectedRef
@@ -689,6 +720,61 @@ struct TraitPickerSheet: View {
         case "ultra": return "Highest Codex tier"
         case "ultracode": return "X-High plus the ultracode setting"
         case "ultrathink": return "Deep-thinking prompt mode"
+        default: return nil
+        }
+    }
+}
+
+// MARK: - Model option picker sheet
+
+/// Generic harness option picker. Codex uses it for Standard/Fast; decoding
+/// the wire shape keeps iOS ready for further server-advertised choices.
+struct ModelOptionPickerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let option: ModelOptionInfo
+    @Binding var choiceId: String
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    SheetLabel(option.label)
+                    ForEach(option.choices) { choice in
+                        PickRow(title: choice.label,
+                                subtitle: hint(for: choice),
+                                selected: choiceId == choice.id) {
+                            UISelectionFeedbackGenerator().selectionChanged()
+                            choiceId = choice.id
+                        }
+                    }
+                }
+                .padding(20)
+                .padding(.bottom, 12)
+            }
+            .background(SheetStyle.panel)
+            .navigationTitle(option.label)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button { dismiss() } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 13, weight: .semibold))
+                    }
+                    .accessibilityLabel("Close")
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .presentationCornerRadius(32)
+        .preferredColorScheme(.dark)
+    }
+
+    private func hint(for choice: ModelOptionChoiceInfo) -> String? {
+        guard option.id == "serviceTier" else { return nil }
+        switch choice.id {
+        case "default": return "Standard response speed"
+        case "fast": return "Faster responses with increased usage"
         default: return nil
         }
     }

--- a/apps/ios/ZeronTests/HarnessCatalogTests.swift
+++ b/apps/ios/ZeronTests/HarnessCatalogTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Zeron
+
+final class HarnessCatalogTests: XCTestCase {
+    func testCodexFallbackStartsWithAstraAndExposesItsTraits() {
+        let models = HarnessCatalog.models(for: "codex")
+        let astra = models.first
+
+        XCTAssertEqual(astra?.id, "gpt-6-astra")
+        XCTAssertEqual(astra?.label, "GPT-6-Astra")
+        XCTAssertEqual(astra?.reasoningLevels,
+                       ["low", "medium", "high", "xhigh", "max", "ultra"])
+        XCTAssertEqual(astra?.options.first?.id, "serviceTier")
+        XCTAssertEqual(astra?.options.first?.choices.map(\.id), ["default", "fast"])
+    }
+
+    func testDefaultReasoningMatchesDesktopPreference() {
+        let astra = HarnessCatalog.defaultModel(for: "codex")
+        XCTAssertEqual(HarnessCatalog.defaultReasoning(for: astra), "high")
+
+        let short = ModelInfo(id: "short", label: "Short", description: nil,
+                              reasoningLevels: ["low", "medium"])
+        XCTAssertEqual(HarnessCatalog.defaultReasoning(for: short), "medium")
+    }
+
+    func testChoiceFallsBackToAdvertisedDefault() {
+        let option = HarnessCatalog.defaultModel(for: "codex").options[0]
+        XCTAssertEqual(HarnessCatalog.selectedChoice(for: option, selectedId: "fast").label, "Fast")
+        XCTAssertEqual(HarnessCatalog.selectedChoice(for: option, selectedId: "stale").id, "default")
+    }
+}

--- a/crates/harness/src/codex/catalog.rs
+++ b/crates/harness/src/codex/catalog.rs
@@ -1,11 +1,9 @@
 //! Model catalog + effort mapping for Codex, ported from zeron's
 //! `packages/harness/src/codex.ts`.
 //!
-//! The TS harness discovers models live via the app server's `model/list`
-//! (experimentalApi) and falls back to a curated snapshot; here the snapshot IS
-//! the catalog, and `CodexHarness::models` is the single seam where a
-//! short-lived `codex app-server` + `model/list` pagination can later be
-//! spliced in (same call t3code's Codex provider makes).
+//! The live catalog comes from the app server's paginated `model/list`
+//! (experimentalApi). This snapshot is the failure/offline fallback, kept in
+//! newest-first order so a picker remains useful when discovery cannot run.
 
 use zeron_proto::{Model, ModelOption, ModelOptionChoice, ReasoningLevel, SandboxLevel};
 
@@ -129,14 +127,19 @@ fn model(
     }
 }
 
-/// The curated catalog: a snapshot of codex-cli 0.146's `model/list`, wire
-/// order (newest family first, Daybreak within the current-gen block) —
-/// efforts as the server reports them (gpt-5.6 goes up to `ultra`). Daybreak
-/// Blue reports NO service tiers, so it carries no trait — sending
-/// `serviceTier: priority` for it would be rejected. Mirrors codex.ts's
-/// `CODEX_MODELS` fallback.
+/// The curated fallback catalog: newest family first, with efforts as the
+/// app server reports them. Daybreak Blue reports NO service tiers, so it
+/// carries no trait — sending `serviceTier: priority` for it would be
+/// rejected. The live `model/list` remains authoritative whenever available.
 pub(crate) fn static_models() -> Vec<Model> {
     vec![
+        model(
+            "gpt-6-astra",
+            "GPT-6-Astra",
+            "Our most capable model for complex, demanding work.",
+            ULTRA_LADDER,
+            vec![service_tier()],
+        ),
         model(
             "gpt-5.6-sol",
             "GPT-5.6-Sol",
@@ -213,10 +216,10 @@ mod tests {
     #[test]
     fn catalog_is_newest_first_with_service_tiers() {
         let models = static_models();
-        assert_eq!(models.len(), 8);
-        assert_eq!(models[0].id, "gpt-5.6-sol");
+        assert_eq!(models.len(), 9);
+        assert_eq!(models[0].id, "gpt-6-astra");
         assert!(models[0].reasoning_levels.contains(&ReasoningLevel::Ultra));
-        assert!(!models[4].reasoning_levels.contains(&ReasoningLevel::Max));
+        assert!(!models[5].reasoning_levels.contains(&ReasoningLevel::Max));
         for m in &models {
             let tier = m.options.iter().find(|o| o.id == "serviceTier");
             // Daybreak Blue reports no service tiers on the wire.

--- a/crates/harness/src/codex/mod.rs
+++ b/crates/harness/src/codex/mod.rs
@@ -3,7 +3,7 @@
 //! uses. Resurrected from the pre-ACP driver and modernized.
 //!
 //! VERSION PIN: the app-server API is EXPERIMENTAL (`capabilities.
-//! experimentalApi`); this driver is validated against codex-cli 0.146.1 —
+//! experimentalApi`); this driver is validated against codex-cli 0.149.0 —
 //! revalidate the method/notification surface when bumping past it.
 //!
 //! - `initialize` handshake (clientInfo + `capabilities.experimentalApi`) then
@@ -53,8 +53,8 @@ use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 
 use zeron_proto::{
-    AgentEvent, DoneStatus, HarnessId, Model, ReasoningLevel, RunRequest, SlashCommand,
-    SteeringMode, UserInputAnswer, UserInputQuestion,
+    AgentEvent, DoneStatus, HarnessId, Model, ModelOption, ModelOptionChoice, ReasoningLevel,
+    RunRequest, SlashCommand, SteeringMode, UserInputAnswer, UserInputQuestion,
 };
 
 use crate::jsonrpc::{Incoming, RpcClient};
@@ -217,6 +217,256 @@ impl CodexHarness {
             Err(_) => Err(HarnessError::Protocol("command discovery timed out".into())),
         }
     }
+
+    /// Short-lived live catalog probe. `model/list` is paginated and already
+    /// applies the signed-in account's rollout/visibility policy, so hidden or
+    /// unavailable models (including staged Astra rollouts) never leak into a
+    /// successful picker response.
+    async fn discover_models(&self) -> Result<Vec<Model>, HarnessError> {
+        let exe = self.resolve_executable()?;
+        let mut cmd = Command::new(&exe);
+        cmd.arg("app-server");
+        crate::compose_child_path(&mut cmd, &exe);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                HarnessError::NotInstalled(exe.display().to_string())
+            } else {
+                HarnessError::Io(e)
+            }
+        })?;
+        let (Some(stdin), Some(stdout)) = (child.stdin.take(), child.stdout.take()) else {
+            shutdown_child(&mut child, self.kill_grace).await;
+            return Err(HarnessError::Protocol("codex child has no stdio".into()));
+        };
+        let (client, _incoming) = RpcClient::new(stdin, stdout);
+        let discovery = async {
+            client
+                .request(
+                    "initialize",
+                    json!({
+                        "clientInfo": {
+                            "name": "zeron-native",
+                            "title": "Zeron",
+                            "version": env!("CARGO_PKG_VERSION"),
+                        },
+                        "capabilities": { "experimentalApi": true },
+                    }),
+                )
+                .await?;
+            client.notify("initialized", None);
+
+            let mut models = Vec::new();
+            let mut model_ids = HashSet::new();
+            let mut seen_cursors = HashSet::new();
+            let mut cursor: Option<String> = None;
+            let mut default_model_id: Option<String> = None;
+            loop {
+                let mut params = json!({ "limit": 20, "includeHidden": false });
+                if let Some(cursor) = cursor.as_deref() {
+                    params["cursor"] = Value::String(cursor.to_owned());
+                }
+                let page = client.request("model/list", params).await?;
+                let (page_models, next_cursor) = parse_model_list_page(&page);
+                for (model, is_default) in page_models {
+                    if model_ids.insert(model.id.clone()) {
+                        if is_default && default_model_id.is_none() {
+                            default_model_id = Some(model.id.clone());
+                        }
+                        models.push(model);
+                    }
+                }
+                let Some(next) = next_cursor.filter(|next| !next.is_empty()) else {
+                    break;
+                };
+                if !seen_cursors.insert(next.clone()) {
+                    break;
+                }
+                cursor = Some(next);
+            }
+
+            if let Some(default_id) = default_model_id
+                && let Some(index) = models.iter().position(|model| model.id == default_id)
+                && index != 0
+            {
+                let default_model = models.remove(index);
+                models.insert(0, default_model);
+            }
+            Ok::<Vec<Model>, HarnessError>(models)
+        };
+        let result = tokio::time::timeout(Duration::from_secs(10), discovery).await;
+        shutdown_child(&mut child, self.kill_grace).await;
+        match result {
+            Ok(inner) => inner,
+            Err(_) => Err(HarnessError::Protocol("model discovery timed out".into())),
+        }
+    }
+}
+
+fn reasoning_level(value: &str) -> Option<ReasoningLevel> {
+    Some(match value {
+        "minimal" => ReasoningLevel::Minimal,
+        "low" => ReasoningLevel::Low,
+        "medium" => ReasoningLevel::Medium,
+        "high" => ReasoningLevel::High,
+        "xhigh" => ReasoningLevel::XHigh,
+        "max" => ReasoningLevel::Max,
+        "ultra" => ReasoningLevel::Ultra,
+        "ultracode" => ReasoningLevel::Ultracode,
+        "ultrathink" => ReasoningLevel::Ultrathink,
+        _ => return None,
+    })
+}
+
+/// Codex accepts both names, but Zeron has historically persisted `fast`.
+/// Normalize the app server's `priority` id so live and fallback catalogs do
+/// not produce two different settings for the same tier.
+fn normalized_service_tier(value: &str) -> &str {
+    match value {
+        "priority" => "fast",
+        other => other,
+    }
+}
+
+fn service_tier_label(value: &str) -> String {
+    match value {
+        "fast" | "priority" => "Fast".into(),
+        "flex" => "Flex".into(),
+        "ultrafast" => "Ultra Fast".into(),
+        other => other.to_owned(),
+    }
+}
+
+fn model_service_tier(item: &Value) -> Option<ModelOption> {
+    let mut choices = vec![ModelOptionChoice {
+        id: "default".into(),
+        label: "Standard".into(),
+    }];
+    let mut seen = HashSet::from(["default".to_owned()]);
+    for tier in item
+        .get("serviceTiers")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        let Some(wire_id) = tier.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let id = normalized_service_tier(wire_id).to_owned();
+        if !seen.insert(id.clone()) {
+            continue;
+        }
+        let label = tier
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| service_tier_label(wire_id));
+        choices.push(ModelOptionChoice { id, label });
+    }
+    for tier in item
+        .get("additionalSpeedTiers")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        let Some(wire_id) = tier.as_str() else {
+            continue;
+        };
+        let id = normalized_service_tier(wire_id).to_owned();
+        if seen.insert(id.clone()) {
+            choices.push(ModelOptionChoice {
+                id,
+                label: service_tier_label(wire_id),
+            });
+        }
+    }
+    if choices.len() == 1 {
+        return None;
+    }
+    let default_choice = item
+        .get("defaultServiceTier")
+        .and_then(Value::as_str)
+        .map(normalized_service_tier)
+        .filter(|id| seen.contains(*id))
+        .unwrap_or("default")
+        .to_owned();
+    Some(ModelOption {
+        id: "serviceTier".into(),
+        label: "Service Tier".into(),
+        choices,
+        default_choice,
+    })
+}
+
+/// Parse one `model/list` page. Unknown future reasoning levels are ignored
+/// independently instead of invalidating the complete catalog.
+fn parse_model_list_page(result: &Value) -> (Vec<(Model, bool)>, Option<String>) {
+    let mut models = Vec::new();
+    for item in result
+        .get("data")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        if item.get("hidden").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        let Some(id) = item
+            .get("model")
+            .and_then(Value::as_str)
+            .or_else(|| item.get("id").and_then(Value::as_str))
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+        else {
+            continue;
+        };
+        let label = item
+            .get("displayName")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+            .unwrap_or(id)
+            .to_owned();
+        let description = item
+            .get("description")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|description| !description.is_empty())
+            .map(str::to_owned);
+        let reasoning_levels = item
+            .get("supportedReasoningEfforts")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|effort| {
+                effort
+                    .get("reasoningEffort")
+                    .and_then(Value::as_str)
+                    .or_else(|| effort.as_str())
+                    .and_then(reasoning_level)
+            })
+            .collect();
+        let options = model_service_tier(item).into_iter().collect();
+        models.push((
+            Model {
+                id: id.to_owned(),
+                label,
+                description,
+                reasoning_levels,
+                options,
+            },
+            item.get("isDefault").and_then(Value::as_bool) == Some(true),
+        ));
+    }
+    let next_cursor = result
+        .get("nextCursor")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    (models, next_cursor)
 }
 
 /// `skills/list` result → picker commands. `data` groups skills by cwd; the
@@ -296,13 +546,23 @@ impl Harness for CodexHarness {
         true
     }
 
-    /// The curated static catalog (see [`catalog`]); requires an installed CLI
-    /// so an absent binary surfaces as [`HarnessError::NotInstalled`] here.
-    /// This is the seam for live discovery: a short-lived `codex app-server`
-    /// paging `model/list` (experimentalApi) exactly as codex.ts does.
+    /// The signed-in account's visible `model/list` is authoritative. A
+    /// curated snapshot keeps the picker operational when the experimental
+    /// discovery call is unavailable or temporarily fails; failed probes are
+    /// intentionally not cached so reopening the picker retries rollout state.
     async fn models(&self) -> Result<Vec<Model>, HarnessError> {
         self.resolve_executable()?;
-        Ok(static_models())
+        match self.discover_models().await {
+            Ok(models) if !models.is_empty() => Ok(models),
+            Ok(_) => Ok(static_models()),
+            Err(error) => {
+                tracing::debug!(
+                    target: "zeron_harness::codex",
+                    "model/list discovery failed; using fallback catalog: {error}"
+                );
+                Ok(static_models())
+            }
+        }
     }
 
     /// Skills from a short-lived `skills/list` probe (see
@@ -1521,6 +1781,47 @@ mod tests {
             &json!({"command": ["git", "push", "--force"]}),
         );
         assert!(q.question.contains("git push --force"));
+    }
+
+    #[test]
+    fn model_page_skips_hidden_and_unknown_efforts() {
+        let page = json!({
+            "data": [
+                {
+                    "id": "hidden",
+                    "model": "hidden",
+                    "displayName": "Hidden",
+                    "hidden": true,
+                    "supportedReasoningEfforts": [{ "reasoningEffort": "high" }]
+                },
+                {
+                    "id": "gpt-6-astra",
+                    "model": "gpt-6-astra",
+                    "displayName": "GPT-6-Astra",
+                    "description": "  Most capable  ",
+                    "hidden": false,
+                    "supportedReasoningEfforts": [
+                        { "reasoningEffort": "high" },
+                        { "reasoningEffort": "future" }
+                    ],
+                    "serviceTiers": [{ "id": "priority", "name": "Fast" }],
+                    "additionalSpeedTiers": ["fast"],
+                    "defaultServiceTier": null,
+                    "isDefault": true
+                }
+            ],
+            "nextCursor": "next"
+        });
+        let (models, cursor) = parse_model_list_page(&page);
+        assert_eq!(cursor.as_deref(), Some("next"));
+        assert_eq!(models.len(), 1);
+        let (astra, is_default) = &models[0];
+        assert_eq!(astra.id, "gpt-6-astra");
+        assert_eq!(astra.description.as_deref(), Some("Most capable"));
+        assert_eq!(astra.reasoning_levels, vec![ReasoningLevel::High]);
+        assert!(*is_default);
+        assert_eq!(astra.options[0].choices.len(), 2);
+        assert_eq!(astra.options[0].choices[1].id, "fast");
     }
 
     #[test]

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -579,17 +579,31 @@ async fn missing_binary_is_not_installed() {
 }
 
 #[tokio::test]
-async fn models_returns_curated_catalog() {
+async fn models_discovers_visible_catalog_with_pagination() {
     let models = harness().models().await.expect("models");
-    assert_eq!(models.len(), 8);
-    assert_eq!(models[0].id, "gpt-5.6-sol");
+    assert_eq!(models.len(), 3);
+    assert_eq!(models[0].id, "gpt-6-astra");
+    assert_eq!(models[1].id, "gpt-5.6-terra");
+    assert_eq!(models[2].id, "gpt-5.6-sol");
     assert!(models[0].reasoning_levels.contains(&ReasoningLevel::Ultra));
-    assert!(
-        models
-            .iter()
-            .filter(|m| m.id != "gpt-daybreak-blue-latest")
-            .all(|m| m.options.iter().any(|o| o.id == "serviceTier"))
-    );
+    assert!(models.iter().any(|m| m.id == "gpt-5.6-sol"));
+    let tier = models[0]
+        .options
+        .iter()
+        .find(|option| option.id == "serviceTier")
+        .expect("Astra service tier");
+    assert_eq!(tier.choices[0].id, "default");
+    assert_eq!(tier.choices[1].id, "fast");
+    assert_eq!(tier.choices.len(), 2, "priority and fast dedupe");
+
+    // A failed probe stays useful and includes the new model in the fallback.
+    let fallback = CodexHarness::new()
+        .with_executable("/bin/false")
+        .models()
+        .await
+        .expect("fallback models");
+    assert_eq!(fallback.len(), 9);
+    assert_eq!(fallback[0].id, "gpt-6-astra");
 
     let missing = CodexHarness::new().with_executable("/nonexistent/codex-nowhere");
     // models() requires a resolvable binary… but with_executable trusts the

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -33,6 +33,18 @@ if has "$line" '"method":"skills/list"'; then
   emit "{\"id\":$(rid "$line"),\"result\":{\"data\":[{\"cwd\":\"/w\",\"skills\":[{\"name\":\"imagegen\",\"description\":\"Model-facing paragraph about images.\",\"interface\":{\"displayName\":\"Image Gen\",\"shortDescription\":\"Generate or edit images\"}},{\"name\":\"bare\",\"description\":\"No interface block\"}]},{\"cwd\":\"/x\",\"skills\":[{\"name\":\"imagegen\",\"description\":\"dupe\",\"interface\":{\"shortDescription\":\"dupe\"}}]}]}}"
   exec sleep 30
 fi
+if has "$line" '"method":"model/list"'; then
+  # Live model discovery: force pagination and put the default model second,
+  # proving the harness consumes nextCursor and honors isDefault.
+  has "$line" '"includeHidden":false' || exit 1
+  has "$line" '"limit":20' || exit 1
+  emit "{\"id\":$(rid "$line"),\"result\":{\"data\":[{\"id\":\"gpt-5.6-terra\",\"model\":\"gpt-5.6-terra\",\"displayName\":\"GPT-5.6-Terra\",\"description\":\"Balanced agentic coding model for everyday work.\",\"hidden\":false,\"supportedReasoningEfforts\":[{\"reasoningEffort\":\"low\"},{\"reasoningEffort\":\"high\"}],\"additionalSpeedTiers\":[],\"serviceTiers\":[],\"defaultServiceTier\":null,\"isDefault\":false},{\"id\":\"gpt-6-astra\",\"model\":\"gpt-6-astra\",\"displayName\":\"GPT-6-Astra\",\"description\":\"Our most capable model for complex, demanding work.\",\"hidden\":false,\"supportedReasoningEfforts\":[{\"reasoningEffort\":\"low\"},{\"reasoningEffort\":\"medium\"},{\"reasoningEffort\":\"high\"},{\"reasoningEffort\":\"xhigh\"},{\"reasoningEffort\":\"max\"},{\"reasoningEffort\":\"ultra\"}],\"additionalSpeedTiers\":[\"fast\"],\"serviceTiers\":[{\"id\":\"priority\",\"name\":\"Fast\"}],\"defaultServiceTier\":null,\"isDefault\":true}],\"nextCursor\":\"page-2\"}}"
+  read -r line || exit 1
+  has "$line" '"method":"model/list"' || exit 1
+  has "$line" '"cursor":"page-2"' || exit 1
+  emit "{\"id\":$(rid "$line"),\"result\":{\"data\":[{\"id\":\"gpt-5.6-sol\",\"model\":\"gpt-5.6-sol\",\"displayName\":\"GPT-5.6-Sol\",\"description\":\"Reliable agentic workhorse for everyday tasks.\",\"hidden\":false,\"supportedReasoningEfforts\":[{\"reasoningEffort\":\"low\"},{\"reasoningEffort\":\"ultra\"}],\"additionalSpeedTiers\":[],\"serviceTiers\":[],\"defaultServiceTier\":null,\"isDefault\":false}],\"nextCursor\":null}}"
+  exec sleep 30
+fi
 if has "$line" '"method":"thread/resume"'; then
   if has "$line" '"threadId":"resume-fail"'; then
     # Missing/foreign rollout: reject, expect the fresh-start fallback.


### PR DESCRIPTION
## Summary

- discover Codex models from the paginated `model/list` app-server API, respecting account visibility and the server-selected default
- map live reasoning efforts and service tiers while retaining a curated fallback with GPT-6 Astra
- carry model options through the iOS wire model and expose Standard/Fast pickers in new and existing chats
- align iOS model fallback and reasoning defaults with desktop behavior

## Testing

- `cargo test -p zeron-harness --test codex`
- `cargo test -p zeron-harness codex::`
- `cargo check -p zeron-ui`
- `xcodebuild test -project apps/ios/Zeron.xcodeproj -scheme Zeron -destination "platform=iOS Simulator,name=Zeron iPhone 17 Pro"` (50 tests)
- `git diff --check upstream/main...HEAD`

## Notes

- `model/list` remains authoritative when it succeeds, so account-scoped or hidden models such as Daybreak are only shown when Codex advertises them.
- The fallback catalog is used when live discovery is unavailable and includes GPT-6 Astra for desktop and iOS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791144850&installation_model_id=425430&pr_number=248&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F248&signature=3f5e1f44a9137614bc81e175b46bdc465fda027232d50bdbb75147a5d75dcfe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->