### PR TITLE
Restyle tool activity and fix Codex thinking paragraphs

### DIFF
--- a/crates/harness/src/codex/mod.rs
+++ b/crates/harness/src/codex/mod.rs
@@ -61,7 +61,7 @@ use crate::jsonrpc::{Incoming, RpcClient};
 use crate::{Harness, HarnessError, RunControls};
 use catalog::{REASONING_LEVELS, sandbox_mode, sandbox_policy_value, static_models, to_effort};
 use normalize::{
-    ChildRoute, Phase, delta_text, item_id, item_type, map_item, notification_thread_id,
+    ChildRoute, Phase, ReasoningStream, delta_text, item_id, item_type, map_item, notification_thread_id,
     route_child_notification, turn_error_message, turn_id, usage_event, user_message_text,
 };
 
@@ -933,6 +933,7 @@ async fn run_session(session: Session) {
     // Deltas seen per agent-message item, so a model that never streams
     // (item/completed only) still emits its text exactly once.
     let mut streamed_text: HashSet<String> = HashSet::new();
+    let mut reasoning_streams: HashMap<String, ReasoningStream> = HashMap::new();
     // Token usage is held until the turn ends, emitted just before Done.
     let mut pending_usage: Option<AgentEvent> = None;
     // Steers whose `turn/steer` lost the turn-completed race; delivered as the
@@ -1020,10 +1021,9 @@ async fn run_session(session: Session) {
                                         .into_iter()
                                         .collect(),
                                     "item/reasoning/textDelta"
-                                    | "item/reasoning/summaryTextDelta" => delta_text(&params)
-                                        .map(|text| AgentEvent::ReasoningDelta { text })
-                                        .into_iter()
-                                        .collect(),
+                                    | "item/reasoning/summaryTextDelta"
+                                    | "item/reasoning/summaryPartAdded" => reasoning_streams
+                                        .entry(nthread.clone()).or_default().map(&method, &params),
                                     "item/started" | "item/completed" => {
                                         let phase = if method == "item/started" {
                                             Phase::Started
@@ -1111,11 +1111,14 @@ async fn run_session(session: Session) {
                         }
                     }
 
-                    "item/reasoning/textDelta" | "item/reasoning/summaryTextDelta" => {
-                        if let Some(text) = delta_text(&params)
-                            && !send(&event_tx, AgentEvent::ReasoningDelta { text }).await
+                    "item/reasoning/textDelta" | "item/reasoning/summaryTextDelta"
+                    | "item/reasoning/summaryPartAdded" => {
+                        for event in reasoning_streams.entry(thread_id.clone()).or_default()
+                            .map(&method, &params)
                         {
-                            break 'main;
+                            if !send(&event_tx, event).await {
+                                break 'main;
+                            }
                         }
                     }
 

--- a/crates/harness/src/codex/normalize.rs
+++ b/crates/harness/src/codex/normalize.rs
@@ -34,6 +34,69 @@ pub(crate) fn delta_text(params: &Value) -> Option<String> {
         .map(str::to_owned)
 }
 
+/// Codex streams independent reasoning items and indexed parts without text
+/// separators. Preserve those boundaries before the document folds deltas
+/// together; otherwise adjacent Markdown headings become `**one****two**`.
+/// One instance belongs to one thread, so child activity cannot split a
+/// parent's in-flight paragraph.
+#[derive(Default)]
+pub(crate) struct ReasoningStream {
+    last_part: Option<(String, bool, u64)>,
+    announced_summary: Option<(String, u64)>,
+    trailing_newlines: usize,
+}
+
+impl ReasoningStream {
+    pub(crate) fn map(&mut self, method: &str, params: &Value) -> Vec<AgentEvent> {
+        let id = item_id(params);
+        let summary = method != "item/reasoning/textDelta";
+        let index = field(
+            params,
+            if summary {
+                &["summaryIndex", "summary_index"]
+            } else {
+                &["contentIndex", "content_index"]
+            },
+        )
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            self.announced_summary
+                .as_ref()
+                .filter(|(item, _)| summary && item == &id)
+                .map(|(_, index)| *index)
+        })
+        .unwrap_or(0);
+        if method == "item/reasoning/summaryPartAdded" {
+            self.announced_summary = Some((id, index));
+            return Vec::new();
+        }
+        let Some(text) = delta_text(params) else {
+            return Vec::new();
+        };
+        let part = (id, summary, index);
+        let mut events = Vec::new();
+        if self.last_part.as_ref().is_some_and(|last| last != &part) {
+            let leading_newlines = text.chars().take_while(|&c| c == '\n').count();
+            let missing = 2usize.saturating_sub(self.trailing_newlines + leading_newlines);
+            if missing > 0 {
+                events.push(AgentEvent::ReasoningDelta {
+                    text: "\n".repeat(missing),
+                });
+                self.trailing_newlines += missing;
+            }
+        }
+        let trailing = text.chars().rev().take_while(|&c| c == '\n').count();
+        self.trailing_newlines = if trailing == text.len() {
+            self.trailing_newlines + trailing
+        } else {
+            trailing
+        };
+        self.last_part = Some(part);
+        events.push(AgentEvent::ReasoningDelta { text });
+        events
+    }
+}
+
 pub(crate) fn item_id(params: &Value) -> String {
     str_field(params, &["itemId", "item_id"])
 }
@@ -315,6 +378,7 @@ pub(crate) fn route_child_notification(method: &str) -> ChildRoute {
         | "item/agentMessage/delta"
         | "item/reasoning/textDelta"
         | "item/reasoning/summaryTextDelta"
+        | "item/reasoning/summaryPartAdded"
         | "turn/completed"
         | "turn/failed"
         | "turn/aborted"
@@ -327,7 +391,6 @@ pub(crate) fn route_child_notification(method: &str) -> ChildRoute {
         | "thread/status/changed"
         | "thread/tokenUsage/updated"
         // Child chatter with no consumer on this wire.
-        | "item/reasoning/summaryPartAdded"
         | "item/commandExecution/outputDelta"
         | "item/fileChange/outputDelta"
         | "item/fileChange/patchUpdated"
@@ -352,6 +415,30 @@ pub(crate) fn route_child_notification(method: &str) -> ChildRoute {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn reasoning_parts_preserve_chunking_and_existing_paragraph_breaks() {
+        let mut stream = ReasoningStream::default();
+        let mut text = String::new();
+        for params in [
+            json!({"itemId":"r1", "contentIndex":0, "textDelta":"**First"}),
+            json!({"itemId":"r1", "contentIndex":0, "textDelta":" heading**\n"}),
+            json!({"itemId":"r1", "contentIndex":1, "delta":"\nSecond paragraph.\n\n"}),
+            // An empty delta must not consume the next item's boundary.
+            json!({"itemId":"r2", "contentIndex":0, "delta":""}),
+            json!({"item_id":"r2", "content_index":0, "delta":"Third paragraph."}),
+        ] {
+            for event in stream.map("item/reasoning/textDelta", &params) {
+                if let AgentEvent::ReasoningDelta { text: delta } = event {
+                    text.push_str(&delta);
+                }
+            }
+        }
+        assert_eq!(
+            text,
+            "**First heading**\n\nSecond paragraph.\n\nThird paragraph."
+        );
+    }
 
     #[test]
     fn user_message_text_accepts_both_shapes() {

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -89,6 +89,30 @@ async fn run_to_end(
 }
 
 #[tokio::test]
+async fn reasoning_preserves_summary_parts_and_item_boundaries_per_thread() {
+    let (controls, _steer, _token) = controls("Yes");
+    let events = run_to_end(&harness(), request("scenario:reasoning"), controls).await;
+    let mut parent = String::new();
+    let mut child = String::new();
+    for event in &events {
+        match event {
+            AgentEvent::ReasoningDelta { text } => parent.push_str(text),
+            AgentEvent::Subagent { event, .. } => {
+                if let AgentEvent::ReasoningDelta { text } = event.as_ref() {
+                    child.push_str(text);
+                }
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(
+        parent,
+        "**Implementing file badges**\n\n**Preparing fixture screenshots**\n\nChecking the final result."
+    );
+    assert_eq!(child, "**Checking layout**\n\nInspecting the output panel.");
+}
+
+#[tokio::test]
 async fn happy_path_maps_deltas_items_usage_and_done() {
     let (controls, _steer, _token) = controls("Yes");
     let mut req = request("scenario:happy");

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -67,6 +67,24 @@ tid=$(rid "$turnline")
 
 case "$turnline" in
 
+*scenario:reasoning*)
+  emit "{\"id\":$tid,\"result\":{\"turn\":{\"id\":\"t-1\"}}}"
+  emit '{"method":"item/started","params":{"threadId":"th-1","item":{"id":"call_alpha","type":"subAgentActivity","kind":"spawned","agentThreadId":"child-1","agentPath":"/root/alpha"}}}'
+  emit '{"method":"item/reasoning/summaryPartAdded","params":{"threadId":"th-1","itemId":"r1","summaryIndex":0}}'
+  emit '{"method":"item/reasoning/summaryTextDelta","params":{"threadId":"th-1","itemId":"r1","summaryIndex":0,"delta":"**Implementing file"}}'
+  emit '{"method":"item/reasoning/summaryTextDelta","params":{"threadId":"child-1","itemId":"r1","summaryIndex":0,"delta":"**Checking"}}'
+  emit '{"method":"item/reasoning/summaryTextDelta","params":{"threadId":"th-1","itemId":"r1","summaryIndex":0,"delta":" badges**"}}'
+  emit '{"method":"item/reasoning/summaryPartAdded","params":{"threadId":"th-1","itemId":"r1","summaryIndex":1}}'
+  emit '{"method":"item/reasoning/summaryPartAdded","params":{"threadId":"th-1","itemId":"r1","summaryIndex":1}}'
+  emit '{"method":"item/reasoning/summaryTextDelta","params":{"threadId":"th-1","itemId":"r1","summaryIndex":1,"delta":"**Preparing fixture screenshots**"}}'
+  emit '{"method":"item/reasoning/summaryTextDelta","params":{"threadId":"child-1","itemId":"r1","summaryIndex":0,"delta":" layout**"}}'
+  emit '{"method":"item/reasoning/summaryPartAdded","params":{"threadId":"child-1","itemId":"r1","summaryIndex":1}}'
+  emit '{"method":"item/reasoning/summaryTextDelta","params":{"threadId":"child-1","itemId":"r1","delta":"Inspecting the output panel."}}'
+  emit '{"method":"item/reasoning/summaryTextDelta","params":{"threadId":"th-1","itemId":"r2","summaryIndex":0,"delta":"Checking the final result."}}'
+  emit '{"method":"turn/completed","params":{"threadId":"child-1","turn":{"id":"ct-1"}}}'
+  emit '{"method":"turn/completed","params":{"threadId":"th-1","turn":{"id":"t-1"}}}'
+  ;;
+
 *scenario:happy*)
   # Verify the turn/start + thread/start params the harness must send.
   for want in '"method":"turn/start"' '"effort":"ultra"' '"model":"gpt-5.6-sol"' \

--- a/crates/ui/assets/icons/file-code.svg
+++ b/crates/ui/assets/icons/file-code.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V8l-6-6Z"/><path d="M14 2v6h6M9 12l-3 3 3 3m6-6 3 3-3 3m-2-7-2 8"/></svg>

--- a/crates/ui/assets/icons/file-data.svg
+++ b/crates/ui/assets/icons/file-data.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V8l-6-6Z"/><path d="M14 2v6h6M10 11H9v3l-2 1 2 1v3h1m4-8h1v3l2 1-2 1v3h-1"/></svg>

--- a/crates/ui/assets/icons/file-image.svg
+++ b/crates/ui/assets/icons/file-image.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V8l-6-6Z"/><path d="M14 2v6h6M5 20l5-6 3 3 2-2 5 5"/><circle cx="8" cy="10" r="1.5"/></svg>

--- a/crates/ui/assets/icons/file-markdown.svg
+++ b/crates/ui/assets/icons/file-markdown.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V8l-6-6Z"/><path d="M14 2v6h6M7 18v-6l3 3 3-3v6m4-6v6m-2-2 2 2 2-2"/></svg>

--- a/crates/ui/assets/icons/file-style.svg
+++ b/crates/ui/assets/icons/file-style.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V8l-6-6Z"/><path d="M14 2v6h6M10 11l-2 8m7-8-2 8m-6-6h10M6 17h10"/></svg>

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -118,6 +118,12 @@ icon_assets![
     (COMMAND, "command"),
     (DOCUMENT, "document"),
     (DOCUMENT_ADD, "document-add"),
+    // File-kind glyphs, drawn in the same linear family for transcript badges.
+    (FILE_CODE, "file-code"),
+    (FILE_STYLE, "file-style"),
+    (FILE_DATA, "file-data"),
+    (FILE_MARKDOWN, "file-markdown"),
+    (FILE_IMAGE, "file-image"),
     (GLOBAL, "global"),
     (CHECKLIST, "checklist"),
     (WIDGET, "widget"),
@@ -185,9 +191,64 @@ pub fn icon(path: &'static str) -> Svg {
     svg().path(path).flex_none()
 }
 
+/// File badges use the basename so dotted directories cannot affect the icon.
+/// Accept either path separator: transcripts can come from a different OS.
+pub fn for_file(path: &str) -> &'static str {
+    let name = path
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(path)
+        .to_ascii_lowercase();
+    match name.as_str() {
+        "dockerfile" | "makefile" | "justfile" | ".bashrc" | ".zshrc" => return TERMINAL,
+        ".gitignore" | ".gitattributes" | ".editorconfig" | ".env" => return SETTINGS_MINIMALISTIC,
+        "readme" | "license" | "changelog" => return FILE_MARKDOWN,
+        _ if name.starts_with(".env.") => return SETTINGS_MINIMALISTIC,
+        _ => {}
+    }
+    match name.rsplit_once('.').map(|(_, extension)| extension) {
+        Some("css" | "scss" | "sass" | "less") => FILE_STYLE,
+        Some("json" | "jsonc" | "jsonl" | "csv" | "tsv" | "sql") => FILE_DATA,
+        Some("toml" | "yaml" | "yml" | "ini" | "conf" | "config" | "properties") => {
+            SETTINGS_MINIMALISTIC
+        }
+        Some("md" | "mdx" | "markdown" | "rst") => FILE_MARKDOWN,
+        Some("svg" | "png" | "jpg" | "jpeg" | "gif" | "webp" | "ico" | "avif" | "bmp" | "tiff") => {
+            FILE_IMAGE
+        }
+        Some("sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" | "cmd") => TERMINAL,
+        Some("zip" | "gz" | "tar" | "tgz" | "7z" | "rar" | "bz2" | "xz") => ARCHIVE_MINIMALISTIC,
+        Some(
+            "rs" | "js" | "jsx" | "mjs" | "cjs" | "ts" | "tsx" | "mts" | "cts" | "py" | "pyi"
+            | "go" | "rb" | "java" | "kt" | "kts" | "swift" | "c" | "h" | "cc" | "cpp" | "hpp"
+            | "cs" | "fs" | "php" | "lua" | "ex" | "exs" | "erl" | "hs" | "scala" | "dart" | "vue"
+            | "svelte" | "html" | "htm" | "xml" | "graphql" | "gql" | "proto" | "zig",
+        ) => FILE_CODE,
+        _ => DOCUMENT,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn file_icons_handle_paths_case_and_special_names() {
+        for (path, expected) in [
+            ("src/styles/globals.css", FILE_STYLE),
+            ("C:\\project\\README.MD", FILE_MARKDOWN),
+            ("src/component.test.tsx", FILE_CODE),
+            ("config/.env.local", SETTINGS_MINIMALISTIC),
+            ("Dockerfile", TERMINAL),
+            ("assets/LOGO.SVG", FILE_IMAGE),
+            ("package.json", FILE_DATA),
+            ("folder.css/unknown", DOCUMENT),
+            ("file.unrecognized", DOCUMENT),
+            ("", DOCUMENT),
+        ] {
+            assert_eq!(for_file(path), expected, "{path}");
+        }
+    }
 
     #[test]
     fn every_registered_icon_loads_and_parses() {

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -73,10 +73,9 @@ const SELECTION_SCROLL_EDGE_PX: f32 = 36.0;
 const SELECTION_SCROLL_MAX_STEP_PX: f32 = 24.0;
 /// Transcript column max width (zeron 46rem).
 pub const MAX_CONTENT_WIDTH: f32 = 736.0;
-/// Tool chip row height / gap — analytic, so fold heights need no measurement.
-/// A row is the guide rail + a 30px chip card centered in it (zeron
-/// tool-chip.tsx: `TOOL_CHIP_HEIGHT = 38`, card `h-[30px]`); rows stack with no
-/// gap so the rail reads continuous.
+/// Activity row height / gap — analytic, so fold heights need no measurement.
+/// Ordinary tools place their icon on the rail; subagents retain a 30px card.
+/// Rows stack without a gap so the rail continues alongside expanded output.
 pub const CHIP_HEIGHT: f32 = 38.0;
 pub const CHIP_GAP: f32 = 0.0;
 pub const CHIP_CARD_HEIGHT: f32 = 30.0;
@@ -85,6 +84,8 @@ pub const CHIP_CARD_HEIGHT: f32 = 30.0;
 /// header inside a 30px bordered card clips 2px off the bottom and every
 /// glyph/icon reads high (user report).
 const CHIP_HEADER_HEIGHT: f32 = CHIP_CARD_HEIGHT - 2.0;
+/// Border around the inset output panel of an ordinary activity row.
+const ACTIVITY_DETAIL_BORDER: f32 = 2.0;
 
 /// Signed list scroll step for a pointer near a viewport edge.
 ///
@@ -4913,7 +4914,11 @@ impl Transcript {
                 .zip(&detail_opens)
                 .filter(|(_, open)| **open)
                 .map(|(((detail, invocation), affordance), _)| {
-                    invocation.as_deref().map_or(0.0, detail_height)
+                    (if collapses {
+                        ACTIVITY_DETAIL_BORDER
+                    } else {
+                        0.0
+                    }) + invocation.as_deref().map_or(0.0, detail_height)
                         + detail.as_deref().map_or(0.0, detail_height)
                         + if affordance.is_some() {
                             BLOB_AFFORDANCE_HEIGHT
@@ -4926,8 +4931,8 @@ impl Transcript {
         let summary = tool_group_summary(tools);
 
         let toggle_id = row_id.clone();
-        // Header (zeron tool-group.tsx): a small chevron tile centered over the
-        // chips' guide rail, then the quiet 12px summary.
+        // A quiet summary sits above the activity rail; its chevron has the
+        // same footprint as the tool icons below it.
         let header = div()
             .id(SharedString::from(format!("{row_id}-hdr")))
             .flex()
@@ -4954,14 +4959,18 @@ impl Transcript {
                 div()
                     .size(px(18.0))
                     .flex_none()
-                    .rounded(px(5.0))
-                    .bg(crate::theme::ink(0.06))
                     .flex()
                     .items_center()
                     .justify_center()
-                    .text_size(px(10.0))
-                    .text_color(theme.text_muted.opacity(0.7))
-                    .child(SharedString::from(if open { "▾" } else { "▸" })),
+                    .child(
+                        crate::icons::icon(if open {
+                            crate::icons::ALT_ARROW_DOWN
+                        } else {
+                            crate::icons::ALT_ARROW_RIGHT
+                        })
+                        .size(px(14.0))
+                        .text_color(theme.text_muted),
+                    ),
             )
             .child(
                 div()
@@ -5009,7 +5018,14 @@ impl Transcript {
                 let detail = details[ix].clone();
                 let invocation = invocations[ix].clone();
                 if detail.is_none() && invocation.is_none() {
-                    return tool_chip(tool, collapses, theme, cx.entity_id(), cx);
+                    return tool_chip(
+                        tool,
+                        collapses,
+                        ix + 1 < tools.len(),
+                        theme,
+                        cx.entity_id(),
+                        cx,
+                    );
                 }
                 let affordance = affordances[ix].clone();
                 let affordance_h = if affordance.is_some() {
@@ -5020,19 +5036,16 @@ impl Transcript {
                 let open = detail_opens[ix];
                 let dfold = detail_folds[ix];
                 let key = SharedString::from(format!("{row_id}#d{ix}"));
-                // Expandable chip: ONE card whose header row is the chip and
-                // whose body is the detail — not a floating card below it.
-                // The guide rail stretches with the row, so an open detail
-                // never breaks the rail.
-                //
-                // The card's height is EXPLICIT (border-box), not intrinsic:
-                // an auto-height card adds its 2px of borders on top of the
-                // 30px header, and with N chips that overflowed the group's
-                // analytic height by 2N px — the last chips rendered clipped
-                // (user report: "tool calls cut off at the bottom"). The
-                // explicit height is also what the open/close tween animates.
+                // Ordinary tools expand into an inset output panel. Subagent
+                // fallbacks retain their card; both use explicit heights so
+                // the row and group fold animations stay in sync.
                 let closed_h = CHIP_CARD_HEIGHT;
                 let open_h = CHIP_CARD_HEIGHT
+                    + if collapses {
+                        ACTIVITY_DETAIL_BORDER
+                    } else {
+                        0.0
+                    }
                     + invocation.as_deref().map_or(0.0, detail_height)
                     + detail.as_deref().map_or(0.0, detail_height)
                     + affordance_h;
@@ -5051,14 +5064,20 @@ impl Transcript {
                     .flex()
                     .flex_col()
                     .overflow_hidden()
-                    .rounded(px(9.0))
-                    .border_1()
-                    .border_color(crate::theme::hairline(0.07))
-                    .bg(crate::theme::ink(0.03))
+                    .when(!collapses, |card| {
+                        card.rounded(px(9.0))
+                            .border_1()
+                            .border_color(crate::theme::hairline(0.07))
+                            .bg(crate::theme::ink(0.03))
+                    })
                     .child(
                         div()
                             .id(key.clone())
-                            .h(px(CHIP_HEADER_HEIGHT))
+                            .h(px(if collapses {
+                                CHIP_CARD_HEIGHT
+                            } else {
+                                CHIP_HEADER_HEIGHT
+                            }))
                             .flex_none()
                             .flex()
                             .items_center()
@@ -5066,7 +5085,7 @@ impl Transcript {
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 let entry =
                                     this.tool_details.entry(toggle_key.clone()).or_default();
-                                let currently_open = entry.open.unwrap_or(false);
+                                let currently_open = entry.open.unwrap_or(open);
                                 entry.from = if currently_open { open_h } else { closed_h };
                                 entry.open = Some(!currently_open);
                                 entry.epoch += 1;
@@ -5096,8 +5115,21 @@ impl Transcript {
                 // Invocation first (what was asked), then output/diff (what
                 // came back), each under its own hairline.
                 if open || animating {
+                    let mut panel = div()
+                        .flex_none()
+                        .min_w_0()
+                        .flex()
+                        .flex_col()
+                        .overflow_hidden()
+                        .when(collapses, |panel| {
+                            panel
+                                .rounded(px(9.0))
+                                .border_1()
+                                .border_color(crate::theme::hairline(0.09))
+                                .bg(crate::theme::ink(0.025))
+                        });
                     if let Some(invocation) = invocation.as_deref() {
-                        card = card
+                        panel = panel
                             .child(
                                 div()
                                     .h(px(DETAIL_SEPARATOR))
@@ -5107,7 +5139,7 @@ impl Transcript {
                             .child(detail_body(invocation, None, theme));
                     }
                     if let Some(detail) = detail.as_deref() {
-                        card = card
+                        panel = panel
                             .child(
                                 div()
                                     .h(px(DETAIL_SEPARATOR))
@@ -5140,8 +5172,9 @@ impl Transcript {
                                     cx.notify();
                                 }));
                         }
-                        card = card.child(row);
+                        panel = panel.child(row);
                     }
+                    card = card.child(panel);
                 }
                 let card: AnyElement = if animating {
                     let from = dfold.from;
@@ -5160,17 +5193,9 @@ impl Transcript {
                     .flex_none()
                     .flex()
                     .flex_row()
-                    // Guide rail: no fixed height — stretches to the card,
-                    // detail included. Agent-only groups skip it (no header
-                    // chevron for the rail to sit under).
+                    // Stretch the line alongside the entire output panel.
                     .when(collapses, |row| {
-                        row.child(
-                            div()
-                                .ml(px(12.0))
-                                .w(px(1.0))
-                                .flex_none()
-                                .bg(crate::theme::ink(0.08)),
-                        )
+                        row.child(activity_rail(tool, ix + 1 < tools.len(), theme))
                     })
                     .child(card)
                     .into_any_element()
@@ -5437,7 +5462,7 @@ fn input_chip(header: SharedString, resolved: bool, theme: &Theme) -> AnyElement
 /// The glyph for a tool call (zeron tool-chip.tsx `toolIcon`, Solar set).
 fn tool_icon_path(call: &ToolCall) -> &'static str {
     match call {
-        ToolCall::Exec { .. } => crate::icons::COMMAND,
+        ToolCall::Exec { .. } => crate::icons::TERMINAL,
         ToolCall::ReadFile { .. } | ToolCall::ApplyPatch { .. } => crate::icons::DOCUMENT,
         ToolCall::WriteFile { .. } => crate::icons::DOCUMENT_ADD,
         ToolCall::EditFile { .. } => crate::icons::PEN,
@@ -5651,6 +5676,14 @@ fn chip_header_row(
     } else {
         tool_chip_content(&tool.call)
     };
+    let activity = !is_agent_tool(tool);
+    let file = matches!(
+        tool.call,
+        ToolCall::ReadFile { .. }
+            | ToolCall::WriteFile { .. }
+            | ToolCall::EditFile { .. }
+            | ToolCall::ApplyPatch { path: Some(_) }
+    );
     let running = tool.subagent_ref.is_some()
         && matches!(tool.subagent_status, Some(SubagentStatus::Running));
     let failed = tool.is_error
@@ -5662,44 +5695,52 @@ fn chip_header_row(
         theme.text_muted
     };
     div()
-        .h(px(CHIP_HEADER_HEIGHT))
+        .h(px(if activity {
+            CHIP_CARD_HEIGHT
+        } else {
+            CHIP_HEADER_HEIGHT
+        }))
         .w_full()
         .min_w_0()
         .flex()
         .flex_row()
         .items_center()
         .gap(px(8.0))
-        .px(px(8.0))
+        .px(px(if activity { 0.0 } else { 8.0 }))
         .text_size(px(12.0))
         .line_height(px(18.0))
-        .child(
-            // Icon tile (`size-[18px] rounded-[5px] bg-white/[0.08]`,
-            // icon size-3).
-            div()
-                .size(px(18.0))
-                .flex_none()
-                .rounded(px(5.0))
-                .bg(crate::theme::ink(0.08))
-                .flex()
-                .items_center()
-                .justify_center()
-                .child(
-                    crate::icons::icon(if tool.is_thought {
-                        crate::icons::CHAT_ROUND_LINE
-                    } else {
-                        tool_icon_path(&tool.call)
-                    })
-                    .size(px(12.0))
-                    .text_color(theme.text_muted),
-                ),
-        )
+        .when(!activity, |row| {
+            row.child(
+                // Subagent icon tile (`size-[18px] rounded-[5px] bg-white/[0.08]`,
+                // icon size-3).
+                div()
+                    .size(px(18.0))
+                    .flex_none()
+                    .rounded(px(5.0))
+                    .bg(crate::theme::ink(0.08))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(
+                        crate::icons::icon(if tool.is_thought {
+                            crate::icons::CHAT_ROUND_LINE
+                        } else {
+                            tool_icon_path(&tool.call)
+                        })
+                        .size(px(12.0))
+                        .text_color(theme.text_muted),
+                    ),
+            )
+        })
         .child(
             div()
                 .flex_none()
                 .h(px(18.0))
                 .flex()
                 .items_center()
-                .font_weight(gpui::FontWeight::MEDIUM)
+                .when(!activity, |label| {
+                    label.font_weight(gpui::FontWeight::MEDIUM)
+                })
                 .text_color(tint)
                 .child(SharedString::from(label)),
         )
@@ -5707,16 +5748,35 @@ fn chip_header_row(
             div()
                 .flex_1()
                 .min_w_0()
-                .h(px(18.0))
+                .h(px(if file { 24.0 } else { 18.0 }))
                 .flex()
                 .items_center()
                 .truncate()
                 .text_color(if failed {
                     theme.danger
+                } else if activity {
+                    theme.text_muted
                 } else {
                     theme.text.opacity(0.85)
                 })
-                .child(SharedString::from(detail)),
+                .child(
+                    div()
+                        .min_w_0()
+                        .truncate()
+                        .when(file, |name| {
+                            name.px(px(6.0))
+                                .py(px(1.0))
+                                .rounded(px(5.0))
+                                .border_1()
+                                .border_color(crate::theme::hairline(0.09))
+                                .text_color(if failed {
+                                    theme.danger
+                                } else {
+                                    theme.text.opacity(0.85)
+                                })
+                        })
+                        .child(SharedString::from(detail)),
+                ),
         )
         .when_some(tool.call.subagent_model(), |row, model| {
             // Which model the child runs on, when the spawn named one.
@@ -5762,16 +5822,23 @@ fn chip_header_row(
             let tile = div()
                 .size(px(18.0))
                 .flex_none()
-                .rounded(px(5.0))
-                .bg(crate::theme::ink(0.06))
+                .when(!activity, |tile| {
+                    tile.rounded(px(5.0)).bg(crate::theme::ink(0.06))
+                })
                 .flex()
                 .items_center()
                 .justify_center()
                 .text_color(theme.text_muted.opacity(0.8));
             row.child(match trail {
-                ChipTrail::Chevron { open } => tile
-                    .text_size(px(10.0))
-                    .child(SharedString::from(if open { "▾" } else { "▸" })),
+                ChipTrail::Chevron { open } => tile.child(
+                    crate::icons::icon(if open {
+                        crate::icons::ALT_ARROW_DOWN
+                    } else {
+                        crate::icons::ALT_ARROW_RIGHT
+                    })
+                    .size(px(12.0))
+                    .text_color(theme.text_faint),
+                ),
                 ChipTrail::OpenArrow => tile.child(
                     crate::icons::icon(crate::icons::ARROW_UP_RIGHT)
                         .size(px(11.0))
@@ -5853,11 +5920,58 @@ fn subagent_tab_title(call: &ToolCall) -> SharedString {
     "Subagent".into()
 }
 
-/// A plain (non-expandable) chip: bordered card, plus the group guide rail
-/// when the chip lives under a collapsible header.
+/// The icon interrupts the rail, leaving a small breathing gap on each side.
+/// Absolute line segments stretch with the row, including expanded output.
+/// The final row ends at its icon instead of leaving a dangling line.
+fn activity_rail(tool: &ToolItem, continues: bool, theme: &Theme) -> gpui::Div {
+    let tint = if tool.is_error {
+        theme.danger
+    } else {
+        theme.text_muted
+    };
+    div()
+        .relative()
+        .w(px(26.0))
+        .flex_none()
+        .child(
+            div()
+                .absolute()
+                .left(px(12.5))
+                .top_0()
+                .w(px(1.0))
+                .h(px(7.0))
+                .bg(crate::theme::hairline(0.12)),
+        )
+        .when(continues, |rail| {
+            rail.child(
+                div()
+                    .absolute()
+                    .left(px(12.5))
+                    .top(px(31.0))
+                    .bottom_0()
+                    .w(px(1.0))
+                    .bg(crate::theme::hairline(0.12)),
+            )
+        })
+        .child(
+            crate::icons::icon(if tool.is_thought {
+                crate::icons::CHAT_ROUND_LINE
+            } else {
+                tool_icon_path(&tool.call)
+            })
+            .absolute()
+            .left(px(5.0))
+            .top(px(11.0))
+            .size(px(16.0))
+            .text_color(tint),
+        )
+}
+
+/// A plain activity row, or a card for a subagent without a linked document.
 fn tool_chip(
     tool: &ToolItem,
     rail: bool,
+    continues: bool,
     theme: &Theme,
     view: gpui::EntityId,
     cx: &mut gpui::App,
@@ -5868,30 +5982,23 @@ fn tool_chip(
         .flex_none()
         .flex()
         .flex_row()
-        .items_center()
-        .when(rail, |row| {
-            row.child(
-                div()
-                    .ml(px(12.0))
-                    .h_full()
-                    .w(px(1.0))
-                    .flex_none()
-                    .bg(crate::theme::ink(0.08)),
-            )
-        })
+        .when(rail, |row| row.child(activity_rail(tool, continues, theme)))
         .child(
             div()
                 .when(rail, |el| el.ml(px(12.0)))
+                .my(px((CHIP_HEIGHT - CHIP_CARD_HEIGHT) / 2.0))
                 .h(px(CHIP_CARD_HEIGHT))
                 .min_w_0()
                 .flex_1()
                 .flex()
                 .items_center()
                 .overflow_hidden()
-                .rounded(px(9.0))
-                .border_1()
-                .border_color(crate::theme::hairline(0.07))
-                .bg(crate::theme::ink(0.03))
+                .when(!rail, |card| {
+                    card.rounded(px(9.0))
+                        .border_1()
+                        .border_color(crate::theme::hairline(0.07))
+                        .bg(crate::theme::ink(0.03))
+                })
                 .child(chip_header_row(tool, None, theme, view, cx)),
         )
         .into_any_element()
@@ -6792,6 +6899,30 @@ mod tests {
 
     fn line_string(line: &[InlineRun]) -> String {
         line.iter().map(|r| r.text.as_str()).collect()
+    }
+
+    #[test]
+    fn codex_summary_paragraphs_render_as_separate_styled_lines() {
+        let lines = thought_of("**Implementing file badges**\n\n**Preparing fixture screenshots**");
+        assert_eq!(
+            lines
+                .iter()
+                .map(|line| line_string(line))
+                .collect::<Vec<_>>(),
+            [
+                "Implementing file badges",
+                "",
+                "Preparing fixture screenshots"
+            ]
+        );
+        for ix in [0, 2] {
+            assert!(
+                lines[ix]
+                    .iter()
+                    .filter(|run| !run.text.is_empty())
+                    .all(|run| run.style.bold)
+            );
+        }
     }
 
     #[test]

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -5949,9 +5949,9 @@ fn activity_rail(tool: &ToolItem, continues: bool, theme: &Theme) -> gpui::Div {
                 tool_icon_path(&tool.call)
             })
             .absolute()
-            .left(px(5.0))
-            .top(px(11.0))
-            .size(px(16.0))
+            .left(px(6.0))
+            .top(px(12.0))
+            .size(px(14.0))
             .text_color(tint),
         )
 }

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -84,8 +84,10 @@ pub const CHIP_CARD_HEIGHT: f32 = 30.0;
 /// header inside a 30px bordered card clips 2px off the bottom and every
 /// glyph/icon reads high (user report).
 const CHIP_HEADER_HEIGHT: f32 = CHIP_CARD_HEIGHT - 2.0;
-/// Border around the inset output panel of an ordinary activity row.
-const ACTIVITY_DETAIL_BORDER: f32 = 2.0;
+/// Shared columns keep the group summary, tool labels, and expanded text aligned.
+const ACTIVITY_GUTTER_WIDTH: f32 = 26.0;
+const ACTIVITY_TEXT_GAP: f32 = 4.0;
+const TOOL_TEXT_SIZE: f32 = 12.0;
 
 /// Signed list scroll step for a pointer near a viewport edge.
 ///
@@ -4914,11 +4916,7 @@ impl Transcript {
                 .zip(&detail_opens)
                 .filter(|(_, open)| **open)
                 .map(|(((detail, invocation), affordance), _)| {
-                    (if collapses {
-                        ACTIVITY_DETAIL_BORDER
-                    } else {
-                        0.0
-                    }) + invocation.as_deref().map_or(0.0, detail_height)
+                    invocation.as_deref().map_or(0.0, detail_height)
                         + detail.as_deref().map_or(0.0, detail_height)
                         + if affordance.is_some() {
                             BLOB_AFFORDANCE_HEIGHT
@@ -4938,11 +4936,11 @@ impl Transcript {
             .flex()
             .flex_row()
             .items_center()
-            .gap(px(8.0))
-            .px(px(4.0))
+            .gap(px(ACTIVITY_TEXT_GAP))
+            .pr(px(4.0))
             .h(px(26.0))
             .cursor_pointer()
-            .text_size(px(12.0))
+            .text_size(px(TOOL_TEXT_SIZE))
             .line_height(px(18.0))
             // Quiet even when children failed: agents routinely have failed
             // probes mid-work, and a red HEADER read as "this whole step
@@ -4957,7 +4955,8 @@ impl Transcript {
             }))
             .child(
                 div()
-                    .size(px(18.0))
+                    .w(px(ACTIVITY_GUTTER_WIDTH))
+                    .h(px(18.0))
                     .flex_none()
                     .flex()
                     .items_center()
@@ -5036,16 +5035,11 @@ impl Transcript {
                 let open = detail_opens[ix];
                 let dfold = detail_folds[ix];
                 let key = SharedString::from(format!("{row_id}#d{ix}"));
-                // Ordinary tools expand into an inset output panel. Subagent
-                // fallbacks retain their card; both use explicit heights so
-                // the row and group fold animations stay in sync.
+                // Ordinary tools expand into muted text along the same column.
+                // Subagent fallbacks retain their card; explicit heights keep
+                // the row and group fold animations in sync.
                 let closed_h = CHIP_CARD_HEIGHT;
                 let open_h = CHIP_CARD_HEIGHT
-                    + if collapses {
-                        ACTIVITY_DETAIL_BORDER
-                    } else {
-                        0.0
-                    }
                     + invocation.as_deref().map_or(0.0, detail_height)
                     + detail.as_deref().map_or(0.0, detail_height)
                     + affordance_h;
@@ -5058,7 +5052,7 @@ impl Transcript {
                 let group_key = row_id.clone();
                 let mut card = div()
                     .my(px((CHIP_HEIGHT - CHIP_CARD_HEIGHT) / 2.0))
-                    .when(collapses, |el| el.ml(px(12.0)))
+                    .when(collapses, |el| el.ml(px(ACTIVITY_TEXT_GAP)))
                     .min_w_0()
                     .flex_1()
                     .flex()
@@ -5113,28 +5107,21 @@ impl Transcript {
                     );
                 // The body stays mounted while the close tween shrinks over it.
                 // Invocation first (what was asked), then output/diff (what
-                // came back), each under its own hairline.
+                // came back), separated by a small gap.
                 if open || animating {
                     let mut panel = div()
                         .flex_none()
                         .min_w_0()
                         .flex()
                         .flex_col()
-                        .overflow_hidden()
-                        .when(collapses, |panel| {
-                            panel
-                                .rounded(px(9.0))
-                                .border_1()
-                                .border_color(crate::theme::hairline(0.09))
-                                .bg(crate::theme::ink(0.025))
-                        });
+                        .overflow_hidden();
                     if let Some(invocation) = invocation.as_deref() {
                         panel = panel
                             .child(
                                 div()
                                     .h(px(DETAIL_SEPARATOR))
                                     .flex_none()
-                                    .bg(crate::theme::hairline(0.06)),
+                                    .when(!collapses, |line| line.bg(crate::theme::hairline(0.06))),
                             )
                             .child(detail_body(invocation, None, theme));
                     }
@@ -5144,7 +5131,7 @@ impl Transcript {
                                 div()
                                     .h(px(DETAIL_SEPARATOR))
                                     .flex_none()
-                                    .bg(crate::theme::hairline(0.06)),
+                                    .when(!collapses, |line| line.bg(crate::theme::hairline(0.06))),
                             )
                             .child(detail_body(detail, detail_highlights[ix].clone(), theme));
                     }
@@ -5157,10 +5144,9 @@ impl Transcript {
                             .id(SharedString::from(format!("{key}-blob")))
                             .h(px(BLOB_AFFORDANCE_HEIGHT))
                             .flex_none()
-                            .px(px(12.0))
                             .flex()
                             .items_center()
-                            .text_size(px(10.5))
+                            .text_size(px(TOOL_TEXT_SIZE))
                             .text_color(theme.text_faint)
                             .child(label);
                         if !loading {
@@ -5193,7 +5179,7 @@ impl Transcript {
                     .flex_none()
                     .flex()
                     .flex_row()
-                    // Stretch the line alongside the entire output panel.
+                    // Stretch the line alongside the expanded text.
                     .when(collapses, |row| {
                         row.child(activity_rail(tool, ix + 1 < tools.len(), theme))
                     })
@@ -5500,13 +5486,12 @@ fn detail_body(
         ToolDetail::Stats { stats } => body
             .py(px(6.0))
             .font_family(theme.font_mono.clone())
-            .text_size(px(11.5))
+            .text_size(px(TOOL_TEXT_SIZE))
             .children(stats.iter().map(|stat| {
                 div()
                     .h(px(OUTPUT_LINE_HEIGHT))
                     .w_full()
                     .min_w_0()
-                    .px(px(12.0))
                     .flex()
                     .items_center()
                     .gap(px(8.0))
@@ -5515,7 +5500,7 @@ fn detail_body(
                             .min_w_0()
                             .flex_1()
                             .truncate()
-                            .text_color(theme.text.opacity(0.85))
+                            .text_color(theme.text_faint)
                             .child(SharedString::from(stat.path.clone())),
                     )
                     .child(
@@ -5538,16 +5523,15 @@ fn detail_body(
         } => body
             .py(px(6.0))
             .font_family(theme.font_mono.clone())
-            .text_size(px(11.5))
+            .text_size(px(TOOL_TEXT_SIZE))
             .children(lines.iter().map(|line| {
                 div()
                     .h(px(OUTPUT_LINE_HEIGHT))
                     .w_full()
                     .min_w_0()
-                    .px(px(12.0))
                     .flex()
                     .items_center()
-                    .text_color(theme.text.opacity(0.85))
+                    .text_color(theme.text_faint)
                     .child(div().w_full().min_w_0().truncate().child(line.clone()))
             }))
             .when(*truncated_by > 0, |block| {
@@ -5559,13 +5543,12 @@ fn detail_body(
             truncated_by,
         } => body
             .py(px(6.0))
-            .text_size(px(12.0))
+            .text_size(px(TOOL_TEXT_SIZE))
             .children(lines.iter().map(|line| {
                 let row = div()
                     .h(px(OUTPUT_LINE_HEIGHT))
                     .w_full()
                     .min_w_0()
-                    .px(px(12.0))
                     .flex()
                     .items_center();
                 let Some((text, runs)) = thought_line_text(line, theme) else {
@@ -5590,16 +5573,15 @@ fn detail_body(
 fn more_lines_row(truncated_by: usize, theme: &Theme) -> gpui::Div {
     div()
         .h(px(OUTPUT_LINE_HEIGHT))
-        .px(px(12.0))
         .flex()
         .items_center()
-        .text_size(px(10.5))
+        .text_size(px(TOOL_TEXT_SIZE))
         .text_color(theme.text_faint)
         .child(SharedString::from(format!("… {truncated_by} more lines")))
 }
 
 /// Shape one flattened thought line into gpui text runs — the detail-body
-/// palette: muted foreground prose, semibold for bold, violet mono for code,
+/// palette: faint foreground prose, semibold for bold, mono for code,
 /// underlined links (NOT clickable — a thought is a record, not a surface).
 fn thought_line_text(line: &[InlineRun], theme: &Theme) -> Option<(SharedString, Vec<TextRun>)> {
     let mut text = String::new();
@@ -5611,7 +5593,7 @@ fn thought_line_text(line: &[InlineRun], theme: &Theme) -> Option<(SharedString,
         let mut f = if run.style.code {
             gpui::font(theme.font_mono.clone())
         } else {
-            gpui::font(theme.font_sans.clone())
+            gpui::font(theme.font_sans_fixed.clone())
         };
         if run.style.bold {
             f.weight = gpui::FontWeight::SEMIBOLD;
@@ -5622,20 +5604,16 @@ fn thought_line_text(line: &[InlineRun], theme: &Theme) -> Option<(SharedString,
         runs.push(TextRun {
             len: run.text.len(),
             font: f,
-            color: if run.style.code {
-                render::inline_code_text(theme)
-            } else {
-                theme.text.opacity(0.85)
-            },
+            color: theme.text_faint,
             background_color: None,
             underline: run.style.link.is_some().then_some(gpui::UnderlineStyle {
-                color: Some(theme.text_muted),
+                color: Some(theme.text_faint),
                 thickness: px(1.0),
                 wavy: false,
             }),
             strikethrough: run.style.strikethrough.then_some(gpui::StrikethroughStyle {
                 thickness: px(1.0),
-                color: Some(theme.text_muted),
+                color: Some(theme.text_faint),
             }),
         });
         text.push_str(&run.text);
@@ -5707,7 +5685,7 @@ fn chip_header_row(
         .items_center()
         .gap(px(8.0))
         .px(px(if activity { 0.0 } else { 8.0 }))
-        .text_size(px(12.0))
+        .text_size(px(TOOL_TEXT_SIZE))
         .line_height(px(18.0))
         .when(!activity, |row| {
             row.child(
@@ -5931,7 +5909,7 @@ fn activity_rail(tool: &ToolItem, continues: bool, theme: &Theme) -> gpui::Div {
     };
     div()
         .relative()
-        .w(px(26.0))
+        .w(px(ACTIVITY_GUTTER_WIDTH))
         .flex_none()
         .child(
             div()
@@ -5985,7 +5963,7 @@ fn tool_chip(
         .when(rail, |row| row.child(activity_rail(tool, continues, theme)))
         .child(
             div()
-                .when(rail, |el| el.ml(px(12.0)))
+                .when(rail, |el| el.ml(px(ACTIVITY_TEXT_GAP)))
                 .my(px((CHIP_HEIGHT - CHIP_CARD_HEIGHT) / 2.0))
                 .h(px(CHIP_CARD_HEIGHT))
                 .min_w_0()

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -5655,13 +5655,13 @@ fn chip_header_row(
         tool_chip_content(&tool.call)
     };
     let activity = !is_agent_tool(tool);
-    let file = matches!(
-        tool.call,
-        ToolCall::ReadFile { .. }
-            | ToolCall::WriteFile { .. }
-            | ToolCall::EditFile { .. }
-            | ToolCall::ApplyPatch { path: Some(_) }
-    );
+    let file_path = match &tool.call {
+        ToolCall::ReadFile { path }
+        | ToolCall::WriteFile { path, .. }
+        | ToolCall::EditFile { path, .. }
+        | ToolCall::ApplyPatch { path: Some(path) } => Some(path.as_str()),
+        _ => None,
+    };
     let running = tool.subagent_ref.is_some()
         && matches!(tool.subagent_status, Some(SubagentStatus::Running));
     let failed = tool.is_error
@@ -5726,7 +5726,7 @@ fn chip_header_row(
             div()
                 .flex_1()
                 .min_w_0()
-                .h(px(if file { 24.0 } else { 18.0 }))
+                .h(px(if file_path.is_some() { 24.0 } else { 18.0 }))
                 .flex()
                 .items_center()
                 .truncate()
@@ -5737,24 +5737,35 @@ fn chip_header_row(
                 } else {
                     theme.text.opacity(0.85)
                 })
-                .child(
+                .child(if let Some(path) = file_path {
+                    let badge = div()
+                        .min_w_0()
+                        .h(px(22.0))
+                        .flex()
+                        .items_center()
+                        .gap(px(5.0))
+                        .px(px(6.0))
+                        .rounded(px(5.0))
+                        .bg(crate::theme::ink(0.06))
+                        .text_color(if failed {
+                            theme.danger
+                        } else {
+                            theme.text.opacity(0.85)
+                        })
+                        .child(
+                            crate::icons::icon(crate::icons::for_file(path))
+                                .size(px(14.0))
+                                .text_color(tint),
+                        )
+                        .child(div().min_w_0().truncate().child(SharedString::from(detail)));
+                    crate::frost::frosted(5.0, 16.0, badge).into_any_element()
+                } else {
                     div()
                         .min_w_0()
                         .truncate()
-                        .when(file, |name| {
-                            name.px(px(6.0))
-                                .py(px(1.0))
-                                .rounded(px(5.0))
-                                .border_1()
-                                .border_color(crate::theme::hairline(0.09))
-                                .text_color(if failed {
-                                    theme.danger
-                                } else {
-                                    theme.text.opacity(0.85)
-                                })
-                        })
-                        .child(SharedString::from(detail)),
-                ),
+                        .child(SharedString::from(detail))
+                        .into_any_element()
+                }),
         )
         .when_some(tool.call.subagent_model(), |row, model| {
             // Which model the child runs on, when the spawn named one.


### PR DESCRIPTION
Tool calls now render as a quiet activity list: tool-specific icons interrupt a thin vertical line, file names sit in filled badges with file-type icons and theme-aware backdrop blur, and expanded details appear as muted text without cards. Group summaries, tool labels, and nested text share one left edge and a 12px font size. The line stretches beside open details and ends at the final tool. Subagents keep their separate cards and open their own transcript pane.

Codex thinking previously concatenated independent summary parts and reasoning items, turning `**Implementing file badges**` and `**Preparing fixture screenshots**` into one malformed Markdown line. The adapter now preserves paragraph boundaries using item IDs and summary/content indices, with independent state for each parent or child thread. Chunked headings, existing newlines, empty deltas, repeated part announcements, and interleaved subagent traffic are covered. This fixes new streams; previously stored text has already lost those boundaries.

Also fixes the first click on an automatically expanded live thought so it closes immediately.

Validation:

- Native desktop build passed (`cargo build -p zeron`).
- 52 transcript tests passed, including multiline styled thinking and subagent grouping.
- Four icon tests passed, including mixed-case extensions, Windows paths, dotfiles, and unknown file types.
- Checked filled file badges in light/dark themes and narrow windows; long paths truncate while preserving the icon.
- 17 Codex unit tests and 15 Codex integration tests passed; two existing live tests remain ignored.
- Checked the native UI in light/dark themes, expanded/collapsed details, and the separate subagent pane. Captures below use local demo data and show the 14px tool-step icons from `8fc11e1`.

Dark theme, activity icons, and filled file-type badges:

![File-type badges in dark mode](https://github.com/user-attachments/assets/696e9e3e-beff-4f4b-b58d-a5407d52f360)

Expanded codeblock tool output (Read tool, local CSS demo):

![Expanded Read tool with multiline CSS codeblock output](https://github.com/user-attachments/assets/a6d738e0-178e-40d8-be11-68aebed81584)

Light theme:

![File-type badges in light mode](https://github.com/user-attachments/assets/b63fae7f-dc56-4567-9488-f15acd323809)

Subagents remain separate and open their own pane:

![Separate subagent transcript](https://github.com/user-attachments/assets/c2af947d-8000-4e86-8930-4670806d6672)

<details>
<summary>User-provided references and thinking bug</summary>

![File pills and grouped activity](https://github.com/user-attachments/assets/56e9f490-8c36-4f66-b1a6-a8d4604a7ab7)

![Preferred lines and icons](https://github.com/user-attachments/assets/cf4d32c8-86f3-422f-8c34-7659209a8eff)

![Codex thinking before this fix](https://github.com/user-attachments/assets/b3aea3a8-711d-49f4-b615-4405bd33d954)

Follow-up references for flat nested text and shared alignment:

![Nested text reference](https://github.com/user-attachments/assets/6af5f7e6-5cfe-4156-a804-b64b303b9fa2)

![Alignment reference](https://github.com/user-attachments/assets/2b9e564b-f8fe-485b-bf29-bf8a2e0c0ce0)

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791149981&installation_model_id=425430&pr_number=250&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F250&signature=e5bbce468eec40930113e986b96dc9f4845b06117566a568f2825b0347e1680c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->