### PR TITLE
feat(landing): add PostHog traffic and download tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,10 @@ jobs:
         if: steps.changed.outputs.changed == 'true'
         with:
           node-version: 22
+      - name: test
+        if: steps.changed.outputs.changed == 'true'
+        working-directory: apps/landing
+        run: node --test telemetry.test.mjs
       - name: deploy
         if: steps.changed.outputs.changed == 'true' && env.CLOUDFLARE_API_TOKEN != ''
         working-directory: apps/landing

--- a/apps/landing/public/index.html
+++ b/apps/landing/public/index.html
@@ -9,6 +9,7 @@
 <meta property="og:description" content="Control your coding agents from any of your devices." />
 <meta property="og:image" content="/assets/app-screenshot.jpg" />
 <link rel="icon" href="/assets/zeron-favicon-v3.png" type="image/png" sizes="128x128" />
+<script defer src="/telemetry.js"></script>
 <style>
   @font-face {
     font-family: "Geist";

--- a/apps/landing/public/telemetry.js
+++ b/apps/landing/public/telemetry.js
@@ -8,8 +8,7 @@
   ) return;
 
   const distinctId = crypto.randomUUID();
-  const sessionTimestamp = Date.now().toString(16).padStart(12, "0");
-  const sessionId = `${sessionTimestamp.slice(0, 8)}-${sessionTimestamp.slice(8)}-7${crypto.randomUUID().slice(15)}`;
+  let sessionId, sessionStartedAt;
   let referrer = "$direct", referringDomain = "$direct";
   try {
     const url = new URL(document.referrer);
@@ -22,6 +21,12 @@
   const capture = (event, properties = {}) => {
     if (optedOut()) return;
     try {
+      const now = Date.now();
+      if (!sessionId || now < sessionStartedAt || now - sessionStartedAt >= 24 * 60 * 60 * 1000) {
+        const sessionTimestamp = now.toString(16).padStart(12, "0");
+        sessionId = `${sessionTimestamp.slice(0, 8)}-${sessionTimestamp.slice(8)}-7${crypto.randomUUID().slice(15)}`;
+        sessionStartedAt = now;
+      }
       fetch("https://us.i.posthog.com/i/v0/e/?ip=0", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -31,7 +36,7 @@
         body: JSON.stringify({
           api_key: "phc_yAQTUdUM9vQMcHpGmMcNJom6vfrN3r3eo5avDSnt8S9R",
           event,
-          timestamp: new Date().toISOString(),
+          timestamp: new Date(now).toISOString(),
           properties: {
             distinct_id: distinctId,
             $process_person_profile: false,

--- a/apps/landing/public/telemetry.js
+++ b/apps/landing/public/telemetry.js
@@ -1,0 +1,73 @@
+(() => {
+  const optedOut = () => navigator.globalPrivacyControl === true || ["1", "yes"].includes(navigator.doNotTrack);
+  if (
+    !["https://zeron.sh", "https://comet.zeron.sh"].includes(location.origin) ||
+    !["/", "/index.html"].includes(location.pathname) ||
+    optedOut() || typeof fetch !== "function" ||
+    typeof crypto === "undefined" || typeof crypto.randomUUID !== "function"
+  ) return;
+
+  const distinctId = crypto.randomUUID();
+  const sessionId = crypto.randomUUID();
+  let referrer = "$direct", referringDomain = "$direct";
+  try {
+    const url = new URL(document.referrer);
+    if (["https:", "http:"].includes(url.protocol)) {
+      referrer = url.origin + "/";
+      referringDomain = url.hostname;
+    }
+  } catch {}
+
+  const capture = (event, properties = {}) => {
+    if (optedOut()) return;
+    try {
+      fetch("https://us.i.posthog.com/i/v0/e/?ip=0", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "omit",
+        referrerPolicy: "no-referrer",
+        keepalive: true,
+        body: JSON.stringify({
+          api_key: "phc_yAQTUdUM9vQMcHpGmMcNJom6vfrN3r3eo5avDSnt8S9R",
+          distinct_id: distinctId,
+          event,
+          timestamp: new Date().toISOString(),
+          properties: {
+            $process_person_profile: false,
+            $geoip_disable: true,
+            $session_id: sessionId,
+            $current_url: location.origin + location.pathname,
+            $host: location.hostname,
+            $pathname: location.pathname,
+            $referrer: referrer,
+            $referring_domain: referringDomain,
+            ...properties,
+          },
+        }),
+      }).catch(() => {});
+    } catch {}
+  };
+
+  capture("$pageview");
+
+  const placements = { "nav-download": "nav", "hero-download": "hero", "closing-download": "closing" };
+  for (const [id, placement] of Object.entries(placements)) {
+    const link = document.getElementById(id);
+    if (!link) continue;
+    const track = (event) => {
+      if (event.defaultPrevented) return;
+      let url;
+      try { url = new URL(link.href); } catch { return; }
+      const release = url.pathname.match(/^\/releases\/zeron-(\d+\.\d+\.\d+)-macos-arm64\.dmg$/);
+      if (url.origin !== "https://zeron.sh" || !release) return;
+      capture("download_clicked", {
+        placement,
+        version: release[1],
+        platform: "macos",
+        architecture: "arm64",
+      });
+    };
+    link.addEventListener("click", track);
+    link.addEventListener("auxclick", (event) => { if (event.button === 1) track(event); });
+  }
+})();

--- a/apps/landing/public/telemetry.js
+++ b/apps/landing/public/telemetry.js
@@ -8,7 +8,8 @@
   ) return;
 
   const distinctId = crypto.randomUUID();
-  const sessionId = crypto.randomUUID();
+  const sessionTimestamp = Date.now().toString(16).padStart(12, "0");
+  const sessionId = `${sessionTimestamp.slice(0, 8)}-${sessionTimestamp.slice(8)}-7${crypto.randomUUID().slice(15)}`;
   let referrer = "$direct", referringDomain = "$direct";
   try {
     const url = new URL(document.referrer);

--- a/apps/landing/public/telemetry.js
+++ b/apps/landing/public/telemetry.js
@@ -29,10 +29,10 @@
         keepalive: true,
         body: JSON.stringify({
           api_key: "phc_yAQTUdUM9vQMcHpGmMcNJom6vfrN3r3eo5avDSnt8S9R",
-          distinct_id: distinctId,
           event,
           timestamp: new Date().toISOString(),
           properties: {
+            distinct_id: distinctId,
             $process_person_profile: false,
             $geoip_disable: true,
             $session_id: sessionId,

--- a/apps/landing/telemetry.test.mjs
+++ b/apps/landing/telemetry.test.mjs
@@ -89,6 +89,44 @@ for (const now of [0x000123456789, Date.UTC(2026, 8, 4)]) {
   });
 }
 
+for (const [elapsed, rotates] of [[86400000 - 1, false], [86400000, true], [86400000 + 1, true], [3 * 86400000, true], [-1, true]]) {
+  test(`maintains valid sessions after a clock change of ${elapsed} ms`, () => {
+    let now = Date.UTC(2026, 8, 4);
+    const clock = class extends Date {
+      constructor(value = now) { super(value); }
+      static now() { return now; }
+    };
+    const { requests, links } = load({ clock });
+    const first = requests[0].payload;
+    now += elapsed;
+    links["hero-download"].activate();
+    assert.equal(requests.length, 2);
+    const sessionId = requests[1].payload.properties.$session_id;
+    if (rotates) assert.notEqual(sessionId, first.properties.$session_id);
+    else assert.equal(sessionId, first.properties.$session_id);
+    if (rotates) {
+      assert.equal(Number.parseInt(sessionId.slice(0, 13).replace("-", ""), 16), now);
+    }
+    links["hero-download"].activate();
+    assert.equal(requests[2].payload.properties.$session_id, sessionId);
+    now += 86400000;
+    links["hero-download"].activate();
+    assert.equal(requests.length, 4);
+    assert.notEqual(requests[3].payload.properties.$session_id, sessionId);
+    assert.equal(Date.parse(requests[3].payload.timestamp), now);
+    for (const [index, { payload }] of requests.entries()) {
+      const id = payload.properties.$session_id;
+      assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+      const startedAt = Number.parseInt(id.slice(0, 13).replace("-", ""), 16);
+      const eventTime = Date.parse(payload.timestamp);
+      assert.ok(startedAt <= eventTime);
+      assert.ok(eventTime < startedAt + 86400000);
+      assert.equal(payload.properties.distinct_id, first.properties.distinct_id);
+      assert.equal(payload.event, index === 0 ? "$pageview" : "download_clicked");
+    }
+  });
+}
+
 test("drops query strings, fragments, and referrer paths and credentials", () => {
   const { requests } = load({
     url: "https://zeron.sh/?email=private%40example.invalid#secret",

--- a/apps/landing/telemetry.test.mjs
+++ b/apps/landing/telemetry.test.mjs
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { runInNewContext } from "node:vm";
+
+const source = readFileSync(new URL("./public/telemetry.js", import.meta.url), "utf8");
+const html = readFileSync(new URL("./public/index.html", import.meta.url), "utf8");
+const placements = { "nav-download": "nav", "hero-download": "hero", "closing-download": "closing" };
+
+function load({ url = "https://zeron.sh/", referrer = "", navigator = {}, transport } = {}) {
+  const requests = [];
+  const links = Object.fromEntries(Object.keys(placements).map((id) => {
+    const href = html.match(new RegExp(`id="${id}" href="([^"]+)"`))[1];
+    const listeners = {};
+    return [id, {
+      href,
+      addEventListener: (type, listener) => { listeners[type] = listener; },
+      activate(type = "click", button = 0) {
+        listeners[type]?.({ button, defaultPrevented: false });
+      },
+    }];
+  }));
+  const document = { referrer, getElementById: (id) => links[id] };
+  const context = {
+    location: new URL(url),
+    navigator,
+    document,
+    crypto: { randomUUID },
+    URL,
+    fetch: (endpoint, options) => {
+      requests.push({ endpoint, ...options, payload: JSON.parse(options.body) });
+      return transport ? transport() : Promise.resolve({ ok: true });
+    },
+  };
+  for (const property of ["localStorage", "sessionStorage"]) {
+    Object.defineProperty(context, property, { get() { throw new Error(`Accessed ${property}`); } });
+  }
+  Object.defineProperty(document, "cookie", {
+    get() { throw new Error("Read cookies"); },
+    set() { throw new Error("Wrote cookies"); },
+  });
+  runInNewContext(source, context);
+  return { requests, links, navigator };
+}
+
+test("HTML loads the tracker once without blocking parsing", () => {
+  assert.equal(html.match(/<script defer src="\/telemetry\.js"><\/script>/g)?.length, 1);
+});
+
+test("captures one anonymous pageview using the US ingestion endpoint", () => {
+  const { requests } = load();
+  assert.equal(requests.length, 1);
+  const request = requests[0];
+  assert.equal(request.endpoint, "https://us.i.posthog.com/i/v0/e/?ip=0");
+  assert.equal(request.method, "POST");
+  assert.equal(request.headers["Content-Type"], "application/json");
+  assert.equal(request.keepalive, true);
+  assert.equal(request.credentials, "omit");
+  assert.equal(request.referrerPolicy, "no-referrer");
+  assert.match(request.payload.api_key, /^phc_[A-Za-z0-9]+$/);
+  assert.equal(request.payload.event, "$pageview");
+  assert.match(request.payload.distinct_id, /^[0-9a-f-]{36}$/);
+  assert.equal(request.payload.properties.$process_person_profile, false);
+  assert.equal(request.payload.properties.$geoip_disable, true);
+  assert.equal(request.payload.properties.$current_url, "https://zeron.sh/");
+  assert.equal(request.payload.properties.$referring_domain, "$direct");
+});
+
+test("drops query strings, fragments, and referrer paths and credentials", () => {
+  const { requests } = load({
+    url: "https://zeron.sh/?email=private%40example.invalid#secret",
+    referrer: "https://user:password@search.example.invalid/private?token=secret#fragment",
+  });
+  const properties = requests[0].payload.properties;
+  assert.equal(properties.$current_url, "https://zeron.sh/");
+  assert.equal(properties.$referrer, "https://search.example.invalid/");
+  assert.equal(properties.$referring_domain, "search.example.invalid");
+  assert.doesNotMatch(requests[0].body, /private|secret|password|user:|fragment/);
+});
+
+for (const referrer of ["not a URL", "about:blank", "file:///private/secret"]) {
+  test(`ignores invalid or non-web referrer: ${referrer}`, () => {
+    const { requests } = load({ referrer });
+    assert.equal(requests[0].payload.properties.$referring_domain, "$direct");
+    assert.equal(requests[0].payload.properties.$referrer, "$direct");
+  });
+}
+
+for (const [id, placement] of Object.entries(placements)) {
+  test(`tracks ${placement} download clicks with the current release version`, () => {
+    const { requests, links } = load();
+    links[id].href = "https://zeron.sh/releases/zeron-1.2.3-macos-arm64.dmg?private=secret#fragment";
+    links[id].activate();
+    assert.equal(requests.length, 2);
+    const { payload } = requests[1];
+    assert.equal(payload.event, "download_clicked");
+    assert.equal(payload.distinct_id, requests[0].payload.distinct_id);
+    assert.equal(payload.properties.$session_id, requests[0].payload.properties.$session_id);
+    assert.equal(payload.properties.placement, placement);
+    assert.equal(payload.properties.version, "1.2.3");
+    assert.equal(payload.properties.platform, "macos");
+    assert.equal(payload.properties.architecture, "arm64");
+    assert.doesNotMatch(requests[1].body, /private|secret|fragment/);
+  });
+}
+
+test("tracks the pinned fallback download when release lookup has not completed", () => {
+  const { requests, links } = load();
+  links["hero-download"].activate();
+  assert.equal(requests.length, 2);
+  assert.match(requests[1].payload.properties.version, /^\d+\.\d+\.\d+$/);
+});
+
+test("counts middle clicks but ignores right clicks", () => {
+  const { requests, links } = load();
+  links["hero-download"].activate("auxclick", 1);
+  links["hero-download"].activate("auxclick", 2);
+  assert.equal(requests.length, 2);
+});
+
+for (const href of ["https://example.invalid/releases/zeron-1.2.3-macos-arm64.dmg", "https://zeron.sh/private", "invalid"]) {
+  test(`does not report unexpected download targets: ${href}`, () => {
+    const { requests, links } = load();
+    links["hero-download"].href = href;
+    links["hero-download"].activate();
+    assert.equal(requests.length, 1);
+  });
+}
+
+for (const url of ["http://localhost:8000/", "https://preview.workers.dev/", "http://zeron.sh/", "https://zeron.sh/private", "https://zeron.sh:8000/"]) {
+  test(`does not track development or unexpected URLs: ${url}`, () => {
+    const { requests, links } = load({ url });
+    links["hero-download"].activate();
+    assert.equal(requests.length, 0);
+  });
+}
+
+test("tracks the legacy production hostname", () => {
+  assert.equal(load({ url: "https://comet.zeron.sh/" }).requests.length, 1);
+});
+
+for (const navigator of [{ doNotTrack: "1" }, { doNotTrack: "yes" }, { globalPrivacyControl: true }]) {
+  test(`respects browser privacy preference: ${JSON.stringify(navigator)}`, () => {
+    const { requests, links } = load({ navigator });
+    links["hero-download"].activate();
+    assert.equal(requests.length, 0);
+  });
+}
+
+test("respects privacy preferences enabled after page load", () => {
+  const { requests, links, navigator } = load();
+  navigator.globalPrivacyControl = true;
+  links["hero-download"].activate();
+  assert.equal(requests.length, 1);
+});
+
+test("does not persist visitor identifiers across page loads", () => {
+  assert.notEqual(load().requests[0].payload.distinct_id, load().requests[0].payload.distinct_id);
+});
+
+test("network rejection does not break downloads or create an unhandled rejection", async () => {
+  const { requests, links } = load({ transport: () => Promise.reject(new Error("Blocked")) });
+  links["hero-download"].activate();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(requests.length, 2);
+});
+
+test("synchronous transport failures do not break download handlers", () => {
+  const { links } = load({ transport: () => { throw new Error("Unavailable"); } });
+  assert.doesNotThrow(() => links["hero-download"].activate());
+});

--- a/apps/landing/telemetry.test.mjs
+++ b/apps/landing/telemetry.test.mjs
@@ -8,7 +8,7 @@ const source = readFileSync(new URL("./public/telemetry.js", import.meta.url), "
 const html = readFileSync(new URL("./public/index.html", import.meta.url), "utf8");
 const placements = { "nav-download": "nav", "hero-download": "hero", "closing-download": "closing" };
 
-function load({ url = "https://zeron.sh/", referrer = "", navigator = {}, transport } = {}) {
+function load({ url = "https://zeron.sh/", referrer = "", navigator = {}, transport, clock = Date } = {}) {
   const requests = [];
   const links = Object.fromEntries(Object.keys(placements).map((id) => {
     const href = html.match(new RegExp(`id="${id}" href="([^"]+)"`))[1];
@@ -27,6 +27,7 @@ function load({ url = "https://zeron.sh/", referrer = "", navigator = {}, transp
     navigator,
     document,
     crypto: { randomUUID },
+    Date: clock,
     URL,
     fetch: (endpoint, options) => {
       requests.push({ endpoint, ...options, payload: JSON.parse(options.body) });
@@ -60,12 +61,33 @@ test("captures one anonymous pageview using the US ingestion endpoint", () => {
   assert.equal(request.referrerPolicy, "no-referrer");
   assert.match(request.payload.api_key, /^phc_[A-Za-z0-9]+$/);
   assert.equal(request.payload.event, "$pageview");
-  assert.match(request.payload.distinct_id, /^[0-9a-f-]{36}$/);
+  assert.match(request.payload.properties.distinct_id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   assert.equal(request.payload.properties.$process_person_profile, false);
   assert.equal(request.payload.properties.$geoip_disable, true);
   assert.equal(request.payload.properties.$current_url, "https://zeron.sh/");
   assert.equal(request.payload.properties.$referring_domain, "$direct");
 });
+
+for (const now of [0x000123456789, Date.UTC(2026, 8, 4)]) {
+  test(`uses a timestamped UUIDv7 session ID at ${now}`, () => {
+    const clock = class extends Date {
+      constructor() { super(now); }
+      static now() { return now; }
+    };
+    const { requests, links } = load({ clock });
+    const sessionId = requests[0].payload.properties.$session_id;
+    assert.match(sessionId, /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    const timestamp = Number.parseInt(sessionId.slice(0, 13).replace("-", ""), 16);
+    assert.equal(timestamp, now);
+    links["hero-download"].activate();
+    for (const { payload } of requests) {
+      assert.equal(payload.properties.$session_id, sessionId);
+      assert.ok(timestamp <= Date.parse(payload.timestamp));
+      assert.ok(Date.parse(payload.timestamp) < timestamp + 24 * 60 * 60 * 1000);
+    }
+    assert.notEqual(load({ clock }).requests[0].payload.properties.$session_id, sessionId);
+  });
+}
 
 test("drops query strings, fragments, and referrer paths and credentials", () => {
   const { requests } = load({
@@ -95,7 +117,7 @@ for (const [id, placement] of Object.entries(placements)) {
     assert.equal(requests.length, 2);
     const { payload } = requests[1];
     assert.equal(payload.event, "download_clicked");
-    assert.equal(payload.distinct_id, requests[0].payload.distinct_id);
+    assert.equal(payload.properties.distinct_id, requests[0].payload.properties.distinct_id);
     assert.equal(payload.properties.$session_id, requests[0].payload.properties.$session_id);
     assert.equal(payload.properties.placement, placement);
     assert.equal(payload.properties.version, "1.2.3");
@@ -156,7 +178,7 @@ test("respects privacy preferences enabled after page load", () => {
 });
 
 test("does not persist visitor identifiers across page loads", () => {
-  assert.notEqual(load().requests[0].payload.distinct_id, load().requests[0].payload.distinct_id);
+  assert.notEqual(load().requests[0].payload.properties.distinct_id, load().requests[0].payload.properties.distinct_id);
 });
 
 test("network rejection does not break downloads or create an unhandled rejection", async () => {


### PR DESCRIPTION
## Summary
- Capture `$pageview` events and `download_clicked` events with CTA placement and the current release version through the PostHog US ingestion API.
- Use a small first-party tracker with no SDK dependency, cookies, browser storage, autocapture, or session replay. Respect DNT/GPC and exclude URL queries, fragments, and referrer paths.
- Restrict tracking to production landing-page URLs and keep download navigation independent of telemetry delivery.
- Add 27 offline tests and run them before landing-page deployment in CI. The browser uses the public project token; `.env` is not committed.

## Measurement scope
- Download events represent button clicks, not completed transfers or installs.
- IDs reset on each page load, so unique/returning-visitor counts are not reliable.
- This does not certify consent compliance. Hosting region alone does not determine consent requirements.

#### Test plan
- [x] `node --test apps/landing/telemetry.test.mjs` — 27 tests pass with mocked requests; no live events sent.
- [x] `node --check apps/landing/public/telemetry.js`
- [x] `git diff --check`
- [x] Verify the US ingestion endpoint accepts a CORS OPTIONS preflight without sending a project token or event.
- [ ] After deployment, confirm pageview and download-click events appear in PostHog and downloads still work with tracking blocked.

Generated with [Devin](https://devin.ai)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791150141&installation_model_id=425430&pr_number=251&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F251&signature=93cadadaa4e152efee3d0060808ea333dd3f6d12eb3554bfbd72ba75a48b1ce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->