### PR TITLE
Brighten tool-call headers on hover

### DIFF
--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -5667,6 +5667,9 @@ fn chip_header_row(
     let failed = tool.is_error
         || (tool.subagent_ref.is_some()
             && matches!(tool.subagent_status, Some(SubagentStatus::Failed)));
+    // Text resolves its color during layout, so group-hover text needs stable
+    // child IDs under the keyed, expandable header to retain hover state.
+    let hover_text = activity && trail.is_some() && !failed;
     let tint = if failed {
         theme.danger
     } else {
@@ -5721,7 +5724,17 @@ fn chip_header_row(
                     label.font_weight(gpui::FontWeight::MEDIUM)
                 })
                 .text_color(tint)
-                .child(SharedString::from(label)),
+                .child(SharedString::from(label))
+                .map(|label| {
+                    if hover_text {
+                        label
+                            .id("tool-label")
+                            .group_hover("tool-header", |style| style.text_color(theme.text))
+                            .into_any_element()
+                    } else {
+                        label.into_any_element()
+                    }
+                }),
         )
         .child(
             div()
@@ -5757,9 +5770,26 @@ fn chip_header_row(
                         .child(
                             crate::icons::icon(crate::icons::for_file(path))
                                 .size(px(14.0))
-                                .text_color(tint),
+                                .text_color(tint)
+                                .when(activity && !failed, |icon| {
+                                    icon.group_hover("tool-header", |style| {
+                                        style.text_color(theme.text)
+                                    })
+                                }),
                         )
-                        .child(div().min_w_0().truncate().child(SharedString::from(detail)));
+                        .child(div().min_w_0().truncate().child(SharedString::from(detail)))
+                        .map(|badge| {
+                            if hover_text {
+                                badge
+                                    .id("tool-file-badge")
+                                    .group_hover("tool-header", |style| {
+                                        style.text_color(theme.text)
+                                    })
+                                    .into_any_element()
+                            } else {
+                                badge.into_any_element()
+                            }
+                        });
                     crate::frost::frosted(5.0, 16.0, badge).into_any_element()
                 } else {
                     div()
@@ -5767,6 +5797,16 @@ fn chip_header_row(
                         .truncate()
                         .child(SharedString::from(detail))
                         .into_any_element()
+                })
+                .map(|detail| {
+                    if hover_text {
+                        detail
+                            .id("tool-detail")
+                            .group_hover("tool-header", |style| style.text_color(theme.text))
+                            .into_any_element()
+                    } else {
+                        detail.into_any_element()
+                    }
                 }),
         )
         .when_some(tool.call.subagent_model(), |row, model| {
@@ -5832,7 +5872,12 @@ fn chip_header_row(
                         crate::icons::ALT_ARROW_RIGHT
                     })
                     .size(px(12.0))
-                    .text_color(theme.text_faint),
+                    .text_color(theme.text_faint)
+                    .when(activity, |caret| {
+                        caret.group_hover("tool-header", |style| {
+                            style.text_color(if failed { theme.danger } else { theme.text })
+                        })
+                    }),
                 ),
                 ChipTrail::OpenArrow => tile.child(
                     crate::icons::icon(crate::icons::ARROW_UP_RIGHT)


### PR DESCRIPTION
Individual expandable tool headers now brighten to the same text color as their group header on hover. The label, command or file badge, and inline caret brighten together; failed rows retain their error color.

Stable child IDs preserve the hover state during text layout, so the text color changes along with the icons.

Validation: `cargo build -p zeron` passed. Checked idle and hovered tool headers in the native UI in light/dark mode, including command text and file badges. Captures use local demo data.

Idle (dark):

![Idle (dark)](https://github.com/user-attachments/assets/35244442-be8e-406f-b70e-aeed8058fbf0)

Hovered command (dark):

![Hovered command (dark)](https://github.com/user-attachments/assets/a2fc8b2c-dfdd-4b43-87ee-8c38262541d9)

Hovered file badge (dark):

![Hovered file badge (dark)](https://github.com/user-attachments/assets/8f1a1672-e1bd-43b6-8b77-7a266322457b)

Hovered command (light):

![Hovered command (light)](https://github.com/user-attachments/assets/e52d19e1-cd2c-4520-bb76-ebb20fda1a0d)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791157368&installation_model_id=425430&pr_number=254&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F254&signature=66d61b69556ef51b4fc579698887d357d87da61df3cf70f6c82a7c23eae16652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->