### PR TITLE
Keep tool-call carets inline and show them on hover

### DIFF
--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -5673,6 +5673,7 @@ fn chip_header_row(
         theme.text_muted
     };
     div()
+        .group("tool-header")
         .h(px(if activity {
             CHIP_CARD_HEIGHT
         } else {
@@ -5724,10 +5725,11 @@ fn chip_header_row(
         )
         .child(
             div()
-                .flex_1()
+                .when(!activity, |detail| detail.flex_1())
                 .min_w_0()
                 .h(px(if file_path.is_some() { 24.0 } else { 18.0 }))
                 .flex()
+                .when(activity && detail.is_empty(), |detail| detail.hidden())
                 .items_center()
                 .truncate()
                 .text_color(if failed {
@@ -5811,6 +5813,10 @@ fn chip_header_row(
             let tile = div()
                 .size(px(18.0))
                 .flex_none()
+                .when(activity, |tile| {
+                    tile.opacity(0.0)
+                        .group_hover("tool-header", |style| style.opacity(1.0))
+                })
                 .when(!activity, |tile| {
                     tile.rounded(px(5.0)).bg(crate::theme::ink(0.06))
                 })


### PR DESCRIPTION
Tool-call carets now sit immediately after the command text or file badge and appear only while that tool header is hovered. The caret keeps its space while hidden, so hovering does not shift text; long paths still truncate, and clicking the header toggles details. Thought rows use the same behavior.

Validation: `cargo build -p zeron` passed. Checked the native UI in light/dark mode, with idle/hovered headers, expanded details, and a narrow window. Screenshots use local demo data.

Idle — tool carets hidden:

![Idle — tool carets hidden](https://github.com/user-attachments/assets/783cfff6-a84b-466f-857c-787b07906f7d)

Hovered command — caret immediately after its text:

![Hovered command — caret immediately after its text](https://github.com/user-attachments/assets/5729899e-860b-414f-ace7-fb70aa6b132e)

Hovered file badge:

![Hovered file badge](https://github.com/user-attachments/assets/576bfa85-fe3f-4d96-b8ef-7b97c8a04177)

Light theme:

![Light theme](https://github.com/user-attachments/assets/2adf2267-b89d-4730-bbdd-c21c60b9f80a)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791154943&installation_model_id=425430&pr_number=253&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F253&signature=1841df2761cca104868c3dbb7ea50cbc7fc306a204e48ae6f767545aff51589d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->