### PR TITLE
fix(devin): refresh model discovery and select newly released models

### DIFF
--- a/crates/harness/examples/devin_models_probe.rs
+++ b/crates/harness/examples/devin_models_probe.rs
@@ -1,0 +1,68 @@
+//! Live account catalog and optional ACP run (requires authenticated Devin).
+//!
+//!     cargo run -p zeron-harness --example devin_models_probe
+//!     cargo run -p zeron-harness --example devin_models_probe -- gpt-6-astra-medium
+
+use futures::StreamExt;
+use zeron_harness::{AcpHarness, CancellationToken, Harness, RunControls};
+use zeron_proto::{AgentEvent, DoneStatus, RunRequest, SandboxLevel};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let harness = AcpHarness::devin();
+    for attempt in 1..=2 {
+        let start = std::time::Instant::now();
+        let models = harness.models().await?;
+        println!(
+            "Discovery {attempt}: {} variants in {:?}",
+            models.len(),
+            start.elapsed()
+        );
+        for model in models.iter().filter(|m| m.id.contains("astra")) {
+            println!("  {} — {}", model.id, model.label);
+        }
+    }
+    let Some(model) = std::env::args().nth(1) else {
+        return Ok(());
+    };
+    let (_steering, steering) = tokio::sync::mpsc::channel(8);
+    let controls = RunControls {
+        request_input: Box::new(|_| {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let _ = tx.send(Vec::new());
+            rx
+        }),
+        steering,
+        interrupt: CancellationToken::new(),
+    };
+    let request = RunRequest {
+        prompt: "Reply with exactly: Devin model discovery verified. Do not use tools.".into(),
+        harness: None,
+        model: Some(model.clone()),
+        reasoning: None,
+        model_options: Default::default(),
+        cwd: std::env::current_dir()?.to_string_lossy().into_owned(),
+        sandbox: SandboxLevel::ReadOnly,
+        auto_approve: true,
+        attachments: Vec::new(),
+        worktree: None,
+        resume: None,
+    };
+    println!("Running real Devin ACP with {model}");
+    let mut stream = harness.run(request, controls).await?;
+    tokio::time::timeout(std::time::Duration::from_secs(90), async {
+        while let Some(event) = stream.next().await {
+            match event? {
+                AgentEvent::TextDelta { text } => print!("{text}"),
+                AgentEvent::Done { status, error, .. } => {
+                    println!("\nDone: {status:?}");
+                    anyhow::ensure!(status == DoneStatus::Completed, "{error:?}");
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
+        anyhow::bail!("stream closed without Done")
+    })
+    .await?
+}

--- a/crates/harness/src/acp/devin_models.rs
+++ b/crates/harness/src/acp/devin_models.rs
@@ -1,0 +1,196 @@
+//! Devin's ACP session starts with a bundled catalog and refreshes it later.
+//! `models list` waits for the account catalog before writing JSON, so use it
+//! instead of racing `session/new` against `config_option_update` notifications.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::process::Command;
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+
+use zeron_proto::Model;
+
+use crate::HarnessError;
+use crate::jsonrpc::{Incoming, RpcClient};
+
+/// A freshly discovered variant may also arrive after `session/new` in the
+/// process that runs the prompt. Wait for that exact id; the generic ACP
+/// family fallback could otherwise silently select a different GPT model.
+pub(super) async fn wait_for_model(
+    client: &RpcClient,
+    incoming: &mut tokio::sync::mpsc::Receiver<Incoming>,
+    session_id: &str,
+    response: &mut serde_json::Value,
+    model: &str,
+) -> Result<(), HarnessError> {
+    let wait = async {
+        loop {
+            if super::models_from_session(response, &[])
+                .iter()
+                .any(|m| m.id == model)
+            {
+                return Ok(());
+            }
+            match incoming.recv().await {
+                Some(Incoming::Notification { method, params })
+                    if method == "session/update"
+                        && params.get("sessionId").and_then(serde_json::Value::as_str)
+                            == Some(session_id)
+                        && params["update"]["sessionUpdate"] == "config_option_update" =>
+                {
+                    if params["update"]["configOptions"].is_array() {
+                        response["configOptions"] = params["update"]["configOptions"].clone();
+                    }
+                }
+                Some(Incoming::Request { id, method, params }) => {
+                    super::handle_server_request(client, id, &method, &params);
+                }
+                Some(_) => {}
+                None => {
+                    return Err(HarnessError::Protocol(
+                        "Devin exited while refreshing models".into(),
+                    ));
+                }
+            }
+        }
+    };
+    tokio::time::timeout(super::DEFAULT_MODEL_DISCOVERY_TIMEOUT, wait)
+        .await
+        .map_err(|_| {
+            HarnessError::Protocol(format!(
+                "Devin did not advertise requested model {model} after refreshing"
+            ))
+        })?
+}
+
+#[derive(Default)]
+pub(super) struct Catalog {
+    // Only overlapping callers share a result. A later picker open always
+    // probes again, including after errors, login changes, or model rollouts.
+    latest: Mutex<Option<(Instant, Vec<Model>)>>,
+}
+
+impl Catalog {
+    pub(super) async fn refresh(
+        &self,
+        exe: &Path,
+        timeout: Duration,
+    ) -> Result<Vec<Model>, HarnessError> {
+        let requested_at = Instant::now();
+        let mut latest = self.latest.lock().await;
+        if let Some((completed_at, models)) = &*latest
+            && *completed_at >= requested_at
+        {
+            return Ok(models.clone());
+        }
+        let mut cmd = Command::new(exe);
+        cmd.args(["models", "list", "--format", "json"]);
+        crate::compose_child_path(&mut cmd, exe);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let output = tokio::time::timeout(timeout, cmd.output())
+            .await
+            .map_err(|_| HarnessError::Protocol("Devin model discovery timed out".into()))??;
+        if !output.status.success() {
+            return Err(HarnessError::Protocol(format!(
+                "Devin models list failed ({}): {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        let models = parse_catalog(&output.stdout)?;
+        *latest = Some((Instant::now(), models.clone()));
+        Ok(models)
+    }
+}
+
+#[derive(Deserialize)]
+struct ModelList {
+    families: Vec<Family>,
+}
+
+#[derive(Deserialize)]
+struct Family {
+    variants: Vec<Variant>,
+}
+
+#[derive(Deserialize)]
+struct Variant {
+    model_uid: String,
+    label: String,
+    cost_summary: Option<String>,
+}
+
+fn parse_catalog(bytes: &[u8]) -> Result<Vec<Model>, HarnessError> {
+    let catalog: ModelList = serde_json::from_slice(bytes)
+        .map_err(|error| HarnessError::Protocol(format!("invalid Devin model catalog: {error}")))?;
+    let mut models = Vec::new();
+    for variant in catalog.families.into_iter().flat_map(|f| f.variants) {
+        if variant.model_uid.trim().is_empty() || variant.label.trim().is_empty() {
+            return Err(HarnessError::Protocol(
+                "invalid empty Devin model id or label".into(),
+            ));
+        }
+        if models.iter().any(|m: &Model| m.id == variant.model_uid) {
+            continue;
+        }
+        models.push(Model {
+            id: variant.model_uid,
+            label: variant.label,
+            description: variant.cost_summary,
+            // Devin encodes effort and fast mode in the exact variant id.
+            reasoning_levels: Vec::new(),
+            options: Vec::new(),
+        });
+    }
+    if models.is_empty() {
+        return Err(HarnessError::Protocol(
+            "Devin returned an empty model catalog".into(),
+        ));
+    }
+    Ok(models)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_exact_variants_without_turning_family_aliases_into_models() {
+        let models = parse_catalog(br#"{"families":[{
+            "family_uid":"gpt-6-astra", "aliases":["astra"], "variants":[
+                {"model_uid":"gpt-6-astra-medium","label":"GPT-6 Astra Medium Thinking","cost_summary":"Account pricing"},
+                {"model_uid":"gpt-6-astra-high","label":"GPT-6 Astra High Thinking"},
+                {"model_uid":"gpt-6-astra-high","label":"Duplicate"}
+            ]
+        }]}"#).unwrap();
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "gpt-6-astra-medium");
+        assert_eq!(models[0].label, "GPT-6 Astra Medium Thinking");
+        assert_eq!(models[0].description.as_deref(), Some("Account pricing"));
+        assert_eq!(models[1].id, "gpt-6-astra-high");
+        assert!(
+            models
+                .iter()
+                .all(|m| m.reasoning_levels.is_empty() && m.options.is_empty())
+        );
+    }
+
+    #[test]
+    fn invalid_or_empty_catalogs_are_retryable_errors() {
+        for bytes in [
+            "not json",
+            "{}",
+            r#"{"families":[]}"#,
+            r#"{"families":[{"variants":[{"label":"Missing id"}]}]}"#,
+            r#"{"families":[{"variants":[{"model_uid":"","label":"Empty id"}]}]}"#,
+        ] {
+            assert!(parse_catalog(bytes.as_bytes()).is_err(), "{bytes}");
+        }
+    }
+}

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -27,6 +27,7 @@
 //! - Interrupt: `session/cancel`, escalating SIGTERM → SIGKILL; the stream
 //!   always ends with `Done { status: Interrupted }`.
 
+mod devin_models;
 mod normalize;
 mod subagent;
 mod subagent_devin;
@@ -289,8 +290,8 @@ fn devin_spec() -> AcpAgentSpec {
              `curl -fsSL https://cli.devin.ai/install.sh | bash` or \
              `brew install --cask devin-cli`, then `devin auth login`; set \
              DEVIN_EXECUTABLE to override)",
-        // Fallback only: session/new advertises the account's models (~200
-        // flat ids, effort baked into the suffix) and the wire always wins.
+        // Legacy metadata only: discovery uses `devin models list` because
+        // session/new starts with a stale catalog. Effort is baked into ids.
         // These ids were live-verified with CLI 3000.6.14; `swe-1-7-medium`
         // is the session default the server reports.
         models: || {
@@ -528,6 +529,7 @@ pub struct AcpHarness {
     /// Coalesce concurrent picker/title probes. Starting several OpenCode
     /// processes at once makes cold plugin loading slower and wastes memory.
     models_probe: tokio::sync::Mutex<()>,
+    devin_models: devin_models::Catalog,
 }
 
 impl AcpHarness {
@@ -546,6 +548,7 @@ impl AcpHarness {
             commands: tokio::sync::OnceCell::new(),
             models_cache: tokio::sync::OnceCell::new(),
             models_probe: tokio::sync::Mutex::new(()),
+            devin_models: devin_models::Catalog::default(),
         }
     }
 
@@ -1143,14 +1146,18 @@ impl Harness for AcpHarness {
         find_on_paths(self.spec.cli_executable, (self.spec.cli_extra_paths)()).is_some()
     }
 
-    /// ACP is the source of truth: a short-lived probe reads the agent's
-    /// advertised model list (cached on success). The spec's static catalog
-    /// answers when the agent advertises nothing. Most legacy ACP adapters also
-    /// use it when probing fails; OpenCode does not, because presenting two
-    /// static Zen models as a successful load permanently hides a slow or
-    /// failed plugin-backed catalog from the picker.
+    /// Devin refreshes through its native catalog command on each request.
+    /// Other ACP agents use a cached session probe, with the spec's static
+    /// catalog as fallback when they advertise nothing or probing fails.
     async fn models(&self) -> Result<Vec<Model>, HarnessError> {
         self.resolve_launch()?;
+        if self.spec.id == HarnessId::Devin {
+            let (exe, _) = self.resolve_program(false).await?;
+            return self
+                .devin_models
+                .refresh(&exe, self.model_discovery_timeout)
+                .await;
+        }
         if let Some(models) = self.models_cache.get() {
             return Ok(models.clone());
         }
@@ -1811,15 +1818,35 @@ async fn request_draining(
     method: &'static str,
     params: Value,
 ) -> Result<Value, HarnessError> {
+    let loading_session = matches!(method, "session/new" | "session/load");
+    let requested_session = params
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let mut config_updates = std::collections::HashMap::new();
+    let mut handle_incoming = |inc| match inc {
+        Incoming::Request { id, method, params } => {
+            handle_server_request(client, id, &method, &params);
+        }
+        Incoming::Notification { method, params }
+            if loading_session
+                && method == "session/update"
+                && params["update"]["sessionUpdate"] == "config_option_update" =>
+        {
+            if let Some(id) = params.get("sessionId").and_then(Value::as_str)
+                && params["update"]["configOptions"].is_array()
+            {
+                config_updates.insert(id.to_owned(), params["update"]["configOptions"].clone());
+            }
+        }
+        _ => {}
+    };
     let mut fut = prompt_like_request(client.clone(), method, params);
     let res = loop {
         tokio::select! {
             res = &mut fut => break res,
             inc = incoming.recv() => match inc {
-                Some(Incoming::Request { id, method, params }) => {
-                    handle_server_request(client, id, &method, &params);
-                }
-                Some(_) => {}
+                Some(inc) => handle_incoming(inc),
                 None => {
                     return Err(HarnessError::Protocol(format!(
                         "{method}: agent exited during setup"
@@ -1832,11 +1859,21 @@ async fn request_draining(
     // replay updates the reader forwarded BEFORE the response line may still
     // sit in the buffer — flush them now or they'd leak into the live turn.
     while let Ok(inc) = incoming.try_recv() {
-        if let Incoming::Request { id, method, params } = inc {
-            handle_server_request(client, id, &method, &params);
-        }
+        handle_incoming(inc);
     }
-    res
+    // Keep config refreshes even when they race the session response. They
+    // are session state, not replayed transcript, and dropping them can lose
+    // the only notification advertising a newly released Devin model.
+    res.map(|mut response| {
+        let id = response
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .or(requested_session.as_deref());
+        if let Some(options) = id.and_then(|id| config_updates.remove(id)) {
+            response["configOptions"] = options;
+        }
+        response
+    })
 }
 
 fn prompt_like_request(
@@ -1923,7 +1960,7 @@ async fn run_session(session: Session) {
         let init_commands = scan_available_commands(&init);
 
         let session_params = json!({ "cwd": request.cwd, "mcpServers": [] });
-        let (session_id, session_response) = if let Some(resume) = &request.resume {
+        let (session_id, mut session_response) = if let Some(resume) = &request.resume {
             let mut load = session_params.clone();
             load["sessionId"] = Value::String(resume.clone());
             match request_draining(&client, &mut incoming, "session/load", load).await {
@@ -1965,6 +2002,18 @@ async fn run_session(session: Session) {
             return Err(HarnessError::Protocol(
                 "session/new returned no sessionId".into(),
             ));
+        }
+        if harness == HarnessId::Devin
+            && let Some(model) = request.model.as_deref()
+        {
+            devin_models::wait_for_model(
+                &client,
+                &mut incoming,
+                &session_id,
+                &mut session_response,
+                model,
+            )
+            .await?;
         }
         // ACP has had two model-selection surfaces. Newer config-option agents
         // use category=model below; Grok Build currently advertises only the
@@ -2017,6 +2066,19 @@ async fn run_session(session: Session) {
             )
             .await
             {
+                if harness == HarnessId::Devin
+                    && options_snapshot["configOptions"]
+                        .as_array()
+                        .is_some_and(|options| {
+                            options
+                                .iter()
+                                .any(|o| o["id"] == config_id && o["category"] == "model")
+                        })
+                {
+                    return Err(HarnessError::Protocol(format!(
+                        "Devin rejected requested model {requested_model:?}: {e}"
+                    )));
+                }
                 tracing::debug!(
                     target: "zeron_harness::acp",
                     "session/set_config_option {config_id}={payload} rejected (agent default runs): {e}"

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -823,3 +823,205 @@ async fn grok_subagent_lifecycle_tails_the_disk_transcript_into_tagged_events() 
     // the parent's own turn settled cleanly with its single untagged Done.
     assert_eq!(dones(&events), vec![(DoneStatus::Completed, None)]);
 }
+
+#[cfg(unix)]
+fn devin_fixture() -> (tempfile::TempDir, AcpHarness) {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let script = dir.path().join("devin.py");
+    std::fs::write(
+        &script,
+        r#"#!/usr/bin/env python3
+import json, pathlib, sys, threading, time
+root = pathlib.Path(__file__).parent
+
+def emit(frame):
+    print(json.dumps(dict(jsonrpc='2.0', **frame)), flush=True)
+
+def config(model):
+    return [{'id':'model', 'category':'model', 'type':'select',
+             'currentValue':'gpt-old', 'options':[{'value':model, 'name':model}]}]
+
+if sys.argv[1:] == ['models', 'list', '--format', 'json']:
+    with (root / 'probes').open('a') as f: f.write('probe\n')
+    state = (root / 'state').read_text()
+    if state == 'hang': time.sleep(60)
+    if state == 'error':
+        print('account unavailable', file=sys.stderr)
+        sys.exit(1)
+    time.sleep(0.1)
+    print(json.dumps({'families':[{'variants':[{'model_uid':state, 'label':state}]}]}))
+    sys.exit(0)
+assert sys.argv[1:] == ['acp'], sys.argv
+selected = None
+
+def refresh():
+    # An unrelated session must not satisfy the requested-model wait.
+    emit({'method':'session/update', 'params':{'sessionId':'other', 'update':{
+        'sessionUpdate':'config_option_update', 'configOptions':config('gpt-new')}}})
+    time.sleep(0.1)
+    (root / 'refreshed').touch()
+    emit({'method':'session/update', 'params':{'sessionId':'s-1', 'update':{
+        'sessionUpdate':'config_option_update', 'configOptions':config('gpt-new')}}})
+
+for line in sys.stdin:
+    req = json.loads(line)
+    method = req.get('method')
+    result = {}
+    if method == 'initialize': result = {'protocolVersion':1, 'agentCapabilities':{}}
+    elif method == 'session/new':
+        result = {'sessionId':'s-1', 'configOptions':config('gpt-old')}
+    elif method == 'session/set_config_option':
+        selected = req['params']['value']
+        assert (root / 'refreshed').exists(), 'selected before own session refreshed'
+        if (root / 'state').read_text() == 'reject':
+            emit({'id':req['id'], 'error':{'code':-32602, 'message':'model unavailable'}})
+            continue
+        assert selected == 'gpt-new', selected
+    elif method == 'session/prompt':
+        (root / 'prompted').write_text(selected or 'default')
+        result = {'stopReason':'end_turn'}
+    early = (root / 'state').read_text() == 'early'
+    if method == 'session/new' and early: refresh()
+    emit({'id':req['id'], 'result':result})
+    if method == 'session/new' and not early: threading.Thread(target=refresh, daemon=True).start()
+    if method == 'session/prompt': break
+"#,
+    )
+    .unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::write(dir.path().join("state"), "gpt-old").unwrap();
+    let harness = AcpHarness::devin().with_executable(script);
+    (dir, harness)
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn devin_models_refresh_between_calls_and_coalesce_overlapping_probes() {
+    let (dir, harness) = devin_fixture();
+    let (first, overlap) = tokio::join!(harness.models(), harness.models());
+    assert_eq!(first.unwrap()[0].id, "gpt-old");
+    assert_eq!(overlap.unwrap()[0].id, "gpt-old");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("probes"))
+            .unwrap()
+            .lines()
+            .count(),
+        1
+    );
+    std::fs::write(dir.path().join("state"), "gpt-new").unwrap();
+    assert_eq!(harness.models().await.unwrap()[0].id, "gpt-new");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("probes"))
+            .unwrap()
+            .lines()
+            .count(),
+        2
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn devin_discovery_errors_and_timeouts_retry_without_stale_success() {
+    let (dir, harness) = devin_fixture();
+    let harness = harness.with_model_discovery_timeout(Duration::from_millis(500));
+    assert_eq!(harness.models().await.unwrap()[0].id, "gpt-old");
+    std::fs::write(dir.path().join("state"), "error").unwrap();
+    assert!(
+        harness
+            .models()
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("account unavailable")
+    );
+    std::fs::write(dir.path().join("state"), "hang").unwrap();
+    assert!(
+        harness
+            .models()
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("timed out")
+    );
+    std::fs::write(dir.path().join("state"), "gpt-new").unwrap();
+    assert_eq!(harness.models().await.unwrap()[0].id, "gpt-new");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn devin_waits_for_refreshed_variant_before_prompting() {
+    let (dir, harness) = devin_fixture();
+    let (controls, _steer, _token) = controls();
+    let mut req = request("Say hello");
+    req.model = Some("gpt-new".into());
+    let events = run_to_end(&harness, req, controls).await;
+    assert_eq!(
+        dones(&events),
+        vec![(DoneStatus::Completed, None)],
+        "{events:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("prompted")).unwrap(),
+        "gpt-new"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn devin_rejected_model_never_prompts_with_a_different_model() {
+    let (dir, harness) = devin_fixture();
+    std::fs::write(dir.path().join("state"), "reject").unwrap();
+    let (controls, _steer, _token) = controls();
+    let mut req = request("Say hello");
+    req.model = Some("gpt-new".into());
+    let events = run_to_end(&harness, req, controls).await;
+    assert!(
+        dones(&events)
+            .iter()
+            .any(|(status, error)| *status == DoneStatus::Errored
+                && error
+                    .as_deref()
+                    .is_some_and(|e| e.contains("model unavailable"))),
+        "{events:?}"
+    );
+    assert!(!dir.path().join("prompted").exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn devin_keeps_model_refresh_that_precedes_session_response() {
+    let (dir, harness) = devin_fixture();
+    std::fs::write(dir.path().join("state"), "early").unwrap();
+    let (controls, _steer, _token) = controls();
+    let mut req = request("Say hello");
+    req.model = Some("gpt-new".into());
+    let events = run_to_end(&harness, req, controls).await;
+    assert_eq!(
+        dones(&events),
+        vec![(DoneStatus::Completed, None)],
+        "{events:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("prompted")).unwrap(),
+        "gpt-new"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn devin_missing_variant_is_bounded_and_never_prompts() {
+    let (dir, harness) = devin_fixture();
+    let harness = harness.with_handshake_timeout(Duration::from_millis(300));
+    let (controls, _steer, _token) = controls();
+    let mut req = request("Say hello");
+    req.model = Some("gpt-missing".into());
+    let events = run_to_end(&harness, req, controls).await;
+    assert!(
+        dones(&events)
+            .iter()
+            .any(|(status, _)| *status == DoneStatus::Errored),
+        "{events:?}"
+    );
+    assert!(!dir.path().join("prompted").exists());
+}


### PR DESCRIPTION
Devin omitted newly released models because Zeron cached the initial ACP `session/new` catalog for the daemon lifetime. With real Devin CLI 3000.6.14, the initial response advertised 200 variants; a later `config_option_update` advertised 205, including five GPT-6 Astra variants.

Discovery now runs `devin models list --format json` on each new request. Only overlapping requests share a result. Empty, malformed, failed, or timed-out probes remain retryable errors instead of presenting a stale catalog as a successful refresh. Variant IDs, labels, and account pricing come from Devin.

The run path also waits for the exact selected variant when ACP is still refreshing, preserves config updates that race the session response, and fails if Devin rejects the model switch. This prevents the generic GPT-family fallback from silently running a different model.

Validation:

- `cargo test -p zeron-harness`: **172 passed**, 6 existing live tests ignored. Covers refresh without restart, concurrent probes, failure/timeout recovery, updates before and after the session response, unrelated-session updates, missing variants, and rejected model switches.
- `cargo build -p zeron`: passed.
- `cargo run -p zeron-harness --example devin_models_probe -- gpt-6-astra-medium`: two consecutive probes returned all 205 variants, then a real Astra ACP request completed successfully.
- The native catalog's 205 IDs exactly matched the real ACP session's refreshed catalog.
- Built Zeron UI against authenticated Devin on dev, selected Astra, and completed a real prompt. No mock harness or fabricated screenshots.

Devin picker showing all five Astra variants:

![Devin picker with GPT-6 Astra variants](https://github.com/user-attachments/assets/9ff185dc-07fa-441e-988e-4facbf9b81da)

Completed real Devin/Astra conversation:

![Real Devin Astra run completed in Zeron](https://github.com/user-attachments/assets/e318cee3-f4aa-45e7-abf7-3ce53c512ac3)

Requires a Devin CLI supporting `models list --format json` (verified with 3000.6.14). Discovery failures surface in the picker and can be retried by reopening it.
