### PR TITLE
Reduce streaming CPU and memory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,8 @@ jobs:
           path: target/package/*.tar.gz
           if-no-files-found: error
 
-  # Heads-up: the macOS cfg paths (Keychain in agent_accounts.rs) have never
-  # been type-checked against the Apple SDK — this job may surface errors on
-  # its first runs. continue-on-error keeps the Linux release shippable.
+  # All desktop artifacts must build before publishing the release and updater
+  # manifest. A macOS failure must not publish a Linux-only version as latest.
   #
   # Signing/notarization (both optional — absent secrets fall back to an
   # ad-hoc-signed build):
@@ -62,7 +61,6 @@ jobs:
   #     script notarizes and staples the app + dmg (no Gatekeeper warning).
   macos:
     runs-on: macos-latest # Apple silicon
-    continue-on-error: true
     env:
       MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
       MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "schemars",
  "serde",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "anyhow",
  "log",
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4014,7 +4014,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4823,7 +4823,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "collections",
  "serde",
@@ -5664,7 +5664,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "derive_refineable",
 ]
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6568,7 +6568,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -7735,7 +7735,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "perf",
  "quote",
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9456,7 +9456,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/wingleeio/zed?rev=e2ddcc6805f8c5088e62a60dfe517abcccd61a9a#e2ddcc6805f8c5088e62a60dfe517abcccd61a9a"
+source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "zeron"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "clap",
@@ -9443,7 +9443,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-doc"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "chrono",
  "loro",
@@ -9457,7 +9457,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-engine"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9493,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-harness"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-proto"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "chrono",
  "serde",
@@ -9524,7 +9524,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-rpc"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9543,7 +9543,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-sync"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -9566,7 +9566,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-syntax"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "thiserror 2.0.20",
  "tree-sitter",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-theme"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "clap",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-ui"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-update"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,12 +682,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -888,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1006,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1126,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1207,6 +1261,15 @@ name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1398,10 +1461,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1548,7 +1656,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1559,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2446,12 +2554,13 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "accesskit",
  "anyhow",
  "async-channel",
  "async-task",
+ "backtrace",
  "bindgen",
  "bitflags 2.13.1",
  "block",
@@ -2465,6 +2574,7 @@ dependencies = [
  "core-graphics 0.24.0",
  "core-text",
  "core-video",
+ "criterion",
  "ctor",
  "derive_more",
  "embed-resource",
@@ -2476,6 +2586,7 @@ dependencies = [
  "gpui_macros",
  "gpui_shared_string",
  "gpui_util",
+ "hdrhistogram",
  "heapless 0.9.3",
  "http_client",
  "image",
@@ -2495,6 +2606,7 @@ dependencies = [
  "pollster 0.4.0",
  "postage",
  "profiling",
+ "proptest",
  "rand 0.9.5",
  "raw-window-handle",
  "refineable",
@@ -2528,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2580,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2629,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2640,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2653,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "schemars",
  "serde",
@@ -2663,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2674,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "log",
@@ -2684,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2708,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2737,7 +2849,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -2853,6 +2965,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
+dependencies = [
+ "base64",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom 8.0.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -2982,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3259,7 +3385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -3382,6 +3508,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3533,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -4014,7 +4160,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4137,7 +4283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
@@ -4710,6 +4856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "open"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4823,7 +4975,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "collections",
  "serde",
@@ -4981,6 +5133,34 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -5220,6 +5400,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "git+https://github.com/proptest-rs/proptest?rev=3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b#3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "num-traits",
+ "proptest-macro",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-macro"
+version = "0.5.0"
+source = "git+https://github.com/proptest-rs/proptest?rev=3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b#3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b"
+dependencies = [
+ "convert_case 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5285,6 +5495,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -5476,6 +5692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5540,7 +5765,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -5664,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "derive_refineable",
 ]
@@ -5920,6 +6145,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "rustybuzz"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5955,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6568,7 +6805,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -6883,7 +7120,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -6961,6 +7198,16 @@ checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -7598,6 +7845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7735,7 +7988,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "perf",
  "quote",
@@ -7852,6 +8105,15 @@ dependencies = [
  "log",
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -8153,8 +8415,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
  "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
@@ -8215,7 +8477,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "block2 0.6.2",
  "bytemuck",
@@ -9365,6 +9627,7 @@ dependencies = [
  "gpui",
  "gpui_platform",
  "gpui_tokio",
+ "mimalloc",
  "objc",
  "pulldown-cmark",
  "serde",
@@ -9374,6 +9637,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "ttf-parser",
  "unicode-segmentation",
  "unicode-width",
@@ -9439,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9456,7 +9720,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9467,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "schemars",
  "serde",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "anyhow",
  "log",
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4014,7 +4014,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4823,7 +4823,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "collections",
  "serde",
@@ -5664,7 +5664,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "derive_refineable",
 ]
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6568,7 +6568,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -7735,7 +7735,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "perf",
  "quote",
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9456,7 +9456,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=25f1c948cef229df2536cf4b7b6731bcb30602e1#25f1c948cef229df2536cf4b7b6731bcb30602e1"
+source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,9 @@ loro = "1.13"
 # frames, cross-checked by its js_snapshots tests).
 loro-protocol = "0.3"
 
-# gpui — the wingleeio/zed fork: upstream f14fea9 + commits on
+# gpui — zeronsh/zui, extracted from wingleeio/zed e2ddcc6 with identical
+# crate sources; adds bounded blur passes and shared Gaussian weights.
+# Preserved fork history: upstream f14fea9 + commits on
 # `comet/edge-fade-horizontal` (tip of `comet/line-wrap-closing-punctuation`
 # + 5d1f83d horizontal per-pixel EdgeFade for quads/images; rebase when bumping the
 # upstream rev): a6bf17c fixes BOTH wrap-rule copies (LineWrapper +
@@ -59,14 +61,14 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/wingleeio/zed", rev = "e2ddcc6805f8c5088e62a60dfe517abcccd61a9a" }
-gpui_platform = { git = "https://github.com/wingleeio/zed", rev = "e2ddcc6805f8c5088e62a60dfe517abcccd61a9a", features = [
+gpui = { git = "https://github.com/zeronsh/zui", rev = "25f1c948cef229df2536cf4b7b6731bcb30602e1" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "25f1c948cef229df2536cf4b7b6731bcb30602e1", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/wingleeio/zed", rev = "e2ddcc6805f8c5088e62a60dfe517abcccd61a9a" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "25f1c948cef229df2536cf4b7b6731bcb30602e1" }
 
 # diffs
 similar = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,14 +61,14 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/zeronsh/zui", rev = "49f9abd196705eda6a27080c506295a19b5da63e" }
-gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "49f9abd196705eda6a27080c506295a19b5da63e", features = [
+gpui = { git = "https://github.com/zeronsh/zui", rev = "0003b923354ea8938b2d0cadbd17ef93108e2ae5" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "0003b923354ea8938b2d0cadbd17ef93108e2ae5", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "49f9abd196705eda6a27080c506295a19b5da63e" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "0003b923354ea8938b2d0cadbd17ef93108e2ae5" }
 
 # diffs
 similar = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.37"
+version = "0.2.38"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,14 +61,14 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/zeronsh/zui", rev = "25f1c948cef229df2536cf4b7b6731bcb30602e1" }
-gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "25f1c948cef229df2536cf4b7b6731bcb30602e1", features = [
+gpui = { git = "https://github.com/zeronsh/zui", rev = "49f9abd196705eda6a27080c506295a19b5da63e" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "49f9abd196705eda6a27080c506295a19b5da63e", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "25f1c948cef229df2536cf4b7b6731bcb30602e1" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "49f9abd196705eda6a27080c506295a19b5da63e" }
 
 # diffs
 similar = "2"

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -372,7 +372,7 @@ pub struct ChatDocHandle {
     chat_id: String,
     device_id: String,
     doc: Arc<SessionDoc>,
-    messages_tx: watch::Sender<Vec<SessionMessageEntry>>,
+    messages_tx: watch::Sender<Arc<Vec<SessionMessageEntry>>>,
     /// True when the doc changed while nobody watched: the mirror rebuild is
     /// deferred to the next `watch_messages` attach instead of paid per commit.
     mirror_dirty: AtomicBool,
@@ -430,7 +430,7 @@ impl ChatDocHandle {
     /// Attach-time refresh: the mirror is only maintained while watched, so a
     /// doc that changed unwatched materializes here, once, instead of on every
     /// commit it sat through in the background.
-    pub fn watch_messages(&self) -> watch::Receiver<Vec<SessionMessageEntry>> {
+    pub fn watch_messages(&self) -> watch::Receiver<Arc<Vec<SessionMessageEntry>>> {
         self.touch();
         // Attach is a user signal: verify a quiet room is actually alive
         // (a doc-wedged DO keeps answering pings while delivering nothing,
@@ -517,7 +517,7 @@ impl ChatDocHandle {
                 let joined = join_continuation_entries(entries);
                 // send_replace: update the watch even with no subscribers yet, so a
                 // late subscriber's first borrow sees the current transcript.
-                self.messages_tx.send_replace(joined);
+                self.messages_tx.send_replace(Arc::new(joined));
             }
             Err(err) => {
                 tracing::warn!(chat = %self.chat_id, error = %err, "transcript read failed");
@@ -532,7 +532,7 @@ impl ChatDocHandle {
         if self.messages_tx.receiver_count() == 0 {
             self.mirror_dirty.store(true, Ordering::Release);
             // Shrink the stale mirror: watch_messages rebuilds on attach.
-            self.messages_tx.send_replace(Vec::new());
+            self.messages_tx.send_replace(Arc::default());
         } else {
             self.publish_messages();
         }
@@ -1019,7 +1019,7 @@ impl DocHost {
         // The mirror starts dirty and empty: many opens (command queueing,
         // drains, nudges) never watch the transcript, and the first
         // watch_messages attach materializes it on demand.
-        let (messages_tx, _) = watch::channel(Vec::new());
+        let (messages_tx, _) = watch::channel(Arc::default());
 
         let handle = Arc::new(ChatDocHandle {
             chat_id: chat_id.to_string(),

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -980,17 +980,22 @@ where
 /// full `reset` first, then only changed entries per commit — the whole-Vec
 /// serialization here was the per-tick cost that scaled with transcript size.
 fn doc_messages_stream(
-    rx: watch::Receiver<Vec<zeron_doc::SessionMessageEntry>>,
+    rx: watch::Receiver<std::sync::Arc<Vec<zeron_doc::SessionMessageEntry>>>,
 ) -> BoxStream<'static, serde_json::Value> {
     use zeron_doc::transcript_delta::{TranscriptFrame, diff_transcript};
     futures::stream::unfold(
-        (rx, None::<Vec<zeron_doc::SessionMessageEntry>>),
+        (
+            rx,
+            None::<std::sync::Arc<Vec<zeron_doc::SessionMessageEntry>>>,
+        ),
         |(mut rx, mut prev)| async move {
             loop {
                 if prev.is_some() {
                     rx.changed().await.ok()?;
                 }
-                let current: Vec<_> = rx.borrow_and_update().clone();
+                // Watchers retain the immutable published snapshot. Each
+                // connection used to deep-copy the entire transcript here.
+                let current = rx.borrow_and_update().clone();
                 let frame = match prev.as_deref() {
                     None => TranscriptFrame::reset(&current),
                     Some(prev) => diff_transcript(prev, &current),

--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -10,7 +10,7 @@ zeron-proto.workspace = true
 base64 = "0.22"
 reqwest.workspace = true
 tokio.workspace = true
-tokio-util.workspace = true
+tokio-util = { workspace = true, features = ["io-util"] }
 uuid.workspace = true
 futures.workspace = true
 async-trait.workspace = true

--- a/crates/harness/src/opencode/mod.rs
+++ b/crates/harness/src/opencode/mod.rs
@@ -273,7 +273,7 @@ impl OpencodeHarness {
         }
         let mut server = self.server(None).await?;
         let result = async {
-            let providers = server.get_json("/provider", None).await?;
+            let providers: ProviderCatalog = server.get("/provider", None).await?;
             let models = models_from_providers(&providers);
             if models.is_empty() {
                 return Err(HarnessError::Protocol(
@@ -517,6 +517,29 @@ impl Server {
     /// GET with the session's directory scope (the server's per-request
     /// instance selector; both carriers set, matching the official SDK).
     async fn get_json(&self, path: &str, directory: Option<&str>) -> Result<Value, HarnessError> {
+        self.get_response(path, directory)
+            .await?
+            .json()
+            .await
+            .map_err(|e| HarnessError::Protocol(format!("opencode GET {path}: {e}")))
+    }
+
+    async fn get<T: serde::de::DeserializeOwned + Send + 'static>(
+        &self,
+        path: &str,
+        directory: Option<&str>,
+    ) -> Result<T, HarnessError> {
+        let response = self.get_response(path, directory).await?;
+        decode_json_response(response)
+            .await
+            .map_err(|e| HarnessError::Protocol(format!("opencode GET {path}: {e}")))
+    }
+
+    async fn get_response(
+        &self,
+        path: &str,
+        directory: Option<&str>,
+    ) -> Result<reqwest::Response, HarnessError> {
         let mut req = self
             .request(reqwest::Method::GET, path)
             .timeout(CALL_TIMEOUT);
@@ -537,9 +560,7 @@ impl Server {
                 truncate_body(&body)
             )));
         }
-        resp.json::<Value>()
-            .await
-            .map_err(|e| HarnessError::Protocol(format!("opencode GET {path}: {e}")))
+        Ok(resp)
     }
 
     async fn post_json(
@@ -622,6 +643,51 @@ fn truncate_body(body: &str) -> String {
 /// `GET /provider` → picker models: `{providerID}/{modelID}` ids, effort
 /// ladder from the model's reasoning variants.
 ///
+/// Only retain what the picker and run setup consume. `/provider` includes
+/// the entire models.dev catalog, with large nested capabilities/config maps.
+/// Building and cloning a Value for it measured a 112 MB engine heap peak.
+/// Serde skips unknown fields and variant bodies without allocating trees.
+#[derive(Debug, Default, serde::Deserialize)]
+struct ProviderCatalog {
+    all: Option<Vec<Provider>>,
+    connected: Option<Vec<String>>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Provider {
+    id: Option<String>,
+    name: Option<String>,
+    models: Option<std::collections::BTreeMap<String, ProviderModel>>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ProviderModel {
+    name: Option<String>,
+    variants: Option<std::collections::BTreeMap<String, serde::de::IgnoredAny>>,
+}
+
+/// Decode large catalogs without collecting a second, full HTTP body first.
+/// The blocking parser reads through a 64KiB buffer; network reads stay on
+/// Tokio. Dropping the caller also interrupts an outstanding body read.
+async fn decode_json_response<T: serde::de::DeserializeOwned + Send + 'static>(
+    response: reqwest::Response,
+) -> Result<T, String> {
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let _cancel_on_drop = cancel.clone().drop_guard();
+    let stream = response
+        .bytes_stream()
+        .map(|chunk| chunk.map_err(std::io::Error::other))
+        .take_until(cancel.cancelled_owned());
+    let reader = tokio_util::io::StreamReader::new(Box::pin(stream));
+    let reader = tokio_util::io::SyncIoBridge::new(reader);
+    tokio::task::spawn_blocking(move || {
+        serde_json::from_reader(std::io::BufReader::with_capacity(64 * 1024, reader))
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 /// Filtered to CONNECTED providers: `all` is the entire models.dev catalog
 /// (measured live: 194 providers / 7,203 models, nearly all needing an API
 /// key the user hasn't set) — offering it verbatim made the picker slow to
@@ -629,43 +695,32 @@ fn truncate_body(body: &str) -> String {
 /// "Model not found" (field report, v0.2.21). `connected` names exactly
 /// the usable set (credentialed + config-declared + the anonymous Zen
 /// tier). An absent/empty `connected` (older server) falls back to `all`.
-fn models_from_providers(providers: &Value) -> Vec<Model> {
+fn models_from_providers(providers: &ProviderCatalog) -> Vec<Model> {
     let connected: std::collections::HashSet<&str> = providers
-        .get("connected")
-        .and_then(Value::as_array)
-        .map(|list| list.iter().filter_map(Value::as_str).collect())
-        .unwrap_or_default();
-    let list = providers
-        .get("all")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
+        .connected
+        .iter()
+        .flatten()
+        .map(String::as_str)
+        .collect();
     let mut out = Vec::new();
-    for provider in &list {
-        let Some(provider_id) = provider.get("id").and_then(Value::as_str) else {
+    for provider in providers.all.iter().flatten() {
+        let Some(provider_id) = provider.id.as_deref() else {
             continue;
         };
         if !connected.is_empty() && !connected.contains(provider_id) {
             continue;
         }
-        let provider_name = provider
-            .get("name")
-            .and_then(Value::as_str)
-            .unwrap_or(provider_id);
-        let Some(models) = provider.get("models").and_then(Value::as_object) else {
+        let provider_name = provider.name.as_deref().unwrap_or(provider_id);
+        let Some(models) = &provider.models else {
             continue;
         };
         let mut provider_models: Vec<Model> = models
             .iter()
             .map(|(model_id, model)| {
-                let label = model
-                    .get("name")
-                    .and_then(Value::as_str)
-                    .unwrap_or(model_id)
-                    .to_owned();
+                let label = model.name.as_deref().unwrap_or(model_id).to_owned();
                 let mut levels: Vec<ReasoningLevel> = model
-                    .get("variants")
-                    .and_then(Value::as_object)
+                    .variants
+                    .as_ref()
                     .map(|variants| {
                         variants
                             .keys()
@@ -873,10 +928,10 @@ async fn run_session(session: Session) {
         // Provider catalog: resolves the model's advertised reasoning
         // variants so the requested effort only rides models that have it.
         let providers = server
-            .get_json("/provider", dir)
+            .get::<ProviderCatalog>("/provider", dir)
             .await
-            .unwrap_or(Value::Null);
-        Ok::<(String, Value), HarnessError>((session_id, providers))
+            .unwrap_or_default();
+        Ok::<(String, ProviderCatalog), HarnessError>((session_id, providers))
     };
     let (session_id, providers) = tokio::select! {
         res = setup => match res {
@@ -912,6 +967,7 @@ async fn run_session(session: Session) {
     let variant = model.as_ref().and_then(|(provider, model_id)| {
         pick_variant(&providers, provider, model_id, request.reasoning)
     });
+    drop(providers);
 
     let mut assistant_message_id = new_message_id();
     if !send(
@@ -1310,7 +1366,7 @@ async fn create_session(server: &Server, dir: Option<&str>) -> Result<String, Ha
 
 /// The requested effort as a variant id the model actually advertises.
 fn pick_variant(
-    providers: &Value,
+    providers: &ProviderCatalog,
     provider_id: &str,
     model_id: &str,
     reasoning: Option<ReasoningLevel>,
@@ -1320,14 +1376,15 @@ fn pick_variant(
         return None;
     }
     let variants = providers
-        .get("all")?
-        .as_array()?
+        .all
+        .as_ref()?
         .iter()
-        .find(|p| p.get("id").and_then(Value::as_str) == Some(provider_id))?
-        .get("models")?
+        .find(|p| p.id.as_deref() == Some(provider_id))?
+        .models
+        .as_ref()?
         .get(model_id)?
-        .get("variants")?
-        .as_object()?;
+        .variants
+        .as_ref()?;
     candidates
         .into_iter()
         .find(|c| variants.contains_key(*c))

--- a/crates/harness/src/opencode/tests.rs
+++ b/crates/harness/src/opencode/tests.rs
@@ -1,9 +1,107 @@
 use super::*;
+
+#[tokio::test]
+async fn catalog_decodes_fragmented_http_without_retaining_unused_fields() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let body = json!({
+        "all": [{"id":"test", "models":{"model":{"name":"模型", "variants":{"high":{"unused":"x".repeat(128 * 1024)}}}}}],
+        "connected":["test"]
+    }).to_string();
+    let expected: ProviderCatalog = serde_json::from_str(&body).unwrap();
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        socket.read(&mut [0; 4096]).await.unwrap();
+        socket
+            .write_all(
+                format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len()).as_bytes(),
+            )
+            .await
+            .unwrap();
+        for chunk in body.as_bytes().chunks(257) {
+            socket.write_all(chunk).await.unwrap();
+            tokio::task::yield_now().await;
+        }
+    });
+    let response = reqwest::get(format!("http://{address}")).await.unwrap();
+    let catalog: ProviderCatalog = decode_json_response(response).await.unwrap();
+    assert_eq!(
+        models_from_providers(&catalog),
+        models_from_providers(&expected)
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn cancelled_catalog_decode_releases_a_stalled_http_body() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        socket.read(&mut [0; 4096]).await.unwrap();
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 100000\r\n\r\n{")
+            .await
+            .unwrap();
+        let result = socket.read(&mut [0; 1]).await;
+        let _ = closed_tx.send(result);
+    });
+    let response = reqwest::get(format!("http://{address}")).await.unwrap();
+    let decode = tokio::spawn(decode_json_response::<ProviderCatalog>(response));
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    decode.abort();
+    assert!(decode.await.unwrap_err().is_cancelled());
+    let result = tokio::time::timeout(Duration::from_secs(2), closed_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        matches!(result, Ok(0) | Err(_)),
+        "cancel must close the body reader"
+    );
+    server.await.unwrap();
+}
 use serde_json::json;
 
 #[test]
+fn provider_discovery_ignores_metadata_and_accepts_null_optional_fields() {
+    let catalog: ProviderCatalog = serde_json::from_str(
+        r#"{
+        "all": [{
+            "id": "local", "name": null,
+            "models": {
+                "small": {"name": null, "variants": null},
+                "thinking": {
+                    "variants": {"high": {"nested": [{"unused": "configuration"}]}},
+                    "capabilities": {"large": [1, 2, 3]},
+                    "cost": {"input": 1}, "limit": {"context": 200000}
+                }
+            },
+            "options": {"unused": [true, false, null]}
+        }, {"id": "empty", "models": null}],
+        "connected": null,
+        "default": {"unused": "model"}
+    }"#,
+    )
+    .unwrap();
+    let models = models_from_providers(&catalog);
+    assert_eq!(models.len(), 2);
+    assert_eq!(models[0].id, "local/small");
+    assert_eq!(models[0].description.as_deref(), Some("local"));
+    assert!(models[0].reasoning_levels.is_empty());
+    assert_eq!(models[1].reasoning_levels, vec![ReasoningLevel::High]);
+    assert_eq!(
+        pick_variant(&catalog, "local", "thinking", Some(ReasoningLevel::High)).as_deref(),
+        Some("high")
+    );
+}
+
+#[test]
 fn models_map_provider_catalog_with_variant_ladders() {
-    let providers = json!({
+    let providers: ProviderCatalog = serde_json::from_value(json!({
         "all": [
             {
                 "id": "anthropic",
@@ -24,7 +122,8 @@ fn models_map_provider_catalog_with_variant_ladders() {
         ],
         "default": {},
         "connected": ["anthropic"],
-    });
+    }))
+    .unwrap();
     let models = models_from_providers(&providers);
     // `connected` filters: the full catalog is 194 providers / 7k models of
     // which the user can run almost none (v0.2.21 field report).
@@ -57,26 +156,28 @@ fn models_map_provider_catalog_with_variant_ladders() {
 
 #[test]
 fn missing_connected_list_falls_back_to_the_full_catalog() {
-    let providers = json!({
+    let providers: ProviderCatalog = serde_json::from_value(json!({
         "all": [
             {"id": "a", "models": {"m1": {}}},
             {"id": "b", "models": {"m2": {}}},
         ],
-    });
+    }))
+    .unwrap();
     assert_eq!(models_from_providers(&providers).len(), 2);
-    let providers = json!({
+    let providers: ProviderCatalog = serde_json::from_value(json!({
         "all": [
             {"id": "a", "models": {"m1": {}}},
             {"id": "b", "models": {"m2": {}}},
         ],
         "connected": [],
-    });
+    }))
+    .unwrap();
     assert_eq!(models_from_providers(&providers).len(), 2);
 }
 
 #[test]
 fn variants_only_ride_models_that_advertise_them() {
-    let providers = json!({
+    let providers: ProviderCatalog = serde_json::from_value(json!({
         "all": [{
             "id": "anthropic",
             "models": {
@@ -84,7 +185,8 @@ fn variants_only_ride_models_that_advertise_them() {
                 "haiku": {},
             }
         }]
-    });
+    }))
+    .unwrap();
     assert_eq!(
         pick_variant(&providers, "anthropic", "opus", Some(ReasoningLevel::High)).as_deref(),
         Some("high")

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -123,7 +123,7 @@ pub struct HighlightRequest<'a> {
     pub fence_tag: Option<&'a str>,
 }
 
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum HighlightError {
     #[error("the source language is not registered")]
     UnknownLanguage,
@@ -310,35 +310,20 @@ pub fn highlight_with_limits(
         return Err(HighlightError::GrammarUnavailable(language));
     }
 
-    let mut primary_configuration = configuration(language)?;
-    primary_configuration.configure(CAPTURE_NAMES);
-    let injected = if matches!(
-        language,
-        LanguageId::Html | LanguageId::Markdown | LanguageId::Dockerfile
-    ) {
-        injected_languages(language)
-            .into_iter()
-            .filter_map(|language| {
-                let mut config = configuration(language).ok()?;
-                config.configure(CAPTURE_NAMES);
-                Some((language, config))
-            })
-            .collect::<Vec<_>>()
-    } else {
-        Vec::new()
-    };
+    let primary_configuration = cached_configuration(language)?;
+    let injected = injected_languages(language);
     let mut highlighter = Highlighter::new();
     let events = highlighter
         .highlight(
-            &primary_configuration,
+            primary_configuration,
             request.source.as_bytes(),
             cancellation_flag,
             |name| {
                 let language = language_for_alias(name)?;
-                injected
-                    .iter()
-                    .find(|(candidate, _)| *candidate == language)
-                    .map(|(_, config)| config)
+                if !injected.contains(&language) {
+                    return None;
+                }
+                cached_configuration(language).ok()
             },
         )
         .map_err(|error| HighlightError::Parser(error.to_string()))?;
@@ -378,6 +363,36 @@ fn injected_languages(parent: LanguageId) -> Vec<LanguageId> {
         Dockerfile => vec![Bash, Json, Yaml, Toml],
         _ => Vec::new(),
     }
+}
+
+/// Compiled queries contain no document/theme state and are immutable after
+/// capture configuration. Keep one per used grammar instead of recompiling
+/// for every fence or eagerly compiling all 27 Markdown injection targets.
+/// Each grammar has its own cell: concurrent requests compile it only once,
+/// while unrelated languages never wait on a global compilation lock.
+fn cached_configuration(
+    language: LanguageId,
+) -> Result<&'static HighlightConfiguration, HighlightError> {
+    macro_rules! registry {
+        ($($variant:ident),+ $(,)?) => {
+            match language {
+                $(LanguageId::$variant => {
+                    static CONFIG: std::sync::OnceLock<Result<HighlightConfiguration, HighlightError>> =
+                        std::sync::OnceLock::new();
+                    CONFIG.get_or_init(|| {
+                        let mut config = configuration(language)?;
+                        config.configure(CAPTURE_NAMES);
+                        Ok(config)
+                    }).as_ref().map_err(Clone::clone)
+                }),+
+            }
+        };
+    }
+    registry!(
+        Rust, JavaScript, Jsx, TypeScript, Tsx, Python, Go, Json, Jsonc, Bash, Toml, Markdown,
+        Html, Css, Yaml, C, Cpp, CSharp, Java, Kotlin, Swift, Ruby, Php, Sql, Lua, Dockerfile, Nix,
+        Make,
+    )
 }
 
 fn rust_configuration() -> Result<HighlightConfiguration, HighlightError> {
@@ -782,6 +797,28 @@ fn language_for_shebang(line: &str) -> Option<LanguageId> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn compiled_queries_are_shared_across_concurrent_documents() {
+        let config = super::cached_configuration(super::LanguageId::Rust).unwrap();
+        std::thread::scope(|scope| {
+            for i in 0..8 {
+                scope.spawn(move || {
+                    let shared = super::cached_configuration(super::LanguageId::Rust).unwrap();
+                    assert!(std::ptr::eq(config, shared));
+                    let source = format!("fn example_{i}() {{ let value = {i}; }}");
+                    let document = super::highlight(super::HighlightRequest {
+                        source: &source,
+                        path: None,
+                        fence_tag: Some("rust"),
+                    })
+                    .unwrap();
+                    assert_eq!(document.language, super::LanguageId::Rust);
+                    assert!(document.lines.iter().flatten().next().is_some());
+                });
+            }
+        });
+    }
+
     use super::*;
 
     #[test]

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -5,6 +5,13 @@ edition.workspace = true
 license.workspace = true
 publish.workspace = true
 
+[features]
+resource-profile = ["gpui/bench", "gpui_platform/test-support"]
+
+[[example]]
+name = "macos-resource-profile"
+required-features = ["resource-profile"]
+
 [dependencies]
 zeron-proto.workspace = true
 similar.workspace = true
@@ -41,3 +48,5 @@ objc = "0.2"
 
 [dev-dependencies]
 tempfile.workspace = true
+mimalloc.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/ui/examples/macos-resource-profile.rs
+++ b/crates/ui/examples/macos-resource-profile.rs
@@ -1,0 +1,167 @@
+//! UI-only replay with native CoreText/Metal and real animation clocks.
+//! Input is frames.json from scripts/resource-profile.mjs. An offscreen target
+//! replaces the window compositor; this is not a whole-app CPU measurement.
+use gpui::{AppContext, Bounds, WindowBounds, WindowOptions, px, size};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    time::{Duration, Instant},
+};
+use zeron_ui::*;
+
+#[cfg(target_os = "macos")]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[derive(serde::Deserialize)]
+struct Frame {
+    at: u64,
+    frame: zeron_doc::TranscriptFrame,
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() -> anyhow::Result<()> {
+    anyhow::bail!("This profiler requires macOS")
+}
+
+#[cfg(target_os = "macos")]
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+    let args: Vec<_> = std::env::args().collect();
+    anyhow::ensure!(
+        args.len() == 3,
+        "Usage: macos-resource-profile FRAMES_JSON OUTPUT_DIR"
+    );
+    let frames: Vec<Frame> = serde_json::from_slice(&std::fs::read(&args[1])?)?;
+    anyhow::ensure!(!frames.is_empty(), "Empty replay");
+    let output = std::path::PathBuf::from(&args[2]);
+    std::fs::create_dir_all(&output)?;
+    let native = gpui_platform::current_platform(true);
+    let platform = gpui::bench_platform(
+        Some(Box::new(gpui_platform::current_headless_renderer)),
+        native.text_system(),
+    );
+    let executor = platform.background_executor();
+    let handles = Rc::new(RefCell::new(None));
+    let captured = handles.clone();
+    let data = output.clone();
+    let app = gpui::Application::with_platform(platform).with_assets(icons::Assets)
+        .run_embedded(move |cx| {
+            gpui_tokio::init(cx);
+            let settings = settings::UiSettings::default();
+            settings::init(settings.clone(), data.clone(), cx);
+            let fonts = typography::register_fonts(cx);
+            typography::init(settings.ui_font_family.clone(), settings.ui_font_size, fonts, cx);
+            theme_library::init(data.clone(), cx);
+            appearance::init(appearance::AppearanceMode::Dark, settings.theme_selection,
+                settings.accent, settings.surface, cx);
+            composer::init(cx);
+            terminal::panel::init(cx);
+            app_menus::init(cx);
+            let state = cx.new(|_| {
+                let mut state = state::AppState::new();
+                state.connection = zeron_proto::view::ConnectionStatus::Ready;
+                state.workspace_scope = Some(zeron_proto::WorkspaceScope::Local);
+                state.selected_chat = Some("profile".into());
+                state.selected_space = Some("project".into());
+                state.auto_selected = true;
+                state.chats_synced = true;
+                state.spaces_synced = true;
+                state.spaces = vec![serde_json::from_value(serde_json::json!({
+                    "id":"project", "deviceId":"local", "path":"/tmp/resource-profile",
+                    "createdAt":"2026-09-05T00:00:00Z"
+                })).unwrap()];
+                state.chats = vec![serde_json::from_value(serde_json::json!({
+                    "id":"profile", "deviceId":"local", "spaceId":"project", "title":"Resource profile",
+                    "archived":false, "createdAt":"2026-09-05T00:00:00Z",
+                    "config":{"harness":"claude-code", "model":"claude-haiku-4-5", "reasoning":null, "sandbox":"workspace-write"}
+                })).unwrap()];
+                state
+            });
+            let boot = EngineBootConfig { data_dir:data, ipc_port:0,
+                edge_url:String::new(), edge_token:None, org_id:None,
+                workos_client_id:None, default_harness:HarnessId::ClaudeCode };
+            let window = cx.open_window(WindowOptions {
+                window_bounds:Some(WindowBounds::Windowed(Bounds::new(
+                    gpui::point(px(0.),px(0.)),size(px(1320.),px(880.))))),
+                ..Default::default()
+            }, |_,cx| cx.new(|cx| shell::Shell::new(state.clone(),boot,cx))).unwrap();
+            *captured.borrow_mut() = Some((state,window));
+        });
+    let (state, window) = handles.borrow_mut().take().unwrap();
+    let dispatcher = executor.dispatcher().as_bench().unwrap();
+    let start = Instant::now();
+    let first_at = frames[0].at;
+    let mut frames = frames.into_iter().peekable();
+    let mut completed_at = None;
+    eprintln!("pid={} phase=replay", std::process::id());
+    loop {
+        objc::rc::autoreleasepool(|| {
+            let elapsed = start.elapsed().as_millis() as u64;
+            while frames.peek().is_some_and(|f| f.at - first_at <= elapsed) {
+                let frame = frames.next().unwrap();
+                app.update(|cx| {
+                    state.update(cx, |state, cx| {
+                        state.apply_transcript_frame(frame.frame).unwrap();
+                        let streaming = state
+                            .transcript
+                            .iter()
+                            .any(|entry| entry.status == Some(zeron_doc::MessageStatus::Streaming));
+                        state.apply_sessions(vec![zeron_proto::Session {
+                            chat_id: "profile".into(),
+                            device_id: "local".into(),
+                            status: if streaming {
+                                zeron_proto::SessionStatus::Working
+                            } else {
+                                zeron_proto::SessionStatus::Idle
+                            },
+                            started_at: Some(chrono::Utc::now()),
+                            updated_at: chrono::Utc::now(),
+                        }]);
+                        cx.notify();
+                    })
+                });
+            }
+            app.update(|cx| {
+                window
+                    .update(cx, |_, window, cx| {
+                        window.simulate_next_frame(cx);
+                    })
+                    .unwrap()
+            });
+            dispatcher.run_until_idle();
+            app.update(|cx| {
+                window
+                    .update(cx, |_, window, _| window.present_if_needed())
+                    .unwrap()
+            });
+        });
+        if frames.peek().is_none() && completed_at.is_none() {
+            eprintln!("phase=settled elapsed={:?}", start.elapsed());
+            completed_at = Some(Instant::now());
+            app.update(|cx| {
+                window
+                    .update(cx, |_, window, _| {
+                        window
+                            .render_to_image()
+                            .unwrap()
+                            .save(output.join("complete.png"))
+                            .unwrap();
+                    })
+                    .unwrap()
+            });
+        }
+        if completed_at.is_some_and(|t| t.elapsed() > Duration::from_secs(15)) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(8));
+    }
+    eprintln!("elapsed={:?}", start.elapsed());
+    drop(state);
+    app.update(|cx| cx.quit());
+    drop(app);
+    Ok(())
+}

--- a/crates/ui/examples/macos-resource-profile.rs
+++ b/crates/ui/examples/macos-resource-profile.rs
@@ -163,10 +163,15 @@ fn main() -> anyhow::Result<()> {
     // layout after idle, panel transitions and scrolling. Keep this outside
     // measured phases; screenshot readback and forced refreshes add work.
     if std::env::var_os("ZERON_VERIFY_CACHE").is_some() {
-        for scenario in ["settled", "sidebar-hidden", "sidebar-restored", "scrolled"] {
+        let mut scenarios = vec!["settled", "sidebar-hidden", "sidebar-restored", "scrolled"];
+        // These hit coordinates target the bundled 80-section fixture. General
+        // frame replays can still use the cache checks above on their own.
+        if std::env::var_os("ZERON_VERIFY_INTERACTIONS").is_some() {
+            scenarios.extend(["selected", "typed", "model-menu", "menu-dismissed"]);
+        }
+        for scenario in scenarios {
             app.update(|cx| {
-                window
-                    .update(cx, |_, window, cx| match scenario {
+                cx.update_window(window.into(), |_, window, cx| match scenario {
                         "sidebar-hidden" | "sidebar-restored" => {
                             window.dispatch_action(Box::new(shell::ToggleSidebar), cx)
                         }
@@ -181,6 +186,33 @@ fn main() -> anyhow::Result<()> {
                                 cx,
                             );
                         }
+                        "selected" => {
+                            window.dispatch_event(gpui::PlatformInput::MouseDown(gpui::MouseDownEvent {
+                                position: gpui::point(px(430.), px(283.)),
+                                click_count: 1,
+                                ..Default::default()
+                            }), cx);
+                            window.dispatch_event(gpui::PlatformInput::MouseMove(gpui::MouseMoveEvent {
+                                position: gpui::point(px(580.), px(349.)),
+                                pressed_button: Some(gpui::MouseButton::Left),
+                                ..Default::default()
+                            }), cx);
+                            window.dispatch_event(gpui::PlatformInput::MouseUp(gpui::MouseUpEvent {
+                                position: gpui::point(px(580.), px(349.)),
+                                click_count: 1,
+                                ..Default::default()
+                            }), cx);
+                            assert!(markdown::selection::selected_text().is_some_and(|text| text.len() > 20),
+                                "The fixed 80-section fixture must support dragging across text after scene reuse");
+                        }
+                        "typed" => {
+                            click(window, cx, 550., 839.);
+                            for key in ["c", "a", "c", "h", "e", "space", "c", "h", "e", "c", "k"] {
+                                assert!(window.dispatch_keystroke(gpui::Keystroke::parse(key).unwrap(), cx));
+                            }
+                        }
+                        "model-menu" => click(window, cx, 1020., 839.),
+                        "menu-dismissed" => click(window, cx, 1250., 500.),
                         _ => {}
                     })
                     .unwrap()
@@ -211,11 +243,25 @@ fn main() -> anyhow::Result<()> {
             });
             cached.save(output.join(format!("{scenario}-cached.png")))?;
             fresh.save(output.join(format!("{scenario}-fresh.png")))?;
-            anyhow::ensure!(
-                cached == fresh,
-                "Cached scene differs from fresh layout: {scenario}"
-            );
-            eprintln!("cache pixels match: {scenario}");
+            if scenario == "model-menu" {
+                // With no engine catalog the menu animates its loading bars.
+                // Their phase advances between readbacks; compare the rest of
+                // the window, and retain both full images for visual review.
+                for (x, y, pixel) in cached.enumerate_pixels() {
+                    let in_menu = (1550..2170).contains(&x) && (1190..1640).contains(&y);
+                    anyhow::ensure!(
+                        in_menu || pixel == fresh.get_pixel(x, y),
+                        "Scene outside the animated model menu differs at {x},{y}"
+                    );
+                }
+                eprintln!("cache pixels match outside animated model menu");
+            } else {
+                anyhow::ensure!(
+                    cached == fresh,
+                    "Cached scene differs from fresh layout: {scenario}"
+                );
+                eprintln!("cache pixels match: {scenario}");
+            }
         }
     }
     eprintln!("elapsed={:?}", start.elapsed());
@@ -223,4 +269,25 @@ fn main() -> anyhow::Result<()> {
     app.update(|cx| cx.quit());
     drop(app);
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn click(window: &mut gpui::Window, cx: &mut gpui::App, x: f32, y: f32) {
+    let position = gpui::point(px(x), px(y));
+    window.dispatch_event(
+        gpui::PlatformInput::MouseDown(gpui::MouseDownEvent {
+            position,
+            click_count: 1,
+            ..Default::default()
+        }),
+        cx,
+    );
+    window.dispatch_event(
+        gpui::PlatformInput::MouseUp(gpui::MouseUpEvent {
+            position,
+            click_count: 1,
+            ..Default::default()
+        }),
+        cx,
+    );
 }

--- a/crates/ui/examples/macos-resource-profile.rs
+++ b/crates/ui/examples/macos-resource-profile.rs
@@ -159,6 +159,65 @@ fn main() -> anyhow::Result<()> {
         }
         std::thread::sleep(Duration::from_millis(8));
     }
+    // Opt-in correctness check: a reused transcript scene must match a fresh
+    // layout after idle, panel transitions and scrolling. Keep this outside
+    // measured phases; screenshot readback and forced refreshes add work.
+    if std::env::var_os("ZERON_VERIFY_CACHE").is_some() {
+        for scenario in ["settled", "sidebar-hidden", "sidebar-restored", "scrolled"] {
+            app.update(|cx| {
+                window
+                    .update(cx, |_, window, cx| match scenario {
+                        "sidebar-hidden" | "sidebar-restored" => {
+                            window.dispatch_action(Box::new(shell::ToggleSidebar), cx)
+                        }
+                        "scrolled" => {
+                            window.dispatch_event(
+                                gpui::PlatformInput::ScrollWheel(gpui::ScrollWheelEvent {
+                                    position: gpui::point(px(700.), px(400.)),
+                                    delta: gpui::ScrollDelta::Pixels(gpui::point(px(0.), px(500.))),
+                                    modifiers: gpui::Modifiers::default(),
+                                    touch_phase: gpui::TouchPhase::Moved,
+                                }),
+                                cx,
+                            );
+                        }
+                        _ => {}
+                    })
+                    .unwrap()
+            });
+            let settle = Instant::now();
+            while settle.elapsed() < Duration::from_secs(1) {
+                app.update(|cx| {
+                    window
+                        .update(cx, |_, window, cx| {
+                            window.simulate_next_frame(cx);
+                        })
+                        .unwrap()
+                });
+                dispatcher.run_until_idle();
+                std::thread::sleep(Duration::from_millis(8));
+            }
+            let cached = app.update(|cx| {
+                window
+                    .update(cx, |_, window, _| window.render_to_image().unwrap())
+                    .unwrap()
+            });
+            app.update(|cx| window.update(cx, |_, window, _| window.refresh()).unwrap());
+            dispatcher.run_until_idle();
+            let fresh = app.update(|cx| {
+                window
+                    .update(cx, |_, window, _| window.render_to_image().unwrap())
+                    .unwrap()
+            });
+            cached.save(output.join(format!("{scenario}-cached.png")))?;
+            fresh.save(output.join(format!("{scenario}-fresh.png")))?;
+            anyhow::ensure!(
+                cached == fresh,
+                "Cached scene differs from fresh layout: {scenario}"
+            );
+            eprintln!("cache pixels match: {scenario}");
+        }
+    }
     eprintln!("elapsed={:?}", start.elapsed());
     drop(state);
     app.update(|cx| cx.quit());

--- a/crates/ui/src/loaders.rs
+++ b/crates/ui/src/loaders.rs
@@ -2,10 +2,9 @@
 //! splash content. All motion routes through `crate::motion` pure helpers, so
 //! the math is unit-tested and these elements are testable-by-compile.
 //!
-//! Rendering pattern: each cell is its own `with_animation` repeating element
-//! sharing one period; per-cell offsets come from [`motion::staggered_phase`],
-//! so all cells stay phase-locked (they start on the same frame) without a
-//! shared clock. Cells animate inside fixed-size slots — opacity and inner size
+//! Rendering pattern: cells share a self-parking pulse clock; per-cell offsets
+//! come from [`motion::staggered_phase`], so all cells stay phase-locked.
+//! Cells animate inside fixed-size slots — opacity and inner size
 //! are paint-local and never move surrounding layout. Reduced motion snaps every
 //! cell to its rest state automatically (gpui `reduce_motion`).
 
@@ -122,7 +121,7 @@ pub fn gradient_spinner(
 ) -> impl IntoElement {
     let center = (MATRIX_SIDE as f32 - 1.0) / 2.0;
     let max = MATRIX_SIDE as f32 - 1.0 + center;
-    let delta = motion::pulse_delta(&GRADIENT_SPIN, view, cx);
+    let delta = motion::pulse_delta_slow(&GRADIENT_SPIN, view, cx);
     div()
         .flex()
         .flex_col()

--- a/crates/ui/src/markdown/parser.rs
+++ b/crates/ui/src/markdown/parser.rs
@@ -12,6 +12,7 @@
 //! through both paths and assert equality.
 
 use std::ops::Range;
+use std::sync::Arc;
 
 use pulldown_cmark::{Alignment, CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag};
 
@@ -87,7 +88,9 @@ pub struct TopBlock {
 /// The parse result: top-level blocks in document order.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct BlockTree {
-    pub blocks: Vec<TopBlock>,
+    // Completed blocks are immutable. Canonical/display trees and old/new
+    // transcript rows share their contents across streamed tail updates.
+    pub blocks: Vec<Arc<TopBlock>>,
 }
 
 impl BlockTree {
@@ -123,17 +126,17 @@ pub fn parse_full(source: &str) -> BlockTree {
         match event {
             Event::Rule => {
                 cur.bump();
-                blocks.push(TopBlock {
+                blocks.push(Arc::new(TopBlock {
                     range,
                     block: Block::Rule,
-                });
+                }));
             }
             Event::Start(_) => {
                 for block in parse_started_block(&mut cur) {
-                    blocks.push(TopBlock {
+                    blocks.push(Arc::new(TopBlock {
                         range: range.clone(),
                         block,
-                    });
+                    }));
                 }
             }
             // Stray inline events at top level (shouldn't happen): skip.
@@ -559,7 +562,7 @@ pub struct IncrementalParser {
     /// has hanging inline markers ([`super::mend`]): `None` means the display
     /// tree is exactly [`Self::tree`]. Never fed back into the incremental
     /// state — the canonical tree stays parity-exact with `parse_full`.
-    display_tail: Option<Vec<TopBlock>>,
+    display_tail: Option<Vec<Arc<TopBlock>>>,
     /// Link-reference definitions act at a distance — full reparses only.
     full_only: bool,
     /// Bytes fed through `parse_full` by the most recent `set_text`/`append`/
@@ -587,7 +590,7 @@ impl IncrementalParser {
     /// The tree to render while streaming: the canonical tree with the last
     /// block swapped for its mended parse when inline markers hang (an
     /// unclosed `**bold`, a half-streamed `[link](url…`). Same shape and cost
-    /// as `tree().clone()` — the stable prefix is copied either way; only a
+    /// as `tree().clone()` — the stable prefix shares its blocks; only a
     /// hanging tail adds one O(tail) reparse, done at append time.
     pub fn display_tree(&self) -> BlockTree {
         let Some(tail) = &self.display_tail else {
@@ -613,13 +616,13 @@ impl IncrementalParser {
     /// Set the source: appends take the incremental path, anything else resets.
     pub fn set_text(&mut self, text: &str) {
         if text.len() >= self.source.len() && text.starts_with(self.source.as_str()) {
-            let delta = text[self.source.len()..].to_string();
+            let delta = &text[self.source.len()..];
             if delta.is_empty() {
                 self.last_parse_bytes = 0;
                 self.stable_prefix_blocks = self.tree.blocks.len();
                 return;
             }
-            self.append(&delta);
+            self.append(delta);
         } else {
             self.reset(text);
         }
@@ -678,8 +681,9 @@ impl IncrementalParser {
         self.tree.blocks.retain(|b| b.range.start < boundary);
         self.stable_prefix_blocks = self.tree.blocks.len();
         for mut top in tail.blocks {
-            top.range.start += boundary;
-            top.range.end += boundary;
+            let block = Arc::make_mut(&mut top);
+            block.range.start += boundary;
+            block.range.end += boundary;
             self.tree.blocks.push(top);
         }
         self.remend();
@@ -713,6 +717,7 @@ impl IncrementalParser {
         self.last_parse_bytes += mended.len();
         let mut tail = parse_full(&mended).blocks;
         for top in &mut tail {
+            let top = Arc::make_mut(top);
             // Display ranges point back into the unmended source; synthetic
             // closers at the end clamp away.
             top.range.start += start;
@@ -734,6 +739,31 @@ fn has_link_defs(text: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn display_snapshots_share_stable_blocks_without_mutating_old_frames() {
+        let mut parser = IncrementalParser::new();
+        parser.set_text("first **bold** paragraph\n\nsecond paragraph\n\nlast **open");
+        let before = parser.display_tree();
+        let frozen = format!("{before:?}");
+        assert!(Arc::ptr_eq(&before.blocks[0], &parser.tree().blocks[0]));
+        parser.append(" tail**\n\nnext paragraph");
+        let after = parser.display_tree();
+        assert!(Arc::ptr_eq(&before.blocks[0], &after.blocks[0]));
+        assert_eq!(
+            format!("{before:?}"),
+            frozen,
+            "old paint snapshot is immutable"
+        );
+        assert_eq!(parser.tree(), &parse_full(parser.source()));
+        parser.reset("replacement");
+        assert_eq!(
+            format!("{before:?}"),
+            frozen,
+            "reset cannot alter an old frame"
+        );
+        assert_eq!(parser.tree(), &parse_full("replacement"));
+    }
 
     fn stream(chunks: usize, text: &str) -> IncrementalParser {
         let mut p = IncrementalParser::new();

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -202,6 +202,13 @@ pub struct CachedCode {
 }
 
 impl RenderCache {
+    /// Keep rows laid out in the previous viewport, including GPUI overdraw.
+    /// Scrolling back regenerates these derived strings and code-line runs.
+    pub(crate) fn retain_rows(&mut self, rows: &std::collections::HashSet<SharedString>) {
+        self.flats.retain(|(row, _, _), _| rows.contains(row));
+        self.code.retain(|(row, _, _), _| rows.contains(row));
+    }
+
     /// Drop every cached entry for `row`.
     pub fn invalidate_row(&mut self, row: &str) {
         self.flats.retain(|(r, _, _), _| r.as_ref() != row);
@@ -1863,6 +1870,37 @@ mod tests {
         ];
         let flat = flatten_runs(&runs, &theme, false);
         assert_eq!(flat.links, vec![(0..9, "https://x.dev".to_string())]);
+    }
+
+    #[test]
+    fn viewport_cache_releases_offscreen_paint_data() {
+        let mut cache = RenderCache::default();
+        for row in ["visible", "offscreen"] {
+            cache.flats.insert(
+                (row.into(), 0, 0),
+                Rc::new(FlatText {
+                    text: "text".into(),
+                    runs: Vec::new(),
+                    links: Vec::new(),
+                    code_ranges: Vec::new(),
+                }),
+            );
+            cache.code.insert(
+                (row.into(), 0, 0),
+                Rc::new(CachedCode {
+                    code_len: 0,
+                    hl_key: (0, 0),
+                    lines: Vec::new(),
+                }),
+            );
+        }
+        cache.retain_rows(&std::collections::HashSet::from(["visible".into()]));
+        assert_eq!(cache.flats.len(), 1);
+        assert_eq!(cache.code.len(), 1);
+        assert!(cache.flats.keys().all(|(row, _, _)| row == "visible"));
+        cache.retain_rows(&std::collections::HashSet::new());
+        assert!(cache.flats.is_empty());
+        assert!(cache.code.is_empty());
     }
 
     #[test]

--- a/crates/ui/src/motion.rs
+++ b/crates/ui/src/motion.rs
@@ -59,8 +59,31 @@ const PULSE_LEASE: Duration = Duration::from_millis(300);
 
 struct PulseClock {
     epoch: Instant,
-    leases: HashMap<EntityId, Instant>,
+    leases: HashMap<EntityId, PulseLease>,
+    tick: u64,
     running: bool,
+}
+
+struct PulseLease {
+    until: Instant,
+    stride: u64,
+}
+
+impl PulseLease {
+    fn renew(&mut self, now: Instant, stride: u64) {
+        self.until = now + PULSE_LEASE;
+        self.stride = self.stride.min(stride);
+    }
+
+    fn take_tick(&mut self, tick: u64) -> bool {
+        if !tick.is_multiple_of(self.stride) {
+            return false;
+        }
+        // Each paint re-establishes the fastest mounted animation. A retired
+        // 30Hz animation must not permanently pull a 15Hz loader up to 30Hz.
+        self.stride = u64::MAX;
+        true
+    }
 }
 
 impl Global for PulseClock {}
@@ -70,6 +93,7 @@ impl Default for PulseClock {
         Self {
             epoch: Instant::now(),
             leases: HashMap::new(),
+            tick: 0,
             running: false,
         }
     }
@@ -81,13 +105,45 @@ impl Default for PulseClock {
 /// loaders stay phase-locked. Reduced motion returns a static 0 and schedules
 /// nothing.
 pub fn pulse_delta(spec: &MotionSpec, view: EntityId, cx: &mut App) -> f32 {
+    pulse_delta_every(spec, view, 1, cx)
+}
+
+/// Coarser cell loaders on the shell need only 15Hz; their wall-clock period
+/// and phase stay identical. Text dissolves still use the full 30Hz clock.
+pub fn pulse_delta_slow(spec: &MotionSpec, view: EntityId, cx: &mut App) -> f32 {
+    pulse_delta_every(spec, view, 2, cx)
+}
+
+fn pulse_delta_every(spec: &MotionSpec, view: EntityId, stride: u64, cx: &mut App) -> f32 {
     if cx.reduce_motion() {
         return 0.0;
     }
+    pulse_lease_every(view, stride, cx);
     let clock = cx.default_global::<PulseClock>();
-    clock.leases.insert(view, Instant::now() + PULSE_LEASE);
-    let period = spec.total().as_secs_f32();
-    let phase = (clock.epoch.elapsed().as_secs_f32() / period).fract();
+    (clock.epoch.elapsed().as_secs_f32() / spec.total().as_secs_f32()).fract()
+}
+
+/// Schedule cosmetic animation through the same bounded clock as loaders.
+/// Renew only while painting an active animation; the clock parks after the
+/// last lease expires, including when a view is hidden or removed.
+pub fn pulse_lease(view: EntityId, cx: &mut App) {
+    pulse_lease_every(view, 1, cx);
+}
+
+fn pulse_lease_every(view: EntityId, stride: u64, cx: &mut App) {
+    if cx.reduce_motion() {
+        return;
+    }
+    let clock = cx.default_global::<PulseClock>();
+    let now = Instant::now();
+    clock
+        .leases
+        .entry(view)
+        .or_insert(PulseLease {
+            until: now + PULSE_LEASE,
+            stride,
+        })
+        .renew(now, stride);
     if !clock.running {
         clock.running = true;
         cx.spawn(async move |cx| {
@@ -96,12 +152,18 @@ pub fn pulse_delta(spec: &MotionSpec, view: EntityId, cx: &mut App) -> f32 {
                 let parked = cx.update(|cx| {
                     let clock = cx.default_global::<PulseClock>();
                     let now = Instant::now();
-                    clock.leases.retain(|_, until| *until > now);
+                    clock.leases.retain(|_, lease| lease.until > now);
                     if clock.leases.is_empty() {
                         clock.running = false;
                         return true;
                     }
-                    let views: Vec<EntityId> = clock.leases.keys().copied().collect();
+                    clock.tick = clock.tick.wrapping_add(1);
+                    let tick = clock.tick;
+                    let views: Vec<EntityId> = clock
+                        .leases
+                        .iter_mut()
+                        .filter_map(|(view, lease)| lease.take_tick(tick).then_some(*view))
+                        .collect();
                     for view in views {
                         cx.notify(view);
                     }
@@ -114,7 +176,6 @@ pub fn pulse_delta(spec: &MotionSpec, view: EntityId, cx: &mut App) -> f32 {
         })
         .detach();
     }
-    phase
 }
 
 // ---------------------------------------------------------------------------
@@ -642,6 +703,30 @@ pub fn reduced_motion(cx: &App) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn pulse_stride_reestablishes_after_each_paint() {
+        let now = Instant::now();
+        let mut lease = PulseLease {
+            until: now + PULSE_LEASE,
+            stride: 2,
+        };
+        assert!(!lease.take_tick(1), "slow loader skips odd ticks");
+        assert!(lease.take_tick(2));
+        lease.renew(now, 2);
+        lease.renew(now, 1);
+        assert!(lease.take_tick(3), "fast animation wins while mounted");
+        lease.renew(now, 2);
+        assert!(lease.take_tick(4));
+        lease.renew(now, 2);
+        assert!(
+            !lease.take_tick(5),
+            "retired fast animation leaves no sticky stride"
+        );
+        assert!(lease.take_tick(6));
+        assert!(!lease.take_tick(7), "unpainted view cannot renew itself");
+        assert!(lease.until <= now + PULSE_LEASE);
+    }
+
     #[test]
     fn eval_never_escapes_unit_interval_dense_sweep() {
         // Regression: f32 rounding produced 1.000000119 near the tail of

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -974,8 +974,34 @@ struct SubagentTab {
     _events: Subscription,
 }
 
+/// Sidebar render identity lets transcript/caret frames reuse its GPUI scene.
+/// State and event handlers stay on Shell. Explicit Shell notifications still
+/// invalidate the sidebar, including selection, menus, theme and navigation.
+struct SidebarPane {
+    shell: gpui::WeakEntity<Shell>,
+    _observation: Subscription,
+}
+
+impl Render for SidebarPane {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        crate::transcript::record_view_frame("sidebar");
+        let Some(shell) = self.shell.upgrade() else {
+            return div().into_any_element();
+        };
+        let inner = shell.update(cx, |shell, cx| {
+            let theme = Theme::of(cx).clone();
+            match shell.route {
+                Route::Settings(section) => shell.render_settings_nav(section, &theme, cx),
+                Route::Chat => shell.render_chat_sidebar(&theme, cx),
+            }
+        });
+        div().size_full().child(inner).into_any_element()
+    }
+}
+
 pub struct Shell {
     state: Entity<AppState>,
+    sidebar_pane: Entity<SidebarPane>,
     transcript: Entity<Transcript>,
     composer: Entity<Composer>,
     /// Measured height of the bottom chrome stack (status strip + composer +
@@ -1288,8 +1314,14 @@ impl Shell {
             Route::Chat => NavEntry::Chat(String::new()),
             Route::Settings(section) => NavEntry::Settings(section),
         });
+        let shell = cx.entity();
+        let sidebar_pane = cx.new(|cx| SidebarPane {
+            shell: shell.downgrade(),
+            _observation: cx.observe(&shell, |_, _, cx| cx.notify()),
+        });
         Self {
             state,
+            sidebar_pane,
             transcript,
             composer,
             // Seed with the compact composer stack's rough height so the
@@ -3668,15 +3700,16 @@ impl Shell {
         out
     }
 
-    fn render_sidebar(&mut self, cx: &mut Context<Self>) -> AnyElement {
+    fn render_sidebar(&mut self, _cx: &mut Context<Self>) -> AnyElement {
         // The sidebar is part of the resolved theme. A second fixed-Zeron
         // palette here made imported families look split in half and froze
         // activity/glyph personality independently of the selected variant.
-        let theme = Theme::of(cx).clone();
-        let inner: AnyElement = match self.route {
-            Route::Settings(section) => self.render_settings_nav(section, &theme, cx),
-            Route::Chat => self.render_chat_sidebar(&theme, cx),
-        };
+        let inner = self.sidebar_pane.clone().cached(
+            gpui::StyleRefinement::default()
+                .w(px(self.settings.sidebar_width))
+                .h_full()
+                .flex_none(),
+        );
         let target = self.sidebar_target();
         // Transparent — the sidebar sits directly on the frost shell; the main
         // card's own border provides the separation. The content row spans the
@@ -3951,7 +3984,7 @@ impl Shell {
                             format!("chat-working-{id}"),
                             2.0,
                             theme.glyph,
-                            cx.entity_id(),
+                            self.sidebar_pane.entity_id(),
                             cx,
                         )
                         .into_any_element()
@@ -4202,7 +4235,7 @@ impl Shell {
                     "connection-spinner",
                     2.0,
                     theme.text_muted,
-                    cx.entity_id(),
+                    self.sidebar_pane.entity_id(),
                     cx,
                 )
                 .into_any_element(),
@@ -7299,6 +7332,7 @@ fn header_icon_button(
 
 impl Render for Shell {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        crate::transcript::record_view_frame("shell");
         self.viewport_width = f32::from(window.viewport_size().width);
         // Appearance actions persist independently of the shell. Mirror the
         // globals before any later debounced settings save can overwrite them.
@@ -7440,9 +7474,7 @@ impl Render for Shell {
             // forward the slot instead of eating it.
             .on_action(cx.listener(|this, jump: &JumpSession, _, cx| {
                 let pickers = this.composer.read(cx).pickers().clone();
-                let handled = pickers.update(cx, |pickers, cx| {
-                    pickers.jump_model_slot(jump.0, cx)
-                });
+                let handled = pickers.update(cx, |pickers, cx| pickers.jump_model_slot(jump.0, cx));
                 if !handled && !this.overlay_owns_keyboard(cx) {
                     this.jump_to_session(jump.0, cx)
                 }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -1210,6 +1210,7 @@ pub struct Shell {
     _composer_events: Subscription,
     /// The primary transcript's spawn-chip events (subagent tabs).
     _transcript_events: Subscription,
+    _transcript_invalidation: Subscription,
 }
 
 impl Shell {
@@ -1313,6 +1314,11 @@ impl Shell {
         let nav = NavHistory::new(match route {
             Route::Chat => NavEntry::Chat(String::new()),
             Route::Settings(section) => NavEntry::Settings(section),
+        });
+        // Parent notifications carry presentation changes (session status,
+        // elapsed labels, menus); sibling animation/caret ticks do not.
+        let transcript_invalidation = cx.observe_self(|shell, cx| {
+            shell.transcript.update(cx, |_, cx| cx.notify());
         });
         let shell = cx.entity();
         let sidebar_pane = cx.new(|cx| SidebarPane {
@@ -1420,6 +1426,7 @@ impl Shell {
             _state_observation: observation,
             _composer_events: composer_events,
             _transcript_events: transcript_events,
+            _transcript_invalidation: transcript_invalidation,
         }
     }
 
@@ -5556,7 +5563,10 @@ impl Shell {
         // at all → the onboarding card. The composer sits below the first two
         // (new-chat mode mints the chat id on first send).
         let outlet: AnyElement = if has_selection {
-            self.transcript.clone().into_any_element()
+            self.transcript
+                .clone()
+                .cached(gpui::StyleRefinement::default().size_full())
+                .into_any_element()
         } else if !has_spaces && !no_project {
             // Onboarding (first boot / after the destructive wipe): no folders
             // to work in yet — one clear affordance.

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -624,6 +624,9 @@ pub struct AppState {
     /// empty transcript is otherwise indistinguishable from the pre-replay
     /// gap after selection, where optimistic echoes may already be visible.
     pub transcript_replayed: bool,
+    /// Changes only when transcript/optimistic content changes. Presence,
+    /// catalogs and other app-state notifications need no row derivation.
+    pub(crate) transcript_revision: u64,
     /// Optimistic user echoes per chat id, shown until the doc frame carrying
     /// the same message id arrives (client-minted ids make dedup exact).
     echoes: HashMap<String, Vec<SessionMessageEntry>>,
@@ -686,6 +689,7 @@ impl AppState {
             selected_chat: None,
             transcript: Vec::new(),
             transcript_replayed: false,
+            transcript_revision: 0,
             echoes: HashMap::new(),
             pending_sends: HashMap::new(),
             upload_progress: None,
@@ -760,6 +764,7 @@ impl AppState {
             // Selected chat vanished (deleted elsewhere): drop selection + transcript.
             self.selected_chat = None;
             self.transcript.clear();
+            self.transcript_revision = self.transcript_revision.wrapping_add(1);
             self.transcript_replayed = false;
             self.transcript_task = None;
         }
@@ -915,6 +920,7 @@ impl AppState {
     }
 
     pub fn apply_transcript(&mut self, entries: Vec<SessionMessageEntry>) {
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         // Doc frames supersede optimistic echoes carrying the same id.
         if let Some(chat_id) = self.selected_chat.as_deref()
             && let Some(echoes) = self.echoes.get_mut(chat_id)
@@ -932,6 +938,7 @@ impl AppState {
         &mut self,
         frame: TranscriptFrame,
     ) -> Result<(), TranscriptDesync> {
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         let is_reset = matches!(&frame, TranscriptFrame::Reset { .. });
         zeron_doc::apply_transcript_frame(&mut self.transcript, frame)?;
         if is_reset {
@@ -974,6 +981,7 @@ impl AppState {
     /// Tab closed: drop the watch task (cancels the engine-side watch and
     /// unpins the doc from the engine LRU) and the rows.
     pub fn unwatch_subagent_doc(&mut self, doc_id: &str) {
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         self.sub_watch_tasks.remove(doc_id);
         self.sub_transcripts.remove(doc_id);
     }
@@ -981,6 +989,7 @@ impl AppState {
     /// Frozen-blob path: the finished subagent's uploaded transcript, no
     /// watch needed (and any in-flight watch is superseded).
     pub fn set_subagent_snapshot(&mut self, doc_id: String, entries: Vec<SessionMessageEntry>) {
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         self.sub_watch_tasks.remove(&doc_id);
         self.sub_transcripts.insert(doc_id, entries);
     }
@@ -990,13 +999,18 @@ impl AppState {
         let echoes = self.echoes.entry(chat_id.to_string()).or_default();
         if !echoes.iter().any(|e| e.id == entry.id) {
             echoes.push(entry);
+            self.transcript_revision = self.transcript_revision.wrapping_add(1);
         }
     }
 
     /// Drop an echo (send failed — the prompt returns to the draft).
     pub fn remove_echo(&mut self, chat_id: &str, message_id: &str) {
         if let Some(echoes) = self.echoes.get_mut(chat_id) {
+            let previous_len = echoes.len();
             echoes.retain(|e| e.id != message_id);
+            if echoes.len() != previous_len {
+                self.transcript_revision = self.transcript_revision.wrapping_add(1);
+            }
         }
     }
 
@@ -1372,6 +1386,7 @@ impl AppState {
         self.chats_synced = false;
         self.spaces_synced = false;
         self.transcript.clear();
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         self.transcript_replayed = false;
         self.echoes.clear();
         self.pending_sends.clear();
@@ -1583,6 +1598,7 @@ impl AppState {
         self.selected_chat = chat_id.clone();
         self.auto_selected = true;
         self.transcript.clear();
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         self.transcript_replayed = false;
         self.transcript_task = None;
         if let Some(id) = chat_id.as_deref() {
@@ -2048,6 +2064,7 @@ fn spawn_subagent_watch(
                 let alive = this.update(cx, |state, cx| {
                     // A stale pump racing a snapshot/unwatch finds no key.
                     if let Some(rows) = state.sub_transcripts.get_mut(&doc_id) {
+                        state.transcript_revision = state.transcript_revision.wrapping_add(1);
                         if let Err(err) = zeron_doc::apply_transcript_frame(rows, frame) {
                             tracing::warn!(%doc_id, error = %err, "resubscribing subagent watch");
                             desync = true;
@@ -2658,6 +2675,53 @@ mod tests {
             status: None,
             continuation_of: None,
         }
+    }
+
+    #[test]
+    fn transcript_revision_tracks_replay_echoes_and_subagent_content() {
+        let mut state = AppState::new();
+        state.selected_chat = Some("c".into());
+        let initial = state.transcript_revision;
+        state.apply_transfers(Vec::new());
+        state.apply_auth(AuthState::SignedOut);
+        assert_eq!(
+            state.transcript_revision, initial,
+            "unrelated notifications are inert"
+        );
+
+        state.push_echo("c", user_entry("m1"));
+        let echo = state.transcript_revision;
+        assert_ne!(echo, initial);
+        state.push_echo("c", user_entry("m1"));
+        state.remove_echo("c", "absent");
+        assert_eq!(
+            state.transcript_revision, echo,
+            "unchanged echoes do not invalidate"
+        );
+        state.apply_transcript(vec![user_entry("m1")]);
+        assert!(state.pending_echoes().is_empty());
+        assert_ne!(
+            state.transcript_revision, echo,
+            "echo-to-replay handoff invalidates"
+        );
+
+        let before_reset = state.transcript_revision;
+        state
+            .apply_transcript_frame(TranscriptFrame::Reset { reset: Vec::new() })
+            .unwrap();
+        assert!(state.transcript_replayed);
+        assert_ne!(
+            state.transcript_revision, before_reset,
+            "empty replay is authoritative"
+        );
+
+        let before_subagent = state.transcript_revision;
+        state.set_subagent_snapshot("sub".into(), vec![user_entry("nested")]);
+        assert_ne!(state.transcript_revision, before_subagent);
+        let before_close = state.transcript_revision;
+        state.unwatch_subagent_doc("sub");
+        assert!(state.sub_transcript("sub").is_empty());
+        assert_ne!(state.transcript_revision, before_close);
     }
 
     fn device(id: &str, name: &str) -> Device {

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -158,8 +158,8 @@ fn should_anchor_live_stream(pinned: bool, distance_from_bottom: f32, streaming:
     pinned && streaming && distance_from_bottom <= AT_BOTTOM_PX
 }
 
-/// Keep the spring loop warm this long after landing, so a streaming pause
-/// resumes at cruise instead of re-accelerating from zero.
+/// Retain the spring's state this long after landing, so a streaming pause
+/// resumes at cruise. Retaining state does not require drawing idle frames.
 pub const SPRING_SETTLE_GRACE_MS: u64 = 500;
 /// Teleport when farther than this many viewports from the end; glide the rest.
 pub const GLIDE_MAX_VIEWPORTS: f32 = 2.5;
@@ -228,6 +228,13 @@ impl StickSpring {
     /// < .05`)?
     pub fn is_idle(&self) -> bool {
         self.velocity < 0.05 && self.target_vel < 0.05
+    }
+
+    fn needs_frame(distance: f32) -> bool {
+        // The spring is clamped to the target. Residual velocity cannot move
+        // a viewport already there; virtual-list height estimates can keep
+        // that velocity nonzero indefinitely even after a turn completes.
+        distance > 0.5
     }
 
     #[cfg(test)]
@@ -1418,6 +1425,34 @@ fn frame_stats_enabled() -> bool {
 
 const FRAME_STATS_WINDOW: usize = 240;
 
+/// Opt-in cadence counters complement per-row timings: inexpensive rows can
+/// still exhaust a battery when an unrelated animation rebuilds them at 120Hz.
+pub(crate) fn record_view_frame(view: &'static str) -> bool {
+    if !frame_stats_enabled() {
+        return false;
+    }
+    thread_local! {
+        static COUNTERS: RefCell<HashMap<&'static str, (Instant, u64)>> = RefCell::default();
+    }
+    COUNTERS.with(|counters| {
+        let mut counters = counters.borrow_mut();
+        let (start, frames) = counters.entry(view).or_insert_with(|| (Instant::now(), 0));
+        *frames += 1;
+        let elapsed = start.elapsed().as_secs_f64();
+        if elapsed >= 1.0 {
+            tracing::warn!(
+                view,
+                frames_per_second = *frames as f64 / elapsed,
+                "view render cadence"
+            );
+            *start = Instant::now();
+            *frames = 0;
+            return true;
+        }
+        false
+    })
+}
+
 /// `ZERON_NO_RENDER_CACHE=1` bypasses the cross-frame flatten cache — the
 /// A/B knob for the frame-cost measurement above.
 fn render_cache_disabled() -> bool {
@@ -2229,6 +2264,7 @@ pub struct Transcript {
     /// frames reuse settled blocks' text+runs; the incremental parser's stable
     /// boundary invalidates only the live tail per commit.
     render_cache: Rc<RefCell<RenderCache>>,
+    rendered_rows: HashSet<SharedString>,
     /// Last UI typography generation reflected in `list` item measurements.
     /// Family and size changes can alter prose wrapping without changing row
     /// identity, so the virtual list must explicitly discard cached heights.
@@ -2434,6 +2470,7 @@ impl Transcript {
             veil_baseline: std::collections::HashSet::new(),
             veil_attach_pending: true,
             render_cache: Rc::new(RefCell::new(RenderCache::default())),
+            rendered_rows: HashSet::new(),
             typography_generation: crate::typography::generation(cx),
             code_fences_generation: crate::settings::code_fences_generation(cx),
             highlights: HighlightStore::default(),
@@ -3288,17 +3325,20 @@ impl Transcript {
     /// Arm the per-frame spring driver — `render` schedules the next frame
     /// while [`Self::spring_should_run`].
     fn wake_spring(&mut self) {
+        if self.spring_settled_at.is_some_and(|settled| {
+            settled.elapsed() >= Duration::from_millis(SPRING_SETTLE_GRACE_MS)
+        }) {
+            self.spring.reset();
+            self.spring_last_tick = None;
+        }
         self.spring_settled_at = None;
         self.spring_kick = true;
     }
 
-    /// Whether the spring loop needs another frame: off the bottom, carrying
-    /// residual motion, or inside the post-landing settle grace.
+    /// A layout kick needs one observation; otherwise only unfinished motion
+    /// needs another frame. The settle grace retains state without repainting.
     fn spring_should_run(&self) -> bool {
-        self.spring_kick
-            || self.distance_from_bottom() > 0.5
-            || !self.spring.is_idle()
-            || self.spring_settled_at.is_some()
+        self.spring_kick || StickSpring::needs_frame(self.distance_from_bottom())
     }
 
     /// Whether the scroll offset is in a bottom-glued representation (`None`
@@ -3309,7 +3349,7 @@ impl Transcript {
     }
 
     /// One spring frame: observe target growth, step the stepper, apply the
-    /// delta, park after the settle grace. Runs from `window.on_next_frame`,
+    /// delta, and park on landing. Runs from `window.on_next_frame`,
     /// i.e. after layout — measurements are fresh.
     fn step_spring(&mut self, cx: &mut Context<Self>) {
         self.spring_kick = false;
@@ -3318,6 +3358,13 @@ impl Transcript {
             return;
         }
         let now = Instant::now();
+        if self.spring_settled_at.is_some_and(|settled| {
+            now.duration_since(settled) >= Duration::from_millis(SPRING_SETTLE_GRACE_MS)
+        }) {
+            self.spring.reset();
+            self.spring_last_tick = None;
+            self.spring_settled_at = None;
+        }
         let frames = match self.spring_last_tick {
             Some(last) => (now.duration_since(last).as_secs_f32() * 1000.0 / SPRING_FRAME_MS)
                 .min(SPRING_MAX_CATCHUP_FRAMES),
@@ -3342,36 +3389,32 @@ impl Transcript {
         self.last_scroll_distance = (target - next).max(0.0);
 
         if target - next <= 0.5 {
-            let settled = *self.spring_settled_at.get_or_insert(now);
-            if now.duration_since(settled) >= Duration::from_millis(SPRING_SETTLE_GRACE_MS)
-                && self.spring.is_idle()
-            {
-                // Park: stop scheduling frames until the next wake.
-                self.spring.reset();
-                self.spring_last_tick = None;
-                self.spring_settled_at = None;
-                return;
-            }
+            // Land on the final item, not the scrollbar's estimated pixel
+            // total. Remeasuring virtual rows can otherwise move that total
+            // after every landing and restart the glide indefinitely.
+            self.list.scroll_to_end();
+            self.spring_settled_at.get_or_insert(now);
         } else {
             self.spring_settled_at = None;
         }
-        cx.notify();
+        // A stationary spring used to repaint throughout the 500ms grace.
+        // Repeated layout kicks kept that loop alive for entire streams even
+        // at distance=0, velocity=0. Preserve the final movement's paint and
+        // every moving frame; a settled spring wakes on the next layout kick.
+        if next > pos || StickSpring::needs_frame(self.last_scroll_distance) {
+            cx.notify();
+        }
     }
 
     /// Rebuild rows from app state; splice minimal ranges into the list.
     fn sync(&mut self, cx: &mut Context<Self>) {
-        let (selected, entries, echoes, replay) = {
+        let (selected, replay) = {
             let s = self.state.read(cx);
             match &self.doc_override {
                 // Pinned to a subagent doc: `selected` equals `chat_id` by
                 // construction, so the attach/reset branch below never fires,
                 // and echoes stay empty (nothing is ever sent from here).
-                Some(doc_id) => (
-                    Some(doc_id.clone()),
-                    s.sub_transcript(doc_id).to_vec(),
-                    Vec::new(),
-                    TranscriptReplayState::Populated,
-                ),
+                Some(doc_id) => (Some(doc_id.clone()), TranscriptReplayState::Populated),
                 None => {
                     let replay = if !s.transcript_replayed {
                         TranscriptReplayState::Pending
@@ -3380,12 +3423,7 @@ impl Transcript {
                     } else {
                         TranscriptReplayState::Populated
                     };
-                    (
-                        s.selected_chat.clone(),
-                        s.transcript.clone(),
-                        s.pending_echoes().to_vec(),
-                        replay,
-                    )
+                    (s.selected_chat.clone(), replay)
                 }
             }
         };
@@ -3462,12 +3500,31 @@ impl Transcript {
         }
 
         let mut new_rows: Vec<Row> = Vec::new();
-        for entry in &entries {
-            new_rows.extend(self.rows_for(entry, false));
-        }
-        for echo in &echoes {
-            new_rows.extend(self.rows_for(echo, true));
-        }
+        // Borrow the transcript only while deriving rows. Cloning the entity
+        // handle lets rows_for mutate our caches without copying every text
+        // and tool payload on each app-state notification.
+        let (entries_empty, tail_streaming) = {
+            let state = self.state.clone();
+            let state = state.read(cx);
+            let entries = match &self.doc_override {
+                Some(doc_id) => state.sub_transcript(doc_id),
+                None => state.transcript.as_slice(),
+            };
+            for entry in entries {
+                new_rows.extend(self.rows_for(entry, false));
+            }
+            if self.doc_override.is_none() {
+                for echo in state.pending_echoes() {
+                    new_rows.extend(self.rows_for(echo, true));
+                }
+            }
+            (
+                entries.is_empty(),
+                entries
+                    .last()
+                    .is_some_and(|e| e.status == Some(MessageStatus::Streaming)),
+            )
+        };
 
         // Runtime scroll handles follow the stable code rows exactly. A live
         // block keeps its handle through completion; deleted/reindexed tail
@@ -3502,7 +3559,7 @@ impl Transcript {
             self.veil_baseline.clear();
             self.veil_attach_pending = true;
         }
-        if self.veil_attach_pending && !entries.is_empty() {
+        if self.veil_attach_pending && !entries_empty {
             self.veil_attach_pending = false;
             self.veil_baseline = new_rows
                 .iter()
@@ -3530,13 +3587,8 @@ impl Transcript {
         // keeps the in-flow working trailer at the same viewport position as
         // transcript lines grow above it. Nothing about the trailer's layout
         // or coordinates changes.
-        let live_following = should_anchor_live_stream(
-            self.pinned,
-            self.distance_from_bottom(),
-            entries
-                .last()
-                .is_some_and(|entry| entry.status == Some(MessageStatus::Streaming)),
-        );
+        let live_following =
+            should_anchor_live_stream(self.pinned, self.distance_from_bottom(), tail_streaming);
         let was_empty = self.rows.is_empty();
         let old_last = self.rows.len().checked_sub(1);
         match diff_rows(&self.rows, &new_rows) {
@@ -4181,6 +4233,7 @@ impl Transcript {
         let Some(row) = self.rows.get(ix).cloned() else {
             return gpui::Empty.into_any_element();
         };
+        self.rendered_rows.insert(row.id.clone());
         let theme = Theme::of(cx).clone();
         // The viewport spans the full window (under the titlebar): the first
         // row's gap adds the titlebar's height so a top-scrolled transcript
@@ -4366,11 +4419,11 @@ impl Transcript {
                 if let Some(veil) = &veil {
                     veil.borrow_mut().finish_seeding();
                 }
-                // Drive the veil clock: while any chunk is still dissolving,
-                // repaint next frame (self-limiting — one callback per frame).
+                // Share the loaders' bounded clock. A display-frame callback
+                // here would pin the transcript to 60/120Hz for the whole
+                // stream, bypassing the clock even with no loader mounted.
                 if veil.is_some_and(|v| v.borrow().is_fading()) {
-                    let id = cx.entity_id();
-                    window.on_next_frame(move |_, cx| cx.notify(id));
+                    motion::pulse_lease(cx.entity_id(), cx);
                 }
                 el
             }
@@ -6152,6 +6205,21 @@ fn entry_fingerprint(entry: &SessionMessageEntry, pending: bool) -> u64 {
 
 impl Render for Transcript {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if record_view_frame("transcript") {
+            tracing::warn!(
+                distance = self.distance_from_bottom(),
+                spring = self.spring_should_run(),
+                velocity = self.spring.velocity,
+                target_velocity = self.spring.target_vel,
+                own_turn = self.own_turn.is_some(),
+                veils = self.veils.len(),
+                "transcript motion state"
+            );
+        }
+        self.render_cache
+            .borrow_mut()
+            .retain_rows(&self.rendered_rows);
+        self.rendered_rows.clear();
         let code_fences_generation = crate::settings::code_fences_generation(cx);
         if self.code_fences_generation != code_fences_generation {
             self.code_fences_generation = code_fences_generation;
@@ -6406,6 +6474,45 @@ mod tests {
     }
 
     // ---- stick-to-bottom spring ----
+
+    #[test]
+    fn stationary_spring_does_not_keep_requesting_frames() {
+        let mut spring = StickSpring::new();
+        let mut pos = 600.0;
+        for _ in 0..120 {
+            let next = spring.step(pos, 600.0, 1.0);
+            assert_eq!(next, pos);
+            assert!(!StickSpring::needs_frame(600.0 - next));
+            pos = next;
+        }
+        // Real growth must still wake and complete the same smooth glide.
+        let target = 900.0;
+        let mut moving_frames = 0;
+        while StickSpring::needs_frame(target - pos) && moving_frames < 600 {
+            let next = spring.step(pos, target, 1.0);
+            assert!(next >= pos && next <= target);
+            pos = next;
+            moving_frames += 1;
+        }
+        assert_eq!(pos, target);
+        assert!(moving_frames > 1 && moving_frames < 600);
+        assert!(!StickSpring::needs_frame(0.0));
+    }
+
+    #[test]
+    fn estimated_height_growth_at_the_bottom_cannot_keep_spring_awake() {
+        let mut spring = StickSpring::new();
+        // Virtualized height estimates can grow while the viewport remains
+        // anchored to exactly the same final row. This previously kept the
+        // feed-forward velocity and the redraw loop alive after completion.
+        for frame in 0..120 {
+            let target = 10000.0 + frame as f32 * 400.0;
+            let next = spring.step(target, target, 1.0);
+            assert_eq!(next, target);
+            assert!(!StickSpring::needs_frame(target - next));
+        }
+        assert!(spring.target_vel() > 1.0, "exercise a nonzero estimate");
+    }
 
     #[test]
     fn spring_converges_to_a_fixed_target() {

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2201,6 +2201,7 @@ pub struct Transcript {
     state: Entity<AppState>,
     list: ListState,
     rows: Vec<Row>,
+    last_source: Option<(Option<String>, TranscriptReplayState, u64)>,
     chat_id: Option<String>,
     /// `Some(doc_id)` pins this instance to a SUBAGENT doc: rows come from
     /// `AppState::sub_transcript(doc_id)` instead of the selected chat, and
@@ -2449,6 +2450,7 @@ impl Transcript {
             state,
             list,
             rows: Vec::new(),
+            last_source: None,
             // Pre-set so `sync` never sees an attach edge — an override
             // instance must not reset (or re-pin) on selection changes.
             chat_id: doc_override.clone(),
@@ -3428,6 +3430,16 @@ impl Transcript {
             }
         };
 
+        let source = (
+            selected.clone(),
+            replay,
+            self.state.read(cx).transcript_revision,
+        );
+        if self.last_source.as_ref() == Some(&source) {
+            return;
+        }
+        self.last_source = Some(source);
+
         let attached = selected != self.chat_id;
         if attached {
             // Read the incoming snapshot before inserting the outgoing one:
@@ -3684,7 +3696,13 @@ impl Transcript {
     /// Cached row build for one entry (streaming entries bypass the cache).
     fn rows_for(&mut self, entry: &SessionMessageEntry, pending: bool) -> Vec<Row> {
         let streaming = entry.status == Some(MessageStatus::Streaming);
-        let fingerprint = entry_fingerprint(entry, pending);
+        // Live entries always rebuild; don't allocate a fingerprint that the
+        // streaming path cannot use.
+        let fingerprint = if streaming {
+            0
+        } else {
+            entry_fingerprint(entry, pending)
+        };
         if !streaming
             && let Some(cached) = self.row_cache.get(&entry.id)
             && cached.fingerprint == fingerprint

--- a/docs/performance-macos.md
+++ b/docs/performance-macos.md
@@ -1,0 +1,104 @@
+# Native macOS resource follow-up
+
+This follows PR #255 at `f10ef38c`. The app pins zui `0003b923`, which gates
+unnecessary main-queue frame callbacks and bounds native Metal blur resources.
+The Linux software-Vulkan results in [the earlier report](performance-resource-usage.md)
+do not predict native Metal usage.
+
+## Changes
+
+- Transcript row derivation now has a content revision. Presence, catalog and
+  other unrelated state notifications skip rebuilding rows, while selection,
+  replay readiness, optimistic echo insertion/removal, transcript deltas and
+  subagent content invalidate the cache. Live entries also skip an unused
+  serialized fingerprint.
+- The native frame loop parks clean-window callbacks and wakes for content,
+  input or animations. It keeps the existing display clock and lifecycle
+  protections. The timing thread still runs while the window is subscribed.
+- Metal uses a per-frame autorelease pool and bounded caches for alternating
+  blur surfaces. Smaller texture buckets reduce over-allocation; window shrink
+  and idle transitions release obsolete extents. Current surfaces retain their
+  resources. Blur sigma, shaders, clipping, animation clocks and scroll behavior
+  stay unchanged.
+- The resource driver now reports native process CPU and physical footprint as
+  well as RSS. Its window helper rejects locked/asleep displays and invalidates
+  measurements if the app loses the foreground or its window disappears.
+- Replay recording clones frames before the transcript applier mutates them.
+  Otherwise later appends corrupt historical reset/upsert records.
+
+## Validation and limits
+
+593 UI tests, 207 GPUI library tests and 15 native macOS tests passed. The native
+suite covers wake after idle, animation continuation, resize, Gaussian blur
+pixels, identical cold/warm rendering, cache bounds and menu-close trimming.
+The macOS pasteboard tests share the system clipboard and are run serially.
+The optional native UI replay example uses CoreText, Metal, the real shell and
+real animation clocks; its completed transcript is rendered to `complete.png`.
+The profiling feature and its benchmark dependencies are not enabled in normal
+application builds.
+
+The Mac's display was locked during this work. Native offscreen rendering is
+valid for checking pixels and isolated rendering cost. It cannot verify native
+window presentation, desktop background blur, display pacing, interactive input
+or foreground whole-app CPU/memory savings. The user's reported memory swings
+are not yet conclusively attributed. RSS alone is insufficient for comparison
+because the native physical-footprint counter also accounts for charged
+compressed and GPU memory.
+
+Before merge, repeat foreground baseline/candidate runs and check typing,
+selection/copy, scrolling, streaming/completion, menus, resizing, occlusion and
+display reconnection with the Mac unlocked. This is a draft pending those checks.
+
+## Repeated native offscreen comparison
+
+Two sequential runs per build, ordered baseline/candidate/candidate/baseline,
+on macOS 26.0.1 (25A362), arm64 Mac16,7 with 24 GiB RAM. The synthetic shell
+replays the same protocol frames at the recorded cadence, at 1320×880 logical
+pixels and 2× scale, then waits 15 seconds. Each phase excludes its first two
+seconds. Both drivers use the same allocator and native text/Metal backends.
+The baseline adds only the profiling driver and embedded-platform launch support.
+[Raw samples and executable/trace hashes](performance/resource-macos-offscreen.json).
+
+| UI-only replay metric | PR #255 | Candidate |
+| --- | ---: | ---: |
+| CPU, 100% per core | 18.49% | 18.46% |
+| Mean of per-run peak physical footprint | 282.85 MiB | 286.69 MiB |
+
+These runs establish **no meaningful streaming CPU or memory improvement** in
+this isolated workload. It excludes native display-link dispatch and desktop
+composition and does not open alternating menus. The completed 2640×1760 app
+image is byte-identical between baseline and candidate in the first matched pair.
+The frame-gating and unused-resource cleanup benefits still require a foreground
+comparison. Do not present these results as a reduction in the reported whole-app
+streaming usage, or as a universal memory floor.
+
+## Reproduction
+
+Requires Node 22+, Rust and Xcode Command Line Tools. Foreground profiling needs
+existing Accessibility access to activate and size the isolated window. Keep
+that window foreground and the display awake for the entire run. Replay uses
+an isolated profile and the bundled sanitized fixture; it makes no model API call.
+
+```sh
+cargo build --release --locked -p zeron
+ZERON_FRAME_STATS=0 ZERON_PROFILE_IDLE_MS=45000 \
+  CLAUDE_CODE_EXECUTABLE="$PWD/scripts/replay-claude.py" \
+  ZERON_REPLAY_JOURNAL="$PWD/scripts/fixtures/resource-stream.jsonl" \
+  node scripts/resource-profile.mjs target/release/zeron /tmp/zeron-native claude-code
+
+# UI-only offscreen replay of those verified protocol frames:
+cargo build --release --locked -p zeron-ui --features resource-profile \
+  --example macos-resource-profile
+ZERON_FRAME_STATS=0 target/release/examples/macos-resource-profile \
+  /tmp/zeron-native/frames.json /tmp/zeron-native-ui
+
+# Native counter usable with either process (CPU uses 100% per core):
+xcrun clang -O2 scripts/macos-resource-stat.c -o /tmp/zeron-stat
+/tmp/zeron-stat PID
+```
+
+Compare fresh release builds in alternating order, with the same trace,
+window geometry, display scale and settings. Do not compile or run a profiler
+concurrently with timed comparisons. Engine and harness processes are reported
+separately from the UI; the offscreen example excludes both and the window
+compositor. Its polling loop must not be reported as native idle CPU.

--- a/docs/performance-macos.md
+++ b/docs/performance-macos.md
@@ -44,9 +44,17 @@ application builds.
 The final completed native replay image is pixel-identical to the baseline.
 With `ZERON_VERIFY_CACHE=1`, the example also compares the reused scene with a
 forced fresh render after settling, hiding/restoring the sidebar and scrolling;
-all four comparisons are pixel-identical. A precompiled-shader experiment also
-produced identical pixels but no meaningful foreground memory improvement, so
-the existing runtime-shader build configuration is retained.
+all four comparisons are pixel-identical. With the bundled 80-section fixture,
+`ZERON_VERIFY_INTERACTIONS=1` also drives a text-selection drag, composer typing,
+and model-menu open/outside-click dismissal. Selection, typed text and dismissal match a fresh
+render byte for byte. The model menu has no engine catalog in this isolated
+example, so its loading bars keep animating: the comparison excludes the menu
+rectangle, and both complete images are retained for visual review. This checks
+opening/dismissing the popover, not selecting a live provider model.
+
+A precompiled-shader experiment also produced identical pixels but no meaningful
+foreground memory improvement, so the existing runtime-shader build
+configuration is retained.
 
 ## Native foreground measurements
 
@@ -73,6 +81,16 @@ observations averaged 0.83–0.87% UI CPU and ended at 323.31–326.25 MiB; the
 baseline used a longer 30-second observation, so those settled averages are
 not a matched-duration before/after claim. All completed replies have the same
 52,624-byte combined text/reasoning digest.
+
+A larger replay repeated the fixture four times at a 10 ms provider delay,
+producing 210,502 combined text/reasoning bytes in about 21.5 seconds. Two valid
+foreground runs used 13.03–15.34% streaming UI CPU and peaked at
+328.74–329.75 MiB UI physical footprint. The first ten seconds after completion
+included additional work (3.50% UI CPU in the first run); the second run's final
+ten seconds of a 30-second observation averaged 0.80% and ended at 332.41 MiB.
+This checks a larger, faster reply without establishing long-duration memory
+stability or a matched baseline improvement.
+[Stress-run counters and executable identity](performance/resource-macos-stress.json).
 
 CPU uses 100% per core. Physical footprint includes memory charged by macOS,
 including compressed and GPU allocations; RSS alone cannot represent this.
@@ -123,8 +141,13 @@ ZERON_FRAME_STATS=0 ZERON_PROFILE_IDLE_MS=10000 \
 # UI-only offscreen replay of those verified protocol frames:
 cargo build --release --locked -p zeron-ui --features resource-profile \
   --example macos-resource-profile
-ZERON_VERIFY_CACHE=1 ZERON_FRAME_STATS=0 target/release/examples/macos-resource-profile \
+ZERON_VERIFY_CACHE=1 ZERON_VERIFY_INTERACTIONS=1 ZERON_FRAME_STATS=0 \
+  target/release/examples/macos-resource-profile \
   /tmp/zeron-native/frames.json /tmp/zeron-native-ui
+
+# Larger/faster reply: use the foreground command above with these added:
+# ZERON_REPLAY_REPEAT=4 ZERON_REPLAY_DELAY_MS=10 ZERON_PROFILE_IDLE_MS=30000
+# and a fresh output directory.
 
 # Native counter usable with either process (CPU uses 100% per core):
 xcrun clang -O2 scripts/macos-resource-stat.c -o /tmp/zeron-stat

--- a/docs/performance-macos.md
+++ b/docs/performance-macos.md
@@ -12,6 +12,10 @@ do not predict native Metal usage.
   replay readiness, optimistic echo insertion/removal, transcript deltas and
   subagent content invalidate the cache. Live entries also skip an unused
   serialized fingerprint.
+- The primary transcript reuses its GPUI scene on unrelated sidebar animation
+  and caret frames. Transcript updates, explicit shell notifications, scrolling,
+  geometry changes and full refreshes still invalidate it. This retains live
+  session status and elapsed labels while avoiding redundant layout and paint.
 - The native frame loop parks clean-window callbacks and wakes for content,
   input or animations. It keeps the existing display clock and lifecycle
   protections. The timing thread still runs while the window is subscribed.
@@ -37,19 +41,49 @@ real animation clocks; its completed transcript is rendered to `complete.png`.
 The profiling feature and its benchmark dependencies are not enabled in normal
 application builds.
 
-The Mac's display was locked during this work. Native offscreen rendering is
-valid for checking pixels and isolated rendering cost. It cannot verify native
-window presentation, desktop background blur, display pacing, interactive input
-or foreground whole-app CPU/memory savings. The user's reported memory swings
-are not yet conclusively attributed. RSS alone is insufficient for comparison
-because the native physical-footprint counter also accounts for charged
-compressed and GPU memory.
+The final completed native replay image is pixel-identical to the baseline.
+With `ZERON_VERIFY_CACHE=1`, the example also compares the reused scene with a
+forced fresh render after settling, hiding/restoring the sidebar and scrolling;
+all four comparisons are pixel-identical. A precompiled-shader experiment also
+produced identical pixels but no meaningful foreground memory improvement, so
+the existing runtime-shader build configuration is retained.
 
-Before merge, repeat foreground baseline/candidate runs and check typing,
-selection/copy, scrolling, streaming/completion, menus, resizing, occlusion and
-display reconnection with the Mac unlocked. This is a draft pending those checks.
+## Native foreground measurements
 
-## Repeated native offscreen comparison
+The display was subsequently unlocked for native-window replay. One valid run
+of the earlier PR head (`f10ef38c`) and two of the final application changes used
+the same sanitized 80-section Rust reply, real engine/Claude adapter/RPC, default
+dark appearance, and 1320×880 logical window at 2× scale. Builds and sampling
+profilers were stopped during measurement. The helper verified foreground
+activation and window visibility throughout every retained run. Interrupted
+runs and runs with diagnostic sampling are excluded.
+[Raw counters, executable hashes and source identity](performance/resource-macos-foreground.json).
+
+| Native metric | Earlier PR head | Updated, two runs |
+| --- | ---: | ---: |
+| Empty-chat UI CPU | 1.25% | 0.59–0.61% |
+| Streaming UI CPU | 15.16% | 12.48–13.31% |
+| Streaming UI + engine CPU | 16.06% | 13.26–14.09% |
+| Empty-chat peak UI physical footprint | 306.38 MiB | 302.11–303.50 MiB |
+| Streaming peak UI physical footprint | 328.84 MiB | 323.11–325.99 MiB |
+
+Mean streaming UI CPU is 12.90%, about 15% below the earlier PR head in this
+workload. The native memory reduction is modest. The final 10-second settled
+observations averaged 0.83–0.87% UI CPU and ended at 323.31–326.25 MiB; the
+baseline used a longer 30-second observation, so those settled averages are
+not a matched-duration before/after claim. All completed replies have the same
+52,624-byte combined text/reasoning digest.
+
+CPU uses 100% per core. Physical footprint includes memory charged by macOS,
+including compressed and GPU allocations; RSS alone cannot represent this.
+These are short replay measurements on one Apple Silicon Mac, not a guarantee
+for every model, transcript length, display or interaction. They do not prove
+that every reported idle memory swing is fixed. Native foreground rendering
+and replay completion passed; typing/selection across multiple panes, display
+reconnection and long-duration mixed-use coverage remain limited. Existing
+animation timing, blur sigma, shaders and clipping are unchanged.
+
+## Earlier isolated native offscreen comparison
 
 Two sequential runs per build, ordered baseline/candidate/candidate/baseline,
 on macOS 26.0.1 (25A362), arm64 Mac16,7 with 24 GiB RAM. The synthetic shell
@@ -64,13 +98,13 @@ The baseline adds only the profiling driver and embedded-platform launch support
 | CPU, 100% per core | 18.49% | 18.46% |
 | Mean of per-run peak physical footprint | 282.85 MiB | 286.69 MiB |
 
-These runs establish **no meaningful streaming CPU or memory improvement** in
-this isolated workload. It excludes native display-link dispatch and desktop
+These earlier runs, before the primary transcript scene-cache change, establish
+**no meaningful streaming CPU or memory improvement** in the isolated workload. It excludes native display-link dispatch and desktop
 composition and does not open alternating menus. The completed 2640×1760 app
 image is byte-identical between baseline and candidate in the first matched pair.
-The frame-gating and unused-resource cleanup benefits still require a foreground
-comparison. Do not present these results as a reduction in the reported whole-app
-streaming usage, or as a universal memory floor.
+Keep this historical result separate from the later native-window measurements
+above; its polling loop and compositor coverage differ. It is not a universal
+memory floor.
 
 ## Reproduction
 
@@ -81,7 +115,7 @@ an isolated profile and the bundled sanitized fixture; it makes no model API cal
 
 ```sh
 cargo build --release --locked -p zeron
-ZERON_FRAME_STATS=0 ZERON_PROFILE_IDLE_MS=45000 \
+ZERON_FRAME_STATS=0 ZERON_PROFILE_IDLE_MS=10000 \
   CLAUDE_CODE_EXECUTABLE="$PWD/scripts/replay-claude.py" \
   ZERON_REPLAY_JOURNAL="$PWD/scripts/fixtures/resource-stream.jsonl" \
   node scripts/resource-profile.mjs target/release/zeron /tmp/zeron-native claude-code
@@ -89,7 +123,7 @@ ZERON_FRAME_STATS=0 ZERON_PROFILE_IDLE_MS=45000 \
 # UI-only offscreen replay of those verified protocol frames:
 cargo build --release --locked -p zeron-ui --features resource-profile \
   --example macos-resource-profile
-ZERON_FRAME_STATS=0 target/release/examples/macos-resource-profile \
+ZERON_VERIFY_CACHE=1 ZERON_FRAME_STATS=0 target/release/examples/macos-resource-profile \
   /tmp/zeron-native/frames.json /tmp/zeron-native-ui
 
 # Native counter usable with either process (CPU uses 100% per core):

--- a/docs/performance-resource-usage.md
+++ b/docs/performance-resource-usage.md
@@ -1,55 +1,90 @@
 # Resource profiling, 2026-09-05
 
-Baseline: main `f1d4bad` (v0.2.37). Optimized application source: `4902c79`.
-Both are release builds. The optimized build pins
-[`zeronsh/zui` at `25f1c948`](https://github.com/zeronsh/zui/commit/25f1c948cef229df2536cf4b7b6731bcb30602e1).
+Baseline: main `f1d4bad` (v0.2.37). Final application revision: `b09b379`.
+The previous optimized build is `cff81e7`, using zui `25f1c948`; the final build
+pins [`zeronsh/zui` at `49f9abd19`](https://github.com/zeronsh/zui/commit/49f9abd196705eda6a27080c506295a19b5da63e).
+All measured binaries are release builds. The renderer follow-up preserves the
+existing animation clocks, scrolling behavior and visual effects.
 
-## Measured results
+## Repeated CPU comparison
 
-UI + engine totals, foreground window with a focused composer. The short
-workload is the same captured Haiku response in every run: 51,769 bytes of
-assistant Markdown, or 52,624 bytes including reasoning and part separators.
-Values below average two independent runs with one software-rendering worker.
-The exact executable hashes, reply hashes and individual measurements are in
-[baseline](performance/resource-baseline.json) and
-[candidate](performance/resource-candidate.json).
+With four software-rendering workers, streaming CPU fell **40.3%
+from old Zeron**, and **33.3% from the previous optimized build**.
+The six runs were sequential: old, previous, final, final, previous, old. Each
+cell averages two runs. [Raw results](performance/resource-four-workers.json)
+include every executable hash, reply hash, phase and individual measurement.
 
-| Metric | Old Zeron | Optimized | Change |
+| Metric | Old Zeron | Previous optimized | Final |
 | --- | ---: | ---: | ---: |
-| Idle peak RSS | 331.10 MiB | 204.08 MiB | -38.4% |
-| Streaming peak RSS | 359.39 MiB | 230.13 MiB | -36.0% |
-| Streaming CPU | 113.51% | 109.78% | -3.3% |
-| Post-completion CPU, last 10 s | 20.96% | 14.66% | -30.1% |
+| Idle CPU | 27.41% | 15.75% | 7.49% |
+| Streaming CPU | 265.57% | 237.60% | 158.57% |
+| Post-completion CPU, last 10 s | 24.34% | 17.13% | 9.14% |
+| Idle peak RSS | 330.92 MiB | 204.24 MiB | 206.11 MiB |
+| Streaming peak RSS | 358.73 MiB | 229.64 MiB | 235.24 MiB |
+| Streaming peak proportional memory | 301.38 MiB | 172.07 MiB | 177.19 MiB |
 
-The synthetic long workload repeats the same captured deltas ten times,
-producing a 526,258-byte combined reply. Each build ran it once:
+The new pipelines add about 1.9 MiB of idle RSS and
+5.6 MiB of streaming RSS compared with the previous optimized build.
+This is a small memory tradeoff for the CPU reduction, with no new image or scene
+cache. Final idle RSS remains 37.7% below old Zeron.
+
+UI + engine totals, foreground 1280×800 window with a focused composer.
+The short workload is identical captured Haiku output: 51,769 bytes of Markdown,
+or 52,624 bytes including reasoning and part separators, at 40 ms per delta.
+CPU uses **100% per core**. These measurements use Linux software Vulkan;
+they are not measurements of native Metal or a prediction of laptop CPU percentages.
+
+## One-worker and long-transcript checks
+
+The one-worker short comparison also averages two runs per build:
+[baseline](performance/resource-baseline.json),
+[final](performance/resource-candidate.json). It uses the same captured output.
+
+| Metric | Old Zeron | Final |
+| --- | ---: | ---: |
+| Idle CPU | 25.45% | 6.93% |
+| Streaming CPU | 113.51% | 100.64% |
+| Post-completion CPU, last 10 s | 20.96% | 7.88% |
+| Idle peak RSS | 331.10 MiB | 206.64 MiB |
+| Streaming peak RSS | 359.39 MiB | 233.21 MiB |
+
+The synthetic long workload repeats the same deltas ten times at 8 ms per delta,
+producing a 526,258-byte combined reply. Each build ran it once with one worker:
 [baseline](performance/resource-long-baseline.json),
-[candidate](performance/resource-long-candidate.json).
+[final](performance/resource-long-candidate.json).
 
-| Long-stream metric | Old Zeron | Optimized | Change |
-| --- | ---: | ---: | ---: |
-| Streaming peak RSS | 398.13 MiB | 254.06 MiB | -36.2% |
-| Streaming CPU | 112.30% | 113.50% | +1.1% |
-| Post-completion CPU, last 10 s | 92.77% | 15.55% | -83.2% |
+| Metric | Old Zeron | Final |
+| --- | ---: | ---: |
+| Streaming CPU | 112.30% | 103.13% |
+| Post-completion CPU, last 10 s | 92.77% | 8.30% |
+| Streaming peak RSS | 398.13 MiB | 256.27 MiB |
 
-The long completion result captures an actual defect: a landed spring could
-keep requesting frames, and subsequent virtual-list height estimates could
-restart its glide indefinitely. The optimized build parks and anchors to the
-final list item. Real scrolling still uses the existing spring integration.
+A single graphics worker can constrain streaming throughput; the repeated
+four-worker runs are the primary CPU comparison. The long completion check also
+covers the earlier spring defect: completed replies could continue requesting
+frames and restart their glide on virtual-list height estimates. The final build
+parks and anchors to the final list item while retaining real spring motion.
 
-The single graphics worker is saturated while streaming. Total streaming CPU
-is effectively unchanged there; those samples do not establish a meaningful
-streaming CPU reduction. A separate four-worker check reduces that constraint
-and also records proportional memory, which apportions shared mappings instead
-of counting their full RSS in both processes. This is one run per build, not
-the repeated comparison above; see [raw results](performance/resource-four-workers.json).
+## Final renderer changes
 
-| Four-worker metric | Old Zeron | Optimized | Change |
-| --- | ---: | ---: | ---: |
-| Idle peak RSS | 330.69 MiB | 203.04 MiB | -38.6% |
-| Idle peak proportional memory | 274.02 MiB | 146.20 MiB | -46.6% |
-| Streaming peak proportional memory | 300.74 MiB | 173.67 MiB | -42.3% |
-| Streaming CPU | 267.42% | 227.40% | -15.0% |
+- Plain rectangular fills use a small fragment shader that avoids the general
+  quad shader's per-pixel instance reads and control flow.
+- Fully opaque fills skip destination blending and unnecessary clipping only
+  when coverage is proven. The eligibility check rounds geometry outward so
+  rasterization near fractional pixel edges cannot bypass a required clip.
+- On software adapters, large solid shapes use the fast fill in a conservative
+  interior rectangle. Four disjoint exterior strips retain the original shader
+  for corners, borders and fades. Small shapes, gradients, non-finite values and
+  coordinates beyond the precision guard keep the general path.
+- Physical GPUs keep the original batch structure. They use specialized shaders
+  only for homogeneous batches, avoiding the extra draw-call overhead of the
+  software-specific split.
+
+Diagnostic category omissions identified quads as the largest remaining cost:
+removing quads temporarily reduced streaming CPU from about 234% to 95%; removing
+text, paths or shadows barely changed it. Those incomplete diagnostic frames are
+not shipped and are not performance results for a functioning application.
+The full-scene measurements above use the final release binary and complete output.
 
 ## Changes supported by profiling
 
@@ -94,73 +129,74 @@ These are parser-only allocation/time results, not whole-process RSS or CPU.
 
 ## Method and limits
 
-Linux x86-64, Xvfb 1440×900, app window 1280×800, GPUI software Vulkan rendering.
-CPU uses one core = 100% and includes every process thread. RSS totals sum each
-process's phase peak; those peaks need not occur simultaneously. UI + engine
-figures exclude Claude/OpenCode child processes, which are sampled separately.
-OpenCode is installed and automatic model discovery is included. Catalog-related
-memory savings depend on that workload. Sampling begins after the initial
-window configure/focus, so the idle phase is not a complete startup-peak capture.
+Linux x86-64, Xvfb 1440×900, window 1280×800, software Vulkan rendering. CPU sums
+all process threads. RSS totals sum each process's phase peak; those peaks need
+not occur simultaneously. Proportional memory apportions shared mappings. UI +
+engine figures exclude Claude/OpenCode child processes, which are sampled separately.
+OpenCode automatic model discovery is included, so some memory savings depend
+on its catalog workload. Sampling starts after window configure/focus and does
+not capture the complete startup peak.
 
-Each matched run uses a new profile, project and chat; 10 seconds before sending,
-fixed replay cadence (40 ms short, 8 ms long), and 45 seconds after completion.
-The last 10 seconds are reported separately from final scroll/fade settling.
-Runs were sequential with no concurrent task builds. Frame diagnostics were
-disabled for matched measurements. Each driver snapshots and hashes its binary,
-validates production transcript reset/upsert/append/remove frames, and requires
-successful completion. Matching reply hashes verify identical content.
+Every matched run uses a fresh profile, project and chat, 10 seconds before the
+prompt, a fixed replay cadence and 45 seconds after completion. The last ten
+seconds are reported separately from scroll/fade settling. Runs are sequential,
+with no concurrent task builds or manual interaction. Frame diagnostics are off.
+The one-worker baseline comes from the earlier pass on this host; the four-worker
+comparison reruns all three builds together in forward and reverse order.
 
-A process-targeted `perf` sample attributed about 95% of UI CPU to software
-rendering. UI heaptrack's largest allocation groups were 54.32 MB in lavapipe
-and 28.38 MB in Gallium/EGL. Those are graphics-driver costs on this host;
-they are not measurements of macOS Metal or a universal laptop resource ceiling.
+The driver snapshots and hashes its executable, validates production transcript
+reset/upsert/append/remove frames and requires successful completion. Matching
+reply hashes establish identical replay content. Earlier process-targeted `perf`
+samples attributed about 95% of UI CPU to software rendering; heaptrack's largest
+UI groups were 54.32 MB in lavapipe and 28.38 MB in Gallium/EGL. A final live-run sample attributed 74.01% of UI CPU to JIT shader code and
+16.27% to lavapipe, versus 4.23% in the application binary. Remaining CPU on
+this host is still predominantly software graphics. These host-specific costs
+are not a universal desktop memory floor.
 
 ## Validation and reproduction
 
-978 application tests passed, with four existing ignored tests: UI (592),
-document (87), engine library (127), harness library (103), RPC (12), syntax
-library/integration (25), Claude/OpenCode adapter integration (21), and targeted
-engine integration (11). The 592 UI tests were rerun in release mode against
-the final zui dependency. Five additional zui numerical tests cover convolution
-equivalence, paired samples at texture edges, oversized radii, scissor coverage
-and translated snapshots. Script checks and `git diff --check` passed. This is
-not a claim that every workspace integration target ran.
+978 application tests passed during this optimization work, with four existing
+ignored tests. The 592 UI tests were rerun in release mode against the final zui
+pin. The other coverage includes document (87), engine library (127), harness
+library (103), RPC (12), syntax library/integration (25), Claude/OpenCode adapter
+integration (21) and targeted engine integration (11).
 
-A fresh authenticated Haiku 4.5 turn was submitted through the composer on the
-final executable. It completed a shell-tool call successfully and produced
-30 sections and 27,062 bytes of reply text/reasoning. Sidebar collapse/expand,
-scrolling away and returning to the live tail, syntax highlighting, selected
-text copy/paste and the completed state were checked in the real window. Its
-[summary](performance/resource-live.json) is functional verification: manual
-interactions and a concurrent test build make its CPU values unsuitable for
-the matched comparison.
+28 zui renderer/text/atlas tests pass, including the five existing blur numerical
+tests and five new fill-path tests. The two graphics tests perform **1,888
+byte-identical offscreen image comparisons**: individual shapes and overlapping
+batches, opaque and translucent colors, fractional geometry and clipping,
+nonuniform and dashed borders, rounded corners, fades, two target formats and
+both alpha modes. The real Vulkan tests are explicitly opt-in on machines with
+an adapter; they were run here, rather than counted as skipped checks.
 
-Requires Node 22+, Rust, Python 3, Xvfb/xdotool for Linux desktop profiling,
-and an authenticated Claude CLI for a live run. Live mode incurs API usage.
-The checked-in [sanitized fixture](../scripts/fixtures/README.md) reproduces the
-measured replay without an API call. Use a dedicated display and new output
-directories; the driver requires exactly one Zeron window.
+A fresh authenticated Haiku 4.5 turn was submitted through the final application's
+composer. It completed a shell-tool call and produced 10,902 bytes of
+reply text/reasoning. Sidebar, scrolling, text selection/copy, resizing, the model menu and completion
+were checked in the real window, reopening the saved transcript for the last checks. Its [summary](performance/resource-live.json) is
+functional verification, separate from the fixed-output performance comparison.
+Script checks and diff checks passed. This is not a claim that every workspace
+integration target ran, or that native Metal performance was measured.
+
+Requires Node 22+, Rust, Python 3 and Xvfb/xdotool for Linux desktop profiling.
+The [sanitized fixture](../scripts/fixtures/README.md) reproduces the measured
+replay without an API call. Use a dedicated display and fresh output directories;
+the driver requires exactly one Zeron window.
 
 ```sh
 cargo build --release -p zeron
 Xvfb :98 -screen 0 1440x900x24 -nolisten tcp
-# In another terminal, run the exact short replay:
-DISPLAY=:98 WAYLAND_DISPLAY= LP_NUM_THREADS=1 ZERON_FRAME_STATS=0 \
-  ZERON_PROFILE_IDLE_MS=45000 \
+# In another terminal:
+DISPLAY=:98 WAYLAND_DISPLAY= LP_NUM_THREADS=4 ZERON_FRAME_STATS=0 \
+  ZERON_PROFILE_PSS=1 ZERON_PROFILE_IDLE_MS=45000 \
   CLAUDE_CODE_EXECUTABLE="$PWD/scripts/replay-claude.py" \
   ZERON_REPLAY_JOURNAL="$PWD/scripts/fixtures/resource-stream.jsonl" \
   node scripts/resource-profile.mjs target/release/zeron /tmp/zeron-short claude-code
 
+# Use LP_NUM_THREADS=1 for the one-worker check.
 # Add ZERON_REPLAY_REPEAT=10 ZERON_REPLAY_DELAY_MS=8 for the long workload.
-# Use LP_NUM_THREADS=4 ZERON_PROFILE_PSS=1 for the four-worker check.
-# For a live turn, omit the replay variables and point
-# CLAUDE_CODE_EXECUTABLE to the real CLI. ZERON_PROFILE_SUBMIT_UI=1
-# submits through the composer instead of QueueCommand.
-```
+# For a live turn, omit replay variables and point CLAUDE_CODE_EXECUTABLE to
+# the authenticated CLI; ZERON_PROFILE_SUBMIT_UI=1 submits through the composer.
 
-Each run writes its summary, raw process samples, RPC frames, final transcript
-and process logs. Optional `ZERON_MAX_ENGINE_RSS_MIB` / `ZERON_MAX_UI_RSS_MIB`
-set machine-specific peak-RSS budgets. `ZERON_FRAME_STATS=1` enables render
-cadence and row-cost diagnostics; application diagnostics are off by default.
-The replay helper deliberately rejects failed/tool/subagent journals: those
-features require the real harness or integration suites.
+# In the zui checkout, on a host with Vulkan (software Vulkan works):
+LP_NUM_THREADS=4 cargo test --release -p gpui_wgpu --lib -- --include-ignored
+```

--- a/docs/performance-resource-usage.md
+++ b/docs/performance-resource-usage.md
@@ -1,5 +1,8 @@
 # Resource profiling, 2026-09-05
 
+For the subsequent native macOS work and its validation limits, see
+[Native macOS resource follow-up](performance-macos.md).
+
 Baseline: main `f1d4bad` (v0.2.37). Final application revision: `b09b379`.
 The previous optimized build is `cff81e7`, using zui `25f1c948`; the final build
 pins [`zeronsh/zui` at `49f9abd19`](https://github.com/zeronsh/zui/commit/49f9abd196705eda6a27080c506295a19b5da63e).

--- a/docs/performance-resource-usage.md
+++ b/docs/performance-resource-usage.md
@@ -1,0 +1,166 @@
+# Resource profiling, 2026-09-05
+
+Baseline: main `f1d4bad` (v0.2.37). Optimized application source: `4902c79`.
+Both are release builds. The optimized build pins
+[`zeronsh/zui` at `25f1c948`](https://github.com/zeronsh/zui/commit/25f1c948cef229df2536cf4b7b6731bcb30602e1).
+
+## Measured results
+
+UI + engine totals, foreground window with a focused composer. The short
+workload is the same captured Haiku response in every run: 51,769 bytes of
+assistant Markdown, or 52,624 bytes including reasoning and part separators.
+Values below average two independent runs with one software-rendering worker.
+The exact executable hashes, reply hashes and individual measurements are in
+[baseline](performance/resource-baseline.json) and
+[candidate](performance/resource-candidate.json).
+
+| Metric | Old Zeron | Optimized | Change |
+| --- | ---: | ---: | ---: |
+| Idle peak RSS | 331.10 MiB | 204.08 MiB | -38.4% |
+| Streaming peak RSS | 359.39 MiB | 230.13 MiB | -36.0% |
+| Streaming CPU | 113.51% | 109.78% | -3.3% |
+| Post-completion CPU, last 10 s | 20.96% | 14.66% | -30.1% |
+
+The synthetic long workload repeats the same captured deltas ten times,
+producing a 526,258-byte combined reply. Each build ran it once:
+[baseline](performance/resource-long-baseline.json),
+[candidate](performance/resource-long-candidate.json).
+
+| Long-stream metric | Old Zeron | Optimized | Change |
+| --- | ---: | ---: | ---: |
+| Streaming peak RSS | 398.13 MiB | 254.06 MiB | -36.2% |
+| Streaming CPU | 112.30% | 113.50% | +1.1% |
+| Post-completion CPU, last 10 s | 92.77% | 15.55% | -83.2% |
+
+The long completion result captures an actual defect: a landed spring could
+keep requesting frames, and subsequent virtual-list height estimates could
+restart its glide indefinitely. The optimized build parks and anchors to the
+final list item. Real scrolling still uses the existing spring integration.
+
+The single graphics worker is saturated while streaming. Total streaming CPU
+is effectively unchanged there; those samples do not establish a meaningful
+streaming CPU reduction. A separate four-worker check reduces that constraint
+and also records proportional memory, which apportions shared mappings instead
+of counting their full RSS in both processes. This is one run per build, not
+the repeated comparison above; see [raw results](performance/resource-four-workers.json).
+
+| Four-worker metric | Old Zeron | Optimized | Change |
+| --- | ---: | ---: | ---: |
+| Idle peak RSS | 330.69 MiB | 203.04 MiB | -38.6% |
+| Idle peak proportional memory | 274.02 MiB | 146.20 MiB | -46.6% |
+| Streaming peak proportional memory | 300.74 MiB | 173.67 MiB | -42.3% |
+| Streaming CPU | 267.42% | 227.40% | -15.0% |
+
+## Changes supported by profiling
+
+- OpenCode model discovery built a full generic JSON tree for `/provider` and
+  deep-copied it before filtering. Heaptrack measured a 112.25 MB engine heap
+  peak dominated by this catalog. Discovery and run setup now decode only the
+  required IDs, names and reasoning variant keys, skip unused nested bodies,
+  and stream the response through a 64 KiB buffer. Cancellation interrupts a
+  stalled body read. Connected-provider filtering and older-server fallback
+  remain. The catalog is dropped once run setup chooses the variant.
+- Engine transcript snapshots are shared across RPC watches. UI row derivation
+  borrows app-state messages instead of copying the complete transcript.
+- Incremental Markdown trees share immutable completed blocks across canonical,
+  display and previous frames. Only the changing tail reparses and mends.
+- Tree-sitter queries compile once per used grammar. Injection grammars load
+  when actually requested; Markdown no longer eagerly compiles 27 languages.
+- Text dissolves use the shared 30 Hz clock; small shell spinners use a 15 Hz
+  lease. Leases expire when hidden or retired. Real scroll motion and reduced
+  motion behavior remain intact. A stationary spring no longer redraws its
+  500 ms state-retention grace period.
+- The sidebar has a cached GPUI view identity, invalidated by shell changes
+  and its own animations. Markdown flatten/code caches retain the viewport
+  and overdraw rather than every row visited while scrolling.
+- The wgpu blur prepares normalized Gaussian weights once per surface, pairs
+  adjacent unit-stride texture samples, and scissors each pass to the pixels
+  needed by compositing and the next pass. Original downsampled tap positions,
+  blur radius and an oversized-kernel fallback remain. Zui's extracted crate
+  sources matched the previous fork revision before this patch was applied.
+
+An optimized standalone parser benchmark holds the previous display tree while
+constructing the next, using the captured text and 160-byte commits:
+
+| Parser-only metric | Baseline | Optimized |
+| --- | ---: | ---: |
+| Allocated bytes | 24,268,705 | 8,927,654 |
+| Allocation calls | 133,054 | 11,210 |
+| Peak live bytes above input | 377,910 | 206,520 |
+| Retained bytes above input | 279,770 | 188,057 |
+| Elapsed time | 12.84 ms | 2.21 ms |
+
+These are parser-only allocation/time results, not whole-process RSS or CPU.
+
+## Method and limits
+
+Linux x86-64, Xvfb 1440×900, app window 1280×800, GPUI software Vulkan rendering.
+CPU uses one core = 100% and includes every process thread. RSS totals sum each
+process's phase peak; those peaks need not occur simultaneously. UI + engine
+figures exclude Claude/OpenCode child processes, which are sampled separately.
+OpenCode is installed and automatic model discovery is included. Catalog-related
+memory savings depend on that workload. Sampling begins after the initial
+window configure/focus, so the idle phase is not a complete startup-peak capture.
+
+Each matched run uses a new profile, project and chat; 10 seconds before sending,
+fixed replay cadence (40 ms short, 8 ms long), and 45 seconds after completion.
+The last 10 seconds are reported separately from final scroll/fade settling.
+Runs were sequential with no concurrent task builds. Frame diagnostics were
+disabled for matched measurements. Each driver snapshots and hashes its binary,
+validates production transcript reset/upsert/append/remove frames, and requires
+successful completion. Matching reply hashes verify identical content.
+
+A process-targeted `perf` sample attributed about 95% of UI CPU to software
+rendering. UI heaptrack's largest allocation groups were 54.32 MB in lavapipe
+and 28.38 MB in Gallium/EGL. Those are graphics-driver costs on this host;
+they are not measurements of macOS Metal or a universal laptop resource ceiling.
+
+## Validation and reproduction
+
+978 application tests passed, with four existing ignored tests: UI (592),
+document (87), engine library (127), harness library (103), RPC (12), syntax
+library/integration (25), Claude/OpenCode adapter integration (21), and targeted
+engine integration (11). The 592 UI tests were rerun in release mode against
+the final zui dependency. Five additional zui numerical tests cover convolution
+equivalence, paired samples at texture edges, oversized radii, scissor coverage
+and translated snapshots. Script checks and `git diff --check` passed. This is
+not a claim that every workspace integration target ran.
+
+A fresh authenticated Haiku 4.5 turn was submitted through the composer on the
+final executable. It completed a shell-tool call successfully and produced
+30 sections and 27,062 bytes of reply text/reasoning. Sidebar collapse/expand,
+scrolling away and returning to the live tail, syntax highlighting, selected
+text copy/paste and the completed state were checked in the real window. Its
+[summary](performance/resource-live.json) is functional verification: manual
+interactions and a concurrent test build make its CPU values unsuitable for
+the matched comparison.
+
+Requires Node 22+, Rust, Python 3, Xvfb/xdotool for Linux desktop profiling,
+and an authenticated Claude CLI for a live run. Live mode incurs API usage.
+The checked-in [sanitized fixture](../scripts/fixtures/README.md) reproduces the
+measured replay without an API call. Use a dedicated display and new output
+directories; the driver requires exactly one Zeron window.
+
+```sh
+cargo build --release -p zeron
+Xvfb :98 -screen 0 1440x900x24 -nolisten tcp
+# In another terminal, run the exact short replay:
+DISPLAY=:98 WAYLAND_DISPLAY= LP_NUM_THREADS=1 ZERON_FRAME_STATS=0 \
+  ZERON_PROFILE_IDLE_MS=45000 \
+  CLAUDE_CODE_EXECUTABLE="$PWD/scripts/replay-claude.py" \
+  ZERON_REPLAY_JOURNAL="$PWD/scripts/fixtures/resource-stream.jsonl" \
+  node scripts/resource-profile.mjs target/release/zeron /tmp/zeron-short claude-code
+
+# Add ZERON_REPLAY_REPEAT=10 ZERON_REPLAY_DELAY_MS=8 for the long workload.
+# Use LP_NUM_THREADS=4 ZERON_PROFILE_PSS=1 for the four-worker check.
+# For a live turn, omit the replay variables and point
+# CLAUDE_CODE_EXECUTABLE to the real CLI. ZERON_PROFILE_SUBMIT_UI=1
+# submits through the composer instead of QueueCommand.
+```
+
+Each run writes its summary, raw process samples, RPC frames, final transcript
+and process logs. Optional `ZERON_MAX_ENGINE_RSS_MIB` / `ZERON_MAX_UI_RSS_MIB`
+set machine-specific peak-RSS budgets. `ZERON_FRAME_STATS=1` enables render
+cadence and row-cost diagnostics; application diagnostics are off by default.
+The replay helper deliberately rejects failed/tool/subagent journals: those
+features require the real harness or integration suites.

--- a/docs/performance/resource-baseline.json
+++ b/docs/performance/resource-baseline.json
@@ -1,0 +1,154 @@
+{
+  "sourceRevision": "f1d4bad36b77eed5cf4432bb68291840987ebeb5",
+  "build": "release",
+  "runs": [
+    {
+      "binary": "/tmp/zeron-resource-profile/zeron-release-baseline",
+      "binarySha256": "3329082b8e76b4e4dec263c15077f1cf7f30b989ede851a9dde26f2441ab9995",
+      "harness": "claude-code",
+      "mode": "replay",
+      "renderThreads": "1",
+      "frameStats": "0",
+      "submission": "rpc",
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 55067,
+      "frames": 130,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.015,
+          "engine": {
+            "peakRssMiB": 159.1328125,
+            "endRssMiB": 159.1328125,
+            "cpuPercent": 3.5496394897393233,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 172.01953125,
+            "endRssMiB": 172.01953125,
+            "cpuPercent": 22.628951747088188,
+            "mainCpuPercent": 0.6655574043261231
+          }
+        },
+        "stream": {
+          "durationSeconds": 17.508,
+          "engine": {
+            "peakRssMiB": 161.890625,
+            "endRssMiB": 161.890625,
+            "cpuPercent": 0.856751199451679,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 197.2734375,
+            "endRssMiB": 197.2734375,
+            "cpuPercent": 112.51999086132054,
+            "mainCpuPercent": 3.9981722641078363
+          }
+        },
+        "settled": {
+          "durationSeconds": 44.583,
+          "engine": {
+            "peakRssMiB": 162.5078125,
+            "endRssMiB": 162.5078125,
+            "cpuPercent": 0.26916089092254897,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 196.2265625,
+            "endRssMiB": 196.16015625,
+            "cpuPercent": 28.261893546867636,
+            "mainCpuPercent": 1.0542134894466502
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.518,
+        "engine": {
+          "endRssMiB": 162.5078125,
+          "cpuPercent": 0.31519226728304295,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 196.16015625,
+          "cpuPercent": 20.697625551586455,
+          "mainCpuPercent": 0.8405127127547788
+        }
+      }
+    },
+    {
+      "binary": "/tmp/zeron-resource-profile/zeron-release-baseline",
+      "binarySha256": "3329082b8e76b4e4dec263c15077f1cf7f30b989ede851a9dde26f2441ab9995",
+      "harness": "claude-code",
+      "mode": "replay",
+      "renderThreads": "1",
+      "frameStats": "0",
+      "submission": "rpc",
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 55067,
+      "frames": 129,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.017,
+          "engine": {
+            "peakRssMiB": 159.41015625,
+            "endRssMiB": 159.41015625,
+            "cpuPercent": 3.770655428634801,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 171.64453125,
+            "endRssMiB": 171.64453125,
+            "cpuPercent": 20.960408117999336,
+            "mainCpuPercent": 0.7763114117777532
+          }
+        },
+        "stream": {
+          "durationSeconds": 17.512,
+          "engine": {
+            "peakRssMiB": 163.21875,
+            "endRssMiB": 163.21875,
+            "cpuPercent": 0.8565555047967109,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 196.390625,
+            "endRssMiB": 196.390625,
+            "cpuPercent": 112.77980813156692,
+            "mainCpuPercent": 4.111466423024212
+          }
+        },
+        "settled": {
+          "durationSeconds": 44.581,
+          "engine": {
+            "peakRssMiB": 163.83203125,
+            "endRssMiB": 163.83203125,
+            "cpuPercent": 0.2467418855566272,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 196.07421875,
+            "endRssMiB": 196.0078125,
+            "cpuPercent": 44.50326372221349,
+            "mainCpuPercent": 1.637468876875799
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.519,
+        "engine": {
+          "endRssMiB": 163.83203125,
+          "cpuPercent": 0.21010610358230924,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 196.0078125,
+          "cpuPercent": 20.69545120285743,
+          "mainCpuPercent": 0.7353713625380824
+        }
+      }
+    }
+  ]
+}

--- a/docs/performance/resource-candidate.json
+++ b/docs/performance/resource-candidate.json
@@ -1,10 +1,10 @@
 {
-  "sourceRevision": "4902c792576ed1392c210f0e07c000ee1afc924c",
-  "build": "release",
+  "sourceRevision": "b09b37963cf9c78e1aa6acd5195f8a4427dfe21f",
+  "gpuiRevision": "49f9abd196705eda6a27080c506295a19b5da63e",
   "runs": [
     {
-      "binary": "/tmp/zeron-resource-profile/zeron-release-final",
-      "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+      "binary": "/tmp/zeron-cpu-round2/zeron-final",
+      "binarySha256": "f4b91201706962a9a29a52dfbe89ccc959870132d28ff8cf1a6b964dbd1dbe20",
       "harness": "claude-code",
       "mode": "replay",
       "renderThreads": "1",
@@ -14,71 +14,83 @@
       "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
       "replyBytes": 52624,
       "transcriptBytes": 55067,
-      "frames": 131,
+      "frames": 128,
       "phases": {
         "idle": {
-          "durationSeconds": 9.013,
+          "durationSeconds": 9.011,
           "engine": {
-            "peakRssMiB": 31.703125,
-            "endRssMiB": 31.06640625,
-            "cpuPercent": 0.9985576389659383,
+            "peakPssMiB": 23.197265625,
+            "endPssMiB": 23.1923828125,
+            "peakRssMiB": 30.31640625,
+            "endRssMiB": 30.31640625,
+            "cpuPercent": 0.8878037953612252,
             "mainCpuPercent": 0
           },
           "ui": {
-            "peakRssMiB": 172.4453125,
-            "endRssMiB": 172.4453125,
-            "cpuPercent": 13.203151004105182,
-            "mainCpuPercent": 0.6657050926439587
+            "peakPssMiB": 125.328125,
+            "endPssMiB": 125.306640625,
+            "peakRssMiB": 174.69921875,
+            "endRssMiB": 174.69140625,
+            "cpuPercent": 6.103651093108424,
+            "mainCpuPercent": 0.6658528465209189
           }
         },
         "stream": {
-          "durationSeconds": 17.512,
+          "durationSeconds": 17.506,
           "engine": {
-            "peakRssMiB": 34.94140625,
-            "endRssMiB": 34.94140625,
-            "cpuPercent": 0.8565555047967108,
+            "peakPssMiB": 25.9609375,
+            "endPssMiB": 25.9609375,
+            "peakRssMiB": 33.44140625,
+            "endRssMiB": 33.44140625,
+            "cpuPercent": 0.8568490803153205,
             "mainCpuPercent": 0
           },
           "ui": {
-            "peakRssMiB": 195.9765625,
-            "endRssMiB": 194.66796875,
-            "cpuPercent": 109.12517131110096,
-            "mainCpuPercent": 5.367747830059388
+            "peakPssMiB": 149.8681640625,
+            "endPssMiB": 148.4951171875,
+            "peakRssMiB": 199.734375,
+            "endRssMiB": 198.36328125,
+            "cpuPercent": 99.90860276476636,
+            "mainCpuPercent": 8.79698389123729
           }
         },
         "settled": {
-          "durationSeconds": 44.574,
+          "durationSeconds": 44.571,
           "engine": {
-            "peakRssMiB": 35.875,
-            "endRssMiB": 35.875,
-            "cpuPercent": 0.24678063445057652,
+            "peakPssMiB": 26.7451171875,
+            "endPssMiB": 26.7412109375,
+            "peakRssMiB": 34.234375,
+            "endRssMiB": 34.22265625,
+            "cpuPercent": 0.2692333580130578,
             "mainCpuPercent": 0
           },
           "ui": {
-            "peakRssMiB": 195.1953125,
-            "endRssMiB": 195.12890625,
-            "cpuPercent": 14.76196886077085,
-            "mainCpuPercent": 0.785211109615471
+            "peakPssMiB": 151.552734375,
+            "endPssMiB": 149.75,
+            "peakRssMiB": 201.484375,
+            "endRssMiB": 199.6796875,
+            "cpuPercent": 11.330237149716185,
+            "mainCpuPercent": 1.054497318884476
           }
         }
       },
       "postCompletionTail": {
-        "durationSeconds": 9.518,
+        "durationSeconds": 9.514,
         "engine": {
-          "endRssMiB": 35.875,
-          "cpuPercent": 0.2101281781886953,
+          "endRssMiB": 34.22265625,
+          "cpuPercent": 0.3153247845280636,
           "mainCpuPercent": 0
         },
         "ui": {
-          "endRssMiB": 195.12890625,
-          "cpuPercent": 14.814036562303006,
-          "mainCpuPercent": 0.7354486236604335
+          "endRssMiB": 199.6796875,
+          "cpuPercent": 7.462686567164188,
+          "mainCpuPercent": 0.7357578305654807
         }
       }
     },
     {
-      "binary": "/tmp/zeron-resource-profile/zeron-release-final",
-      "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+      "binary": "/tmp/zeron-cpu-round2/zeron-final",
+      "binarySha256": "f4b91201706962a9a29a52dfbe89ccc959870132d28ff8cf1a6b964dbd1dbe20",
       "harness": "claude-code",
       "mode": "replay",
       "renderThreads": "1",
@@ -88,65 +100,77 @@
       "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
       "replyBytes": 52624,
       "transcriptBytes": 55067,
-      "frames": 129,
+      "frames": 132,
       "phases": {
         "idle": {
-          "durationSeconds": 9.016,
+          "durationSeconds": 9.014,
           "engine": {
-            "peakRssMiB": 31.578125,
-            "endRssMiB": 31.578125,
-            "cpuPercent": 0.8873114463176575,
+            "peakPssMiB": 26.505859375,
+            "endPssMiB": 26.5,
+            "peakRssMiB": 33.8125,
+            "endRssMiB": 33.8125,
+            "cpuPercent": 0.7765697803416908,
             "mainCpuPercent": 0
           },
           "ui": {
-            "peakRssMiB": 172.4375,
-            "endRssMiB": 172.4375,
-            "cpuPercent": 13.309671694764864,
-            "mainCpuPercent": 0.6654835847382431
+            "peakPssMiB": 124.921875,
+            "endPssMiB": 124.8525390625,
+            "peakRssMiB": 174.453125,
+            "endRssMiB": 174.4453125,
+            "cpuPercent": 6.101619702684713,
+            "mainCpuPercent": 0.6656312402928778
           }
         },
         "stream": {
-          "durationSeconds": 17.503,
+          "durationSeconds": 17.509,
           "engine": {
-            "peakRssMiB": 34.33984375,
-            "endRssMiB": 34.33984375,
-            "cpuPercent": 0.7998628806490314,
+            "peakPssMiB": 26.44140625,
+            "endPssMiB": 26.44140625,
+            "peakRssMiB": 33.96484375,
+            "endRssMiB": 33.96484375,
+            "cpuPercent": 0.8567022674053344,
             "mainCpuPercent": 0
           },
           "ui": {
-            "peakRssMiB": 195.0078125,
-            "endRssMiB": 194.7109375,
-            "cpuPercent": 108.7813517682683,
-            "mainCpuPercent": 5.427640975832714
+            "peakPssMiB": 149.3916015625,
+            "endPssMiB": 147.779296875,
+            "peakRssMiB": 199.26953125,
+            "endRssMiB": 197.65234375,
+            "cpuPercent": 99.66303044148724,
+            "mainCpuPercent": 8.624136158547033
           }
         },
         "settled": {
-          "durationSeconds": 44.588,
+          "durationSeconds": 44.553,
           "engine": {
-            "peakRssMiB": 35.53125,
-            "endRssMiB": 35.53125,
-            "cpuPercent": 0.24670314882928138,
+            "peakPssMiB": 27.26171875,
+            "endPssMiB": 27.2607421875,
+            "peakRssMiB": 34.78515625,
+            "endRssMiB": 34.78515625,
+            "cpuPercent": 0.24689695418939236,
             "mainCpuPercent": 0
           },
           "ui": {
-            "peakRssMiB": 195.4765625,
-            "endRssMiB": 195.41015625,
-            "cpuPercent": 14.263927514129362,
-            "mainCpuPercent": 0.7849645644568047
+            "peakPssMiB": 148.1376953125,
+            "endPssMiB": 148.1357421875,
+            "peakRssMiB": 199.67578125,
+            "endRssMiB": 198.0703125,
+            "cpuPercent": 7.653805579871165,
+            "mainCpuPercent": 0.8529167508360832
           }
         }
       },
       "postCompletionTail": {
-        "durationSeconds": 9.518,
+        "durationSeconds": 9.512,
         "engine": {
-          "endRssMiB": 35.53125,
-          "cpuPercent": 0.2101281781886947,
+          "endRssMiB": 34.78515625,
+          "cpuPercent": 0.3153910849453319,
           "mainCpuPercent": 0
         },
         "ui": {
-          "endRssMiB": 195.41015625,
-          "cpuPercent": 14.078587938642572,
-          "mainCpuPercent": 0.7354486236604335
+          "endRssMiB": 198.0703125,
+          "cpuPercent": 7.6745164003364215,
+          "mainCpuPercent": 0.8410428931875533
         }
       }
     }

--- a/docs/performance/resource-candidate.json
+++ b/docs/performance/resource-candidate.json
@@ -1,0 +1,154 @@
+{
+  "sourceRevision": "4902c792576ed1392c210f0e07c000ee1afc924c",
+  "build": "release",
+  "runs": [
+    {
+      "binary": "/tmp/zeron-resource-profile/zeron-release-final",
+      "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+      "harness": "claude-code",
+      "mode": "replay",
+      "renderThreads": "1",
+      "frameStats": "0",
+      "submission": "rpc",
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 55067,
+      "frames": 131,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.013,
+          "engine": {
+            "peakRssMiB": 31.703125,
+            "endRssMiB": 31.06640625,
+            "cpuPercent": 0.9985576389659383,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 172.4453125,
+            "endRssMiB": 172.4453125,
+            "cpuPercent": 13.203151004105182,
+            "mainCpuPercent": 0.6657050926439587
+          }
+        },
+        "stream": {
+          "durationSeconds": 17.512,
+          "engine": {
+            "peakRssMiB": 34.94140625,
+            "endRssMiB": 34.94140625,
+            "cpuPercent": 0.8565555047967108,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 195.9765625,
+            "endRssMiB": 194.66796875,
+            "cpuPercent": 109.12517131110096,
+            "mainCpuPercent": 5.367747830059388
+          }
+        },
+        "settled": {
+          "durationSeconds": 44.574,
+          "engine": {
+            "peakRssMiB": 35.875,
+            "endRssMiB": 35.875,
+            "cpuPercent": 0.24678063445057652,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 195.1953125,
+            "endRssMiB": 195.12890625,
+            "cpuPercent": 14.76196886077085,
+            "mainCpuPercent": 0.785211109615471
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.518,
+        "engine": {
+          "endRssMiB": 35.875,
+          "cpuPercent": 0.2101281781886953,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 195.12890625,
+          "cpuPercent": 14.814036562303006,
+          "mainCpuPercent": 0.7354486236604335
+        }
+      }
+    },
+    {
+      "binary": "/tmp/zeron-resource-profile/zeron-release-final",
+      "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+      "harness": "claude-code",
+      "mode": "replay",
+      "renderThreads": "1",
+      "frameStats": "0",
+      "submission": "rpc",
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 55067,
+      "frames": 129,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.016,
+          "engine": {
+            "peakRssMiB": 31.578125,
+            "endRssMiB": 31.578125,
+            "cpuPercent": 0.8873114463176575,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 172.4375,
+            "endRssMiB": 172.4375,
+            "cpuPercent": 13.309671694764864,
+            "mainCpuPercent": 0.6654835847382431
+          }
+        },
+        "stream": {
+          "durationSeconds": 17.503,
+          "engine": {
+            "peakRssMiB": 34.33984375,
+            "endRssMiB": 34.33984375,
+            "cpuPercent": 0.7998628806490314,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 195.0078125,
+            "endRssMiB": 194.7109375,
+            "cpuPercent": 108.7813517682683,
+            "mainCpuPercent": 5.427640975832714
+          }
+        },
+        "settled": {
+          "durationSeconds": 44.588,
+          "engine": {
+            "peakRssMiB": 35.53125,
+            "endRssMiB": 35.53125,
+            "cpuPercent": 0.24670314882928138,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakRssMiB": 195.4765625,
+            "endRssMiB": 195.41015625,
+            "cpuPercent": 14.263927514129362,
+            "mainCpuPercent": 0.7849645644568047
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.518,
+        "engine": {
+          "endRssMiB": 35.53125,
+          "cpuPercent": 0.2101281781886947,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 195.41015625,
+          "cpuPercent": 14.078587938642572,
+          "mainCpuPercent": 0.7354486236604335
+        }
+      }
+    }
+  ]
+}

--- a/docs/performance/resource-four-workers.json
+++ b/docs/performance/resource-four-workers.json
@@ -1,0 +1,176 @@
+{
+  "baseline": {
+    "sourceRevision": "f1d4bad36b77eed5cf4432bb68291840987ebeb5",
+    "binary": "/tmp/zeron-resource-profile/zeron-release-baseline",
+    "binarySha256": "3329082b8e76b4e4dec263c15077f1cf7f30b989ede851a9dde26f2441ab9995",
+    "harness": "claude-code",
+    "mode": "replay",
+    "renderThreads": "4",
+    "frameStats": "0",
+    "submission": "rpc",
+    "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+    "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+    "replyBytes": 52624,
+    "transcriptBytes": 55067,
+    "frames": 133,
+    "phases": {
+      "idle": {
+        "durationSeconds": 9.008,
+        "engine": {
+          "peakPssMiB": 151.3671875,
+          "endPssMiB": 151.365234375,
+          "peakRssMiB": 158.59765625,
+          "endRssMiB": 158.59765625,
+          "cpuPercent": 3.4413854351687387,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "peakPssMiB": 122.6552734375,
+          "endPssMiB": 122.65234375,
+          "peakRssMiB": 172.09375,
+          "endRssMiB": 172.09375,
+          "cpuPercent": 24.311722912966253,
+          "mainCpuPercent": 0.7770870337477795
+        }
+      },
+      "stream": {
+        "durationSeconds": 17.508,
+        "engine": {
+          "peakPssMiB": 153.267578125,
+          "endPssMiB": 153.2666015625,
+          "peakRssMiB": 160.83984375,
+          "endRssMiB": 160.83984375,
+          "cpuPercent": 0.9138679460817911,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "peakPssMiB": 147.47265625,
+          "endPssMiB": 145.908203125,
+          "peakRssMiB": 197.1640625,
+          "endRssMiB": 195.81640625,
+          "cpuPercent": 266.50673977610234,
+          "mainCpuPercent": 8.281928261366232
+        }
+      },
+      "settled": {
+        "durationSeconds": 44.561,
+        "engine": {
+          "peakPssMiB": 154.1845703125,
+          "endPssMiB": 154.1787109375,
+          "peakRssMiB": 161.7578125,
+          "endRssMiB": 161.75390625,
+          "cpuPercent": 0.2468526289804986,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "peakPssMiB": 152.255859375,
+          "endPssMiB": 147.7333984375,
+          "peakRssMiB": 202.453125,
+          "endRssMiB": 197.703125,
+          "cpuPercent": 63.64309598079038,
+          "mainCpuPercent": 2.019703328022261
+        }
+      }
+    },
+    "postCompletionTail": {
+      "durationSeconds": 9.511,
+      "engine": {
+        "endRssMiB": 161.75390625,
+        "cpuPercent": 0.3154242456103462,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "endRssMiB": 197.703125,
+        "cpuPercent": 23.8671012511828,
+        "mainCpuPercent": 0.8411313216275899
+      }
+    }
+  },
+  "candidate": {
+    "sourceRevision": "4902c792576ed1392c210f0e07c000ee1afc924c",
+    "binary": "/tmp/zeron-resource-profile/zeron-release-final",
+    "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+    "harness": "claude-code",
+    "mode": "replay",
+    "renderThreads": "4",
+    "frameStats": "0",
+    "submission": "rpc",
+    "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+    "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+    "replyBytes": 52624,
+    "transcriptBytes": 55067,
+    "frames": 130,
+    "phases": {
+      "idle": {
+        "durationSeconds": 9.009,
+        "engine": {
+          "peakPssMiB": 23.1630859375,
+          "endPssMiB": 23.1630859375,
+          "peakRssMiB": 30.47265625,
+          "endRssMiB": 30.47265625,
+          "cpuPercent": 0.8880008880008881,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "peakPssMiB": 123.03515625,
+          "endPssMiB": 123.00390625,
+          "peakRssMiB": 172.56640625,
+          "endRssMiB": 172.56640625,
+          "cpuPercent": 14.652014652014648,
+          "mainCpuPercent": 0.666000666000666
+        }
+      },
+      "stream": {
+        "durationSeconds": 17.511,
+        "engine": {
+          "peakPssMiB": 26.6123046875,
+          "endPssMiB": 26.611328125,
+          "peakRssMiB": 34.23046875,
+          "endRssMiB": 34.23046875,
+          "cpuPercent": 0.8566044200788077,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "peakPssMiB": 147.0537109375,
+          "endPssMiB": 147.0537109375,
+          "peakRssMiB": 197.05078125,
+          "endRssMiB": 197.05078125,
+          "cpuPercent": 226.54331563017533,
+          "mainCpuPercent": 9.822397350236994
+        }
+      },
+      "settled": {
+        "durationSeconds": 44.559,
+        "engine": {
+          "peakPssMiB": 27.59765625,
+          "endPssMiB": 27.595703125,
+          "peakRssMiB": 35.21484375,
+          "endRssMiB": 35.21484375,
+          "cpuPercent": 0.24686370879059222,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "peakPssMiB": 147.2666015625,
+          "endPssMiB": 145.587890625,
+          "peakRssMiB": 197.53515625,
+          "endRssMiB": 195.6484375,
+          "cpuPercent": 16.539868488969674,
+          "mainCpuPercent": 0.7854754370609754
+        }
+      }
+    },
+    "postCompletionTail": {
+      "durationSeconds": 9.51,
+      "engine": {
+        "endRssMiB": 35.21484375,
+        "cpuPercent": 0.2103049421661411,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "endRssMiB": 195.6484375,
+        "cpuPercent": 16.614090431125113,
+        "mainCpuPercent": 0.7360672975814915
+      }
+    }
+  }
+}

--- a/docs/performance/resource-four-workers.json
+++ b/docs/performance/resource-four-workers.json
@@ -1,176 +1,534 @@
 {
+  "method": "Sequential release runs in forward and reverse order, four software-rendering workers, identical captured response at 40 ms per delta, 45 seconds after completion; CPU 100% is one core.",
   "baseline": {
     "sourceRevision": "f1d4bad36b77eed5cf4432bb68291840987ebeb5",
-    "binary": "/tmp/zeron-resource-profile/zeron-release-baseline",
-    "binarySha256": "3329082b8e76b4e4dec263c15077f1cf7f30b989ede851a9dde26f2441ab9995",
-    "harness": "claude-code",
-    "mode": "replay",
-    "renderThreads": "4",
-    "frameStats": "0",
-    "submission": "rpc",
-    "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
-    "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
-    "replyBytes": 52624,
-    "transcriptBytes": 55067,
-    "frames": 133,
-    "phases": {
-      "idle": {
-        "durationSeconds": 9.008,
-        "engine": {
-          "peakPssMiB": 151.3671875,
-          "endPssMiB": 151.365234375,
-          "peakRssMiB": 158.59765625,
-          "endRssMiB": 158.59765625,
-          "cpuPercent": 3.4413854351687387,
-          "mainCpuPercent": 0
+    "runs": [
+      {
+        "binary": "/tmp/zeron-resource-profile/zeron-release-baseline",
+        "binarySha256": "3329082b8e76b4e4dec263c15077f1cf7f30b989ede851a9dde26f2441ab9995",
+        "harness": "claude-code",
+        "mode": "replay",
+        "renderThreads": "4",
+        "frameStats": "0",
+        "submission": "rpc",
+        "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+        "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+        "replyBytes": 52624,
+        "transcriptBytes": 55067,
+        "frames": 132,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.011,
+            "engine": {
+              "peakPssMiB": 151.533203125,
+              "endPssMiB": 151.5302734375,
+              "peakRssMiB": 158.80078125,
+              "endRssMiB": 158.80078125,
+              "cpuPercent": 3.3292642326045945,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 123.283203125,
+              "endPssMiB": 123.28125,
+              "peakRssMiB": 172.78515625,
+              "endRssMiB": 172.78515625,
+              "cpuPercent": 24.414604372433697,
+              "mainCpuPercent": 0.6658528465209189
+            }
+          },
+          "stream": {
+            "durationSeconds": 17.51,
+            "engine": {
+              "peakPssMiB": 154.826171875,
+              "endPssMiB": 154.826171875,
+              "peakRssMiB": 162.33203125,
+              "endRssMiB": 162.33203125,
+              "cpuPercent": 0.8566533409480295,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 148.3017578125,
+              "endPssMiB": 146.5595703125,
+              "peakRssMiB": 198.2109375,
+              "endRssMiB": 196.46484375,
+              "cpuPercent": 264.6487721302113,
+              "mainCpuPercent": 8.166761850371216
+            }
+          },
+          "settled": {
+            "durationSeconds": 44.557,
+            "engine": {
+              "peakPssMiB": 155.509765625,
+              "endPssMiB": 155.5048828125,
+              "peakRssMiB": 163.01171875,
+              "endRssMiB": 163.01171875,
+              "cpuPercent": 0.2693179522858361,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 148.7353515625,
+              "endPssMiB": 147.05078125,
+              "peakRssMiB": 198.93359375,
+              "endRssMiB": 197.015625,
+              "cpuPercent": 34.60735686872993,
+              "mainCpuPercent": 1.1446012972148034
+            }
+          }
         },
-        "ui": {
-          "peakPssMiB": 122.6552734375,
-          "endPssMiB": 122.65234375,
-          "peakRssMiB": 172.09375,
-          "endRssMiB": 172.09375,
-          "cpuPercent": 24.311722912966253,
-          "mainCpuPercent": 0.7770870337477795
+        "postCompletionTail": {
+          "durationSeconds": 9.511,
+          "engine": {
+            "endRssMiB": 163.01171875,
+            "cpuPercent": 0.21028283040689746,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "endRssMiB": 197.015625,
+            "cpuPercent": 24.392808327200015,
+            "mainCpuPercent": 0.9462727368310362
+          }
         }
       },
-      "stream": {
-        "durationSeconds": 17.508,
-        "engine": {
-          "peakPssMiB": 153.267578125,
-          "endPssMiB": 153.2666015625,
-          "peakRssMiB": 160.83984375,
-          "endRssMiB": 160.83984375,
-          "cpuPercent": 0.9138679460817911,
-          "mainCpuPercent": 0
+      {
+        "binary": "/tmp/zeron-resource-profile/zeron-release-baseline",
+        "binarySha256": "3329082b8e76b4e4dec263c15077f1cf7f30b989ede851a9dde26f2441ab9995",
+        "harness": "claude-code",
+        "mode": "replay",
+        "renderThreads": "4",
+        "frameStats": "0",
+        "submission": "rpc",
+        "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+        "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+        "replyBytes": 52624,
+        "transcriptBytes": 55067,
+        "frames": 132,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.012,
+            "engine": {
+              "peakPssMiB": 150.970703125,
+              "endPssMiB": 150.9697265625,
+              "peakRssMiB": 158.1796875,
+              "endRssMiB": 158.1796875,
+              "cpuPercent": 3.3288948069241013,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 122.654296875,
+              "endPssMiB": 122.654296875,
+              "peakRssMiB": 172.06640625,
+              "endRssMiB": 172.06640625,
+              "cpuPercent": 23.746116289391917,
+              "mainCpuPercent": 0.6657789613848203
+            }
+          },
+          "stream": {
+            "durationSeconds": 17.509,
+            "engine": {
+              "peakPssMiB": 153.7841796875,
+              "endPssMiB": 153.7841796875,
+              "peakRssMiB": 161.26171875,
+              "endRssMiB": 161.26171875,
+              "cpuPercent": 0.9138157518990233,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 145.85546875,
+              "endPssMiB": 145.85546875,
+              "peakRssMiB": 195.6640625,
+              "endRssMiB": 195.6640625,
+              "cpuPercent": 264.7210006282483,
+              "mainCpuPercent": 8.224341767091211
+            }
+          },
+          "settled": {
+            "durationSeconds": 44.562,
+            "engine": {
+              "peakPssMiB": 154.875,
+              "endPssMiB": 154.8720703125,
+              "peakRssMiB": 162.34765625,
+              "endRssMiB": 162.34765625,
+              "cpuPercent": 0.26928773394371885,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 146.564453125,
+              "endPssMiB": 146.4970703125,
+              "peakRssMiB": 196.4296875,
+              "endRssMiB": 196.36328125,
+              "cpuPercent": 34.73811767873974,
+              "mainCpuPercent": 1.1444728692608053
+            }
+          }
         },
-        "ui": {
-          "peakPssMiB": 147.47265625,
-          "endPssMiB": 145.908203125,
-          "peakRssMiB": 197.1640625,
-          "endRssMiB": 195.81640625,
-          "cpuPercent": 266.50673977610234,
-          "mainCpuPercent": 8.281928261366232
-        }
-      },
-      "settled": {
-        "durationSeconds": 44.561,
-        "engine": {
-          "peakPssMiB": 154.1845703125,
-          "endPssMiB": 154.1787109375,
-          "peakRssMiB": 161.7578125,
-          "endRssMiB": 161.75390625,
-          "cpuPercent": 0.2468526289804986,
-          "mainCpuPercent": 0
-        },
-        "ui": {
-          "peakPssMiB": 152.255859375,
-          "endPssMiB": 147.7333984375,
-          "peakRssMiB": 202.453125,
-          "endRssMiB": 197.703125,
-          "cpuPercent": 63.64309598079038,
-          "mainCpuPercent": 2.019703328022261
+        "postCompletionTail": {
+          "durationSeconds": 9.51,
+          "engine": {
+            "endRssMiB": 162.34765625,
+            "cpuPercent": 0.2103049421661411,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "endRssMiB": 196.36328125,
+            "cpuPercent": 23.8696109358571,
+            "mainCpuPercent": 0.8412197686645644
+          }
         }
       }
-    },
-    "postCompletionTail": {
-      "durationSeconds": 9.511,
-      "engine": {
-        "endRssMiB": 161.75390625,
-        "cpuPercent": 0.3154242456103462,
-        "mainCpuPercent": 0
+    ]
+  },
+  "previous": {
+    "sourceRevision": "cff81e787e90e51cf51a43776ddb420f3823aa05",
+    "runs": [
+      {
+        "binary": "/tmp/zeron-resource-profile/zeron-release-final",
+        "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+        "harness": "claude-code",
+        "mode": "replay",
+        "renderThreads": "4",
+        "frameStats": "0",
+        "submission": "rpc",
+        "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+        "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+        "replyBytes": 52624,
+        "transcriptBytes": 55067,
+        "frames": 129,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.014,
+            "engine": {
+              "peakPssMiB": 24.4501953125,
+              "endPssMiB": 23.7578125,
+              "peakRssMiB": 31.703125,
+              "endRssMiB": 31.00390625,
+              "cpuPercent": 0.7765697803416906,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 122.9697265625,
+              "endPssMiB": 122.96875,
+              "peakRssMiB": 172.421875,
+              "endRssMiB": 172.421875,
+              "cpuPercent": 14.643887286443311,
+              "mainCpuPercent": 0.6656312402928778
+            }
+          },
+          "stream": {
+            "durationSeconds": 17.514,
+            "engine": {
+              "peakPssMiB": 26.380859375,
+              "endPssMiB": 26.380859375,
+              "peakRssMiB": 33.984375,
+              "endRssMiB": 33.984375,
+              "cpuPercent": 0.9135548703894028,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 145.0869140625,
+              "endPssMiB": 144.908203125,
+              "peakRssMiB": 195.01953125,
+              "endRssMiB": 194.90234375,
+              "cpuPercent": 236.26812835445932,
+              "mainCpuPercent": 10.163297933082106
+            }
+          },
+          "settled": {
+            "durationSeconds": 44.557,
+            "engine": {
+              "peakPssMiB": 27.7578125,
+              "endPssMiB": 27.7529296875,
+              "peakRssMiB": 35.359375,
+              "endRssMiB": 35.35546875,
+              "cpuPercent": 0.2693179522858361,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 148.330078125,
+              "endPssMiB": 146.5751953125,
+              "peakRssMiB": 198.38671875,
+              "endRssMiB": 196.5703125,
+              "cpuPercent": 24.328388356487185,
+              "mainCpuPercent": 1.0772718091433444
+            }
+          }
+        },
+        "postCompletionTail": {
+          "durationSeconds": 9.511,
+          "engine": {
+            "endRssMiB": 35.35546875,
+            "cpuPercent": 0.31542424561034565,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "endRssMiB": 196.5703125,
+            "cpuPercent": 16.822626432551797,
+            "mainCpuPercent": 0.8411313216275899
+          }
+        }
       },
-      "ui": {
-        "endRssMiB": 197.703125,
-        "cpuPercent": 23.8671012511828,
-        "mainCpuPercent": 0.8411313216275899
+      {
+        "binary": "/tmp/zeron-resource-profile/zeron-release-final",
+        "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+        "harness": "claude-code",
+        "mode": "replay",
+        "renderThreads": "4",
+        "frameStats": "0",
+        "submission": "rpc",
+        "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+        "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+        "replyBytes": 52624,
+        "transcriptBytes": 55067,
+        "frames": 130,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.013,
+            "engine": {
+              "peakPssMiB": 24.1552734375,
+              "endPssMiB": 24.1513671875,
+              "peakRssMiB": 31.53515625,
+              "endRssMiB": 31.53515625,
+              "cpuPercent": 0.7766559414179518,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 123.1708984375,
+              "endPssMiB": 123.1669921875,
+              "peakRssMiB": 172.82421875,
+              "endRssMiB": 172.82421875,
+              "cpuPercent": 15.311217130811054,
+              "mainCpuPercent": 0.7766559414179519
+            }
+          },
+          "stream": {
+            "durationSeconds": 17.511,
+            "engine": {
+              "peakPssMiB": 27.0947265625,
+              "endPssMiB": 27.0947265625,
+              "peakRssMiB": 34.69140625,
+              "endRssMiB": 34.69140625,
+              "cpuPercent": 0.970818342755982,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 145.5830078125,
+              "endPssMiB": 145.3271484375,
+              "peakRssMiB": 195.58203125,
+              "endRssMiB": 195.32421875,
+              "cpuPercent": 237.05099651647535,
+              "mainCpuPercent": 10.10793215692993
+            }
+          },
+          "settled": {
+            "durationSeconds": 44.567,
+            "engine": {
+              "peakPssMiB": 28.2958984375,
+              "endPssMiB": 28.2939453125,
+              "peakRssMiB": 35.8984375,
+              "endRssMiB": 35.890625,
+              "cpuPercent": 0.26925752238203154,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 146.046875,
+              "endPssMiB": 145.978515625,
+              "peakRssMiB": 197.64453125,
+              "endRssMiB": 196.03515625,
+              "cpuPercent": 16.58177575336011,
+              "mainCpuPercent": 0.8302106940112641
+            }
+          }
+        },
+        "postCompletionTail": {
+          "durationSeconds": 9.517,
+          "engine": {
+            "endRssMiB": 35.890625,
+            "cpuPercent": 0.3152253861510983,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "endRssMiB": 196.03515625,
+            "cpuPercent": 16.812020594725244,
+            "mainCpuPercent": 0.8406010297362622
+          }
+        }
       }
-    }
+    ]
   },
   "candidate": {
-    "sourceRevision": "4902c792576ed1392c210f0e07c000ee1afc924c",
-    "binary": "/tmp/zeron-resource-profile/zeron-release-final",
-    "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
-    "harness": "claude-code",
-    "mode": "replay",
-    "renderThreads": "4",
-    "frameStats": "0",
-    "submission": "rpc",
-    "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
-    "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
-    "replyBytes": 52624,
-    "transcriptBytes": 55067,
-    "frames": 130,
-    "phases": {
-      "idle": {
-        "durationSeconds": 9.009,
-        "engine": {
-          "peakPssMiB": 23.1630859375,
-          "endPssMiB": 23.1630859375,
-          "peakRssMiB": 30.47265625,
-          "endRssMiB": 30.47265625,
-          "cpuPercent": 0.8880008880008881,
-          "mainCpuPercent": 0
+    "sourceRevision": "b09b37963cf9c78e1aa6acd5195f8a4427dfe21f",
+    "runs": [
+      {
+        "binary": "/tmp/zeron-cpu-round2/zeron-final",
+        "binarySha256": "f4b91201706962a9a29a52dfbe89ccc959870132d28ff8cf1a6b964dbd1dbe20",
+        "harness": "claude-code",
+        "mode": "replay",
+        "renderThreads": "4",
+        "frameStats": "0",
+        "submission": "rpc",
+        "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+        "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+        "replyBytes": 52624,
+        "transcriptBytes": 55067,
+        "frames": 131,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.012,
+            "engine": {
+              "peakPssMiB": 23.9853515625,
+              "endPssMiB": 23.982421875,
+              "peakRssMiB": 31.3203125,
+              "endRssMiB": 31.3203125,
+              "cpuPercent": 0.7767421216156235,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 125.5546875,
+              "endPssMiB": 125.537109375,
+              "peakRssMiB": 175.09765625,
+              "endRssMiB": 175.08984375,
+              "cpuPercent": 6.657789613848204,
+              "mainCpuPercent": 0.7767421216156237
+            }
+          },
+          "stream": {
+            "durationSeconds": 17.513,
+            "engine": {
+              "peakPssMiB": 27.134765625,
+              "endPssMiB": 27.134765625,
+              "peakRssMiB": 34.640625,
+              "endRssMiB": 34.640625,
+              "cpuPercent": 0.8565065951007823,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 150.1572265625,
+              "endPssMiB": 148.556640625,
+              "peakRssMiB": 200,
+              "endRssMiB": 198.41015625,
+              "cpuPercent": 157.59721349854394,
+              "mainCpuPercent": 12.105293210757722
+            }
+          },
+          "settled": {
+            "durationSeconds": 44.574,
+            "engine": {
+              "peakPssMiB": 28.017578125,
+              "endPssMiB": 28.015625,
+              "peakRssMiB": 35.52734375,
+              "endRssMiB": 35.5234375,
+              "cpuPercent": 0.24678063445057652,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 148.984375,
+              "endPssMiB": 148.982421875,
+              "peakRssMiB": 198.890625,
+              "endRssMiB": 198.890625,
+              "cpuPercent": 9.06357966527571,
+              "mainCpuPercent": 0.8749495221429536
+            }
+          }
         },
-        "ui": {
-          "peakPssMiB": 123.03515625,
-          "endPssMiB": 123.00390625,
-          "peakRssMiB": 172.56640625,
-          "endRssMiB": 172.56640625,
-          "cpuPercent": 14.652014652014648,
-          "mainCpuPercent": 0.666000666000666
+        "postCompletionTail": {
+          "durationSeconds": 9.52,
+          "engine": {
+            "endRssMiB": 35.5234375,
+            "cpuPercent": 0.3151260504201678,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "endRssMiB": 198.890625,
+            "cpuPercent": 9.033613445378146,
+            "mainCpuPercent": 0.8403361344537823
+          }
         }
       },
-      "stream": {
-        "durationSeconds": 17.511,
-        "engine": {
-          "peakPssMiB": 26.6123046875,
-          "endPssMiB": 26.611328125,
-          "peakRssMiB": 34.23046875,
-          "endRssMiB": 34.23046875,
-          "cpuPercent": 0.8566044200788077,
-          "mainCpuPercent": 0
+      {
+        "binary": "/tmp/zeron-cpu-round2/zeron-final",
+        "binarySha256": "f4b91201706962a9a29a52dfbe89ccc959870132d28ff8cf1a6b964dbd1dbe20",
+        "harness": "claude-code",
+        "mode": "replay",
+        "renderThreads": "4",
+        "frameStats": "0",
+        "submission": "rpc",
+        "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+        "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+        "replyBytes": 52624,
+        "transcriptBytes": 55067,
+        "frames": 132,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.008,
+            "engine": {
+              "peakPssMiB": 23.369140625,
+              "endPssMiB": 23.36328125,
+              "peakRssMiB": 30.63671875,
+              "endRssMiB": 30.63671875,
+              "cpuPercent": 0.8880994671403197,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 125.662109375,
+              "endPssMiB": 125.5732421875,
+              "peakRssMiB": 175.15625,
+              "endRssMiB": 175.1484375,
+              "cpuPercent": 6.660746003552399,
+              "mainCpuPercent": 0.6660746003552398
+            }
+          },
+          "stream": {
+            "durationSeconds": 17.506,
+            "engine": {
+              "peakPssMiB": 26.6396484375,
+              "endPssMiB": 26.6396484375,
+              "peakRssMiB": 34.17578125,
+              "endRssMiB": 34.17578125,
+              "cpuPercent": 0.8568490803153205,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 150.4560546875,
+              "endPssMiB": 148.8603515625,
+              "peakRssMiB": 201.6640625,
+              "endRssMiB": 198.765625,
+              "cpuPercent": 157.83160059408203,
+              "mainCpuPercent": 12.053010396435507
+            }
+          },
+          "settled": {
+            "durationSeconds": 44.583,
+            "engine": {
+              "peakPssMiB": 27.837890625,
+              "endPssMiB": 27.837890625,
+              "peakRssMiB": 35.37109375,
+              "endRssMiB": 35.37109375,
+              "cpuPercent": 0.26916089092254897,
+              "mainCpuPercent": 0
+            },
+            "ui": {
+              "peakPssMiB": 150.9580078125,
+              "endPssMiB": 149.2763671875,
+              "peakRssMiB": 201.1484375,
+              "endRssMiB": 199.2421875,
+              "cpuPercent": 8.90473947468765,
+              "mainCpuPercent": 0.8074826727676465
+            }
+          }
         },
-        "ui": {
-          "peakPssMiB": 147.0537109375,
-          "endPssMiB": 147.0537109375,
-          "peakRssMiB": 197.05078125,
-          "endRssMiB": 197.05078125,
-          "cpuPercent": 226.54331563017533,
-          "mainCpuPercent": 9.822397350236994
-        }
-      },
-      "settled": {
-        "durationSeconds": 44.559,
-        "engine": {
-          "peakPssMiB": 27.59765625,
-          "endPssMiB": 27.595703125,
-          "peakRssMiB": 35.21484375,
-          "endRssMiB": 35.21484375,
-          "cpuPercent": 0.24686370879059222,
-          "mainCpuPercent": 0
-        },
-        "ui": {
-          "peakPssMiB": 147.2666015625,
-          "endPssMiB": 145.587890625,
-          "peakRssMiB": 197.53515625,
-          "endRssMiB": 195.6484375,
-          "cpuPercent": 16.539868488969674,
-          "mainCpuPercent": 0.7854754370609754
+        "postCompletionTail": {
+          "durationSeconds": 9.521,
+          "engine": {
+            "endRssMiB": 35.37109375,
+            "cpuPercent": 0.3150929524209639,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "endRssMiB": 199.2421875,
+            "cpuPercent": 8.612540699506358,
+            "mainCpuPercent": 0.735216888982248
+          }
         }
       }
-    },
-    "postCompletionTail": {
-      "durationSeconds": 9.51,
-      "engine": {
-        "endRssMiB": 35.21484375,
-        "cpuPercent": 0.2103049421661411,
-        "mainCpuPercent": 0
-      },
-      "ui": {
-        "endRssMiB": 195.6484375,
-        "cpuPercent": 16.614090431125113,
-        "mainCpuPercent": 0.7360672975814915
-      }
-    }
+    ]
   }
 }

--- a/docs/performance/resource-live.json
+++ b/docs/performance/resource-live.json
@@ -1,75 +1,76 @@
 {
-  "binary": "/tmp/zeron-resource-profile/zeron-release-final",
-  "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+  "sourceRevision": "b09b37963cf9c78e1aa6acd5195f8a4427dfe21f",
+  "binary": "/tmp/zeron-cpu-round2/zeron-final",
+  "binarySha256": "f4b91201706962a9a29a52dfbe89ccc959870132d28ff8cf1a6b964dbd1dbe20",
   "harness": "claude-code",
   "mode": "live",
-  "renderThreads": "1",
+  "renderThreads": "4",
   "frameStats": "1",
   "submission": "composer",
-  "prompt": "Run pwd once using your shell tool, then write a Rust ownership tutorial in 30 numbered sections. Each section should contain a heading, a paragraph of at least 50 words and a short Rust example. Finish all 30 sections without asking questions.",
-  "replySha256": "fb6438f16e24d9b49ef86651c6691e3d08e1e07500e619d6f50853a0f9be3598",
-  "replyBytes": 27062,
-  "transcriptBytes": 28559,
-  "frames": 520,
+  "prompt": "Run pwd using the shell tool. Then write a tutorial on Rust ownership in 20 numbered sections, each with a heading, a paragraph, and a short Rust code block. Do not create or modify any files.",
+  "replySha256": "c665755f852c296481a13bffffd4d584202165993436424e29d8e085502fb4cb",
+  "replyBytes": 10902,
+  "transcriptBytes": 12132,
+  "frames": 100,
   "phases": {
     "idle": {
       "durationSeconds": 9.013,
       "engine": {
-        "peakRssMiB": 31.0546875,
-        "endRssMiB": 31.0546875,
-        "cpuPercent": 0.9985576389659381,
+        "peakRssMiB": 30.8203125,
+        "endRssMiB": 30.8203125,
+        "cpuPercent": 0.7766559414179518,
         "mainCpuPercent": 0
       },
       "ui": {
-        "peakRssMiB": 172.1953125,
-        "endRssMiB": 172.1953125,
-        "cpuPercent": 14.867413735715079,
-        "mainCpuPercent": 0.7766559414179517
+        "peakRssMiB": 175.19140625,
+        "endRssMiB": 175.18359375,
+        "cpuPercent": 7.10085432153556,
+        "mainCpuPercent": 0.6657050926439587
       }
     },
     "stream": {
-      "durationSeconds": 73.589,
+      "durationSeconds": 34.546,
       "engine": {
-        "peakRssMiB": 34.68359375,
-        "endRssMiB": 34.68359375,
-        "cpuPercent": 0.9648181114025194,
+        "peakRssMiB": 32.6640625,
+        "endRssMiB": 32.6640625,
+        "cpuPercent": 0.4920974931974758,
         "mainCpuPercent": 0
       },
       "ui": {
-        "peakRssMiB": 195.546875,
-        "endRssMiB": 195.26953125,
-        "cpuPercent": 91.72566552066206,
-        "mainCpuPercent": 4.932802456888938
+        "peakRssMiB": 197.06640625,
+        "endRssMiB": 196.17578125,
+        "cpuPercent": 131.7663405314653,
+        "mainCpuPercent": 10.855091761709026
       }
     },
     "settled": {
-      "durationSeconds": 14.523,
+      "durationSeconds": 14.525,
       "engine": {
-        "peakRssMiB": 34.74609375,
-        "endRssMiB": 34.74609375,
-        "cpuPercent": 0.27542518763340934,
+        "peakRssMiB": 32.76953125,
+        "endRssMiB": 32.76953125,
+        "cpuPercent": 0.27538726333907043,
         "mainCpuPercent": 0
       },
       "ui": {
-        "peakRssMiB": 197.98828125,
-        "endRssMiB": 196.14453125,
-        "cpuPercent": 24.925979480823553,
-        "mainCpuPercent": 1.3771259381670435
+        "peakRssMiB": 196.48828125,
+        "endRssMiB": 196.37109375,
+        "cpuPercent": 9.63855421686746,
+        "mainCpuPercent": 0.9638554216867509
       }
     }
   },
   "postCompletionTail": {
-    "durationSeconds": 9.516,
+    "durationSeconds": 9.518,
     "engine": {
-      "endRssMiB": 34.74609375,
-      "cpuPercent": 0.2101723413198825,
+      "endRssMiB": 32.76953125,
+      "cpuPercent": 0.3151922672830424,
       "mainCpuPercent": 0
     },
     "ui": {
-      "endRssMiB": 196.14453125,
-      "cpuPercent": 29.52921395544349,
-      "mainCpuPercent": 1.576292559899121
+      "endRssMiB": 196.37109375,
+      "cpuPercent": 9.876024374868646,
+      "mainCpuPercent": 0.8405127127547812
     }
   },
-  "notes": "Functional verification with composer submission, a successful shell tool call, sidebar/scroll/selection interactions, and a concurrent test build. CPU values are not a matched benchmark."
+  "notes": "Functional verification: authenticated Haiku 4.5 composer submission, successful pwd tool call, and targeted perf sampling. Not a matched CPU comparison. Sidebar, scroll-away/return, selected-text copy/paste, resize and the model menu were checked in the real window, with the saved transcript reopened for the final interaction checks."
 }

--- a/docs/performance/resource-live.json
+++ b/docs/performance/resource-live.json
@@ -1,0 +1,75 @@
+{
+  "binary": "/tmp/zeron-resource-profile/zeron-release-final",
+  "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+  "harness": "claude-code",
+  "mode": "live",
+  "renderThreads": "1",
+  "frameStats": "1",
+  "submission": "composer",
+  "prompt": "Run pwd once using your shell tool, then write a Rust ownership tutorial in 30 numbered sections. Each section should contain a heading, a paragraph of at least 50 words and a short Rust example. Finish all 30 sections without asking questions.",
+  "replySha256": "fb6438f16e24d9b49ef86651c6691e3d08e1e07500e619d6f50853a0f9be3598",
+  "replyBytes": 27062,
+  "transcriptBytes": 28559,
+  "frames": 520,
+  "phases": {
+    "idle": {
+      "durationSeconds": 9.013,
+      "engine": {
+        "peakRssMiB": 31.0546875,
+        "endRssMiB": 31.0546875,
+        "cpuPercent": 0.9985576389659381,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "peakRssMiB": 172.1953125,
+        "endRssMiB": 172.1953125,
+        "cpuPercent": 14.867413735715079,
+        "mainCpuPercent": 0.7766559414179517
+      }
+    },
+    "stream": {
+      "durationSeconds": 73.589,
+      "engine": {
+        "peakRssMiB": 34.68359375,
+        "endRssMiB": 34.68359375,
+        "cpuPercent": 0.9648181114025194,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "peakRssMiB": 195.546875,
+        "endRssMiB": 195.26953125,
+        "cpuPercent": 91.72566552066206,
+        "mainCpuPercent": 4.932802456888938
+      }
+    },
+    "settled": {
+      "durationSeconds": 14.523,
+      "engine": {
+        "peakRssMiB": 34.74609375,
+        "endRssMiB": 34.74609375,
+        "cpuPercent": 0.27542518763340934,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "peakRssMiB": 197.98828125,
+        "endRssMiB": 196.14453125,
+        "cpuPercent": 24.925979480823553,
+        "mainCpuPercent": 1.3771259381670435
+      }
+    }
+  },
+  "postCompletionTail": {
+    "durationSeconds": 9.516,
+    "engine": {
+      "endRssMiB": 34.74609375,
+      "cpuPercent": 0.2101723413198825,
+      "mainCpuPercent": 0
+    },
+    "ui": {
+      "endRssMiB": 196.14453125,
+      "cpuPercent": 29.52921395544349,
+      "mainCpuPercent": 1.576292559899121
+    }
+  },
+  "notes": "Functional verification with composer submission, a successful shell tool call, sidebar/scroll/selection interactions, and a concurrent test build. CPU values are not a matched benchmark."
+}

--- a/docs/performance/resource-long-baseline.json
+++ b/docs/performance/resource-long-baseline.json
@@ -1,0 +1,75 @@
+{
+  "sourceRevision": "f1d4bad36b77eed5cf4432bb68291840987ebeb5",
+  "binary": "/tmp/zeron-resource-profile/zeron-release-baseline",
+  "binarySha256": "3329082b8e76b4e4dec263c15077f1cf7f30b989ede851a9dde26f2441ab9995",
+  "harness": "claude-code",
+  "mode": "replay",
+  "renderThreads": "1",
+  "frameStats": "0",
+  "submission": "rpc",
+  "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+  "replySha256": "5963799b9710ff90f7ab11ddb78f78b3f8cd2bdc0dbbafc4a4b141f507603286",
+  "replyBytes": 526258,
+  "transcriptBytes": 545037,
+  "frames": 298,
+  "phases": {
+    "idle": {
+      "durationSeconds": 9.011,
+      "engine": {
+        "peakRssMiB": 159.96484375,
+        "endRssMiB": 159.96484375,
+        "cpuPercent": 3.4402397070247477,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "peakRssMiB": 171.1953125,
+        "endRssMiB": 171.1484375,
+        "cpuPercent": 19.64265897236711,
+        "mainCpuPercent": 0.6658528465209189
+      }
+    },
+    "stream": {
+      "durationSeconds": 36.018,
+      "engine": {
+        "peakRssMiB": 179.5546875,
+        "endRssMiB": 179.5546875,
+        "cpuPercent": 1.6103059581320454,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "peakRssMiB": 218.578125,
+        "endRssMiB": 218.578125,
+        "cpuPercent": 110.69465267366319,
+        "mainCpuPercent": 10.411460936198567
+      }
+    },
+    "settled": {
+      "durationSeconds": 44.585,
+      "engine": {
+        "peakRssMiB": 180.55859375,
+        "endRssMiB": 180.55859375,
+        "cpuPercent": 0.2691488168666592,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "peakRssMiB": 219.81640625,
+        "endRssMiB": 219.7421875,
+        "cpuPercent": 92.63205113827519,
+        "mainCpuPercent": 4.239093865649882
+      }
+    }
+  },
+  "postCompletionTail": {
+    "durationSeconds": 9.518,
+    "engine": {
+      "endRssMiB": 180.55859375,
+      "cpuPercent": 0.2101281781886953,
+      "mainCpuPercent": 0
+    },
+    "ui": {
+      "endRssMiB": 219.7421875,
+      "cpuPercent": 92.56146249212021,
+      "mainCpuPercent": 3.9924353855852064
+    }
+  }
+}

--- a/docs/performance/resource-long-candidate.json
+++ b/docs/performance/resource-long-candidate.json
@@ -1,7 +1,7 @@
 {
-  "sourceRevision": "4902c792576ed1392c210f0e07c000ee1afc924c",
-  "binary": "/tmp/zeron-resource-profile/zeron-release-final",
-  "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+  "sourceRevision": "b09b37963cf9c78e1aa6acd5195f8a4427dfe21f",
+  "binary": "/tmp/zeron-cpu-round2/zeron-final",
+  "binarySha256": "f4b91201706962a9a29a52dfbe89ccc959870132d28ff8cf1a6b964dbd1dbe20",
   "harness": "claude-code",
   "mode": "replay",
   "renderThreads": "1",
@@ -16,60 +16,72 @@
     "idle": {
       "durationSeconds": 9.014,
       "engine": {
-        "peakRssMiB": 31.22265625,
-        "endRssMiB": 31.22265625,
-        "cpuPercent": 0.9984468604393169,
+        "peakPssMiB": 24.16015625,
+        "endPssMiB": 23.525390625,
+        "peakRssMiB": 31.5234375,
+        "endRssMiB": 30.88671875,
+        "cpuPercent": 0.7765697803416906,
         "mainCpuPercent": 0
       },
       "ui": {
-        "peakRssMiB": 172.1875,
-        "endRssMiB": 172.1875,
-        "cpuPercent": 12.868870645662305,
-        "mainCpuPercent": 0.554692700244065
+        "peakPssMiB": 125.5888671875,
+        "endPssMiB": 125.583984375,
+        "peakRssMiB": 175.18359375,
+        "endRssMiB": 175.17578125,
+        "cpuPercent": 6.323496782782339,
+        "mainCpuPercent": 0.6656312402928778
       }
     },
     "stream": {
-      "durationSeconds": 36.528,
+      "durationSeconds": 36.516,
       "engine": {
-        "peakRssMiB": 47.43359375,
-        "endRssMiB": 46.60546875,
-        "cpuPercent": 1.6151992991677617,
+        "peakPssMiB": 36.3994140625,
+        "endPssMiB": 35.4365234375,
+        "peakRssMiB": 43.93359375,
+        "endRssMiB": 42.97265625,
+        "cpuPercent": 1.670500602475627,
         "mainCpuPercent": 0
       },
       "ui": {
-        "peakRssMiB": 206.62890625,
-        "endRssMiB": 206.00390625,
-        "cpuPercent": 111.8867717915024,
-        "mainCpuPercent": 10.813622426631625
+        "peakPssMiB": 162.4697265625,
+        "endPssMiB": 159.0517578125,
+        "peakRssMiB": 212.3359375,
+        "endRssMiB": 208.9453125,
+        "cpuPercent": 101.46237265856062,
+        "mainCpuPercent": 14.733267608719466
       }
     },
     "settled": {
-      "durationSeconds": 44.583,
+      "durationSeconds": 44.561,
       "engine": {
-        "peakRssMiB": 49.59765625,
-        "endRssMiB": 49.59765625,
-        "cpuPercent": 0.2467308166790034,
+        "peakPssMiB": 37.19140625,
+        "endPssMiB": 37.189453125,
+        "peakRssMiB": 44.72265625,
+        "endRssMiB": 44.72265625,
+        "cpuPercent": 0.2468526289804986,
         "mainCpuPercent": 0
       },
       "ui": {
-        "peakRssMiB": 207.19921875,
-        "endRssMiB": 207.19921875,
-        "cpuPercent": 15.790772267456203,
-        "mainCpuPercent": 0.8972029697418287
+        "peakPssMiB": 161.119140625,
+        "endPssMiB": 161.0419921875,
+        "peakRssMiB": 211.06640625,
+        "endRssMiB": 210.9921875,
+        "cpuPercent": 8.841812347119689,
+        "mainCpuPercent": 0.9874105159219935
       }
     }
   },
   "postCompletionTail": {
     "durationSeconds": 9.515,
     "engine": {
-      "endRssMiB": 49.59765625,
-      "cpuPercent": 0.31529164477141386,
+      "endRssMiB": 44.72265625,
+      "cpuPercent": 0.31529164477141264,
       "mainCpuPercent": 0
     },
     "ui": {
-      "endRssMiB": 207.19921875,
-      "cpuPercent": 15.239096163951686,
-      "mainCpuPercent": 0.9458749343142392
+      "endRssMiB": 210.9921875,
+      "cpuPercent": 7.987388334209197,
+      "mainCpuPercent": 0.8407777193904369
     }
   }
 }

--- a/docs/performance/resource-long-candidate.json
+++ b/docs/performance/resource-long-candidate.json
@@ -1,0 +1,75 @@
+{
+  "sourceRevision": "4902c792576ed1392c210f0e07c000ee1afc924c",
+  "binary": "/tmp/zeron-resource-profile/zeron-release-final",
+  "binarySha256": "cbad95334488ba5f377d7c8cc32161d9e6ce8a157507bba15bba3ca5624d8643",
+  "harness": "claude-code",
+  "mode": "replay",
+  "renderThreads": "1",
+  "frameStats": "0",
+  "submission": "rpc",
+  "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+  "replySha256": "5963799b9710ff90f7ab11ddb78f78b3f8cd2bdc0dbbafc4a4b141f507603286",
+  "replyBytes": 526258,
+  "transcriptBytes": 545037,
+  "frames": 299,
+  "phases": {
+    "idle": {
+      "durationSeconds": 9.014,
+      "engine": {
+        "peakRssMiB": 31.22265625,
+        "endRssMiB": 31.22265625,
+        "cpuPercent": 0.9984468604393169,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "peakRssMiB": 172.1875,
+        "endRssMiB": 172.1875,
+        "cpuPercent": 12.868870645662305,
+        "mainCpuPercent": 0.554692700244065
+      }
+    },
+    "stream": {
+      "durationSeconds": 36.528,
+      "engine": {
+        "peakRssMiB": 47.43359375,
+        "endRssMiB": 46.60546875,
+        "cpuPercent": 1.6151992991677617,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "peakRssMiB": 206.62890625,
+        "endRssMiB": 206.00390625,
+        "cpuPercent": 111.8867717915024,
+        "mainCpuPercent": 10.813622426631625
+      }
+    },
+    "settled": {
+      "durationSeconds": 44.583,
+      "engine": {
+        "peakRssMiB": 49.59765625,
+        "endRssMiB": 49.59765625,
+        "cpuPercent": 0.2467308166790034,
+        "mainCpuPercent": 0
+      },
+      "ui": {
+        "peakRssMiB": 207.19921875,
+        "endRssMiB": 207.19921875,
+        "cpuPercent": 15.790772267456203,
+        "mainCpuPercent": 0.8972029697418287
+      }
+    }
+  },
+  "postCompletionTail": {
+    "durationSeconds": 9.515,
+    "engine": {
+      "endRssMiB": 49.59765625,
+      "cpuPercent": 0.31529164477141386,
+      "mainCpuPercent": 0
+    },
+    "ui": {
+      "endRssMiB": 207.19921875,
+      "cpuPercent": 15.239096163951686,
+      "mainCpuPercent": 0.9458749343142392
+    }
+  }
+}

--- a/docs/performance/resource-macos-foreground.json
+++ b/docs/performance/resource-macos-foreground.json
@@ -1,0 +1,8323 @@
+{
+  "method": "Native macOS foreground release replay; 1320x880 logical pixels at 2x scale; identical sanitized provider fixture; 500ms CPU and physical-footprint samples; no simultaneous builds or sampling profilers. CPU uses 100% per core. One before run and two after runs. All selected runs passed foreground/display validation for their full duration. Before settled observation is 30s; after observations are 10s, so settled averages are not a matched-duration comparison.",
+  "machine": {
+    "model": "Mac16,7",
+    "architecture": "arm64",
+    "memoryGiB": 24,
+    "os": "macOS 26.0.1 (25A362)"
+  },
+  "beforeRevision": "f10ef38c39256602b984201c01817746cd58ca67",
+  "afterBaseRevision": "338251674bf5412158578f47d3e5df131eb8f145",
+  "afterShellSha256": "b8b2dfd2e3ea55e6e5676201e614aad39d2a178754cef6b1bffd7c4a715bf4d8",
+  "graphicsRevision": "0003b923354ea8938b2d0cadbd17ef93108e2ae5",
+  "fixtureSha256": "8f91503a5a5f36b6344e347a81378696d707f4742b32e8670e76943bb1eca1cc",
+  "runs": [
+    {
+      "summary": {
+        "binarySha256": "7452d54aa47c0dd6f2bdf0e5dd6e0133b1aa378b59d62c8c4cf3743e5bc4273a",
+        "harness": "claude-code",
+        "mode": "replay",
+        "platform": "darwin",
+        "arch": "arm64",
+        "renderThreads": "default",
+        "frameStats": "0",
+        "submission": "rpc",
+        "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+        "replyBytes": 52624,
+        "transcriptBytes": 55067,
+        "frames": 151,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.039,
+            "engine": {
+              "peakFootprintMiB": 23.610245,
+              "endFootprintMiB": 23.516495,
+              "lifetimePeakFootprintMiB": 23.610245,
+              "peakRssMiB": 35.390625,
+              "endRssMiB": 35.390625,
+              "cpuPercent": 0.04602370837482017
+            },
+            "ui": {
+              "peakFootprintMiB": 306.376053,
+              "endFootprintMiB": 301.297905,
+              "lifetimePeakFootprintMiB": 344.876053,
+              "peakRssMiB": 95.875,
+              "endRssMiB": 95.875,
+              "cpuPercent": 1.2480727071578714
+            }
+          },
+          "stream": {
+            "durationSeconds": 19.533,
+            "engine": {
+              "peakFootprintMiB": 23.469643,
+              "endFootprintMiB": 23.469643,
+              "lifetimePeakFootprintMiB": 23.65712,
+              "peakRssMiB": 45.953125,
+              "endRssMiB": 45.953125,
+              "cpuPercent": 0.9000245328418575
+            },
+            "ui": {
+              "peakFootprintMiB": 328.844803,
+              "endFootprintMiB": 328.844803,
+              "lifetimePeakFootprintMiB": 344.876053,
+              "peakRssMiB": 112.515625,
+              "endRssMiB": 112.515625,
+              "cpuPercent": 15.159183602109248
+            }
+          },
+          "settled": {
+            "durationSeconds": 29.556,
+            "engine": {
+              "peakFootprintMiB": 24.391518,
+              "endFootprintMiB": 24.391518,
+              "lifetimePeakFootprintMiB": 24.391518,
+              "peakRssMiB": 46.296875,
+              "endRssMiB": 28.953125,
+              "cpuPercent": 0.05587782514548647
+            },
+            "ui": {
+              "peakFootprintMiB": 329.65728,
+              "endFootprintMiB": 329.62603,
+              "lifetimePeakFootprintMiB": 344.876053,
+              "peakRssMiB": 112.515625,
+              "endRssMiB": 99.9375,
+              "cpuPercent": 1.4698400223304913
+            }
+          }
+        },
+        "postCompletionTail": {
+          "durationSeconds": 9.516,
+          "engine": {
+            "endFootprintMiB": 24.391518,
+            "endRssMiB": 28.953125,
+            "cpuPercent": 0.04758914459857056
+          },
+          "ui": {
+            "endFootprintMiB": 329.62603,
+            "endRssMiB": 99.9375,
+            "cpuPercent": 1.644984331651955
+          }
+        },
+        "label": "before"
+      },
+      "samples": [
+        {
+          "at": 1788626844236,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.076343167,
+            "rssMiB": 34.734375,
+            "footprintMiB": 23.266495,
+            "lifetimePeakFootprintMiB": 23.266495,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.349006583,
+            "rssMiB": 95.546875,
+            "footprintMiB": 305.985428,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": [
+            {
+              "pid": 28220,
+              "cpuSeconds": 1.648926792,
+              "rssMiB": 591.0625,
+              "footprintMiB": 456.235794,
+              "lifetimePeakFootprintMiB": 677.860794,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 28387,
+              "cpuSeconds": 1.853812167,
+              "rssMiB": 166.734375,
+              "footprintMiB": 131.015633,
+              "lifetimePeakFootprintMiB": 131.015633,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626844736,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.076343167,
+            "rssMiB": 34.734375,
+            "footprintMiB": 23.266495,
+            "lifetimePeakFootprintMiB": 23.266495,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.350148542,
+            "rssMiB": 95.546875,
+            "footprintMiB": 305.985428,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": [
+            {
+              "pid": 28220,
+              "cpuSeconds": 1.649203458,
+              "rssMiB": 591.0625,
+              "footprintMiB": 456.204544,
+              "lifetimePeakFootprintMiB": 677.860794,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 28387,
+              "cpuSeconds": 2.151848,
+              "rssMiB": 173.796875,
+              "footprintMiB": 138.6884,
+              "lifetimePeakFootprintMiB": 138.6884,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626845235,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.07639025,
+            "rssMiB": 34.734375,
+            "footprintMiB": 23.266495,
+            "lifetimePeakFootprintMiB": 23.266495,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.353681542,
+            "rssMiB": 95.546875,
+            "footprintMiB": 305.985428,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": [
+            {
+              "pid": 28220,
+              "cpuSeconds": 1.652311042,
+              "rssMiB": 591.0625,
+              "footprintMiB": 456.188919,
+              "lifetimePeakFootprintMiB": 677.860794,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 28387,
+              "cpuSeconds": 2.756036625,
+              "rssMiB": 184.4375,
+              "footprintMiB": 150.424377,
+              "lifetimePeakFootprintMiB": 150.424377,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626845734,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.07639025,
+            "rssMiB": 34.734375,
+            "footprintMiB": 23.266495,
+            "lifetimePeakFootprintMiB": 23.266495,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.35701175,
+            "rssMiB": 95.34375,
+            "footprintMiB": 305.985428,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": [
+            {
+              "pid": 28220,
+              "cpuSeconds": 1.652793167,
+              "rssMiB": 591.0625,
+              "footprintMiB": 456.188919,
+              "lifetimePeakFootprintMiB": 677.860794,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 28387,
+              "cpuSeconds": 3.652488458,
+              "rssMiB": 206.703125,
+              "footprintMiB": 174.802467,
+              "lifetimePeakFootprintMiB": 174.802467,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626846253,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.077801917,
+            "rssMiB": 35.359375,
+            "footprintMiB": 23.59462,
+            "lifetimePeakFootprintMiB": 23.59462,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.362028708,
+            "rssMiB": 95.625,
+            "footprintMiB": 306.266678,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626846758,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.077801917,
+            "rssMiB": 35.359375,
+            "footprintMiB": 23.59462,
+            "lifetimePeakFootprintMiB": 23.59462,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.370291583,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.376053,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626847259,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.077923583,
+            "rssMiB": 35.359375,
+            "footprintMiB": 23.59462,
+            "lifetimePeakFootprintMiB": 23.59462,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.377546917,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.376053,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626847763,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.077923583,
+            "rssMiB": 35.359375,
+            "footprintMiB": 23.59462,
+            "lifetimePeakFootprintMiB": 23.59462,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.384441583,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.376053,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626848262,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078211083,
+            "rssMiB": 35.375,
+            "footprintMiB": 23.59462,
+            "lifetimePeakFootprintMiB": 23.59462,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.392592125,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.376053,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626848764,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078211083,
+            "rssMiB": 35.375,
+            "footprintMiB": 23.59462,
+            "lifetimePeakFootprintMiB": 23.59462,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.400622333,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.376053,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626849250,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078296208,
+            "rssMiB": 35.375,
+            "footprintMiB": 23.59462,
+            "lifetimePeakFootprintMiB": 23.59462,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.406348667,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.31353,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626849765,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078323208,
+            "rssMiB": 35.375,
+            "footprintMiB": 23.59462,
+            "lifetimePeakFootprintMiB": 23.59462,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.413697125,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.31353,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626850260,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078537167,
+            "rssMiB": 35.390625,
+            "footprintMiB": 23.610245,
+            "lifetimePeakFootprintMiB": 23.610245,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.422412958,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.31353,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626850767,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078537167,
+            "rssMiB": 35.390625,
+            "footprintMiB": 23.610245,
+            "lifetimePeakFootprintMiB": 23.610245,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.429662917,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.31353,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626851271,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078641208,
+            "rssMiB": 35.390625,
+            "footprintMiB": 23.610245,
+            "lifetimePeakFootprintMiB": 23.610245,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.437893667,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.297905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626851772,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078653375,
+            "rssMiB": 35.390625,
+            "footprintMiB": 23.610245,
+            "lifetimePeakFootprintMiB": 23.610245,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.444364583,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.297905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626852269,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078864958,
+            "rssMiB": 35.390625,
+            "footprintMiB": 23.610245,
+            "lifetimePeakFootprintMiB": 23.610245,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.452057042,
+            "rssMiB": 95.875,
+            "footprintMiB": 306.297905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 4
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626852778,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.078874167,
+            "rssMiB": 35.390625,
+            "footprintMiB": 23.610245,
+            "lifetimePeakFootprintMiB": 23.610245,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.457204708,
+            "rssMiB": 95.875,
+            "footprintMiB": 301.297905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 4
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626853275,
+          "phase": "idle",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.08050325,
+            "rssMiB": 35.390625,
+            "footprintMiB": 23.516495,
+            "lifetimePeakFootprintMiB": 23.610245,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.461819875,
+            "rssMiB": 95.875,
+            "footprintMiB": 301.297905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 4
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626853763,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.088284833,
+            "rssMiB": 35.953125,
+            "footprintMiB": 23.266495,
+            "lifetimePeakFootprintMiB": 23.610245,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.464631917,
+            "rssMiB": 95.875,
+            "footprintMiB": 301.297905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 4
+          },
+          "harness": []
+        },
+        {
+          "at": 1788626854272,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.103590583,
+            "rssMiB": 38.296875,
+            "footprintMiB": 21.485245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.533676917,
+            "rssMiB": 99.6875,
+            "footprintMiB": 321.03228,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.022847417,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626854768,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.109359792,
+            "rssMiB": 38.3125,
+            "footprintMiB": 21.485245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.602802833,
+            "rssMiB": 106.84375,
+            "footprintMiB": 324.65728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.024027708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626855272,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.113408417,
+            "rssMiB": 38.46875,
+            "footprintMiB": 21.610245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.679779875,
+            "rssMiB": 107.65625,
+            "footprintMiB": 324.62603,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.025386667,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626855780,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.116586625,
+            "rssMiB": 38.515625,
+            "footprintMiB": 21.65712,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.764045417,
+            "rssMiB": 107.96875,
+            "footprintMiB": 324.84478,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.026985417,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626856278,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.120943625,
+            "rssMiB": 38.953125,
+            "footprintMiB": 22.00087,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.843916792,
+            "rssMiB": 108.1875,
+            "footprintMiB": 325.03228,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.028558125,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626856777,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.123826208,
+            "rssMiB": 39.03125,
+            "footprintMiB": 22.06337,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.910191792,
+            "rssMiB": 108.59375,
+            "footprintMiB": 325.360405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.029806583,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626857281,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.127810292,
+            "rssMiB": 39.46875,
+            "footprintMiB": 22.485245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 0.986399875,
+            "rssMiB": 108.671875,
+            "footprintMiB": 325.43853,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.031204,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626857776,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.131545917,
+            "rssMiB": 39.53125,
+            "footprintMiB": 22.547745,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.060806792,
+            "rssMiB": 109.109375,
+            "footprintMiB": 325.87603,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.032575625,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626858274,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.135812542,
+            "rssMiB": 39.71875,
+            "footprintMiB": 22.735245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.13829825,
+            "rssMiB": 109.1875,
+            "footprintMiB": 325.65728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.033734917,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626858781,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.139360583,
+            "rssMiB": 39.71875,
+            "footprintMiB": 22.266495,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.222249792,
+            "rssMiB": 109.421875,
+            "footprintMiB": 325.860405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.035106333,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626859281,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.143958542,
+            "rssMiB": 39.953125,
+            "footprintMiB": 22.485245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.30171775,
+            "rssMiB": 109.453125,
+            "footprintMiB": 325.891655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.036511792,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626859777,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.147463417,
+            "rssMiB": 39.953125,
+            "footprintMiB": 22.485245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.369053333,
+            "rssMiB": 109.546875,
+            "footprintMiB": 325.922905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.03778,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626860278,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.152076167,
+            "rssMiB": 40.21875,
+            "footprintMiB": 22.735245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.446272292,
+            "rssMiB": 109.734375,
+            "footprintMiB": 326.00103,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.039157167,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626860778,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.155722292,
+            "rssMiB": 40.296875,
+            "footprintMiB": 22.78212,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.521571792,
+            "rssMiB": 109.8125,
+            "footprintMiB": 326.06353,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 7
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.040747625,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626861284,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.15926075,
+            "rssMiB": 40.5625,
+            "footprintMiB": 23.047745,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.577680125,
+            "rssMiB": 109.859375,
+            "footprintMiB": 326.110405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 11
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.0418,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626861784,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.162540542,
+            "rssMiB": 40.578125,
+            "footprintMiB": 23.06337,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.657080583,
+            "rssMiB": 109.96875,
+            "footprintMiB": 326.204155,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 11
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.043057667,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626862293,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.167071458,
+            "rssMiB": 40.921875,
+            "footprintMiB": 18.985245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.737267333,
+            "rssMiB": 110.015625,
+            "footprintMiB": 326.25103,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 12
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.04411275,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626862783,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.170074167,
+            "rssMiB": 40.921875,
+            "footprintMiB": 18.985245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.807434542,
+            "rssMiB": 110.03125,
+            "footprintMiB": 326.266655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 12
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.045266125,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626863287,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.174278542,
+            "rssMiB": 41.21875,
+            "footprintMiB": 19.28212,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.87391375,
+            "rssMiB": 110.28125,
+            "footprintMiB": 326.110405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 14
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.046488,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626863787,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.177862208,
+            "rssMiB": 41.234375,
+            "footprintMiB": 19.297745,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 1.953053333,
+            "rssMiB": 110.34375,
+            "footprintMiB": 326.141655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 14
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.047718125,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626864289,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.182179167,
+            "rssMiB": 41.703125,
+            "footprintMiB": 19.610245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.040042792,
+            "rssMiB": 110.390625,
+            "footprintMiB": 326.18853,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 14
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.049112292,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626864788,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.186512542,
+            "rssMiB": 42.046875,
+            "footprintMiB": 19.953995,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.118540792,
+            "rssMiB": 110.5625,
+            "footprintMiB": 326.360405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 14
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.050720542,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626865291,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.190536125,
+            "rssMiB": 42.046875,
+            "footprintMiB": 19.953995,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.202505458,
+            "rssMiB": 110.609375,
+            "footprintMiB": 326.40728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 17
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.052120792,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626865789,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.19475775,
+            "rssMiB": 42.171875,
+            "footprintMiB": 20.047745,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.277855917,
+            "rssMiB": 110.609375,
+            "footprintMiB": 326.40728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 17
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.053921042,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626866288,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.198498958,
+            "rssMiB": 42.171875,
+            "footprintMiB": 20.047745,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.352789792,
+            "rssMiB": 110.6875,
+            "footprintMiB": 326.46978,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 17
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.055371333,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626866796,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.2028755,
+            "rssMiB": 42.34375,
+            "footprintMiB": 20.21962,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.431408208,
+            "rssMiB": 110.6875,
+            "footprintMiB": 326.46978,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 24
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.056843167,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626867292,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.206887833,
+            "rssMiB": 42.609375,
+            "footprintMiB": 20.485245,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.508055458,
+            "rssMiB": 110.734375,
+            "footprintMiB": 326.516655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 24
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.058284375,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626867793,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.2118135,
+            "rssMiB": 42.65625,
+            "footprintMiB": 20.53212,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.592817167,
+            "rssMiB": 110.765625,
+            "footprintMiB": 326.547905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 24
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.059796042,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626868294,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.215904167,
+            "rssMiB": 42.796875,
+            "footprintMiB": 20.672745,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.664766083,
+            "rssMiB": 110.796875,
+            "footprintMiB": 326.56353,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 24
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.061354792,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626868794,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.2204565,
+            "rssMiB": 42.921875,
+            "footprintMiB": 20.797745,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.74442525,
+            "rssMiB": 110.84375,
+            "footprintMiB": 326.579155,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 24
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.062832375,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626869295,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.226775,
+            "rssMiB": 42.953125,
+            "footprintMiB": 20.578995,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.809410333,
+            "rssMiB": 110.984375,
+            "footprintMiB": 326.62603,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 24
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.06393075,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626869795,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.232501208,
+            "rssMiB": 43.21875,
+            "footprintMiB": 20.860268,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.887767167,
+            "rssMiB": 111.015625,
+            "footprintMiB": 326.641655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 26
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.065427458,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626870298,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.236499042,
+            "rssMiB": 43.3125,
+            "footprintMiB": 20.954018,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 2.970240583,
+            "rssMiB": 111.078125,
+            "footprintMiB": 326.672905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 26
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.066754417,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626870790,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.241532917,
+            "rssMiB": 43.375,
+            "footprintMiB": 21.016518,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.049378708,
+            "rssMiB": 111.09375,
+            "footprintMiB": 326.68853,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 26
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.067998708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626871291,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.245360875,
+            "rssMiB": 43.375,
+            "footprintMiB": 21.016518,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.126075917,
+            "rssMiB": 111.15625,
+            "footprintMiB": 326.704155,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 33
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.06934625,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626871805,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.249767,
+            "rssMiB": 44.359375,
+            "footprintMiB": 21.985268,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.197249542,
+            "rssMiB": 111.1875,
+            "footprintMiB": 326.704155,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 39
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.070557583,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626872302,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.253383708,
+            "rssMiB": 44.4375,
+            "footprintMiB": 22.063393,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.267944333,
+            "rssMiB": 111.4375,
+            "footprintMiB": 328.266655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 39
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.071683958,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626872796,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.259020375,
+            "rssMiB": 45.296875,
+            "footprintMiB": 22.922768,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.343469167,
+            "rssMiB": 111.765625,
+            "footprintMiB": 328.266655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 39
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.072922875,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626873296,
+          "phase": "stream",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.264086625,
+            "rssMiB": 45.953125,
+            "footprintMiB": 23.469643,
+            "lifetimePeakFootprintMiB": 23.65712,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.42567525,
+            "rssMiB": 112.515625,
+            "footprintMiB": 328.844803,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 41
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626873803,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.265719625,
+            "rssMiB": 46.296875,
+            "footprintMiB": 23.813393,
+            "lifetimePeakFootprintMiB": 23.813393,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.442291625,
+            "rssMiB": 112.515625,
+            "footprintMiB": 328.844803,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626874301,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.268938167,
+            "rssMiB": 46.296875,
+            "footprintMiB": 23.813393,
+            "lifetimePeakFootprintMiB": 23.813393,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.451851583,
+            "rssMiB": 112.515625,
+            "footprintMiB": 327.360428,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626874803,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.269087833,
+            "rssMiB": 46.296875,
+            "footprintMiB": 23.813393,
+            "lifetimePeakFootprintMiB": 23.813393,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.4615925,
+            "rssMiB": 112.515625,
+            "footprintMiB": 327.360428,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626875302,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.269176667,
+            "rssMiB": 46.296875,
+            "footprintMiB": 23.813393,
+            "lifetimePeakFootprintMiB": 23.813393,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.471303083,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626875806,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.269210917,
+            "rssMiB": 46.296875,
+            "footprintMiB": 23.813393,
+            "lifetimePeakFootprintMiB": 23.813393,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.48093975,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626876300,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.269282708,
+            "rssMiB": 37.46875,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.488952417,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626876810,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.269511625,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.4957375,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626877311,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.269589,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.500604083,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626877813,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.269619417,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.505218833,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626878313,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.26971375,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.508002333,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626878813,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.269859042,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.512886958,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626879315,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.26992025,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.517573958,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626879816,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.269963958,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.522123458,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626880316,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.270028625,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.527177833,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626880817,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.270050167,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.531831167,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626881326,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.270161583,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.537654083,
+            "rssMiB": 112.21875,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626881811,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.270184417,
+            "rssMiB": 37.484375,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 4
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.541635625,
+            "rssMiB": 112.203125,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 43
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626882317,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.270308792,
+            "rssMiB": 37.5,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.547931458,
+            "rssMiB": 112.203125,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 43
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626882816,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.270336083,
+            "rssMiB": 37.5,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.555559208,
+            "rssMiB": 112.203125,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626883319,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.270443917,
+            "rssMiB": 37.5,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.564407125,
+            "rssMiB": 112.203125,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626883817,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.27167775,
+            "rssMiB": 37.578125,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.579512792,
+            "rssMiB": 112.203125,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626884322,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.271734792,
+            "rssMiB": 37.578125,
+            "footprintMiB": 24.172768,
+            "lifetimePeakFootprintMiB": 24.172768,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.589203125,
+            "rssMiB": 112.203125,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626884823,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.272606917,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.597751625,
+            "rssMiB": 112.203125,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626885322,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.272725667,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.605095917,
+            "rssMiB": 112.203125,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626885823,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.272759625,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.6134385,
+            "rssMiB": 112.203125,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626886321,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.273401917,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.628466042,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626886826,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.273460792,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.636539583,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626887326,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.273616,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.646110083,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626887825,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.273675042,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.654792833,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 46
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626888327,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.273748208,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.662813167,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 46
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626888833,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.27378975,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.671951708,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 46
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626889334,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.276845833,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.677232708,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 46
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626889832,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.276908417,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.682325042,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 46
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626890332,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277003583,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.687673792,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 46
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626890823,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277036208,
+            "rssMiB": 37.625,
+            "footprintMiB": 24.219643,
+            "lifetimePeakFootprintMiB": 24.219643,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.690432292,
+            "rssMiB": 112.34375,
+            "footprintMiB": 327.235405,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 46
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 10.078125,
+              "footprintMiB": 6.390877,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626891336,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.2772485,
+            "rssMiB": 36.078125,
+            "footprintMiB": 24.157143,
+            "lifetimePeakFootprintMiB": 24.282143,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.695206875,
+            "rssMiB": 107.8125,
+            "footprintMiB": 328.547905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 46
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 7.375,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626891837,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277309292,
+            "rssMiB": 36.078125,
+            "footprintMiB": 24.157143,
+            "lifetimePeakFootprintMiB": 24.282143,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.699468042,
+            "rssMiB": 108.3125,
+            "footprintMiB": 328.547905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 46
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 7.375,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626892334,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277376125,
+            "rssMiB": 36.078125,
+            "footprintMiB": 24.157143,
+            "lifetimePeakFootprintMiB": 24.282143,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.70438375,
+            "rssMiB": 108.328125,
+            "footprintMiB": 328.547905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 47
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 7.375,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626892838,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277436833,
+            "rssMiB": 36.078125,
+            "footprintMiB": 24.157143,
+            "lifetimePeakFootprintMiB": 24.282143,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.709159042,
+            "rssMiB": 108.328125,
+            "footprintMiB": 328.547905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 47
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 7.375,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626893348,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277654167,
+            "rssMiB": 36.078125,
+            "footprintMiB": 24.157143,
+            "lifetimePeakFootprintMiB": 24.282143,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.715084833,
+            "rssMiB": 108.328125,
+            "footprintMiB": 328.547905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 47
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 7.375,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626893843,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277706292,
+            "rssMiB": 36.078125,
+            "footprintMiB": 24.157143,
+            "lifetimePeakFootprintMiB": 24.282143,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.720180833,
+            "rssMiB": 108.328125,
+            "footprintMiB": 328.547905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 47
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 7.375,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626894340,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277779542,
+            "rssMiB": 36.09375,
+            "footprintMiB": 24.157143,
+            "lifetimePeakFootprintMiB": 24.282143,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.725278583,
+            "rssMiB": 108.328125,
+            "footprintMiB": 328.547905,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 7.375,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626894842,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277854542,
+            "rssMiB": 33.71875,
+            "footprintMiB": 24.313393,
+            "lifetimePeakFootprintMiB": 24.313393,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.730643917,
+            "rssMiB": 105.859375,
+            "footprintMiB": 328.96978,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626895347,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.277906792,
+            "rssMiB": 30.375,
+            "footprintMiB": 24.375893,
+            "lifetimePeakFootprintMiB": 24.375893,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.734527958,
+            "rssMiB": 100.546875,
+            "footprintMiB": 329.56353,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626895845,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.278013833,
+            "rssMiB": 30.109375,
+            "footprintMiB": 24.375893,
+            "lifetimePeakFootprintMiB": 24.375893,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.743848292,
+            "rssMiB": 100,
+            "footprintMiB": 329.56353,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626896372,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.278092542,
+            "rssMiB": 28.703125,
+            "footprintMiB": 24.375893,
+            "lifetimePeakFootprintMiB": 24.375893,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.754257208,
+            "rssMiB": 99.890625,
+            "footprintMiB": 329.641655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626896853,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.278139792,
+            "rssMiB": 28.703125,
+            "footprintMiB": 24.375893,
+            "lifetimePeakFootprintMiB": 24.375893,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.76322475,
+            "rssMiB": 99.890625,
+            "footprintMiB": 329.641655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626897356,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.278198583,
+            "rssMiB": 28.703125,
+            "footprintMiB": 24.375893,
+            "lifetimePeakFootprintMiB": 24.375893,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.771954208,
+            "rssMiB": 99.90625,
+            "footprintMiB": 329.65728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626897846,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.278333667,
+            "rssMiB": 28.71875,
+            "footprintMiB": 24.375893,
+            "lifetimePeakFootprintMiB": 24.375893,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.781820542,
+            "rssMiB": 99.90625,
+            "footprintMiB": 329.65728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626898343,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.278395375,
+            "rssMiB": 28.71875,
+            "footprintMiB": 24.375893,
+            "lifetimePeakFootprintMiB": 24.375893,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.792903167,
+            "rssMiB": 99.90625,
+            "footprintMiB": 329.65728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626898835,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.279619,
+            "rssMiB": 28.796875,
+            "footprintMiB": 24.375893,
+            "lifetimePeakFootprintMiB": 24.375893,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.808384833,
+            "rssMiB": 99.921875,
+            "footprintMiB": 329.65728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626899341,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.279680875,
+            "rssMiB": 28.796875,
+            "footprintMiB": 24.375893,
+            "lifetimePeakFootprintMiB": 24.375893,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.816118125,
+            "rssMiB": 99.921875,
+            "footprintMiB": 329.65728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626899840,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.280764375,
+            "rssMiB": 28.890625,
+            "footprintMiB": 24.391518,
+            "lifetimePeakFootprintMiB": 24.391518,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.825007542,
+            "rssMiB": 99.921875,
+            "footprintMiB": 329.65728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626900348,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.280824708,
+            "rssMiB": 28.890625,
+            "footprintMiB": 24.391518,
+            "lifetimePeakFootprintMiB": 24.391518,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.83295625,
+            "rssMiB": 99.921875,
+            "footprintMiB": 329.65728,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626900850,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.280894667,
+            "rssMiB": 28.890625,
+            "footprintMiB": 24.391518,
+            "lifetimePeakFootprintMiB": 24.391518,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.840271792,
+            "rssMiB": 99.921875,
+            "footprintMiB": 329.641655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626901351,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.281845542,
+            "rssMiB": 28.953125,
+            "footprintMiB": 24.391518,
+            "lifetimePeakFootprintMiB": 24.391518,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.855834833,
+            "rssMiB": 99.9375,
+            "footprintMiB": 329.641655,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626901844,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.282016583,
+            "rssMiB": 28.953125,
+            "footprintMiB": 24.391518,
+            "lifetimePeakFootprintMiB": 24.391518,
+            "idleWakeups": 5
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.862564208,
+            "rssMiB": 99.9375,
+            "footprintMiB": 329.62603,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 51
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626902355,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.2820705,
+            "rssMiB": 28.953125,
+            "footprintMiB": 24.391518,
+            "lifetimePeakFootprintMiB": 24.391518,
+            "idleWakeups": 6
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.86838825,
+            "rssMiB": 99.9375,
+            "footprintMiB": 329.62603,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 55
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626902847,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.282173833,
+            "rssMiB": 28.953125,
+            "footprintMiB": 24.391518,
+            "lifetimePeakFootprintMiB": 24.391518,
+            "idleWakeups": 6
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.873289292,
+            "rssMiB": 99.9375,
+            "footprintMiB": 329.62603,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 55
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788626903359,
+          "phase": "settled",
+          "engine": {
+            "pid": 28152,
+            "cpuSeconds": 0.282234875,
+            "rssMiB": 28.953125,
+            "footprintMiB": 24.391518,
+            "lifetimePeakFootprintMiB": 24.391518,
+            "idleWakeups": 6
+          },
+          "ui": {
+            "pid": 28208,
+            "cpuSeconds": 3.876717542,
+            "rssMiB": 99.9375,
+            "footprintMiB": 329.62603,
+            "lifetimePeakFootprintMiB": 344.876053,
+            "idleWakeups": 55
+          },
+          "harness": [
+            {
+              "pid": 28932,
+              "cpuSeconds": 0.074345708,
+              "rssMiB": 5.96875,
+              "footprintMiB": 6.234627,
+              "lifetimePeakFootprintMiB": 6.390877,
+              "idleWakeups": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "summary": {
+        "binarySha256": "1f6c253eec14756da12efdb41ffbe4c4aba31c925f2bf0df7d48ae781bfda3e6",
+        "harness": "claude-code",
+        "mode": "replay",
+        "platform": "darwin",
+        "arch": "arm64",
+        "renderThreads": "default",
+        "frameStats": "0",
+        "submission": "rpc",
+        "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+        "replyBytes": 52624,
+        "transcriptBytes": 55067,
+        "frames": 151,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.031,
+            "engine": {
+              "peakFootprintMiB": 17.532166,
+              "endFootprintMiB": 16.641541,
+              "lifetimePeakFootprintMiB": 21.704041,
+              "peakRssMiB": 34.265625,
+              "endRssMiB": 26.5625,
+              "cpuPercent": 0.03596407928247153
+            },
+            "ui": {
+              "peakFootprintMiB": 302.110382,
+              "endFootprintMiB": 297.126007,
+              "lifetimePeakFootprintMiB": 340.688507,
+              "peakRssMiB": 97.0625,
+              "endRssMiB": 93.28125,
+              "cpuPercent": 0.5934484996124462
+            }
+          },
+          "stream": {
+            "durationSeconds": 19.551,
+            "engine": {
+              "peakFootprintMiB": 22.235313,
+              "endFootprintMiB": 22.235313,
+              "lifetimePeakFootprintMiB": 22.235313,
+              "peakRssMiB": 40.125,
+              "endRssMiB": 40.125,
+              "cpuPercent": 0.7772226024244284
+            },
+            "ui": {
+              "peakFootprintMiB": 323.110382,
+              "endFootprintMiB": 322.844757,
+              "lifetimePeakFootprintMiB": 340.688507,
+              "peakRssMiB": 109.59375,
+              "endRssMiB": 109.59375,
+              "cpuPercent": 12.4845760268017
+            }
+          },
+          "settled": {
+            "durationSeconds": 9.525,
+            "engine": {
+              "peakFootprintMiB": 22.938438,
+              "endFootprintMiB": 22.938438,
+              "lifetimePeakFootprintMiB": 22.938438,
+              "peakRssMiB": 41.296875,
+              "endRssMiB": 41.296875,
+              "cpuPercent": 0.06323054068241457
+            },
+            "ui": {
+              "peakFootprintMiB": 323.454132,
+              "endFootprintMiB": 323.313507,
+              "lifetimePeakFootprintMiB": 340.688507,
+              "peakRssMiB": 110.421875,
+              "endRssMiB": 110.421875,
+              "cpuPercent": 0.8741719160104965
+            }
+          }
+        },
+        "postCompletionTail": {
+          "durationSeconds": 9.525,
+          "engine": {
+            "endFootprintMiB": 22.938438,
+            "endRssMiB": 41.296875,
+            "cpuPercent": 0.06323054068241457
+          },
+          "ui": {
+            "endFootprintMiB": 323.313507,
+            "endRssMiB": 110.421875,
+            "cpuPercent": 0.8741719160104965
+          }
+        },
+        "label": "after-1"
+      },
+      "samples": [
+        {
+          "at": 1788628521482,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.070233292,
+            "rssMiB": 34.15625,
+            "footprintMiB": 16.313416,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.400256583,
+            "rssMiB": 96.9375,
+            "footprintMiB": 301.719757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 4
+          },
+          "harness": [
+            {
+              "pid": 58864,
+              "cpuSeconds": 1.711783542,
+              "rssMiB": 601.46875,
+              "footprintMiB": 472.829613,
+              "lifetimePeakFootprintMiB": 688.407738,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 58941,
+              "cpuSeconds": 1.014477125,
+              "rssMiB": 147.6875,
+              "footprintMiB": 110.122238,
+              "lifetimePeakFootprintMiB": 110.122238,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628521980,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.070577708,
+            "rssMiB": 34.265625,
+            "footprintMiB": 16.360291,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.40326175,
+            "rssMiB": 97.0625,
+            "footprintMiB": 301.797882,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 58864,
+              "cpuSeconds": 1.712306792,
+              "rssMiB": 601.46875,
+              "footprintMiB": 472.704613,
+              "lifetimePeakFootprintMiB": 688.407738,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 58941,
+              "cpuSeconds": 1.392657958,
+              "rssMiB": 156.421875,
+              "footprintMiB": 119.732895,
+              "lifetimePeakFootprintMiB": 119.889168,
+              "idleWakeups": 9
+            }
+          ]
+        },
+        {
+          "at": 1788628522488,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.070623333,
+            "rssMiB": 34.265625,
+            "footprintMiB": 16.360291,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.404991625,
+            "rssMiB": 97.0625,
+            "footprintMiB": 301.797882,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 58864,
+              "cpuSeconds": 1.714739875,
+              "rssMiB": 601.46875,
+              "footprintMiB": 472.673363,
+              "lifetimePeakFootprintMiB": 688.407738,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 58941,
+              "cpuSeconds": 2.004332458,
+              "rssMiB": 165.125,
+              "footprintMiB": 129.296722,
+              "lifetimePeakFootprintMiB": 129.296722,
+              "idleWakeups": 10
+            }
+          ]
+        },
+        {
+          "at": 1788628522992,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.0706345,
+            "rssMiB": 34.265625,
+            "footprintMiB": 16.360291,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.406560542,
+            "rssMiB": 97.0625,
+            "footprintMiB": 301.797882,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 58864,
+              "cpuSeconds": 1.716499417,
+              "rssMiB": 599.109375,
+              "footprintMiB": 472.673363,
+              "lifetimePeakFootprintMiB": 688.407738,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 58941,
+              "cpuSeconds": 2.593783583,
+              "rssMiB": 177.09375,
+              "footprintMiB": 142.501656,
+              "lifetimePeakFootprintMiB": 142.501656,
+              "idleWakeups": 13
+            }
+          ]
+        },
+        {
+          "at": 1788628523489,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.070849833,
+            "rssMiB": 24.21875,
+            "footprintMiB": 17.110291,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.408833,
+            "rssMiB": 94.421875,
+            "footprintMiB": 301.813507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 58864,
+              "cpuSeconds": 1.719891542,
+              "rssMiB": 533.828125,
+              "footprintMiB": 472.673363,
+              "lifetimePeakFootprintMiB": 688.407738,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 58941,
+              "cpuSeconds": 3.156599125,
+              "rssMiB": 183.5,
+              "footprintMiB": 152.784393,
+              "lifetimePeakFootprintMiB": 152.784393,
+              "idleWakeups": 14
+            }
+          ]
+        },
+        {
+          "at": 1788628523982,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.070963,
+            "rssMiB": 24.03125,
+            "footprintMiB": 17.532166,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.410497333,
+            "rssMiB": 92.5,
+            "footprintMiB": 301.829132,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 58864,
+              "cpuSeconds": 1.720399708,
+              "rssMiB": 533.53125,
+              "footprintMiB": 472.657738,
+              "lifetimePeakFootprintMiB": 688.407738,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 58941,
+              "cpuSeconds": 3.908549708,
+              "rssMiB": 206.234375,
+              "footprintMiB": 180.615883,
+              "lifetimePeakFootprintMiB": 180.615883,
+              "idleWakeups": 115
+            }
+          ]
+        },
+        {
+          "at": 1788628524494,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.071091083,
+            "rssMiB": 23.828125,
+            "footprintMiB": 17.532166,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.412944292,
+            "rssMiB": 92.53125,
+            "footprintMiB": 301.844757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 58864,
+              "cpuSeconds": 1.725206167,
+              "rssMiB": 533.53125,
+              "footprintMiB": 472.657738,
+              "lifetimePeakFootprintMiB": 688.407738,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 58941,
+              "cpuSeconds": 3.987717167,
+              "rssMiB": 217.375,
+              "footprintMiB": 191.537987,
+              "lifetimePeakFootprintMiB": 191.537987,
+              "idleWakeups": 117
+            }
+          ]
+        },
+        {
+          "at": 1788628525006,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.072329042,
+            "rssMiB": 26.484375,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.41557525,
+            "rssMiB": 92.84375,
+            "footprintMiB": 302.094757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 6
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628525500,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.072653625,
+            "rssMiB": 26.515625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.419485917,
+            "rssMiB": 93.0625,
+            "footprintMiB": 302.110382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 6
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628525995,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.072653625,
+            "rssMiB": 26.515625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.424722208,
+            "rssMiB": 93.1875,
+            "footprintMiB": 302.110382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 6
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628526502,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.072787833,
+            "rssMiB": 26.515625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.426856667,
+            "rssMiB": 93.1875,
+            "footprintMiB": 302.110382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 6
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628527009,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.07281425,
+            "rssMiB": 26.515625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.429119667,
+            "rssMiB": 93.1875,
+            "footprintMiB": 302.110382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 7
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628527508,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.07293,
+            "rssMiB": 26.515625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.431079125,
+            "rssMiB": 93.1875,
+            "footprintMiB": 302.110382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 7
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628528010,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.072982167,
+            "rssMiB": 26.515625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.434037875,
+            "rssMiB": 93.21875,
+            "footprintMiB": 302.063507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 7
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628528526,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.0731295,
+            "rssMiB": 26.515625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.437119583,
+            "rssMiB": 93.21875,
+            "footprintMiB": 302.063507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 7
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628529023,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.0731295,
+            "rssMiB": 26.515625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.439881583,
+            "rssMiB": 93.21875,
+            "footprintMiB": 302.063507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 8
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628529513,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.07324575,
+            "rssMiB": 26.515625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.443027458,
+            "rssMiB": 93.21875,
+            "footprintMiB": 302.063507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 8
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628530018,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.073328917,
+            "rssMiB": 26.5625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.44815275,
+            "rssMiB": 93.28125,
+            "footprintMiB": 297.126007,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 14
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628530513,
+          "phase": "idle",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.073481208,
+            "rssMiB": 26.5625,
+            "footprintMiB": 16.641541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.453850917,
+            "rssMiB": 93.28125,
+            "footprintMiB": 297.126007,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 14
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628531002,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.080467917,
+            "rssMiB": 28.421875,
+            "footprintMiB": 16.547791,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.458825958,
+            "rssMiB": 93.28125,
+            "footprintMiB": 297.126007,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 14
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628531505,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.093699875,
+            "rssMiB": 31.1875,
+            "footprintMiB": 14.985291,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.495162375,
+            "rssMiB": 97.96875,
+            "footprintMiB": 316.969757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 15
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.022692875,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628532016,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.10017,
+            "rssMiB": 31.5625,
+            "footprintMiB": 15.188416,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.553887208,
+            "rssMiB": 105.078125,
+            "footprintMiB": 320.391632,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 17
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.023642125,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628532520,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.103022083,
+            "rssMiB": 31.609375,
+            "footprintMiB": 15.188416,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.615794333,
+            "rssMiB": 106.21875,
+            "footprintMiB": 321.407257,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 17
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.024616083,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628533020,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.105212375,
+            "rssMiB": 31.640625,
+            "footprintMiB": 15.219666,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.670308292,
+            "rssMiB": 106.609375,
+            "footprintMiB": 321.688507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 17
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.02547825,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628533520,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.109274958,
+            "rssMiB": 31.890625,
+            "footprintMiB": 15.375916,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.733414625,
+            "rssMiB": 106.8125,
+            "footprintMiB": 321.110382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.026653375,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628534027,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.112742167,
+            "rssMiB": 32.078125,
+            "footprintMiB": 15.516541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.803542917,
+            "rssMiB": 106.921875,
+            "footprintMiB": 321.110382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.027942167,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628534522,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.115989667,
+            "rssMiB": 32.40625,
+            "footprintMiB": 15.688416,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.870959875,
+            "rssMiB": 106.953125,
+            "footprintMiB": 321.141632,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.029064167,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628535032,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.118569833,
+            "rssMiB": 32.46875,
+            "footprintMiB": 15.750916,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.931532375,
+            "rssMiB": 107.40625,
+            "footprintMiB": 321.594757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.030131875,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628535526,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.121957958,
+            "rssMiB": 32.65625,
+            "footprintMiB": 15.907166,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 0.996795042,
+            "rssMiB": 107.46875,
+            "footprintMiB": 321.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.031327542,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628536027,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.12518375,
+            "rssMiB": 32.65625,
+            "footprintMiB": 15.907166,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.066498375,
+            "rssMiB": 107.765625,
+            "footprintMiB": 321.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.032702917,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628536526,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.128715792,
+            "rssMiB": 33.1875,
+            "footprintMiB": 16.422791,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.129953208,
+            "rssMiB": 107.828125,
+            "footprintMiB": 321.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 22
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.033930417,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628537021,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.131948583,
+            "rssMiB": 33.265625,
+            "footprintMiB": 16.500916,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.191363,
+            "rssMiB": 107.90625,
+            "footprintMiB": 321.329132,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 22
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.035019,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628537529,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.136558833,
+            "rssMiB": 33.4375,
+            "footprintMiB": 16.657166,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.258915667,
+            "rssMiB": 108.0625,
+            "footprintMiB": 321.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 22
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.036427,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628538027,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.139768542,
+            "rssMiB": 33.609375,
+            "footprintMiB": 16.797791,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.329276792,
+            "rssMiB": 108.15625,
+            "footprintMiB": 321.516632,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 26
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.037769083,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628538532,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.143849792,
+            "rssMiB": 33.734375,
+            "footprintMiB": 16.907166,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.391315208,
+            "rssMiB": 108.1875,
+            "footprintMiB": 321.547882,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 27
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.038893375,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628539026,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.146323083,
+            "rssMiB": 33.828125,
+            "footprintMiB": 17.000916,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.45848575,
+            "rssMiB": 108.328125,
+            "footprintMiB": 321.657257,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 27
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.040110833,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628539532,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.151592,
+            "rssMiB": 34.75,
+            "footprintMiB": 17.875916,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.519147917,
+            "rssMiB": 108.71875,
+            "footprintMiB": 322.001007,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 28
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.04152675,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628540033,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.154464458,
+            "rssMiB": 34.78125,
+            "footprintMiB": 17.860291,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.58065575,
+            "rssMiB": 108.71875,
+            "footprintMiB": 321.985382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 28
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.042599625,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628540527,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.158060875,
+            "rssMiB": 35.40625,
+            "footprintMiB": 18.454041,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.64310575,
+            "rssMiB": 108.765625,
+            "footprintMiB": 322.032257,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.043806125,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628541033,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.161183417,
+            "rssMiB": 35.578125,
+            "footprintMiB": 18.625916,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.705893042,
+            "rssMiB": 108.859375,
+            "footprintMiB": 322.110382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.044963667,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628541526,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.164476542,
+            "rssMiB": 35.984375,
+            "footprintMiB": 18.391541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.765801208,
+            "rssMiB": 108.90625,
+            "footprintMiB": 322.157257,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.045980958,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628542040,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.168616833,
+            "rssMiB": 36.359375,
+            "footprintMiB": 18.766541,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.845919792,
+            "rssMiB": 109.046875,
+            "footprintMiB": 322.297882,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.047267417,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628542533,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.171158583,
+            "rssMiB": 36.375,
+            "footprintMiB": 18.782166,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.895895917,
+            "rssMiB": 109.109375,
+            "footprintMiB": 322.344757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.048165167,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628543034,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.174562583,
+            "rssMiB": 36.5625,
+            "footprintMiB": 18.922791,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 1.952134333,
+            "rssMiB": 109.140625,
+            "footprintMiB": 322.376007,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0494915,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628543538,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.178413333,
+            "rssMiB": 36.5625,
+            "footprintMiB": 18.922791,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.021610125,
+            "rssMiB": 109.203125,
+            "footprintMiB": 322.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.050977083,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628544036,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.182643917,
+            "rssMiB": 36.671875,
+            "footprintMiB": 19.000916,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.099483958,
+            "rssMiB": 109.234375,
+            "footprintMiB": 322.469757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.052318667,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628544541,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.185639708,
+            "rssMiB": 36.875,
+            "footprintMiB": 19.204041,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.161324125,
+            "rssMiB": 109.25,
+            "footprintMiB": 322.485382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.053435208,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628545041,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.189072958,
+            "rssMiB": 37.140625,
+            "footprintMiB": 19.625938,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.22473275,
+            "rssMiB": 108.921875,
+            "footprintMiB": 322.688507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.054316292,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628545538,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.192028458,
+            "rssMiB": 37.140625,
+            "footprintMiB": 19.625938,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.29409775,
+            "rssMiB": 108.9375,
+            "footprintMiB": 322.688507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0555135,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628546046,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.196699292,
+            "rssMiB": 37.5625,
+            "footprintMiB": 20.047813,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.370744042,
+            "rssMiB": 108.984375,
+            "footprintMiB": 322.688507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.056623958,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628546541,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.202363042,
+            "rssMiB": 37.6875,
+            "footprintMiB": 20.000938,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.424828333,
+            "rssMiB": 109.125,
+            "footprintMiB": 322.813507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.057551542,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628547051,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.20587975,
+            "rssMiB": 37.875,
+            "footprintMiB": 20.188438,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.483187083,
+            "rssMiB": 109.140625,
+            "footprintMiB": 322.719757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.058538208,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628547549,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.209295,
+            "rssMiB": 37.875,
+            "footprintMiB": 20.188438,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.544194458,
+            "rssMiB": 109.171875,
+            "footprintMiB": 322.735382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.059635958,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628548049,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.215294375,
+            "rssMiB": 38.09375,
+            "footprintMiB": 20.407188,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.612198167,
+            "rssMiB": 109.21875,
+            "footprintMiB": 322.782257,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 39
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.061061875,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628548538,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.217394458,
+            "rssMiB": 38.1875,
+            "footprintMiB": 20.485313,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.647043958,
+            "rssMiB": 109.28125,
+            "footprintMiB": 322.829132,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.061898375,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628549051,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.222067583,
+            "rssMiB": 39.03125,
+            "footprintMiB": 21.313438,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.710263292,
+            "rssMiB": 109.28125,
+            "footprintMiB": 322.829132,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.062903208,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628549554,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.224917375,
+            "rssMiB": 39.078125,
+            "footprintMiB": 21.360313,
+            "lifetimePeakFootprintMiB": 21.704041,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.777728917,
+            "rssMiB": 109.3125,
+            "footprintMiB": 322.844757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.064290833,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628550061,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.229884708,
+            "rssMiB": 40.109375,
+            "footprintMiB": 22.219688,
+            "lifetimePeakFootprintMiB": 22.219688,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.836599167,
+            "rssMiB": 109.578125,
+            "footprintMiB": 323.110382,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.065699458,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628550553,
+          "phase": "stream",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.232422708,
+            "rssMiB": 40.125,
+            "footprintMiB": 22.235313,
+            "lifetimePeakFootprintMiB": 22.235313,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.899685417,
+            "rssMiB": 109.59375,
+            "footprintMiB": 322.844757,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 42
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.066747375,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628551058,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.234297583,
+            "rssMiB": 40.515625,
+            "footprintMiB": 22.375938,
+            "lifetimePeakFootprintMiB": 22.375938,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.91263175,
+            "rssMiB": 110.40625,
+            "footprintMiB": 323.454132,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628551551,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.238392667,
+            "rssMiB": 41.265625,
+            "footprintMiB": 22.907188,
+            "lifetimePeakFootprintMiB": 22.907188,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.915413792,
+            "rssMiB": 110.40625,
+            "footprintMiB": 323.454132,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628552063,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.238856292,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.918715208,
+            "rssMiB": 110.40625,
+            "footprintMiB": 323.454132,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628552552,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.238991667,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.922005042,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628553058,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.238991667,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.924901792,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628553558,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.23908325,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.928085792,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628554056,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.239238292,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.932939042,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628554560,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.23938375,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.937552208,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628555066,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.23938375,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.942405208,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628555562,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.239500667,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.948099833,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628556061,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.239500667,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.953291708,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628556570,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.239670292,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.957973833,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628557067,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.239670292,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.962657417,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.438507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628557567,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.239769667,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.968946208,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.17215,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628558065,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.239769667,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.974380917,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 44
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.0159,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628558568,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.239943083,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.979709292,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 45
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.0159,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628559067,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.239943083,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.985511667,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 45
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.0159,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628559569,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.240097333,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.990537333,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 45
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.0159,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628560065,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.240097333,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.992840208,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 45
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.0159,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628560583,
+          "phase": "settled",
+          "engine": {
+            "pid": 58699,
+            "cpuSeconds": 0.240320292,
+            "rssMiB": 41.296875,
+            "footprintMiB": 22.938438,
+            "lifetimePeakFootprintMiB": 22.938438,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 58750,
+            "cpuSeconds": 2.995896625,
+            "rssMiB": 110.421875,
+            "footprintMiB": 323.313507,
+            "lifetimePeakFootprintMiB": 340.688507,
+            "idleWakeups": 45
+          },
+          "harness": [
+            {
+              "pid": 59315,
+              "cpuSeconds": 0.0668315,
+              "rssMiB": 9.84375,
+              "footprintMiB": 6.0159,
+              "lifetimePeakFootprintMiB": 6.17215,
+              "idleWakeups": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "summary": {
+        "binarySha256": "1f6c253eec14756da12efdb41ffbe4c4aba31c925f2bf0df7d48ae781bfda3e6",
+        "harness": "claude-code",
+        "mode": "replay",
+        "platform": "darwin",
+        "arch": "arm64",
+        "renderThreads": "default",
+        "frameStats": "0",
+        "submission": "rpc",
+        "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+        "replyBytes": 52624,
+        "transcriptBytes": 55067,
+        "frames": 151,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.031,
+            "engine": {
+              "peakFootprintMiB": 23.188416,
+              "endFootprintMiB": 23.094666,
+              "lifetimePeakFootprintMiB": 23.188416,
+              "peakRssMiB": 34.84375,
+              "endRssMiB": 30.40625,
+              "cpuPercent": 0.04221753958587081
+            },
+            "ui": {
+              "peakFootprintMiB": 303.50103,
+              "endFootprintMiB": 298.50103,
+              "lifetimePeakFootprintMiB": 342.06353,
+              "peakRssMiB": 97.171875,
+              "endRssMiB": 97.171875,
+              "cpuPercent": 0.6060896689181704
+            }
+          },
+          "stream": {
+            "durationSeconds": 19.551,
+            "engine": {
+              "peakFootprintMiB": 24.672813,
+              "endFootprintMiB": 24.672813,
+              "lifetimePeakFootprintMiB": 24.672813,
+              "peakRssMiB": 37.625,
+              "endRssMiB": 36.859375,
+              "cpuPercent": 0.7798098562733365
+            },
+            "ui": {
+              "peakFootprintMiB": 325.985405,
+              "endFootprintMiB": 325.93853,
+              "lifetimePeakFootprintMiB": 342.06353,
+              "peakRssMiB": 111.46875,
+              "endRssMiB": 103.5,
+              "cpuPercent": 13.307980195386426
+            }
+          },
+          "settled": {
+            "durationSeconds": 9.531,
+            "engine": {
+              "peakFootprintMiB": 24.079063,
+              "endFootprintMiB": 23.954063,
+              "lifetimePeakFootprintMiB": 24.672813,
+              "peakRssMiB": 38.71875,
+              "endRssMiB": 34.84375,
+              "cpuPercent": 0.06391861294722483
+            },
+            "ui": {
+              "peakFootprintMiB": 326.43853,
+              "endFootprintMiB": 326.25103,
+              "lifetimePeakFootprintMiB": 342.06353,
+              "peakRssMiB": 104.390625,
+              "endRssMiB": 103.9375,
+              "cpuPercent": 0.8339392508656004
+            }
+          }
+        },
+        "postCompletionTail": {
+          "durationSeconds": 9.531,
+          "engine": {
+            "endFootprintMiB": 23.954063,
+            "endRssMiB": 34.84375,
+            "cpuPercent": 0.06391861294722483
+          },
+          "ui": {
+            "endFootprintMiB": 326.25103,
+            "endRssMiB": 103.9375,
+            "cpuPercent": 0.8339392508656004
+          }
+        },
+        "label": "after-2"
+      },
+      "samples": [
+        {
+          "at": 1788628705506,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.076221167,
+            "rssMiB": 34.84375,
+            "footprintMiB": 22.860291,
+            "lifetimePeakFootprintMiB": 22.860291,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.346431625,
+            "rssMiB": 96.703125,
+            "footprintMiB": 303.172905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": [
+            {
+              "pid": 61807,
+              "cpuSeconds": 1.644264792,
+              "rssMiB": 610.640625,
+              "footprintMiB": 435.407623,
+              "lifetimePeakFootprintMiB": 654.06385,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 61974,
+              "cpuSeconds": 1.430027292,
+              "rssMiB": 156.796875,
+              "footprintMiB": 120.092247,
+              "lifetimePeakFootprintMiB": 120.092247,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628706002,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.076221167,
+            "rssMiB": 34.84375,
+            "footprintMiB": 22.860291,
+            "lifetimePeakFootprintMiB": 22.860291,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.347817083,
+            "rssMiB": 96.703125,
+            "footprintMiB": 303.172905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": [
+            {
+              "pid": 61807,
+              "cpuSeconds": 1.644867,
+              "rssMiB": 610.640625,
+              "footprintMiB": 435.345123,
+              "lifetimePeakFootprintMiB": 654.06385,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 61974,
+              "cpuSeconds": 1.840909875,
+              "rssMiB": 164.53125,
+              "footprintMiB": 128.640381,
+              "lifetimePeakFootprintMiB": 128.640381,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628706503,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.07626475,
+            "rssMiB": 34.84375,
+            "footprintMiB": 22.860291,
+            "lifetimePeakFootprintMiB": 22.860291,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.349563042,
+            "rssMiB": 96.703125,
+            "footprintMiB": 303.172905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": [
+            {
+              "pid": 61807,
+              "cpuSeconds": 1.648163417,
+              "rssMiB": 545.4375,
+              "footprintMiB": 435.360748,
+              "lifetimePeakFootprintMiB": 654.06385,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 61974,
+              "cpuSeconds": 2.430550625,
+              "rssMiB": 176.125,
+              "footprintMiB": 141.470314,
+              "lifetimePeakFootprintMiB": 141.470314,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788628707004,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.076271,
+            "rssMiB": 28.34375,
+            "footprintMiB": 22.860291,
+            "lifetimePeakFootprintMiB": 22.860291,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.351227417,
+            "rssMiB": 96.703125,
+            "footprintMiB": 303.172905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": [
+            {
+              "pid": 61807,
+              "cpuSeconds": 1.648662625,
+              "rssMiB": 507.4375,
+              "footprintMiB": 435.407623,
+              "lifetimePeakFootprintMiB": 654.06385,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 61974,
+              "cpuSeconds": 3.005669875,
+              "rssMiB": 181.109375,
+              "footprintMiB": 152.299904,
+              "lifetimePeakFootprintMiB": 152.299904,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788628707505,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.076612708,
+            "rssMiB": 27.5625,
+            "footprintMiB": 22.860291,
+            "lifetimePeakFootprintMiB": 22.860291,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.353385708,
+            "rssMiB": 96.640625,
+            "footprintMiB": 303.172905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": [
+            {
+              "pid": 61807,
+              "cpuSeconds": 1.665134542,
+              "rssMiB": 508.8125,
+              "footprintMiB": 0,
+              "lifetimePeakFootprintMiB": 654.06385,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628708020,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.077761375,
+            "rssMiB": 30.40625,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.360979458,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628708519,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.077887125,
+            "rssMiB": 30.40625,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.365865,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628709028,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.077887125,
+            "rssMiB": 30.40625,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.370866333,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628709524,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.078180042,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.376601625,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628710027,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.078180042,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.37945925,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628710529,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.078327708,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.381951292,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628711028,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.078356125,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.383044583,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628711518,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.078632125,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.385571167,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628712038,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.078632125,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.387883667,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628712533,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.078761583,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.39055425,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628713034,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.078761583,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.392846542,
+            "rssMiB": 97.171875,
+            "footprintMiB": 303.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 0
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628713537,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.079043292,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.395957083,
+            "rssMiB": 97.171875,
+            "footprintMiB": 298.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 2
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628714033,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.079043292,
+            "rssMiB": 30.421875,
+            "footprintMiB": 23.188416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.398512542,
+            "rssMiB": 97.171875,
+            "footprintMiB": 298.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 2
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628714537,
+          "phase": "idle",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.080033833,
+            "rssMiB": 30.40625,
+            "footprintMiB": 23.094666,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.401167583,
+            "rssMiB": 97.171875,
+            "footprintMiB": 298.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 2
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628715026,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.087337167,
+            "rssMiB": 31.390625,
+            "footprintMiB": 22.750916,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.403952375,
+            "rssMiB": 97.171875,
+            "footprintMiB": 298.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 2
+          },
+          "harness": []
+        },
+        {
+          "at": 1788628715535,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.102051042,
+            "rssMiB": 33.234375,
+            "footprintMiB": 18.375916,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.461662542,
+            "rssMiB": 100.84375,
+            "footprintMiB": 318.56353,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.023655125,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628716048,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.108107,
+            "rssMiB": 33.484375,
+            "footprintMiB": 18.500916,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.532672375,
+            "rssMiB": 107.53125,
+            "footprintMiB": 322.15728,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.024580875,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628716538,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.110848,
+            "rssMiB": 33.5,
+            "footprintMiB": 18.516541,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.593610792,
+            "rssMiB": 108.703125,
+            "footprintMiB": 323.204155,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.025662542,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628717039,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.113628,
+            "rssMiB": 33.546875,
+            "footprintMiB": 18.547791,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.657661417,
+            "rssMiB": 109.453125,
+            "footprintMiB": 323.59478,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.026833375,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628717541,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.117987083,
+            "rssMiB": 33.84375,
+            "footprintMiB": 18.813416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.726424708,
+            "rssMiB": 110.015625,
+            "footprintMiB": 324.09478,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.028084542,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628718043,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.121529083,
+            "rssMiB": 34.125,
+            "footprintMiB": 19.079041,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.799966458,
+            "rssMiB": 110.15625,
+            "footprintMiB": 323.46978,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.02969675,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628718543,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.125194583,
+            "rssMiB": 34.578125,
+            "footprintMiB": 19.500916,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.863874458,
+            "rssMiB": 110.171875,
+            "footprintMiB": 323.485405,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.0308505,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628719052,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.128009542,
+            "rssMiB": 34.671875,
+            "footprintMiB": 19.594666,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.928387458,
+            "rssMiB": 110.609375,
+            "footprintMiB": 323.922905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.031943542,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628719538,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.13111725,
+            "rssMiB": 35.125,
+            "footprintMiB": 19.922791,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 0.984856667,
+            "rssMiB": 110.671875,
+            "footprintMiB": 323.68853,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.032971417,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628720053,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.134515625,
+            "rssMiB": 35.203125,
+            "footprintMiB": 19.938416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.063959417,
+            "rssMiB": 110.9375,
+            "footprintMiB": 323.735405,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.034125667,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628720537,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.137803292,
+            "rssMiB": 35.390625,
+            "footprintMiB": 20.110291,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.119246417,
+            "rssMiB": 110.984375,
+            "footprintMiB": 323.59478,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.03495925,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628721050,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.140927833,
+            "rssMiB": 35.40625,
+            "footprintMiB": 20.125916,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.192522667,
+            "rssMiB": 111.125,
+            "footprintMiB": 323.62603,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.03620975,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628721557,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.14537175,
+            "rssMiB": 35.890625,
+            "footprintMiB": 20.610291,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.270623,
+            "rssMiB": 111.203125,
+            "footprintMiB": 323.672905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.037546708,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628722057,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.148547542,
+            "rssMiB": 36.09375,
+            "footprintMiB": 20.735291,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.341148208,
+            "rssMiB": 111.328125,
+            "footprintMiB": 323.766655,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.038781208,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628722547,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.151836125,
+            "rssMiB": 36.34375,
+            "footprintMiB": 20.969666,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.3974975,
+            "rssMiB": 111.328125,
+            "footprintMiB": 323.766655,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.039634,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628723062,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.154689125,
+            "rssMiB": 36.421875,
+            "footprintMiB": 21.000916,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.460061958,
+            "rssMiB": 111.4375,
+            "footprintMiB": 323.87603,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.040691625,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628723560,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.159141542,
+            "rssMiB": 36.6875,
+            "footprintMiB": 21.235291,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.537079042,
+            "rssMiB": 111.46875,
+            "footprintMiB": 323.90728,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.041901917,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628724052,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.162228625,
+            "rssMiB": 36.71875,
+            "footprintMiB": 21.063416,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.608539917,
+            "rssMiB": 111.46875,
+            "footprintMiB": 323.90728,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.043054417,
+              "rssMiB": 9.828125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628724544,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.164974042,
+            "rssMiB": 35.671875,
+            "footprintMiB": 21.469666,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.663749792,
+            "rssMiB": 102.859375,
+            "footprintMiB": 324.704155,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.044010375,
+              "rssMiB": 7.765625,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628725064,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.168213708,
+            "rssMiB": 34.875,
+            "footprintMiB": 21.500916,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.728895792,
+            "rssMiB": 102.375,
+            "footprintMiB": 324.860405,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.044945458,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628725552,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.17183,
+            "rssMiB": 35.03125,
+            "footprintMiB": 21.485291,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.796865,
+            "rssMiB": 102.546875,
+            "footprintMiB": 324.860405,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.046241083,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628726060,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.175679333,
+            "rssMiB": 35.46875,
+            "footprintMiB": 21.860291,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.875125,
+            "rssMiB": 103.1875,
+            "footprintMiB": 325.141655,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.047417917,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628726556,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.178132625,
+            "rssMiB": 35.609375,
+            "footprintMiB": 21.922791,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.924054708,
+            "rssMiB": 103.25,
+            "footprintMiB": 325.18853,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.048569125,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628727059,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.181666667,
+            "rssMiB": 35.96875,
+            "footprintMiB": 22.141541,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 1.993713667,
+            "rssMiB": 103.28125,
+            "footprintMiB": 325.141655,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.049696167,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628727556,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.184636292,
+            "rssMiB": 35.96875,
+            "footprintMiB": 22.141541,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.062253792,
+            "rssMiB": 103.359375,
+            "footprintMiB": 325.21978,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.050870917,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628728061,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.188067458,
+            "rssMiB": 36.25,
+            "footprintMiB": 22.422791,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.135889458,
+            "rssMiB": 103.390625,
+            "footprintMiB": 325.235405,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.052038625,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628728561,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.190050875,
+            "rssMiB": 36.25,
+            "footprintMiB": 22.422791,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.186521333,
+            "rssMiB": 103.5625,
+            "footprintMiB": 325.40728,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.053033083,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628729065,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.193650875,
+            "rssMiB": 36.59375,
+            "footprintMiB": 22.454041,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.252361833,
+            "rssMiB": 103.671875,
+            "footprintMiB": 325.50103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.054023833,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628729564,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.196946667,
+            "rssMiB": 36.59375,
+            "footprintMiB": 22.454041,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.326299667,
+            "rssMiB": 103.90625,
+            "footprintMiB": 325.704155,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.055328792,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628730069,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.201988792,
+            "rssMiB": 36.890625,
+            "footprintMiB": 22.610313,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.399396833,
+            "rssMiB": 103.984375,
+            "footprintMiB": 325.53228,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.056563208,
+              "rssMiB": 7.703125,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628730570,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.207539667,
+            "rssMiB": 36.953125,
+            "footprintMiB": 22.610313,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.456085708,
+            "rssMiB": 104.015625,
+            "footprintMiB": 325.547905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.057623333,
+              "rssMiB": 7.71875,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628731066,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.212190667,
+            "rssMiB": 37.265625,
+            "footprintMiB": 22.735313,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.523733667,
+            "rssMiB": 104.109375,
+            "footprintMiB": 325.53228,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.058626375,
+              "rssMiB": 7.71875,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628731571,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.215966625,
+            "rssMiB": 37.5625,
+            "footprintMiB": 22.844688,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.603876708,
+            "rssMiB": 104.15625,
+            "footprintMiB": 325.56353,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.059711417,
+              "rssMiB": 7.71875,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628732077,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.221425,
+            "rssMiB": 37.625,
+            "footprintMiB": 22.860313,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.68237325,
+            "rssMiB": 104.1875,
+            "footprintMiB": 325.579155,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.061152417,
+              "rssMiB": 7.71875,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628732594,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.224573917,
+            "rssMiB": 36.578125,
+            "footprintMiB": 22.985313,
+            "lifetimePeakFootprintMiB": 23.188416,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.745101292,
+            "rssMiB": 103.390625,
+            "footprintMiB": 325.829155,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.062305375,
+              "rssMiB": 7.71875,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628733070,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.228300458,
+            "rssMiB": 35.734375,
+            "footprintMiB": 23.688438,
+            "lifetimePeakFootprintMiB": 23.688438,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.802779583,
+            "rssMiB": 103.28125,
+            "footprintMiB": 325.860405,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 7
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.063440875,
+              "rssMiB": 6.359375,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628733581,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.23195825,
+            "rssMiB": 35.8125,
+            "footprintMiB": 23.766563,
+            "lifetimePeakFootprintMiB": 23.766563,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.87917225,
+            "rssMiB": 103.328125,
+            "footprintMiB": 325.87603,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 7
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.064643625,
+              "rssMiB": 6.359375,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788628734071,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.236386167,
+            "rssMiB": 36.171875,
+            "footprintMiB": 24.032188,
+            "lifetimePeakFootprintMiB": 24.032188,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 2.947999333,
+            "rssMiB": 103.484375,
+            "footprintMiB": 325.985405,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 14
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.065910125,
+              "rssMiB": 6.359375,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628734577,
+          "phase": "stream",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.239797792,
+            "rssMiB": 36.859375,
+            "footprintMiB": 24.672813,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.005795583,
+            "rssMiB": 103.5,
+            "footprintMiB": 325.93853,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 16
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.066954833,
+              "rssMiB": 6.359375,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628735077,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.242229,
+            "rssMiB": 37.65625,
+            "footprintMiB": 23.344688,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.021893208,
+            "rssMiB": 104.34375,
+            "footprintMiB": 326.43853,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 16
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628735578,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.246224958,
+            "rssMiB": 38.65625,
+            "footprintMiB": 24.047813,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.024438292,
+            "rssMiB": 104.34375,
+            "footprintMiB": 326.43853,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 16
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628736073,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.246580792,
+            "rssMiB": 38.71875,
+            "footprintMiB": 24.063438,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.0275405,
+            "rssMiB": 104.34375,
+            "footprintMiB": 326.43853,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 16
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628736570,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.24668525,
+            "rssMiB": 38.71875,
+            "footprintMiB": 24.063438,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.030756833,
+            "rssMiB": 104.375,
+            "footprintMiB": 326.329155,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628737082,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.24668525,
+            "rssMiB": 38.71875,
+            "footprintMiB": 24.063438,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.033321042,
+            "rssMiB": 104.375,
+            "footprintMiB": 326.329155,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.156525,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628737581,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.246779875,
+            "rssMiB": 38.71875,
+            "footprintMiB": 24.063438,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.035944792,
+            "rssMiB": 104.390625,
+            "footprintMiB": 326.297905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628738073,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.246948625,
+            "rssMiB": 38.328125,
+            "footprintMiB": 24.079063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.039401083,
+            "rssMiB": 104.390625,
+            "footprintMiB": 326.297905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 21
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628738587,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.247038208,
+            "rssMiB": 38.328125,
+            "footprintMiB": 24.079063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.042412833,
+            "rssMiB": 104.390625,
+            "footprintMiB": 326.297905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 21
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628739084,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.247038208,
+            "rssMiB": 38.328125,
+            "footprintMiB": 24.079063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.04549025,
+            "rssMiB": 104.390625,
+            "footprintMiB": 326.297905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 21
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628739607,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.247173833,
+            "rssMiB": 35.953125,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.048997,
+            "rssMiB": 104.34375,
+            "footprintMiB": 326.297905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 21
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628740098,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.247319125,
+            "rssMiB": 35.953125,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.05263475,
+            "rssMiB": 104.34375,
+            "footprintMiB": 326.297905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 21
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628740598,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.247471042,
+            "rssMiB": 35.953125,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.058189458,
+            "rssMiB": 104.34375,
+            "footprintMiB": 326.297905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 21
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628741101,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.247479917,
+            "rssMiB": 35.953125,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.062921042,
+            "rssMiB": 104.34375,
+            "footprintMiB": 326.297905,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 21
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628741598,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.247563042,
+            "rssMiB": 35.953125,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.066459167,
+            "rssMiB": 104.34375,
+            "footprintMiB": 326.266655,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 22
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628742101,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.247865125,
+            "rssMiB": 35.46875,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.073891042,
+            "rssMiB": 104.28125,
+            "footprintMiB": 326.266655,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 31
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628742608,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.248017542,
+            "rssMiB": 35.453125,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.079563625,
+            "rssMiB": 104.28125,
+            "footprintMiB": 326.266655,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 31
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628743092,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.248017542,
+            "rssMiB": 35.453125,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.084833875,
+            "rssMiB": 104.28125,
+            "footprintMiB": 326.266655,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 31
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628743609,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.248144125,
+            "rssMiB": 34.921875,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.091422125,
+            "rssMiB": 104.21875,
+            "footprintMiB": 326.25103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 31
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628744115,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.248234375,
+            "rssMiB": 34.90625,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.09811525,
+            "rssMiB": 104.09375,
+            "footprintMiB": 326.25103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 32
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788628744608,
+          "phase": "settled",
+          "engine": {
+            "pid": 61737,
+            "cpuSeconds": 0.248321083,
+            "rssMiB": 34.84375,
+            "footprintMiB": 23.954063,
+            "lifetimePeakFootprintMiB": 24.672813,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 61793,
+            "cpuSeconds": 3.101375958,
+            "rssMiB": 103.9375,
+            "footprintMiB": 326.25103,
+            "lifetimePeakFootprintMiB": 342.06353,
+            "idleWakeups": 35
+          },
+          "harness": [
+            {
+              "pid": 62367,
+              "cpuSeconds": 0.067236208,
+              "rssMiB": 6.5,
+              "footprintMiB": 6.000275,
+              "lifetimePeakFootprintMiB": 6.156525,
+              "idleWakeups": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/performance/resource-macos-offscreen.json
+++ b/docs/performance/resource-macos-offscreen.json
@@ -1,0 +1,3340 @@
+{
+  "platform": "macOS 26.0.1 (25A362), arm64, Mac16,7, 24 GiB RAM",
+  "kind": "UI-only native CoreText/Metal offscreen replay; no window compositor or engine",
+  "windowLogicalPixels": [
+    1320,
+    880
+  ],
+  "scaleFactor": 2,
+  "baselineApp": "f10ef38c39256602b984201c01817746cd58ca67",
+  "baselineZui": "49f9abd196705eda6a27080c506295a19b5da63e",
+  "candidateZui": "0003b923354ea8938b2d0cadbd17ef93108e2ae5",
+  "traceSha256": "9d13d6cc6533ef9822db4332fa5a5d6b41f68851b2993b13a27f1d9d76b44628",
+  "method": "Sequential runs, no concurrent builds. 500ms samples. First 2s of each phase excluded. Replay includes initial gap before text. Settled includes fixed 8ms polling; it is not native window idle CPU. Same profiling driver and allocator for both builds. Baseline adds only the profiling driver and embedded TestPlatform launch support.",
+  "runs": [
+    {
+      "build": "baseline",
+      "binarySha256": "5f5f722926e20a64a528f4c82c4be2bfe3f330e3b42cea689024839dd02469a6",
+      "completedPngSha256": "1239080bd0b08d77780c628a05b43fa76099fa8737d605c5689d1b72ffb3de7c",
+      "summary": {
+        "replay": {
+          "durationSeconds": 23.786408959,
+          "cpuPercent": 18.22799351711087,
+          "peakFootprintMiB": 286.532349,
+          "endFootprintMiB": 286.532349
+        },
+        "settled": {
+          "durationSeconds": 12.435139625000001,
+          "cpuPercent": 0.32687242142646866,
+          "peakFootprintMiB": 128.563667,
+          "endFootprintMiB": 92.626167
+        }
+      },
+      "samples": [
+        {
+          "at": 0.033511416,
+          "phase": "startup",
+          "pid": 20768,
+          "cpuSeconds": 0.000642875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 0.550453125,
+          "phase": "startup",
+          "pid": 20768,
+          "cpuSeconds": 0.000642875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 1.066169708,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.207116708,
+          "rssMiB": 53.984375,
+          "footprintMiB": 233.579201,
+          "lifetimePeakFootprintMiB": 233.579201,
+          "idleWakeups": 0
+        },
+        {
+          "at": 1.587742458,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.271414333,
+          "rssMiB": 53.421875,
+          "footprintMiB": 279.110474,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 2.091233125,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.308089417,
+          "rssMiB": 53.546875,
+          "footprintMiB": 279.126099,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 2.616436041,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.309638542,
+          "rssMiB": 53.5,
+          "footprintMiB": 271.860474,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 3.135988416,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.31151275,
+          "rssMiB": 53.5,
+          "footprintMiB": 69.860474,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 3.654370583,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.313466125,
+          "rssMiB": 53.5,
+          "footprintMiB": 67.422974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 4.175422708,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.315153875,
+          "rssMiB": 53.5,
+          "footprintMiB": 67.422974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 4.68751075,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.316582292,
+          "rssMiB": 53.5,
+          "footprintMiB": 67.422974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 5.198538958,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.352614708,
+          "rssMiB": 54.1875,
+          "footprintMiB": 272.063599,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 5.718412291,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.445226833,
+          "rssMiB": 57.453125,
+          "footprintMiB": 274.344849,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 6.241184583,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.573443,
+          "rssMiB": 66.46875,
+          "footprintMiB": 279.969849,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 6.762305375,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.678251333,
+          "rssMiB": 67.921875,
+          "footprintMiB": 280.563599,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 7.282080166,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.749127167,
+          "rssMiB": 68.375,
+          "footprintMiB": 281.016724,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 7.797170916,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.846818708,
+          "rssMiB": 68.859375,
+          "footprintMiB": 281.485474,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 8.315662166,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.952428667,
+          "rssMiB": 68.96875,
+          "footprintMiB": 281.579224,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 8.836192083,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.049371625,
+          "rssMiB": 69.359375,
+          "footprintMiB": 281.922974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 9.355992,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.149459792,
+          "rssMiB": 69.78125,
+          "footprintMiB": 282.313599,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 9.873664583,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.257006417,
+          "rssMiB": 69.875,
+          "footprintMiB": 282.376099,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 10.386000375,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.339324,
+          "rssMiB": 69.90625,
+          "footprintMiB": 282.407349,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 10.896526125,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.454356708,
+          "rssMiB": 70.296875,
+          "footprintMiB": 282.797974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 11.409421125,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.547157542,
+          "rssMiB": 70.640625,
+          "footprintMiB": 283.141724,
+          "lifetimePeakFootprintMiB": 285.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 11.929161083,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.65513925,
+          "rssMiB": 70.71875,
+          "footprintMiB": 283.204224,
+          "lifetimePeakFootprintMiB": 285.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 12.439635,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.752278667,
+          "rssMiB": 70.78125,
+          "footprintMiB": 283.110474,
+          "lifetimePeakFootprintMiB": 285.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 12.95440525,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.866936125,
+          "rssMiB": 70.90625,
+          "footprintMiB": 283.157349,
+          "lifetimePeakFootprintMiB": 285.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 13.468577666,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.986906667,
+          "rssMiB": 71.234375,
+          "footprintMiB": 283.485474,
+          "lifetimePeakFootprintMiB": 285.485474,
+          "idleWakeups": 0
+        },
+        {
+          "at": 13.986001041,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.088987167,
+          "rssMiB": 71.625,
+          "footprintMiB": 283.844849,
+          "lifetimePeakFootprintMiB": 285.844849,
+          "idleWakeups": 0
+        },
+        {
+          "at": 14.503704625,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.191764042,
+          "rssMiB": 71.703125,
+          "footprintMiB": 283.876099,
+          "lifetimePeakFootprintMiB": 285.860474,
+          "idleWakeups": 0
+        },
+        {
+          "at": 15.023150458,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.291109875,
+          "rssMiB": 71.828125,
+          "footprintMiB": 283.985474,
+          "lifetimePeakFootprintMiB": 285.985474,
+          "idleWakeups": 0
+        },
+        {
+          "at": 15.5424895,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.413381792,
+          "rssMiB": 71.875,
+          "footprintMiB": 284.001099,
+          "lifetimePeakFootprintMiB": 286.001099,
+          "idleWakeups": 0
+        },
+        {
+          "at": 16.054139,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.51961525,
+          "rssMiB": 71.96875,
+          "footprintMiB": 284.079224,
+          "lifetimePeakFootprintMiB": 286.079224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 16.5703625,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.632105833,
+          "rssMiB": 72.34375,
+          "footprintMiB": 284.001099,
+          "lifetimePeakFootprintMiB": 286.079224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 17.089874,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.739234458,
+          "rssMiB": 72.515625,
+          "footprintMiB": 284.094849,
+          "lifetimePeakFootprintMiB": 286.079224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 17.605746083,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.850653583,
+          "rssMiB": 72.640625,
+          "footprintMiB": 284.188599,
+          "lifetimePeakFootprintMiB": 286.157349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 18.124720916,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.955461625,
+          "rssMiB": 72.65625,
+          "footprintMiB": 284.204224,
+          "lifetimePeakFootprintMiB": 286.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 18.641353041,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.050271708,
+          "rssMiB": 72.609375,
+          "footprintMiB": 284.266724,
+          "lifetimePeakFootprintMiB": 286.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 19.155981208,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.159437583,
+          "rssMiB": 72.5,
+          "footprintMiB": 284.485474,
+          "lifetimePeakFootprintMiB": 286.422974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 19.672683458,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.257584583,
+          "rssMiB": 72.515625,
+          "footprintMiB": 284.454224,
+          "lifetimePeakFootprintMiB": 286.438599,
+          "idleWakeups": 0
+        },
+        {
+          "at": 20.190915208,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.359036208,
+          "rssMiB": 70.203125,
+          "footprintMiB": 284.719849,
+          "lifetimePeakFootprintMiB": 286.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 20.713539291,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.463870125,
+          "rssMiB": 69.734375,
+          "footprintMiB": 284.766724,
+          "lifetimePeakFootprintMiB": 286.751099,
+          "idleWakeups": 0
+        },
+        {
+          "at": 21.233471,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.575535875,
+          "rssMiB": 69.734375,
+          "footprintMiB": 284.782349,
+          "lifetimePeakFootprintMiB": 286.782349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 21.752610625,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.685464375,
+          "rssMiB": 67.953125,
+          "footprintMiB": 284.922974,
+          "lifetimePeakFootprintMiB": 286.907349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 22.26963275,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.792121958,
+          "rssMiB": 68.0,
+          "footprintMiB": 284.969849,
+          "lifetimePeakFootprintMiB": 286.969849,
+          "idleWakeups": 0
+        },
+        {
+          "at": 22.78543,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.892053125,
+          "rssMiB": 68.109375,
+          "footprintMiB": 284.985474,
+          "lifetimePeakFootprintMiB": 286.985474,
+          "idleWakeups": 0
+        },
+        {
+          "at": 23.297050833,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.003509375,
+          "rssMiB": 64.1875,
+          "footprintMiB": 286.172974,
+          "lifetimePeakFootprintMiB": 288.172974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 23.815236875,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.110093583,
+          "rssMiB": 63.828125,
+          "footprintMiB": 286.297974,
+          "lifetimePeakFootprintMiB": 288.297974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 24.331643833,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.147101042,
+          "rssMiB": 62.109375,
+          "footprintMiB": 286.297974,
+          "lifetimePeakFootprintMiB": 288.407349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 24.846172208,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.223197542,
+          "rssMiB": 62.1875,
+          "footprintMiB": 286.516724,
+          "lifetimePeakFootprintMiB": 288.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 25.364973416,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.322203833,
+          "rssMiB": 62.21875,
+          "footprintMiB": 286.438599,
+          "lifetimePeakFootprintMiB": 288.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 25.882240875,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.421928917,
+          "rssMiB": 62.25,
+          "footprintMiB": 286.469849,
+          "lifetimePeakFootprintMiB": 288.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 26.400499666,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.532201917,
+          "rssMiB": 62.375,
+          "footprintMiB": 286.485474,
+          "lifetimePeakFootprintMiB": 288.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 26.922397375,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.647297833,
+          "rssMiB": 62.390625,
+          "footprintMiB": 286.532349,
+          "lifetimePeakFootprintMiB": 288.532349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 27.437656791,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.687379083,
+          "rssMiB": 103.515625,
+          "footprintMiB": 335.329292,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 27.951710708,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.688464042,
+          "rssMiB": 103.5,
+          "footprintMiB": 335.391792,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 28.467895916,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.690436,
+          "rssMiB": 102.765625,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 28.986392708,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.691501375,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 29.50460225,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.693314208,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 30.024527708,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.694966458,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 30.54274425,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.696776333,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 31.063910833,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.698234625,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 31.582951416,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.699848458,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 32.10613625,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.702107542,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 32.627684,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.704324333,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 33.13667075,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.706562083,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 33.652862791,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.70862425,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 34.160417708,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.710512958,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 34.680456208,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.712512292,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 35.19953725,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.7141695,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 35.719876666,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.716200375,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 36.241039541,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.717802542,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 36.760757458,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.719601708,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 37.280908791,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.721655792,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 37.795757041,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.723103583,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 38.314448291,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.724424208,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 38.828890375,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.72592625,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 39.348028166,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.727218792,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 39.86949475,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.728549958,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 40.383783583,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.729939083,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 40.904615333,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.731435542,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 41.4190235,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.732680167,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 41.939741875,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.73396125,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        }
+      ]
+    },
+    {
+      "build": "candidate",
+      "binarySha256": "1c97d7d8e64c28fa5c386cc734284d7e5ccee55e579c02a57df1adc954ccc19b",
+      "completedPngSha256": "1239080bd0b08d77780c628a05b43fa76099fa8737d605c5689d1b72ffb3de7c",
+      "summary": {
+        "replay": {
+          "durationSeconds": 23.312508834000006,
+          "cpuPercent": 18.263411490017067,
+          "peakFootprintMiB": 284.844849,
+          "endFootprintMiB": 284.844849
+        },
+        "settled": {
+          "durationSeconds": 12.437986917000003,
+          "cpuPercent": 0.3355677673446769,
+          "peakFootprintMiB": 126.813644,
+          "endFootprintMiB": 91.016769
+        }
+      },
+      "samples": [
+        {
+          "at": 42.467085833,
+          "phase": "startup",
+          "pid": 21514,
+          "cpuSeconds": 0.003089875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 42.97942875,
+          "phase": "startup",
+          "pid": 21514,
+          "cpuSeconds": 0.003089875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 43.495972958,
+          "phase": "startup",
+          "pid": 21514,
+          "cpuSeconds": 0.003089875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 44.001139791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.1904685,
+          "rssMiB": 54.765625,
+          "footprintMiB": 279.204224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 44.522562458,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.26309325,
+          "rssMiB": 53.921875,
+          "footprintMiB": 279.344849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 45.033201541,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.272071542,
+          "rssMiB": 47.484375,
+          "footprintMiB": 279.360474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 45.546255791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.272684792,
+          "rssMiB": 47.5625,
+          "footprintMiB": 272.047974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 46.058633916,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.274521833,
+          "rssMiB": 47.5625,
+          "footprintMiB": 59.610474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 46.576351541,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.27592875,
+          "rssMiB": 47.5625,
+          "footprintMiB": 59.610474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 47.092097375,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.277343375,
+          "rssMiB": 47.5625,
+          "footprintMiB": 59.610474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 47.614557208,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.278938417,
+          "rssMiB": 47.5625,
+          "footprintMiB": 59.610474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 48.135640875,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.3208125,
+          "rssMiB": 50.203125,
+          "footprintMiB": 272.907349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 48.655199708,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.418238458,
+          "rssMiB": 52.421875,
+          "footprintMiB": 274.360474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 49.173301791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.559048875,
+          "rssMiB": 62.109375,
+          "footprintMiB": 280.376099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 49.693863083,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.679105292,
+          "rssMiB": 63.921875,
+          "footprintMiB": 281.172974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 50.210468625,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.780034625,
+          "rssMiB": 64.3125,
+          "footprintMiB": 281.532349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 50.72831825,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.89592525,
+          "rssMiB": 64.828125,
+          "footprintMiB": 282.032349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 51.243031583,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.00374075,
+          "rssMiB": 65.546875,
+          "footprintMiB": 282.672974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 51.762405291,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.109333833,
+          "rssMiB": 65.671875,
+          "footprintMiB": 282.751099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 52.281835708,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.21554525,
+          "rssMiB": 65.8125,
+          "footprintMiB": 282.860474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 52.804713333,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.318153542,
+          "rssMiB": 66.234375,
+          "footprintMiB": 283.251099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 53.319499291,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.415522417,
+          "rssMiB": 66.3125,
+          "footprintMiB": 283.329224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 53.839819,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.514042542,
+          "rssMiB": 66.75,
+          "footprintMiB": 283.719849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 54.362944625,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.615480208,
+          "rssMiB": 66.84375,
+          "footprintMiB": 283.688599,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 54.8807845,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.71991175,
+          "rssMiB": 66.875,
+          "footprintMiB": 283.594849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 55.402702166,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.830747292,
+          "rssMiB": 66.90625,
+          "footprintMiB": 283.626099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 55.918638791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.916299,
+          "rssMiB": 67.15625,
+          "footprintMiB": 283.860474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 56.4381615,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.013708958,
+          "rssMiB": 67.171875,
+          "footprintMiB": 283.797974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 56.955489333,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.120936417,
+          "rssMiB": 67.5625,
+          "footprintMiB": 284.188599,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 57.472667208,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.212696792,
+          "rssMiB": 67.640625,
+          "footprintMiB": 284.219849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 57.992794833,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.332261833,
+          "rssMiB": 67.6875,
+          "footprintMiB": 283.938599,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 58.504922583,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.43825925,
+          "rssMiB": 67.765625,
+          "footprintMiB": 284.001099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 59.015943333,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.538217833,
+          "rssMiB": 67.8125,
+          "footprintMiB": 283.985474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 59.532991791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.648234375,
+          "rssMiB": 67.9375,
+          "footprintMiB": 284.094849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 60.052389291,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.745352458,
+          "rssMiB": 68.0625,
+          "footprintMiB": 284.204224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 60.563573833,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.851104833,
+          "rssMiB": 68.25,
+          "footprintMiB": 284.360474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 61.078091416,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.942907042,
+          "rssMiB": 68.28125,
+          "footprintMiB": 284.391724,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 61.593489708,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.04112375,
+          "rssMiB": 68.328125,
+          "footprintMiB": 284.422974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 62.111160791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.152065208,
+          "rssMiB": 68.40625,
+          "footprintMiB": 284.501099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 62.6297975,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.257396417,
+          "rssMiB": 68.421875,
+          "footprintMiB": 284.516724,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 63.150677583,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.362539958,
+          "rssMiB": 68.4375,
+          "footprintMiB": 284.532349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 63.676821,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.484090042,
+          "rssMiB": 68.53125,
+          "footprintMiB": 284.626099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 64.195272125,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.5863355,
+          "rssMiB": 68.5625,
+          "footprintMiB": 284.657349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 64.714193083,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.690784167,
+          "rssMiB": 68.578125,
+          "footprintMiB": 284.672974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 65.231091291,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.807920167,
+          "rssMiB": 68.703125,
+          "footprintMiB": 284.782349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 65.750555791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.893219042,
+          "rssMiB": 68.703125,
+          "footprintMiB": 284.704224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 66.271050041,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.025864208,
+          "rssMiB": 68.703125,
+          "footprintMiB": 284.704224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 66.79092675,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.117657708,
+          "rssMiB": 68.734375,
+          "footprintMiB": 284.735474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 67.304078375,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.205439333,
+          "rssMiB": 68.78125,
+          "footprintMiB": 284.766724,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 67.816120583,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.302901333,
+          "rssMiB": 68.796875,
+          "footprintMiB": 284.782349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 68.335663083,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.348522833,
+          "rssMiB": 68.8125,
+          "footprintMiB": 284.797974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 68.852326125,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.41242175,
+          "rssMiB": 68.90625,
+          "footprintMiB": 284.829224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 69.37114275,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.53218125,
+          "rssMiB": 68.921875,
+          "footprintMiB": 284.844849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 69.87741775,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.669295,
+          "rssMiB": 110.0,
+          "footprintMiB": 335.782394,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 70.387559291,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.671401125,
+          "rssMiB": 110.0,
+          "footprintMiB": 335.688644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 70.901699708,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.673006292,
+          "rssMiB": 110.0,
+          "footprintMiB": 335.688644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 71.419760625,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.67499225,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 71.936389666,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.676796542,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 72.453209416,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.678142792,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 72.9688405,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.679819375,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 73.499560125,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.681822792,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 74.013079458,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.683687333,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 74.536325166,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.685237167,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 75.054332458,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.687875542,
+          "rssMiB": 109.5625,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 75.573459791,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.689924583,
+          "rssMiB": 109.5625,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 76.090062,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.69166725,
+          "rssMiB": 109.5625,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 76.606845125,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.693390458,
+          "rssMiB": 109.5625,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 77.118404333,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.694644208,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 77.635287083,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.696503083,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 78.145620375,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.698101708,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 78.666431166,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.699576708,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 79.184604625,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.701444833,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 79.704917916,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.703262708,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 80.224885458,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.706908708,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 80.739941541,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.708314667,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 81.255414458,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.709489583,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 81.778310833,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.710967333,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 82.292053166,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.712446417,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 82.804161333,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.713674667,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 83.329868208,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.71507675,
+          "rssMiB": 109.5,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 83.856980666,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.716748125,
+          "rssMiB": 109.234375,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 84.374376583,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.718534417,
+          "rssMiB": 108.609375,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        }
+      ]
+    },
+    {
+      "build": "candidate",
+      "binarySha256": "1c97d7d8e64c28fa5c386cc734284d7e5ccee55e579c02a57df1adc954ccc19b",
+      "completedPngSha256": "1239080bd0b08d77780c628a05b43fa76099fa8737d605c5689d1b72ffb3de7c",
+      "summary": {
+        "replay": {
+          "durationSeconds": 23.331538916,
+          "cpuPercent": 18.665320790363936,
+          "peakFootprintMiB": 288.532394,
+          "endFootprintMiB": 288.454269
+        },
+        "settled": {
+          "durationSeconds": 12.419883374999998,
+          "cpuPercent": 0.3356942391578612,
+          "peakFootprintMiB": 122.298065,
+          "endFootprintMiB": 94.50119
+        }
+      },
+      "samples": [
+        {
+          "at": 84.897251125,
+          "phase": "startup",
+          "pid": 23071,
+          "cpuSeconds": 0.005180083,
+          "rssMiB": 0.71875,
+          "footprintMiB": 0.687614,
+          "lifetimePeakFootprintMiB": 0.687614,
+          "idleWakeups": 0
+        },
+        {
+          "at": 85.414959916,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.175996875,
+          "rssMiB": 54.921875,
+          "footprintMiB": 283.579269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 85.934481,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.271432458,
+          "rssMiB": 55.109375,
+          "footprintMiB": 283.501144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 86.443842166,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.27345475,
+          "rssMiB": 55.140625,
+          "footprintMiB": 273.751144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 86.958479333,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.274809833,
+          "rssMiB": 55.140625,
+          "footprintMiB": 79.751144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 87.480118875,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.276061958,
+          "rssMiB": 55.140625,
+          "footprintMiB": 69.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 87.998413083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.27749675,
+          "rssMiB": 55.140625,
+          "footprintMiB": 69.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 88.514963,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.2790895,
+          "rssMiB": 55.140625,
+          "footprintMiB": 69.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 89.030231666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.280430417,
+          "rssMiB": 55.140625,
+          "footprintMiB": 69.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 89.550729875,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.349731667,
+          "rssMiB": 53.65625,
+          "footprintMiB": 275.891769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 90.069174375,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.473935333,
+          "rssMiB": 62.734375,
+          "footprintMiB": 281.454269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 90.588645833,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.579888375,
+          "rssMiB": 64.859375,
+          "footprintMiB": 283.204269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 91.10004,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.679901458,
+          "rssMiB": 65.140625,
+          "footprintMiB": 282.610519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 91.613816291,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.777135208,
+          "rssMiB": 65.890625,
+          "footprintMiB": 283.329269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 92.134664666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.868670292,
+          "rssMiB": 66.375,
+          "footprintMiB": 283.782394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 92.650918,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.968685625,
+          "rssMiB": 66.4375,
+          "footprintMiB": 283.813644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 93.169560541,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.071347792,
+          "rssMiB": 66.8125,
+          "footprintMiB": 284.157394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 93.683503833,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.179079625,
+          "rssMiB": 67.25,
+          "footprintMiB": 284.548019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 94.223484666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.278404,
+          "rssMiB": 67.59375,
+          "footprintMiB": 284.860519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 94.73972675,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.386979875,
+          "rssMiB": 67.984375,
+          "footprintMiB": 285.251144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 95.262308041,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.513258625,
+          "rssMiB": 68.09375,
+          "footprintMiB": 285.360519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 95.786134333,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.614407375,
+          "rssMiB": 67.8125,
+          "footprintMiB": 285.735519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 96.307091,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.73093325,
+          "rssMiB": 67.671875,
+          "footprintMiB": 285.626144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 96.825367083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.8302025,
+          "rssMiB": 67.703125,
+          "footprintMiB": 285.610519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 97.346767833,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.920027583,
+          "rssMiB": 68.0,
+          "footprintMiB": 285.907394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 97.863932083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.028053458,
+          "rssMiB": 68.390625,
+          "footprintMiB": 286.298019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 98.383885625,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.134918125,
+          "rssMiB": 68.421875,
+          "footprintMiB": 286.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 98.894777875,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.248787417,
+          "rssMiB": 68.515625,
+          "footprintMiB": 286.079269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 99.414188666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.353373167,
+          "rssMiB": 68.546875,
+          "footprintMiB": 286.079269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 99.928624416,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.467906167,
+          "rssMiB": 68.65625,
+          "footprintMiB": 286.157394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 100.448054625,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.586555708,
+          "rssMiB": 67.046875,
+          "footprintMiB": 286.532394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 100.96013825,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.681576958,
+          "rssMiB": 66.78125,
+          "footprintMiB": 286.641769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 101.476905375,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.791988667,
+          "rssMiB": 67.03125,
+          "footprintMiB": 286.782394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 101.997747083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.88543075,
+          "rssMiB": 67.078125,
+          "footprintMiB": 286.829269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 102.515105541,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.982136125,
+          "rssMiB": 67.125,
+          "footprintMiB": 286.876144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 103.03269125,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.076883417,
+          "rssMiB": 67.1875,
+          "footprintMiB": 286.891769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 103.560954833,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.198256,
+          "rssMiB": 65.53125,
+          "footprintMiB": 287.548019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 104.076143375,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.284363167,
+          "rssMiB": 62.46875,
+          "footprintMiB": 288.204269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 104.591727166,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.372216375,
+          "rssMiB": 62.53125,
+          "footprintMiB": 288.329269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 105.121678666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.454920375,
+          "rssMiB": 60.0,
+          "footprintMiB": 288.469894,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 105.637431083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.573610917,
+          "rssMiB": 60.046875,
+          "footprintMiB": 288.485519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 106.150792458,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.676510042,
+          "rssMiB": 60.1875,
+          "footprintMiB": 288.532394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 106.664995291,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.782049417,
+          "rssMiB": 60.34375,
+          "footprintMiB": 288.329269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 107.18523725,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.870260375,
+          "rssMiB": 60.375,
+          "footprintMiB": 288.329269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 107.705839875,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.98257575,
+          "rssMiB": 60.515625,
+          "footprintMiB": 288.360519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 108.224598458,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.073466375,
+          "rssMiB": 60.5625,
+          "footprintMiB": 288.360519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 108.735529791,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.183010708,
+          "rssMiB": 60.65625,
+          "footprintMiB": 288.391769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 109.252967291,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.285995708,
+          "rssMiB": 60.703125,
+          "footprintMiB": 288.391769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 109.772677416,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.408499875,
+          "rssMiB": 60.8125,
+          "footprintMiB": 288.423019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 110.291622083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.523863,
+          "rssMiB": 60.96875,
+          "footprintMiB": 288.423019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 110.811657791,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.630968542,
+          "rssMiB": 61.0,
+          "footprintMiB": 288.454269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 111.330659791,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.726418667,
+          "rssMiB": 102.578125,
+          "footprintMiB": 337.173065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 111.85069075,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.728305042,
+          "rssMiB": 102.578125,
+          "footprintMiB": 337.173065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 112.367757458,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.729689375,
+          "rssMiB": 102.578125,
+          "footprintMiB": 130.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 112.887178541,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.73160725,
+          "rssMiB": 102.578125,
+          "footprintMiB": 130.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 113.406372,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.7336755,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 113.927990708,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.7354315,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 114.437070416,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.737403417,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 114.947087,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.739408958,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 115.46436025,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.741626708,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 115.981970958,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.743473333,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 116.501486958,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.745678292,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 117.012386041,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.7470895,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 117.528358625,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.748723083,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 118.046945458,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.750524667,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 118.567232458,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.752433958,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 119.086454958,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.754260667,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 119.606207041,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.756337542,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 120.121412125,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.757920583,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 120.642519541,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.759760708,
+          "rssMiB": 102.390625,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 121.155048791,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.762684125,
+          "rssMiB": 102.40625,
+          "footprintMiB": 104.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 121.674247,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.764058458,
+          "rssMiB": 102.40625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 122.192893916,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.765479417,
+          "rssMiB": 102.40625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 122.700664416,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.766881,
+          "rssMiB": 102.34375,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 123.222999791,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.767596167,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 123.741344375,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.769085958,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 124.260619708,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.770333042,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 124.784037166,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.771862583,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 125.306831166,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.773528458,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 125.826255375,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.775368333,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        }
+      ]
+    },
+    {
+      "build": "baseline",
+      "binarySha256": "5f5f722926e20a64a528f4c82c4be2bfe3f330e3b42cea689024839dd02469a6",
+      "completedPngSha256": "1239080bd0b08d77780c628a05b43fa76099fa8737d605c5689d1b72ffb3de7c",
+      "summary": {
+        "replay": {
+          "durationSeconds": 23.320005166999977,
+          "cpuPercent": 18.75516147478907,
+          "peakFootprintMiB": 279.172951,
+          "endFootprintMiB": 279.126076
+        },
+        "settled": {
+          "durationSeconds": 12.423877540999996,
+          "cpuPercent": 0.3303541174207052,
+          "peakFootprintMiB": 123.094849,
+          "endFootprintMiB": 87.594849
+        }
+      },
+      "samples": [
+        {
+          "at": 126.343401958,
+          "phase": "startup",
+          "pid": 23703,
+          "cpuSeconds": 0.005699125,
+          "rssMiB": 0.234375,
+          "footprintMiB": 0.234489,
+          "lifetimePeakFootprintMiB": 0.281364,
+          "idleWakeups": 0
+        },
+        {
+          "at": 126.863115666,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.190809375,
+          "rssMiB": 53.40625,
+          "footprintMiB": 265.469826,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 127.379541708,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.2498075,
+          "rssMiB": 53.59375,
+          "footprintMiB": 265.391701,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 127.898172958,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.25162,
+          "rssMiB": 53.640625,
+          "footprintMiB": 265.391701,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 128.414551291,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.252972458,
+          "rssMiB": 53.640625,
+          "footprintMiB": 71.391701,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 128.925446541,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.254739917,
+          "rssMiB": 53.640625,
+          "footprintMiB": 60.954201,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 129.445065208,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.256020583,
+          "rssMiB": 53.640625,
+          "footprintMiB": 60.954201,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 129.962670833,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.257509417,
+          "rssMiB": 53.640625,
+          "footprintMiB": 60.954201,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 130.481042333,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.258870458,
+          "rssMiB": 53.640625,
+          "footprintMiB": 60.954201,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 130.9994045,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.317633417,
+          "rssMiB": 56.765625,
+          "footprintMiB": 267.235451,
+          "lifetimePeakFootprintMiB": 268.235451,
+          "idleWakeups": 0
+        },
+        {
+          "at": 131.516188416,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.422578,
+          "rssMiB": 64.34375,
+          "footprintMiB": 271.922951,
+          "lifetimePeakFootprintMiB": 273.938576,
+          "idleWakeups": 0
+        },
+        {
+          "at": 132.03555725,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.534398333,
+          "rssMiB": 66.75,
+          "footprintMiB": 273.047951,
+          "lifetimePeakFootprintMiB": 275.047951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 132.546594583,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.62432725,
+          "rssMiB": 67.015625,
+          "footprintMiB": 273.297951,
+          "lifetimePeakFootprintMiB": 275.047951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 133.064618333,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.729441208,
+          "rssMiB": 67.640625,
+          "footprintMiB": 273.922951,
+          "lifetimePeakFootprintMiB": 275.297951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 133.583109416,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.835874,
+          "rssMiB": 68.484375,
+          "footprintMiB": 274.735451,
+          "lifetimePeakFootprintMiB": 276.735451,
+          "idleWakeups": 0
+        },
+        {
+          "at": 134.099132916,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.929528375,
+          "rssMiB": 68.53125,
+          "footprintMiB": 274.766701,
+          "lifetimePeakFootprintMiB": 276.735451,
+          "idleWakeups": 0
+        },
+        {
+          "at": 134.61562075,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.034768167,
+          "rssMiB": 68.703125,
+          "footprintMiB": 274.907326,
+          "lifetimePeakFootprintMiB": 276.860451,
+          "idleWakeups": 0
+        },
+        {
+          "at": 135.133568583,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.12009125,
+          "rssMiB": 68.734375,
+          "footprintMiB": 274.922951,
+          "lifetimePeakFootprintMiB": 276.922951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 135.657015166,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.236382708,
+          "rssMiB": 62.984375,
+          "footprintMiB": 276.063576,
+          "lifetimePeakFootprintMiB": 278.063576,
+          "idleWakeups": 0
+        },
+        {
+          "at": 136.169728833,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.352127125,
+          "rssMiB": 63.390625,
+          "footprintMiB": 276.469826,
+          "lifetimePeakFootprintMiB": 278.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 136.702389958,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.455347542,
+          "rssMiB": 63.28125,
+          "footprintMiB": 276.626076,
+          "lifetimePeakFootprintMiB": 278.547951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 137.215838666,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.564007792,
+          "rssMiB": 62.828125,
+          "footprintMiB": 276.532326,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 137.732871958,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.664437625,
+          "rssMiB": 63.0625,
+          "footprintMiB": 276.641701,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 138.25279975,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.777995458,
+          "rssMiB": 63.125,
+          "footprintMiB": 276.516701,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 138.770178416,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.876524458,
+          "rssMiB": 63.171875,
+          "footprintMiB": 276.563576,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 139.288323166,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.990286708,
+          "rssMiB": 63.59375,
+          "footprintMiB": 276.922951,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 139.8072385,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.101478917,
+          "rssMiB": 64.296875,
+          "footprintMiB": 277.532326,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 140.328029,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.205518917,
+          "rssMiB": 64.359375,
+          "footprintMiB": 277.563576,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 0
+        },
+        {
+          "at": 140.843137625,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.321206417,
+          "rssMiB": 64.453125,
+          "footprintMiB": 277.266701,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 0
+        },
+        {
+          "at": 141.359628708,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.433442833,
+          "rssMiB": 64.578125,
+          "footprintMiB": 277.313576,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 0
+        },
+        {
+          "at": 141.877922833,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.534781583,
+          "rssMiB": 64.640625,
+          "footprintMiB": 277.360451,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 4
+        },
+        {
+          "at": 142.393014458,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.646229333,
+          "rssMiB": 64.703125,
+          "footprintMiB": 277.422951,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 4
+        },
+        {
+          "at": 142.9171455,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.757348083,
+          "rssMiB": 64.84375,
+          "footprintMiB": 277.547951,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 4
+        },
+        {
+          "at": 143.435577791,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.863168458,
+          "rssMiB": 64.96875,
+          "footprintMiB": 277.610451,
+          "lifetimePeakFootprintMiB": 279.626076,
+          "idleWakeups": 4
+        },
+        {
+          "at": 143.95495425,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.9549945,
+          "rssMiB": 64.984375,
+          "footprintMiB": 277.610451,
+          "lifetimePeakFootprintMiB": 279.626076,
+          "idleWakeups": 4
+        },
+        {
+          "at": 144.473705291,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.0609745,
+          "rssMiB": 65.09375,
+          "footprintMiB": 277.719826,
+          "lifetimePeakFootprintMiB": 279.626076,
+          "idleWakeups": 4
+        },
+        {
+          "at": 144.9932565,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.170017042,
+          "rssMiB": 65.15625,
+          "footprintMiB": 277.782326,
+          "lifetimePeakFootprintMiB": 279.782326,
+          "idleWakeups": 4
+        },
+        {
+          "at": 145.510684083,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.26506775,
+          "rssMiB": 65.25,
+          "footprintMiB": 277.860451,
+          "lifetimePeakFootprintMiB": 279.860451,
+          "idleWakeups": 4
+        },
+        {
+          "at": 146.028799583,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.352463,
+          "rssMiB": 60.390625,
+          "footprintMiB": 279.094826,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 146.548522083,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.467887792,
+          "rssMiB": 60.421875,
+          "footprintMiB": 279.126076,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 147.060821666,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.583248333,
+          "rssMiB": 60.453125,
+          "footprintMiB": 279.001076,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 147.577100458,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.67402975,
+          "rssMiB": 60.484375,
+          "footprintMiB": 279.032326,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 148.100539916,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.792103583,
+          "rssMiB": 60.640625,
+          "footprintMiB": 279.157326,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 148.624720208,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.893535833,
+          "rssMiB": 60.671875,
+          "footprintMiB": 279.172951,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 149.142225833,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.992702375,
+          "rssMiB": 60.734375,
+          "footprintMiB": 279.063576,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 149.662251875,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.095055667,
+          "rssMiB": 60.78125,
+          "footprintMiB": 279.110451,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 150.174314208,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.193627208,
+          "rssMiB": 60.8125,
+          "footprintMiB": 279.126076,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 150.694725333,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.306322,
+          "rssMiB": 60.96875,
+          "footprintMiB": 279.110451,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 151.205250708,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.410139042,
+          "rssMiB": 61.015625,
+          "footprintMiB": 279.141701,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 151.726,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.522660417,
+          "rssMiB": 61.15625,
+          "footprintMiB": 279.126076,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 152.245451708,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.628444542,
+          "rssMiB": 61.15625,
+          "footprintMiB": 279.126076,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 152.7601945,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.743183375,
+          "rssMiB": 102.875,
+          "footprintMiB": 329.954224,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 153.273564041,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.745342625,
+          "rssMiB": 102.875,
+          "footprintMiB": 329.954224,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 153.794254333,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.746548583,
+          "rssMiB": 102.84375,
+          "footprintMiB": 127.969849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 154.308340083,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.749012708,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 154.829111375,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.750561042,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 155.347716541,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.752321083,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 155.881169916,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.754273625,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 156.401448916,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.75638375,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 156.928805583,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.75844575,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 157.443779291,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.760233208,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 157.962528625,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.762282167,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 158.482125375,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.763958542,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 158.996502916,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.765658292,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 159.517976,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.767370417,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 160.038244,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.769197792,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 160.560993,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.771114792,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 161.075912541,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.772709708,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 161.594452833,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.774483583,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 162.105145,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.776155,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 162.623067708,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.780102333,
+          "rssMiB": 102.84375,
+          "footprintMiB": 97.297974,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 163.141683,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.781530125,
+          "rssMiB": 102.84375,
+          "footprintMiB": 87.297974,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 163.660496875,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.782788625,
+          "rssMiB": 102.84375,
+          "footprintMiB": 87.297974,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 164.165906125,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.783700625,
+          "rssMiB": 102.3125,
+          "footprintMiB": 87.297974,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 164.674999416,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.784952625,
+          "rssMiB": 61.9375,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 165.177985125,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.785651167,
+          "rssMiB": 61.890625,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 165.704633958,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.786164833,
+          "rssMiB": 61.890625,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 166.208982666,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.788147167,
+          "rssMiB": 61.890625,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 166.732567958,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.789933542,
+          "rssMiB": 61.875,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 167.252988916,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.791603833,
+          "rssMiB": 61.875,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        }
+      ]
+    }
+  ]
+}

--- a/docs/performance/resource-macos-stress.json
+++ b/docs/performance/resource-macos-stress.json
@@ -1,0 +1,6345 @@
+{
+  "method": "Native foreground release replay using the bundled sanitized fixture repeated four times at a 10 ms provider delay. Same 1320x880 logical window at 2x scale, 500 ms counters, and foreground/display guards as the standard replay. Both runs passed their complete foreground checks. No simultaneous builds or sampling profilers. The first run observes completion for 10 seconds and the second for 30 seconds; these are stress checks, not a matched baseline comparison.",
+  "machine": {
+    "model": "Mac16,7",
+    "architecture": "arm64",
+    "memoryGiB": 24,
+    "os": "macOS 26.0.1 (25A362)"
+  },
+  "applicationRevision": "9294a95b3c746f6a207a76f57bc51cb942f02197",
+  "graphicsRevision": "0003b923354ea8938b2d0cadbd17ef93108e2ae5",
+  "fixtureSha256": "8f91503a5a5f36b6344e347a81378696d707f4742b32e8670e76943bb1eca1cc",
+  "environment": {
+    "ZERON_REPLAY_REPEAT": "4",
+    "ZERON_REPLAY_DELAY_MS": "10",
+    "ZERON_FRAME_STATS": "0"
+  },
+  "runs": [
+    {
+      "settledObservationSeconds": 10,
+      "summary": {
+        "binarySha256": "1f6c253eec14756da12efdb41ffbe4c4aba31c925f2bf0df7d48ae781bfda3e6",
+        "harness": "claude-code",
+        "mode": "replay",
+        "platform": "darwin",
+        "arch": "arm64",
+        "renderThreads": "default",
+        "frameStats": "0",
+        "submission": "rpc",
+        "replySha256": "cb96ce276ed79aa8d791fc796f56ccf586b29e73d54acc911b42aacf30236f8f",
+        "replyBytes": 210502,
+        "transcriptBytes": 218387,
+        "frames": 175,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.031,
+            "engine": {
+              "peakFootprintMiB": 23.422791,
+              "endFootprintMiB": 22.625916,
+              "lifetimePeakFootprintMiB": 23.454041,
+              "peakRssMiB": 34.375,
+              "endRssMiB": 25.203125,
+              "cpuPercent": 0.041696190898017974
+            },
+            "ui": {
+              "peakFootprintMiB": 321.704155,
+              "endFootprintMiB": 298.735405,
+              "lifetimePeakFootprintMiB": 360.31353,
+              "peakRssMiB": 96.765625,
+              "endRssMiB": 88.828125,
+              "cpuPercent": 0.722870767356882
+            }
+          },
+          "stream": {
+            "durationSeconds": 21.539,
+            "engine": {
+              "peakFootprintMiB": 28.032188,
+              "endFootprintMiB": 27.344688,
+              "lifetimePeakFootprintMiB": 28.032188,
+              "peakRssMiB": 45.53125,
+              "endRssMiB": 45.53125,
+              "cpuPercent": 1.316387134964483
+            },
+            "ui": {
+              "peakFootprintMiB": 328.735405,
+              "endFootprintMiB": 328.516655,
+              "lifetimePeakFootprintMiB": 360.31353,
+              "peakRssMiB": 112.546875,
+              "endRssMiB": 110.890625,
+              "cpuPercent": 15.344746353126887
+            }
+          },
+          "settled": {
+            "durationSeconds": 9.522,
+            "engine": {
+              "peakFootprintMiB": 31.172813,
+              "endFootprintMiB": 30.797813,
+              "lifetimePeakFootprintMiB": 31.172813,
+              "peakRssMiB": 45.875,
+              "endRssMiB": 37.59375,
+              "cpuPercent": 0.035561510186936054
+            },
+            "ui": {
+              "peakFootprintMiB": 333.282303,
+              "endFootprintMiB": 333.282303,
+              "lifetimePeakFootprintMiB": 360.31353,
+              "peakRssMiB": 111.515625,
+              "endRssMiB": 107.875,
+              "cpuPercent": 3.495858275572361
+            }
+          }
+        },
+        "postCompletionTail": {
+          "durationSeconds": 9.522,
+          "engine": {
+            "endFootprintMiB": 30.797813,
+            "endRssMiB": 37.59375,
+            "cpuPercent": 0.035561510186936054
+          },
+          "ui": {
+            "endFootprintMiB": 333.282303,
+            "endRssMiB": 107.875,
+            "cpuPercent": 3.495858275572361
+          }
+        }
+      },
+      "samples": [
+        {
+          "at": 1788630098541,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.08023825,
+            "rssMiB": 34.375,
+            "footprintMiB": 23.360291,
+            "lifetimePeakFootprintMiB": 23.360291,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.383613583,
+            "rssMiB": 96.75,
+            "footprintMiB": 321.59478,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 73195,
+              "cpuSeconds": 1.620445667,
+              "rssMiB": 613.53125,
+              "footprintMiB": 438.845032,
+              "lifetimePeakFootprintMiB": 609.595032,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 73274,
+              "cpuSeconds": 0.824129167,
+              "rssMiB": 145.34375,
+              "footprintMiB": 107.418587,
+              "lifetimePeakFootprintMiB": 107.418587,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 73199,
+              "cpuSeconds": 0.125016958,
+              "rssMiB": 67.421875,
+              "footprintMiB": 49.947685,
+              "lifetimePeakFootprintMiB": 49.947685,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 73201,
+              "cpuSeconds": 0.663597083,
+              "rssMiB": 154.46875,
+              "footprintMiB": 134.140129,
+              "lifetimePeakFootprintMiB": 134.140129,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 73284,
+              "cpuSeconds": 0.355985458,
+              "rssMiB": 111.3125,
+              "footprintMiB": 80.431488,
+              "lifetimePeakFootprintMiB": 80.431488,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630099054,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.08023825,
+            "rssMiB": 26.515625,
+            "footprintMiB": 23.360291,
+            "lifetimePeakFootprintMiB": 23.360291,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.38407925,
+            "rssMiB": 96.5625,
+            "footprintMiB": 321.59478,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 73195,
+              "cpuSeconds": 1.62592575,
+              "rssMiB": 501.09375,
+              "footprintMiB": 432.938782,
+              "lifetimePeakFootprintMiB": 609.595032,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 73274,
+              "cpuSeconds": 1.0863575,
+              "rssMiB": 145.640625,
+              "footprintMiB": 113.216331,
+              "lifetimePeakFootprintMiB": 113.216331,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 73199,
+              "cpuSeconds": 0.125016958,
+              "rssMiB": 67.421875,
+              "footprintMiB": 49.947685,
+              "lifetimePeakFootprintMiB": 49.947685,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 73201,
+              "cpuSeconds": 0.663597083,
+              "rssMiB": 154.421875,
+              "footprintMiB": 134.140129,
+              "lifetimePeakFootprintMiB": 134.140129,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 73284,
+              "cpuSeconds": 0.575638125,
+              "rssMiB": 160.3125,
+              "footprintMiB": 118.20034,
+              "lifetimePeakFootprintMiB": 118.20034,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630099537,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.080684542,
+            "rssMiB": 25.765625,
+            "footprintMiB": 23.422791,
+            "lifetimePeakFootprintMiB": 23.422791,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.388364,
+            "rssMiB": 96.765625,
+            "footprintMiB": 321.672905,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 73195,
+              "cpuSeconds": 1.626880917,
+              "rssMiB": 500.96875,
+              "footprintMiB": 432.641907,
+              "lifetimePeakFootprintMiB": 609.595032,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 73274,
+              "cpuSeconds": 1.688710917,
+              "rssMiB": 154.9375,
+              "footprintMiB": 124.342865,
+              "lifetimePeakFootprintMiB": 124.342865,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630100039,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.080708125,
+            "rssMiB": 25.765625,
+            "footprintMiB": 23.422791,
+            "lifetimePeakFootprintMiB": 23.422791,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.390267833,
+            "rssMiB": 96.765625,
+            "footprintMiB": 321.672905,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 73195,
+              "cpuSeconds": 1.630054542,
+              "rssMiB": 500.96875,
+              "footprintMiB": 432.641907,
+              "lifetimePeakFootprintMiB": 609.595032,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 73274,
+              "cpuSeconds": 2.266256667,
+              "rssMiB": 166.125,
+              "footprintMiB": 137.40699,
+              "lifetimePeakFootprintMiB": 137.40699,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630100541,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.080870292,
+            "rssMiB": 23.59375,
+            "footprintMiB": 23.422791,
+            "lifetimePeakFootprintMiB": 23.422791,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.392181625,
+            "rssMiB": 90.453125,
+            "footprintMiB": 321.704155,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 73195,
+              "cpuSeconds": 1.630971917,
+              "rssMiB": 500.953125,
+              "footprintMiB": 432.641907,
+              "lifetimePeakFootprintMiB": 609.595032,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 73274,
+              "cpuSeconds": 2.841344833,
+              "rssMiB": 174.71875,
+              "footprintMiB": 147.971024,
+              "lifetimePeakFootprintMiB": 147.971024,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630101041,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.081086458,
+            "rssMiB": 22.84375,
+            "footprintMiB": 23.422791,
+            "lifetimePeakFootprintMiB": 23.422791,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.394237,
+            "rssMiB": 89.875,
+            "footprintMiB": 303.56353,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 73195,
+              "cpuSeconds": 1.635794125,
+              "rssMiB": 500.953125,
+              "footprintMiB": 432.641907,
+              "lifetimePeakFootprintMiB": 609.595032,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 73274,
+              "cpuSeconds": 3.566452708,
+              "rssMiB": 196.375,
+              "footprintMiB": 169.880043,
+              "lifetimePeakFootprintMiB": 169.880043,
+              "idleWakeups": 54
+            }
+          ]
+        },
+        {
+          "at": 1788630101545,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.081158208,
+            "rssMiB": 21.9375,
+            "footprintMiB": 23.422791,
+            "lifetimePeakFootprintMiB": 23.422791,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.397188875,
+            "rssMiB": 88.015625,
+            "footprintMiB": 303.56353,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 2
+          },
+          "harness": [
+            {
+              "pid": 73195,
+              "cpuSeconds": 1.636496083,
+              "rssMiB": 499.796875,
+              "footprintMiB": 432.641907,
+              "lifetimePeakFootprintMiB": 609.595032,
+              "idleWakeups": 2
+            },
+            {
+              "pid": 73274,
+              "cpuSeconds": 3.841572042,
+              "rssMiB": 213.171875,
+              "footprintMiB": 188.459541,
+              "lifetimePeakFootprintMiB": 188.459541,
+              "idleWakeups": 55
+            }
+          ]
+        },
+        {
+          "at": 1788630102057,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.082690917,
+            "rssMiB": 25.109375,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.401095,
+            "rssMiB": 88.390625,
+            "footprintMiB": 303.797905,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 3
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630102559,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.082807292,
+            "rssMiB": 25.109375,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.405677292,
+            "rssMiB": 88.5,
+            "footprintMiB": 303.81353,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 3
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630103062,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.08302575,
+            "rssMiB": 25.171875,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.411559208,
+            "rssMiB": 88.640625,
+            "footprintMiB": 303.81353,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 3
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630103559,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.083153042,
+            "rssMiB": 25.171875,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.416064875,
+            "rssMiB": 88.640625,
+            "footprintMiB": 303.81353,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 3
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630104063,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.083153042,
+            "rssMiB": 25.171875,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.420456333,
+            "rssMiB": 88.78125,
+            "footprintMiB": 303.766655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 3
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630104566,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.083281917,
+            "rssMiB": 25.171875,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.4250285,
+            "rssMiB": 88.78125,
+            "footprintMiB": 303.766655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 3
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630105067,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.083431083,
+            "rssMiB": 25.171875,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.429964042,
+            "rssMiB": 88.78125,
+            "footprintMiB": 303.766655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 3
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630105566,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.083582583,
+            "rssMiB": 25.171875,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.434586083,
+            "rssMiB": 88.8125,
+            "footprintMiB": 303.78228,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 3
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630106074,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.083582583,
+            "rssMiB": 25.171875,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.4420575,
+            "rssMiB": 88.828125,
+            "footprintMiB": 303.735405,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 3
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630106572,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.083669,
+            "rssMiB": 25.171875,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.445202375,
+            "rssMiB": 88.828125,
+            "footprintMiB": 303.735405,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 5
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630107069,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.083841208,
+            "rssMiB": 25.1875,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.447875167,
+            "rssMiB": 88.828125,
+            "footprintMiB": 303.735405,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 5
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630107572,
+          "phase": "idle",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.084003833,
+            "rssMiB": 25.203125,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.448896042,
+            "rssMiB": 88.828125,
+            "footprintMiB": 298.735405,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 5
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630108062,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.093790917,
+            "rssMiB": 27.453125,
+            "footprintMiB": 22.625916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.451321583,
+            "rssMiB": 88.828125,
+            "footprintMiB": 298.735405,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 5
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630108563,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.10929675,
+            "rssMiB": 30.765625,
+            "footprintMiB": 16.875916,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.530714083,
+            "rssMiB": 102.796875,
+            "footprintMiB": 322.391655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.0302785,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630109083,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.117550375,
+            "rssMiB": 31.265625,
+            "footprintMiB": 17.157166,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.595164458,
+            "rssMiB": 104.125,
+            "footprintMiB": 323.422905,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.0323215,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630109570,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.123689167,
+            "rssMiB": 31.546875,
+            "footprintMiB": 16.313416,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.67846725,
+            "rssMiB": 104.9375,
+            "footprintMiB": 323.40728,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.035895083,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630110078,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.128920667,
+            "rssMiB": 31.75,
+            "footprintMiB": 16.454041,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.758403458,
+            "rssMiB": 105.296875,
+            "footprintMiB": 323.610405,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.03905025,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630110574,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.134753583,
+            "rssMiB": 32.734375,
+            "footprintMiB": 17.235291,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.833871625,
+            "rssMiB": 105.953125,
+            "footprintMiB": 324.079155,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 7
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.042085417,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630111076,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.140405042,
+            "rssMiB": 33.03125,
+            "footprintMiB": 17.516541,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 0.918708667,
+            "rssMiB": 106.359375,
+            "footprintMiB": 324.110405,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.045243958,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630111574,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.146835042,
+            "rssMiB": 34.09375,
+            "footprintMiB": 18.516563,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.007487083,
+            "rssMiB": 106.640625,
+            "footprintMiB": 324.28228,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.048477875,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630112083,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.151874208,
+            "rssMiB": 34.4375,
+            "footprintMiB": 18.360313,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.085182958,
+            "rssMiB": 106.859375,
+            "footprintMiB": 324.50103,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.051254667,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630112581,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.158970083,
+            "rssMiB": 35.171875,
+            "footprintMiB": 19.094688,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.163603667,
+            "rssMiB": 107.140625,
+            "footprintMiB": 324.59478,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.054930125,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630113066,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.163829625,
+            "rssMiB": 35.390625,
+            "footprintMiB": 19.313438,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.245337083,
+            "rssMiB": 107.515625,
+            "footprintMiB": 324.90728,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.057691917,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630113583,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.170611,
+            "rssMiB": 35.859375,
+            "footprintMiB": 19.782188,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.335531333,
+            "rssMiB": 108.015625,
+            "footprintMiB": 325.03228,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.0607995,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630114082,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.176558458,
+            "rssMiB": 36.328125,
+            "footprintMiB": 20.219688,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.410333958,
+            "rssMiB": 108.390625,
+            "footprintMiB": 325.34478,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.063598833,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630114583,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.182126875,
+            "rssMiB": 36.515625,
+            "footprintMiB": 20.172813,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.478566708,
+            "rssMiB": 108.421875,
+            "footprintMiB": 325.37603,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.066747083,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630115085,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.188298917,
+            "rssMiB": 37.15625,
+            "footprintMiB": 20.797813,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.5566855,
+            "rssMiB": 108.4375,
+            "footprintMiB": 325.18853,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.06956925,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630115587,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.193508,
+            "rssMiB": 37.203125,
+            "footprintMiB": 20.844688,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.633602167,
+            "rssMiB": 108.65625,
+            "footprintMiB": 325.40728,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.072421667,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630116084,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.20040525,
+            "rssMiB": 37.46875,
+            "footprintMiB": 21.047813,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.711134833,
+            "rssMiB": 108.6875,
+            "footprintMiB": 325.43853,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.075919833,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630116572,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.205399542,
+            "rssMiB": 37.234375,
+            "footprintMiB": 21.094688,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.778784208,
+            "rssMiB": 108.609375,
+            "footprintMiB": 325.75103,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.078825208,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630117080,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.212270125,
+            "rssMiB": 37.59375,
+            "footprintMiB": 21.438438,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.855055125,
+            "rssMiB": 108.640625,
+            "footprintMiB": 325.78228,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.082290583,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630117591,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.218580542,
+            "rssMiB": 38.015625,
+            "footprintMiB": 21.860313,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 1.934243208,
+            "rssMiB": 108.859375,
+            "footprintMiB": 326.00103,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.085268458,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630118087,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.225334792,
+            "rssMiB": 38.15625,
+            "footprintMiB": 22.000938,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.016987542,
+            "rssMiB": 109.125,
+            "footprintMiB": 325.96978,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 9
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.088441125,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630118588,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.231037625,
+            "rssMiB": 38.640625,
+            "footprintMiB": 22.297813,
+            "lifetimePeakFootprintMiB": 23.454041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.092986917,
+            "rssMiB": 109.1875,
+            "footprintMiB": 325.90728,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 10
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.091273125,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630119085,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.23847825,
+            "rssMiB": 40.53125,
+            "footprintMiB": 23.547813,
+            "lifetimePeakFootprintMiB": 23.547813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.170300042,
+            "rssMiB": 109.625,
+            "footprintMiB": 326.329155,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 10
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.09382825,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630119585,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.244815417,
+            "rssMiB": 41.09375,
+            "footprintMiB": 23.844688,
+            "lifetimePeakFootprintMiB": 24.000938,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.245294792,
+            "rssMiB": 110.25,
+            "footprintMiB": 326.954155,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 10
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.097081375,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630120092,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.251999,
+            "rssMiB": 41.609375,
+            "footprintMiB": 24.250938,
+            "lifetimePeakFootprintMiB": 24.360313,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.318554,
+            "rssMiB": 110.265625,
+            "footprintMiB": 326.96978,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 10
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.099786792,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630120590,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.25656925,
+            "rssMiB": 41.625,
+            "footprintMiB": 24.266563,
+            "lifetimePeakFootprintMiB": 24.360313,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.391794958,
+            "rssMiB": 110.328125,
+            "footprintMiB": 327.03228,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 10
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.102555417,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630121092,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.264182625,
+            "rssMiB": 42.140625,
+            "footprintMiB": 24.407188,
+            "lifetimePeakFootprintMiB": 24.657188,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.465811458,
+            "rssMiB": 110.328125,
+            "footprintMiB": 327.03228,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 10
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.105079625,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630121591,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.26739825,
+            "rssMiB": 42.140625,
+            "footprintMiB": 24.407188,
+            "lifetimePeakFootprintMiB": 24.657188,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.519864542,
+            "rssMiB": 110.375,
+            "footprintMiB": 326.954155,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 10
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.106513958,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630122088,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.275260583,
+            "rssMiB": 42.359375,
+            "footprintMiB": 24.438438,
+            "lifetimePeakFootprintMiB": 24.657188,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.59535325,
+            "rssMiB": 110.390625,
+            "footprintMiB": 326.954155,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 14
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.109257917,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630122590,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.280564583,
+            "rssMiB": 42.375,
+            "footprintMiB": 24.454063,
+            "lifetimePeakFootprintMiB": 24.657188,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.672928125,
+            "rssMiB": 110.578125,
+            "footprintMiB": 327.141655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 14
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.111767333,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630123093,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.285709708,
+            "rssMiB": 42.6875,
+            "footprintMiB": 24.766563,
+            "lifetimePeakFootprintMiB": 24.766563,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.73236325,
+            "rssMiB": 110.65625,
+            "footprintMiB": 327.21978,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 15
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.113719458,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630123584,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.291959833,
+            "rssMiB": 42.78125,
+            "footprintMiB": 24.860313,
+            "lifetimePeakFootprintMiB": 24.860313,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.788398583,
+            "rssMiB": 110.96875,
+            "footprintMiB": 327.25103,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 16
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.115265792,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630124078,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.297948958,
+            "rssMiB": 43.734375,
+            "footprintMiB": 25.610313,
+            "lifetimePeakFootprintMiB": 25.797813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.865841083,
+            "rssMiB": 111.03125,
+            "footprintMiB": 327.141655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 23
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.117846833,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 4
+            }
+          ]
+        },
+        {
+          "at": 1788630124593,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.305224583,
+            "rssMiB": 44.671875,
+            "footprintMiB": 26.547813,
+            "lifetimePeakFootprintMiB": 26.547813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 2.945107292,
+            "rssMiB": 111.890625,
+            "footprintMiB": 327.75103,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 32
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.120573125,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 6
+            }
+          ]
+        },
+        {
+          "at": 1788630125095,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.313974583,
+            "rssMiB": 45,
+            "footprintMiB": 26.875938,
+            "lifetimePeakFootprintMiB": 26.875938,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.0256745,
+            "rssMiB": 112.515625,
+            "footprintMiB": 327.547905,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 32
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.123428958,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 6
+            }
+          ]
+        },
+        {
+          "at": 1788630125603,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.320061167,
+            "rssMiB": 45,
+            "footprintMiB": 26.875938,
+            "lifetimePeakFootprintMiB": 26.875938,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.112699333,
+            "rssMiB": 112.515625,
+            "footprintMiB": 327.516655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 33
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.126147042,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 6
+            }
+          ]
+        },
+        {
+          "at": 1788630126091,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.327046083,
+            "rssMiB": 45.328125,
+            "footprintMiB": 27.204063,
+            "lifetimePeakFootprintMiB": 27.204063,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.185688792,
+            "rssMiB": 112.53125,
+            "footprintMiB": 327.516655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 34
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.128603333,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 6
+            }
+          ]
+        },
+        {
+          "at": 1788630126597,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.332827458,
+            "rssMiB": 45.390625,
+            "footprintMiB": 27.266563,
+            "lifetimePeakFootprintMiB": 27.266563,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.26962675,
+            "rssMiB": 112.53125,
+            "footprintMiB": 327.516655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 34
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.131355042,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 6
+            }
+          ]
+        },
+        {
+          "at": 1788630127098,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.340852792,
+            "rssMiB": 45.515625,
+            "footprintMiB": 27.391563,
+            "lifetimePeakFootprintMiB": 27.391563,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.34991075,
+            "rssMiB": 112.546875,
+            "footprintMiB": 327.53228,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 34
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.13400425,
+              "rssMiB": 9.859375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 6
+            }
+          ]
+        },
+        {
+          "at": 1788630127594,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.346204792,
+            "rssMiB": 45.265625,
+            "footprintMiB": 27.500938,
+            "lifetimePeakFootprintMiB": 27.500938,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.430759042,
+            "rssMiB": 109.890625,
+            "footprintMiB": 328.56353,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.137111583,
+              "rssMiB": 7.15625,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630128101,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.355633583,
+            "rssMiB": 45.34375,
+            "footprintMiB": 27.579063,
+            "lifetimePeakFootprintMiB": 27.579063,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.515616167,
+            "rssMiB": 109.984375,
+            "footprintMiB": 328.422905,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.139832125,
+              "rssMiB": 7.15625,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630128594,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.363583333,
+            "rssMiB": 45.4375,
+            "footprintMiB": 27.672813,
+            "lifetimePeakFootprintMiB": 27.672813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.589391708,
+            "rssMiB": 110.421875,
+            "footprintMiB": 328.53228,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.142041417,
+              "rssMiB": 7.15625,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630129099,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.3708275,
+            "rssMiB": 45.53125,
+            "footprintMiB": 28.032188,
+            "lifetimePeakFootprintMiB": 28.032188,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.669990125,
+            "rssMiB": 110.6875,
+            "footprintMiB": 328.735405,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.144550375,
+              "rssMiB": 7.15625,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630129601,
+          "phase": "stream",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.377327542,
+            "rssMiB": 45.53125,
+            "footprintMiB": 27.344688,
+            "lifetimePeakFootprintMiB": 28.032188,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.7564265,
+            "rssMiB": 110.890625,
+            "footprintMiB": 328.516655,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147096542,
+              "rssMiB": 7.15625,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630130102,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.380463833,
+            "rssMiB": 45.875,
+            "footprintMiB": 28.813438,
+            "lifetimePeakFootprintMiB": 28.813438,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.851236667,
+            "rssMiB": 111.515625,
+            "footprintMiB": 331.094803,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 7.234375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630130604,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.381539208,
+            "rssMiB": 41.125,
+            "footprintMiB": 31.063438,
+            "lifetimePeakFootprintMiB": 31.063438,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 3.996508,
+            "rssMiB": 110.109375,
+            "footprintMiB": 332.844803,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630131125,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.38188225,
+            "rssMiB": 40.921875,
+            "footprintMiB": 31.094688,
+            "lifetimePeakFootprintMiB": 31.094688,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.110263542,
+            "rssMiB": 109.546875,
+            "footprintMiB": 333.126053,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630131616,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382099833,
+            "rssMiB": 40.953125,
+            "footprintMiB": 31.094688,
+            "lifetimePeakFootprintMiB": 31.094688,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.117959792,
+            "rssMiB": 109.6875,
+            "footprintMiB": 333.126053,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630132119,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382099833,
+            "rssMiB": 40.90625,
+            "footprintMiB": 31.094688,
+            "lifetimePeakFootprintMiB": 31.094688,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.124580208,
+            "rssMiB": 109.640625,
+            "footprintMiB": 333.126053,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630132616,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382238583,
+            "rssMiB": 40.90625,
+            "footprintMiB": 31.094688,
+            "lifetimePeakFootprintMiB": 31.094688,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.128704167,
+            "rssMiB": 109.640625,
+            "footprintMiB": 333.126053,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630133126,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382238583,
+            "rssMiB": 40.578125,
+            "footprintMiB": 31.094688,
+            "lifetimePeakFootprintMiB": 31.094688,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.134498208,
+            "rssMiB": 109.546875,
+            "footprintMiB": 333.188553,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630133617,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382549625,
+            "rssMiB": 40.578125,
+            "footprintMiB": 31.094688,
+            "lifetimePeakFootprintMiB": 31.094688,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.137220542,
+            "rssMiB": 109.609375,
+            "footprintMiB": 333.172928,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630134109,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382549625,
+            "rssMiB": 40.578125,
+            "footprintMiB": 31.094688,
+            "lifetimePeakFootprintMiB": 31.094688,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.139356458,
+            "rssMiB": 109.609375,
+            "footprintMiB": 333.172928,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.172127,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630134611,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382675,
+            "rssMiB": 38.125,
+            "footprintMiB": 31.110313,
+            "lifetimePeakFootprintMiB": 31.110313,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.141962458,
+            "rssMiB": 108.75,
+            "footprintMiB": 333.219803,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630135112,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382675,
+            "rssMiB": 37.640625,
+            "footprintMiB": 31.172813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.144506875,
+            "rssMiB": 107.484375,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630135622,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382940958,
+            "rssMiB": 37.59375,
+            "footprintMiB": 31.172813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.148382417,
+            "rssMiB": 107.484375,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630136119,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.382940958,
+            "rssMiB": 37.59375,
+            "footprintMiB": 31.172813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.151396542,
+            "rssMiB": 107.484375,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630136618,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.383104208,
+            "rssMiB": 37.609375,
+            "footprintMiB": 31.172813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.154741083,
+            "rssMiB": 107.484375,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630137122,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.383104208,
+            "rssMiB": 37.609375,
+            "footprintMiB": 31.172813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.157736667,
+            "rssMiB": 107.484375,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630137618,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.3834065,
+            "rssMiB": 37.609375,
+            "footprintMiB": 31.172813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.161694958,
+            "rssMiB": 107.484375,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630138122,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.383549792,
+            "rssMiB": 37.640625,
+            "footprintMiB": 31.172813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.166713208,
+            "rssMiB": 107.484375,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630138616,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.383630292,
+            "rssMiB": 37.640625,
+            "footprintMiB": 31.172813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.172270167,
+            "rssMiB": 107.484375,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630139117,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.383630292,
+            "rssMiB": 37.609375,
+            "footprintMiB": 31.172813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.179547333,
+            "rssMiB": 107.875,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630139624,
+          "phase": "settled",
+          "engine": {
+            "pid": 73029,
+            "cpuSeconds": 0.38385,
+            "rssMiB": 37.59375,
+            "footprintMiB": 30.797813,
+            "lifetimePeakFootprintMiB": 31.172813,
+            "idleWakeups": 2
+          },
+          "ui": {
+            "pid": 73088,
+            "cpuSeconds": 4.184112292,
+            "rssMiB": 107.875,
+            "footprintMiB": 333.282303,
+            "lifetimePeakFootprintMiB": 360.31353,
+            "idleWakeups": 37
+          },
+          "harness": [
+            {
+              "pid": 73665,
+              "cpuSeconds": 0.147554708,
+              "rssMiB": 6.984375,
+              "footprintMiB": 6.015877,
+              "lifetimePeakFootprintMiB": 6.172127,
+              "idleWakeups": 8
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "settledObservationSeconds": 30,
+      "summary": {
+        "binarySha256": "1f6c253eec14756da12efdb41ffbe4c4aba31c925f2bf0df7d48ae781bfda3e6",
+        "harness": "claude-code",
+        "mode": "replay",
+        "platform": "darwin",
+        "arch": "arm64",
+        "renderThreads": "default",
+        "frameStats": "0",
+        "submission": "rpc",
+        "replySha256": "cb96ce276ed79aa8d791fc796f56ccf586b29e73d54acc911b42aacf30236f8f",
+        "replyBytes": 210502,
+        "transcriptBytes": 218387,
+        "frames": 175,
+        "phases": {
+          "idle": {
+            "durationSeconds": 9.039,
+            "engine": {
+              "peakFootprintMiB": 22.313416,
+              "endFootprintMiB": 22.313416,
+              "lifetimePeakFootprintMiB": 22.329041,
+              "peakRssMiB": 35.609375,
+              "endRssMiB": 35.609375,
+              "cpuPercent": 0.04349808607146797
+            },
+            "ui": {
+              "peakFootprintMiB": 303.735405,
+              "endFootprintMiB": 298.81353,
+              "lifetimePeakFootprintMiB": 342.266632,
+              "peakRssMiB": 95.78125,
+              "endRssMiB": 95.78125,
+              "cpuPercent": 0.5590699524283659
+            }
+          },
+          "stream": {
+            "durationSeconds": 21.557,
+            "engine": {
+              "peakFootprintMiB": 32.454041,
+              "endFootprintMiB": 32.454041,
+              "lifetimePeakFootprintMiB": 32.454041,
+              "peakRssMiB": 48.15625,
+              "endRssMiB": 41.546875,
+              "cpuPercent": 1.1582558287331264
+            },
+            "ui": {
+              "peakFootprintMiB": 329.75103,
+              "endFootprintMiB": 329.53228,
+              "lifetimePeakFootprintMiB": 342.266632,
+              "peakRssMiB": 114.828125,
+              "endRssMiB": 110.953125,
+              "cpuPercent": 13.029838530407757
+            }
+          },
+          "settled": {
+            "durationSeconds": 29.574,
+            "engine": {
+              "peakFootprintMiB": 35.922791,
+              "endFootprintMiB": 35.094666,
+              "lifetimePeakFootprintMiB": 35.922791,
+              "peakRssMiB": 44.46875,
+              "endRssMiB": 29.53125,
+              "cpuPercent": 0.060375525799688884
+            },
+            "ui": {
+              "peakFootprintMiB": 332.422905,
+              "endFootprintMiB": 332.40728,
+              "lifetimePeakFootprintMiB": 342.266632,
+              "peakRssMiB": 113.3125,
+              "endRssMiB": 99.21875,
+              "cpuPercent": 1.6046579461689334
+            }
+          }
+        },
+        "postCompletionTail": {
+          "durationSeconds": 9.524,
+          "engine": {
+            "endFootprintMiB": 35.094666,
+            "endRssMiB": 29.53125,
+            "cpuPercent": 0.104197291054179
+          },
+          "ui": {
+            "endFootprintMiB": 332.40728,
+            "endRssMiB": 99.21875,
+            "cpuPercent": 0.7998079378412455
+          }
+        }
+      },
+      "samples": [
+        {
+          "at": 1788630382452,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.072139958,
+            "rssMiB": 33.75,
+            "footprintMiB": 22.204041,
+            "lifetimePeakFootprintMiB": 22.204041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.359203542,
+            "rssMiB": 95.203125,
+            "footprintMiB": 303.485405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 76256,
+              "cpuSeconds": 1.677403417,
+              "rssMiB": 611.71875,
+              "footprintMiB": 433.657623,
+              "lifetimePeakFootprintMiB": 654.938873,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76413,
+              "cpuSeconds": 1.194871083,
+              "rssMiB": 156.203125,
+              "footprintMiB": 119.310722,
+              "lifetimePeakFootprintMiB": 119.310722,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76258,
+              "cpuSeconds": 0.022888833,
+              "rssMiB": 31.875,
+              "footprintMiB": 12.423409,
+              "lifetimePeakFootprintMiB": 12.423409,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76301,
+              "cpuSeconds": 0.529438917,
+              "rssMiB": 96.015625,
+              "footprintMiB": 65.547607,
+              "lifetimePeakFootprintMiB": 80.469482,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76359,
+              "cpuSeconds": 1.317999292,
+              "rssMiB": 157.125,
+              "footprintMiB": 121.889168,
+              "lifetimePeakFootprintMiB": 121.889168,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630382950,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.072166667,
+            "rssMiB": 33.75,
+            "footprintMiB": 22.204041,
+            "lifetimePeakFootprintMiB": 22.204041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.360733583,
+            "rssMiB": 95.203125,
+            "footprintMiB": 303.485405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 76256,
+              "cpuSeconds": 1.677928375,
+              "rssMiB": 611.71875,
+              "footprintMiB": 433.313873,
+              "lifetimePeakFootprintMiB": 654.938873,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76413,
+              "cpuSeconds": 1.68554475,
+              "rssMiB": 163.265625,
+              "footprintMiB": 127.046127,
+              "lifetimePeakFootprintMiB": 127.046127,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76258,
+              "cpuSeconds": 0.022888833,
+              "rssMiB": 31.875,
+              "footprintMiB": 12.423409,
+              "lifetimePeakFootprintMiB": 12.423409,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76301,
+              "cpuSeconds": 0.530212333,
+              "rssMiB": 96.03125,
+              "footprintMiB": 65.563232,
+              "lifetimePeakFootprintMiB": 80.469482,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76359,
+              "cpuSeconds": 1.748264458,
+              "rssMiB": 163.046875,
+              "footprintMiB": 128.515244,
+              "lifetimePeakFootprintMiB": 128.515244,
+              "idleWakeups": 0
+            }
+          ]
+        },
+        {
+          "at": 1788630383450,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.0722125,
+            "rssMiB": 33.75,
+            "footprintMiB": 22.204041,
+            "lifetimePeakFootprintMiB": 22.204041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.362567917,
+            "rssMiB": 95.203125,
+            "footprintMiB": 303.485405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 76256,
+              "cpuSeconds": 1.681466708,
+              "rssMiB": 611.71875,
+              "footprintMiB": 433.266998,
+              "lifetimePeakFootprintMiB": 654.938873,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76413,
+              "cpuSeconds": 2.280846042,
+              "rssMiB": 175.328125,
+              "footprintMiB": 140.21965,
+              "lifetimePeakFootprintMiB": 140.21965,
+              "idleWakeups": 1
+            },
+            {
+              "pid": 76258,
+              "cpuSeconds": 0.022888833,
+              "rssMiB": 31.875,
+              "footprintMiB": 12.423409,
+              "lifetimePeakFootprintMiB": 12.423409,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76301,
+              "cpuSeconds": 0.536104958,
+              "rssMiB": 96.578125,
+              "footprintMiB": 65.703857,
+              "lifetimePeakFootprintMiB": 80.469482,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76359,
+              "cpuSeconds": 2.334282292,
+              "rssMiB": 175.03125,
+              "footprintMiB": 141.563766,
+              "lifetimePeakFootprintMiB": 141.563766,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788630383950,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.073278417,
+            "rssMiB": 35.03125,
+            "footprintMiB": 22.172791,
+            "lifetimePeakFootprintMiB": 22.204041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.365834833,
+            "rssMiB": 95.21875,
+            "footprintMiB": 303.485405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 76256,
+              "cpuSeconds": 1.681858625,
+              "rssMiB": 609.109375,
+              "footprintMiB": 433.266998,
+              "lifetimePeakFootprintMiB": 654.938873,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76413,
+              "cpuSeconds": 2.861820542,
+              "rssMiB": 184.875,
+              "footprintMiB": 150.799286,
+              "lifetimePeakFootprintMiB": 150.799286,
+              "idleWakeups": 2
+            }
+          ]
+        },
+        {
+          "at": 1788630384464,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.07350325,
+            "rssMiB": 35.140625,
+            "footprintMiB": 22.219666,
+            "lifetimePeakFootprintMiB": 22.219666,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.367954333,
+            "rssMiB": 95.21875,
+            "footprintMiB": 303.485405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": [
+            {
+              "pid": 76256,
+              "cpuSeconds": 1.685062542,
+              "rssMiB": 558.9375,
+              "footprintMiB": 433.266998,
+              "lifetimePeakFootprintMiB": 654.938873,
+              "idleWakeups": 0
+            },
+            {
+              "pid": 76413,
+              "cpuSeconds": 3.644228333,
+              "rssMiB": 206.453125,
+              "footprintMiB": 174.364693,
+              "lifetimePeakFootprintMiB": 174.364693,
+              "idleWakeups": 41
+            }
+          ]
+        },
+        {
+          "at": 1788630384968,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.074609292,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.372223292,
+            "rssMiB": 95.5625,
+            "footprintMiB": 303.71978,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630385469,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.074726875,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.376852417,
+            "rssMiB": 95.625,
+            "footprintMiB": 303.71978,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630385975,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.074726875,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.379736708,
+            "rssMiB": 95.625,
+            "footprintMiB": 303.71978,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630386472,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.075155917,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.381695417,
+            "rssMiB": 95.625,
+            "footprintMiB": 303.71978,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630386980,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.075155917,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.383732583,
+            "rssMiB": 95.625,
+            "footprintMiB": 303.71978,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630387476,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.075256083,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.386127917,
+            "rssMiB": 95.625,
+            "footprintMiB": 303.71978,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630387973,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.075282167,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.388676542,
+            "rssMiB": 95.625,
+            "footprintMiB": 303.71978,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630388479,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.075533042,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.3916135,
+            "rssMiB": 95.640625,
+            "footprintMiB": 303.735405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630388981,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.075533042,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.394094042,
+            "rssMiB": 95.640625,
+            "footprintMiB": 303.735405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630389482,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.0756745,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.396582083,
+            "rssMiB": 95.640625,
+            "footprintMiB": 303.735405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630389985,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.0756745,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.399067875,
+            "rssMiB": 95.640625,
+            "footprintMiB": 303.735405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630390489,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.075933875,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.402015042,
+            "rssMiB": 95.640625,
+            "footprintMiB": 303.735405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630390985,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.075933875,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.404992208,
+            "rssMiB": 95.640625,
+            "footprintMiB": 303.735405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630391491,
+          "phase": "idle",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.07607175,
+            "rssMiB": 35.609375,
+            "footprintMiB": 22.313416,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.409737875,
+            "rssMiB": 95.78125,
+            "footprintMiB": 298.81353,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630391978,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.082986208,
+            "rssMiB": 36.421875,
+            "footprintMiB": 22.329041,
+            "lifetimePeakFootprintMiB": 22.329041,
+            "idleWakeups": 0
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.41464675,
+            "rssMiB": 95.796875,
+            "footprintMiB": 298.81353,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 1
+          },
+          "harness": []
+        },
+        {
+          "at": 1788630392482,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.096137458,
+            "rssMiB": 38.359375,
+            "footprintMiB": 20.391541,
+            "lifetimePeakFootprintMiB": 22.563416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.48134075,
+            "rssMiB": 106.765625,
+            "footprintMiB": 322.172905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 3
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.03155675,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630392990,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.102910708,
+            "rssMiB": 38.71875,
+            "footprintMiB": 20.563416,
+            "lifetimePeakFootprintMiB": 22.563416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.534226208,
+            "rssMiB": 108.015625,
+            "footprintMiB": 323.204155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 3
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.033211375,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630393495,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.107821917,
+            "rssMiB": 38.921875,
+            "footprintMiB": 20.657166,
+            "lifetimePeakFootprintMiB": 22.563416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.604555125,
+            "rssMiB": 108.765625,
+            "footprintMiB": 323.31353,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 4
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.03607225,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630393999,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.113172667,
+            "rssMiB": 39.125,
+            "footprintMiB": 20.735291,
+            "lifetimePeakFootprintMiB": 22.563416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.6818425,
+            "rssMiB": 109.015625,
+            "footprintMiB": 323.50103,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 4
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.0391735,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630394495,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.118204083,
+            "rssMiB": 39.796875,
+            "footprintMiB": 21.407166,
+            "lifetimePeakFootprintMiB": 22.563416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.751119042,
+            "rssMiB": 109.5625,
+            "footprintMiB": 323.84478,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.041343417,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630394994,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.122257125,
+            "rssMiB": 40.109375,
+            "footprintMiB": 21.688416,
+            "lifetimePeakFootprintMiB": 22.563416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.814082583,
+            "rssMiB": 110.140625,
+            "footprintMiB": 323.954155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.043443833,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630395496,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.127233333,
+            "rssMiB": 40.984375,
+            "footprintMiB": 22.485291,
+            "lifetimePeakFootprintMiB": 22.563416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.893988042,
+            "rssMiB": 110.375,
+            "footprintMiB": 324.141655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 5
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.046150667,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630395991,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.132056792,
+            "rssMiB": 41.390625,
+            "footprintMiB": 22.891541,
+            "lifetimePeakFootprintMiB": 22.891541,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 0.976206625,
+            "rssMiB": 110.546875,
+            "footprintMiB": 324.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.048582167,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630396488,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.13504325,
+            "rssMiB": 42.421875,
+            "footprintMiB": 23.860291,
+            "lifetimePeakFootprintMiB": 23.860291,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.020029542,
+            "rssMiB": 110.9375,
+            "footprintMiB": 324.641655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.050010292,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630396999,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.139476875,
+            "rssMiB": 42.8125,
+            "footprintMiB": 24.250916,
+            "lifetimePeakFootprintMiB": 24.250916,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.08352975,
+            "rssMiB": 111.21875,
+            "footprintMiB": 324.922905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.052404583,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630397504,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.14541475,
+            "rssMiB": 43.5,
+            "footprintMiB": 24.891541,
+            "lifetimePeakFootprintMiB": 24.891541,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.156086,
+            "rssMiB": 111.34375,
+            "footprintMiB": 324.610405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 6
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.055092333,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 1
+            }
+          ]
+        },
+        {
+          "at": 1788630398006,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.150636583,
+            "rssMiB": 44.03125,
+            "footprintMiB": 25.407166,
+            "lifetimePeakFootprintMiB": 25.407166,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.219346167,
+            "rssMiB": 112.671875,
+            "footprintMiB": 325.422905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.058018125,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788630398502,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.158204125,
+            "rssMiB": 44.6875,
+            "footprintMiB": 26.063416,
+            "lifetimePeakFootprintMiB": 26.063416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.281930417,
+            "rssMiB": 112.6875,
+            "footprintMiB": 325.43853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.060709125,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788630399007,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.163216875,
+            "rssMiB": 44.75,
+            "footprintMiB": 26.125916,
+            "lifetimePeakFootprintMiB": 26.125916,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.346540417,
+            "rssMiB": 112.734375,
+            "footprintMiB": 325.485405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.063601542,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788630399501,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.169767958,
+            "rssMiB": 44.90625,
+            "footprintMiB": 26.110291,
+            "lifetimePeakFootprintMiB": 26.125916,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.414794042,
+            "rssMiB": 112.984375,
+            "footprintMiB": 325.735405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.066338042,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788630399998,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.174882417,
+            "rssMiB": 45.046875,
+            "footprintMiB": 26.250916,
+            "lifetimePeakFootprintMiB": 26.250916,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.479259917,
+            "rssMiB": 113.015625,
+            "footprintMiB": 325.766655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.068859375,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788630400511,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.181002042,
+            "rssMiB": 45.5,
+            "footprintMiB": 26.657166,
+            "lifetimePeakFootprintMiB": 26.657166,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.540538708,
+            "rssMiB": 113.140625,
+            "footprintMiB": 325.891655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.071555958,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788630401003,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.184796875,
+            "rssMiB": 45.5,
+            "footprintMiB": 26.657166,
+            "lifetimePeakFootprintMiB": 26.657166,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.596492333,
+            "rssMiB": 113.15625,
+            "footprintMiB": 325.90728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 8
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.073658375,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788630401500,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.190129208,
+            "rssMiB": 45.890625,
+            "footprintMiB": 27.047791,
+            "lifetimePeakFootprintMiB": 27.047791,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.655967833,
+            "rssMiB": 113.171875,
+            "footprintMiB": 325.90728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 9
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.075924625,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788630402009,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.195868042,
+            "rssMiB": 46.28125,
+            "footprintMiB": 27.438416,
+            "lifetimePeakFootprintMiB": 27.438416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.732093083,
+            "rssMiB": 113.578125,
+            "footprintMiB": 326.297905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 9
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.079016875,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 3
+            }
+          ]
+        },
+        {
+          "at": 1788630402511,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.2013865,
+            "rssMiB": 46.78125,
+            "footprintMiB": 27.860291,
+            "lifetimePeakFootprintMiB": 27.860291,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.781166208,
+            "rssMiB": 113.609375,
+            "footprintMiB": 325.71978,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 11
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.08066775,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 4
+            }
+          ]
+        },
+        {
+          "at": 1788630403022,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.207089792,
+            "rssMiB": 47.78125,
+            "footprintMiB": 27.907166,
+            "lifetimePeakFootprintMiB": 27.907166,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.8421835,
+            "rssMiB": 114.40625,
+            "footprintMiB": 326.454155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 11
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.08280625,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 4
+            }
+          ]
+        },
+        {
+          "at": 1788630403504,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.212688833,
+            "rssMiB": 48.15625,
+            "footprintMiB": 28.047791,
+            "lifetimePeakFootprintMiB": 28.219666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.909643458,
+            "rssMiB": 114.828125,
+            "footprintMiB": 326.735405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 11
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.085735083,
+              "rssMiB": 9.9375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 4
+            }
+          ]
+        },
+        {
+          "at": 1788630404022,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.218544833,
+            "rssMiB": 35.09375,
+            "footprintMiB": 29.313416,
+            "lifetimePeakFootprintMiB": 29.313416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 1.977662458,
+            "rssMiB": 106.171875,
+            "footprintMiB": 329.141655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.088757042,
+              "rssMiB": 7.34375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 7
+            }
+          ]
+        },
+        {
+          "at": 1788630404512,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.223836375,
+            "rssMiB": 35.3125,
+            "footprintMiB": 29.329041,
+            "lifetimePeakFootprintMiB": 29.329041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.036475625,
+            "rssMiB": 106.953125,
+            "footprintMiB": 329.141655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 20
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.091306,
+              "rssMiB": 7.34375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 7
+            }
+          ]
+        },
+        {
+          "at": 1788630405013,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.229590542,
+            "rssMiB": 36.25,
+            "footprintMiB": 29.782166,
+            "lifetimePeakFootprintMiB": 29.782166,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.100964375,
+            "rssMiB": 107.25,
+            "footprintMiB": 329.079155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 25
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.09341525,
+              "rssMiB": 7.359375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630405516,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.235860958,
+            "rssMiB": 36.4375,
+            "footprintMiB": 29.735291,
+            "lifetimePeakFootprintMiB": 29.813416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.172182292,
+            "rssMiB": 107.46875,
+            "footprintMiB": 329.110405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 25
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.096416042,
+              "rssMiB": 7.359375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630406018,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.242518,
+            "rssMiB": 36.890625,
+            "footprintMiB": 29.563416,
+            "lifetimePeakFootprintMiB": 29.813416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.253986583,
+            "rssMiB": 107.8125,
+            "footprintMiB": 329.12603,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 26
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.099191208,
+              "rssMiB": 7.359375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630406518,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.246556,
+            "rssMiB": 36.9375,
+            "footprintMiB": 29.563416,
+            "lifetimePeakFootprintMiB": 29.813416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.318942875,
+            "rssMiB": 107.90625,
+            "footprintMiB": 329.18853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 26
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.101161125,
+              "rssMiB": 7.359375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630407018,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.251478542,
+            "rssMiB": 37.1875,
+            "footprintMiB": 29.813416,
+            "lifetimePeakFootprintMiB": 29.813416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.380825083,
+            "rssMiB": 107.984375,
+            "footprintMiB": 329.204155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 27
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.103269792,
+              "rssMiB": 7.359375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630407517,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.260011625,
+            "rssMiB": 37.296875,
+            "footprintMiB": 29.829041,
+            "lifetimePeakFootprintMiB": 29.829041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.443350083,
+            "rssMiB": 108.265625,
+            "footprintMiB": 329.28228,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 27
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.105625208,
+              "rssMiB": 7.375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630408022,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.266869958,
+            "rssMiB": 38.09375,
+            "footprintMiB": 30.407166,
+            "lifetimePeakFootprintMiB": 30.407166,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.521338583,
+            "rssMiB": 108.421875,
+            "footprintMiB": 329.329155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 27
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.108256625,
+              "rssMiB": 7.375,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630408523,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.272138458,
+            "rssMiB": 39.140625,
+            "footprintMiB": 31.422791,
+            "lifetimePeakFootprintMiB": 31.422791,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.572165917,
+            "rssMiB": 109.015625,
+            "footprintMiB": 329.579155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 27
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.110141042,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630409022,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.278083625,
+            "rssMiB": 39.484375,
+            "footprintMiB": 31.766541,
+            "lifetimePeakFootprintMiB": 31.766541,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.634231917,
+            "rssMiB": 109.09375,
+            "footprintMiB": 329.610405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 27
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.112222875,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630409523,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.28365825,
+            "rssMiB": 39.53125,
+            "footprintMiB": 31.782166,
+            "lifetimePeakFootprintMiB": 31.782166,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.708970208,
+            "rssMiB": 109.09375,
+            "footprintMiB": 329.610405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 27
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.115157708,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630410029,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.291034625,
+            "rssMiB": 40.15625,
+            "footprintMiB": 32.125916,
+            "lifetimePeakFootprintMiB": 32.266541,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.784929292,
+            "rssMiB": 109.3125,
+            "footprintMiB": 329.641655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 27
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.117920208,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630410525,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.29650375,
+            "rssMiB": 40.15625,
+            "footprintMiB": 32.125916,
+            "lifetimePeakFootprintMiB": 32.266541,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.854199125,
+            "rssMiB": 109.484375,
+            "footprintMiB": 329.75103,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 28
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.120543083,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630411030,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.303270375,
+            "rssMiB": 40.59375,
+            "footprintMiB": 31.500916,
+            "lifetimePeakFootprintMiB": 32.454041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.917918375,
+            "rssMiB": 109.671875,
+            "footprintMiB": 329.641655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.122605708,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630411520,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.306548625,
+            "rssMiB": 40.59375,
+            "footprintMiB": 31.500916,
+            "lifetimePeakFootprintMiB": 32.454041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 2.968900792,
+            "rssMiB": 109.703125,
+            "footprintMiB": 329.62603,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.1241485,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630412029,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.314701667,
+            "rssMiB": 40.96875,
+            "footprintMiB": 31.875916,
+            "lifetimePeakFootprintMiB": 32.454041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.04248225,
+            "rssMiB": 109.953125,
+            "footprintMiB": 329.516655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.127190167,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630412526,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.321856833,
+            "rssMiB": 41.078125,
+            "footprintMiB": 31.985291,
+            "lifetimePeakFootprintMiB": 32.454041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.096217292,
+            "rssMiB": 110.3125,
+            "footprintMiB": 329.516655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.128905417,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630413032,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.327817208,
+            "rssMiB": 41.484375,
+            "footprintMiB": 32.391541,
+            "lifetimePeakFootprintMiB": 32.454041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.153963625,
+            "rssMiB": 110.921875,
+            "footprintMiB": 329.71978,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.130635042,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630413535,
+          "phase": "stream",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.332671417,
+            "rssMiB": 41.546875,
+            "footprintMiB": 32.454041,
+            "lifetimePeakFootprintMiB": 32.454041,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.223489042,
+            "rssMiB": 110.953125,
+            "footprintMiB": 329.53228,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133012167,
+              "rssMiB": 7.40625,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630414036,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.337628875,
+            "rssMiB": 44.4375,
+            "footprintMiB": 34.500916,
+            "lifetimePeakFootprintMiB": 34.500916,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.317856917,
+            "rssMiB": 113.28125,
+            "footprintMiB": 331.329178,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630414530,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.337682125,
+            "rssMiB": 44.4375,
+            "footprintMiB": 34.500916,
+            "lifetimePeakFootprintMiB": 34.500916,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.445156833,
+            "rssMiB": 113.296875,
+            "footprintMiB": 331.329178,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630415038,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.337952958,
+            "rssMiB": 44.46875,
+            "footprintMiB": 34.516541,
+            "lifetimePeakFootprintMiB": 34.516541,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.537215042,
+            "rssMiB": 113.296875,
+            "footprintMiB": 331.329178,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.250252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630415534,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.3380715,
+            "rssMiB": 44.46875,
+            "footprintMiB": 34.516541,
+            "lifetimePeakFootprintMiB": 34.516541,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.540681375,
+            "rssMiB": 113.3125,
+            "footprintMiB": 331.28228,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630416028,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.3380715,
+            "rssMiB": 44.46875,
+            "footprintMiB": 34.516541,
+            "lifetimePeakFootprintMiB": 34.516541,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.543682083,
+            "rssMiB": 113.3125,
+            "footprintMiB": 331.28228,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630416550,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.338260375,
+            "rssMiB": 44.46875,
+            "footprintMiB": 34.516541,
+            "lifetimePeakFootprintMiB": 34.516541,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.546817792,
+            "rssMiB": 112.40625,
+            "footprintMiB": 331.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630417038,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.338405292,
+            "rssMiB": 44.40625,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.550676542,
+            "rssMiB": 112.359375,
+            "footprintMiB": 331.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630417543,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.338521292,
+            "rssMiB": 44.3125,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.555181042,
+            "rssMiB": 112.09375,
+            "footprintMiB": 331.37603,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630418042,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.338521292,
+            "rssMiB": 44.3125,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.561592292,
+            "rssMiB": 112.09375,
+            "footprintMiB": 331.37603,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630418543,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.338660708,
+            "rssMiB": 44.3125,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.56793725,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630419040,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.338803167,
+            "rssMiB": 44.3125,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.573817,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630419547,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.338943583,
+            "rssMiB": 44.3125,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.580285667,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630420047,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.338943583,
+            "rssMiB": 44.3125,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.586592583,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630420554,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.339071667,
+            "rssMiB": 44.3125,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.592263417,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630421051,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.339071667,
+            "rssMiB": 44.296875,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.597620083,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630421548,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.339253458,
+            "rssMiB": 44.296875,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.604107833,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630422055,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.339349,
+            "rssMiB": 44.296875,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.610416167,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 29
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630422556,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.339480417,
+            "rssMiB": 44.296875,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.616212875,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630423059,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.339480417,
+            "rssMiB": 44.296875,
+            "footprintMiB": 34.594666,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.621246958,
+            "rssMiB": 112.09375,
+            "footprintMiB": 330.68853,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630423560,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.339656208,
+            "rssMiB": 44.1875,
+            "footprintMiB": 34.297791,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.6250025,
+            "rssMiB": 112.046875,
+            "footprintMiB": 330.704155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630424054,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.339656208,
+            "rssMiB": 44.1875,
+            "footprintMiB": 34.297791,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.627011167,
+            "rssMiB": 112.046875,
+            "footprintMiB": 330.704155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630424563,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.340452292,
+            "rssMiB": 44.1875,
+            "footprintMiB": 34.297791,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.633815625,
+            "rssMiB": 112.046875,
+            "footprintMiB": 330.704155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630425052,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.340452292,
+            "rssMiB": 44.1875,
+            "footprintMiB": 34.297791,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.636158833,
+            "rssMiB": 112.046875,
+            "footprintMiB": 330.704155,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630425562,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.340725375,
+            "rssMiB": 44.1875,
+            "footprintMiB": 34.297791,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.639515667,
+            "rssMiB": 111.984375,
+            "footprintMiB": 330.922905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630426061,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.340725375,
+            "rssMiB": 43.96875,
+            "footprintMiB": 34.407166,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.641993667,
+            "rssMiB": 111.9375,
+            "footprintMiB": 331.110405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.125252,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630426564,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.3408705,
+            "rssMiB": 43.96875,
+            "footprintMiB": 34.407166,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.644887792,
+            "rssMiB": 111.9375,
+            "footprintMiB": 331.110405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630427068,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.340885833,
+            "rssMiB": 43.96875,
+            "footprintMiB": 34.407166,
+            "lifetimePeakFootprintMiB": 34.594666,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.647277875,
+            "rssMiB": 111.9375,
+            "footprintMiB": 331.110405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630427559,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.344451125,
+            "rssMiB": 38.6875,
+            "footprintMiB": 35.688416,
+            "lifetimePeakFootprintMiB": 35.688416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.65067175,
+            "rssMiB": 109.453125,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 30
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630428060,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.344451125,
+            "rssMiB": 38.6875,
+            "footprintMiB": 35.688416,
+            "lifetimePeakFootprintMiB": 35.688416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.654701417,
+            "rssMiB": 109.453125,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 34
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630428580,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.344604625,
+            "rssMiB": 38.6875,
+            "footprintMiB": 35.688416,
+            "lifetimePeakFootprintMiB": 35.688416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.657832333,
+            "rssMiB": 109.453125,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 34
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630429066,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.344613667,
+            "rssMiB": 38.6875,
+            "footprintMiB": 35.688416,
+            "lifetimePeakFootprintMiB": 35.688416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.66098,
+            "rssMiB": 109.453125,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 34
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630429570,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.344946833,
+            "rssMiB": 38.6875,
+            "footprintMiB": 35.688416,
+            "lifetimePeakFootprintMiB": 35.688416,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.667891542,
+            "rssMiB": 109.453125,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 34
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630430076,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.344946833,
+            "rssMiB": 38.609375,
+            "footprintMiB": 35.735291,
+            "lifetimePeakFootprintMiB": 35.735291,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.673945417,
+            "rssMiB": 109.21875,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 35
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630430567,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.345093,
+            "rssMiB": 38.609375,
+            "footprintMiB": 35.735291,
+            "lifetimePeakFootprintMiB": 35.735291,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.677278958,
+            "rssMiB": 109.21875,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 35
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630431079,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.345093,
+            "rssMiB": 38.609375,
+            "footprintMiB": 35.735291,
+            "lifetimePeakFootprintMiB": 35.735291,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.683859333,
+            "rssMiB": 109.21875,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 35
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630431577,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.34526525,
+            "rssMiB": 38.609375,
+            "footprintMiB": 35.735291,
+            "lifetimePeakFootprintMiB": 35.735291,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.686934792,
+            "rssMiB": 109.21875,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 35
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630432093,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.34526525,
+            "rssMiB": 37.640625,
+            "footprintMiB": 35.735291,
+            "lifetimePeakFootprintMiB": 35.735291,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.692904833,
+            "rssMiB": 108.34375,
+            "footprintMiB": 332.266655,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 35
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 7.53125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630432582,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.345357208,
+            "rssMiB": 30.703125,
+            "footprintMiB": 35.922791,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.698403333,
+            "rssMiB": 101.84375,
+            "footprintMiB": 332.360405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 36
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630433087,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.34538725,
+            "rssMiB": 29.59375,
+            "footprintMiB": 35.922791,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 1
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.704554458,
+            "rssMiB": 100.453125,
+            "footprintMiB": 332.360405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 36
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630433578,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.345486292,
+            "rssMiB": 29.5625,
+            "footprintMiB": 35.766541,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.711131375,
+            "rssMiB": 100.21875,
+            "footprintMiB": 332.360405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 47
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.109375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630434086,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.345560583,
+            "rssMiB": 29.578125,
+            "footprintMiB": 35.766541,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.71624475,
+            "rssMiB": 100.21875,
+            "footprintMiB": 332.360405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 47
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.109375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630434586,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.345710458,
+            "rssMiB": 29.578125,
+            "footprintMiB": 35.766541,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.72089225,
+            "rssMiB": 100.21875,
+            "footprintMiB": 332.360405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 48
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.109375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630435089,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.345710458,
+            "rssMiB": 29.578125,
+            "footprintMiB": 35.766541,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.724108833,
+            "rssMiB": 100.21875,
+            "footprintMiB": 332.360405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 48
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.109375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630435574,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.345842417,
+            "rssMiB": 29.578125,
+            "footprintMiB": 35.766541,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.725007417,
+            "rssMiB": 100.21875,
+            "footprintMiB": 332.360405,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 48
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.109375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630436086,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.345902417,
+            "rssMiB": 27.5625,
+            "footprintMiB": 35.797791,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.727860042,
+            "rssMiB": 98.5625,
+            "footprintMiB": 332.422905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 48
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.09375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630436587,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.346036708,
+            "rssMiB": 27.484375,
+            "footprintMiB": 35.797791,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.730171375,
+            "rssMiB": 98.546875,
+            "footprintMiB": 332.422905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 48
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.09375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630437088,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.348556167,
+            "rssMiB": 29.359375,
+            "footprintMiB": 34.938416,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.738257417,
+            "rssMiB": 100.078125,
+            "footprintMiB": 332.422905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 48
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.09375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630437592,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.348666583,
+            "rssMiB": 29.359375,
+            "footprintMiB": 34.938416,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.74070975,
+            "rssMiB": 100.078125,
+            "footprintMiB": 332.40728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 48
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.09375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630438088,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.349724583,
+            "rssMiB": 29.828125,
+            "footprintMiB": 34.954041,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.744128083,
+            "rssMiB": 100.09375,
+            "footprintMiB": 332.40728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 48
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.09375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630438595,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.34983025,
+            "rssMiB": 29.828125,
+            "footprintMiB": 34.954041,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.746731292,
+            "rssMiB": 100.09375,
+            "footprintMiB": 332.40728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 48
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.09375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630439105,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.34983025,
+            "rssMiB": 29.828125,
+            "footprintMiB": 34.954041,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.750044833,
+            "rssMiB": 100.125,
+            "footprintMiB": 332.40728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 50
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.09375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630439593,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.351133458,
+            "rssMiB": 30.0625,
+            "footprintMiB": 34.954041,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.760152125,
+            "rssMiB": 100.28125,
+            "footprintMiB": 332.40728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 50
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.09375,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630440101,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.351338042,
+            "rssMiB": 29.53125,
+            "footprintMiB": 34.954041,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.7638325,
+            "rssMiB": 99.640625,
+            "footprintMiB": 332.40728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 50
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.078125,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630440600,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.351461208,
+            "rssMiB": 29.28125,
+            "footprintMiB": 34.954041,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.766607333,
+            "rssMiB": 99.46875,
+            "footprintMiB": 332.422905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 50
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.046875,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630441102,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.351486375,
+            "rssMiB": 29.28125,
+            "footprintMiB": 34.954041,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.769872333,
+            "rssMiB": 99.453125,
+            "footprintMiB": 332.422905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 50
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.046875,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630441604,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.351587333,
+            "rssMiB": 29.25,
+            "footprintMiB": 34.954041,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.772801125,
+            "rssMiB": 99.375,
+            "footprintMiB": 332.422905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 54
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.046875,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630442097,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.351732583,
+            "rssMiB": 29.265625,
+            "footprintMiB": 34.954041,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.778626583,
+            "rssMiB": 99.375,
+            "footprintMiB": 332.422905,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 54
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.046875,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630442604,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.355362667,
+            "rssMiB": 29.53125,
+            "footprintMiB": 35.094666,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.781223458,
+            "rssMiB": 99.375,
+            "footprintMiB": 332.40728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 55
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.046875,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630443105,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.355362667,
+            "rssMiB": 29.53125,
+            "footprintMiB": 35.094666,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.786655542,
+            "rssMiB": 99.25,
+            "footprintMiB": 332.40728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 58
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.046875,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        },
+        {
+          "at": 1788630443610,
+          "phase": "settled",
+          "engine": {
+            "pid": 76177,
+            "cpuSeconds": 0.355484333,
+            "rssMiB": 29.53125,
+            "footprintMiB": 35.094666,
+            "lifetimePeakFootprintMiB": 35.922791,
+            "idleWakeups": 3
+          },
+          "ui": {
+            "pid": 76234,
+            "cpuSeconds": 3.792418458,
+            "rssMiB": 99.21875,
+            "footprintMiB": 332.40728,
+            "lifetimePeakFootprintMiB": 342.266632,
+            "idleWakeups": 58
+          },
+          "harness": [
+            {
+              "pid": 76810,
+              "cpuSeconds": 0.133547208,
+              "rssMiB": 6.046875,
+              "footprintMiB": 6.047127,
+              "lifetimePeakFootprintMiB": 6.250252,
+              "idleWakeups": 8
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/fixtures/README.md
+++ b/scripts/fixtures/README.md
@@ -1,0 +1,13 @@
+`resource-stream.jsonl` contains sanitized deltas from a successful Haiku
+profiling response: an 80-section Rust ownership tutorial with code fences.
+Only text/reasoning deltas and the successful completion marker are retained;
+account, session, timestamp and usage metadata are omitted.
+
+The assistant text is 51,769 bytes, SHA-256
+`c1809f92c26c682c6f035478f7ca63980e25fb5e97ea7746dcb41ecd7dbb0a25`.
+Reasoning contributes another 853 bytes. The production transcript's part
+separators bring the combined short reply to 52,624 bytes.
+
+Use `ZERON_REPLAY_REPEAT=10 ZERON_REPLAY_DELAY_MS=8` for the synthetic long
+workload. See [the profiling report](../../docs/performance-resource-usage.md)
+for build settings, commands and measured results.

--- a/scripts/fixtures/resource-stream.jsonl
+++ b/scripts/fixtures/resource-stream.jsonl
@@ -1,0 +1,445 @@
+{"event": {"type": "reasoningDelta", "text": "The user wants"}}
+{"event": {"type": "reasoningDelta", "text": " me to write a detailed tutorial on Rust ownership with exactly 80 numbered sections. Each section needs:\n1. A heading\n2. A paragraph of at least 60 words\n3. A"}}
+{"event": {"type": "reasoningDelta", "text": " short Rust code example\n\nThey explicitly say \"Do not use tools\" and \"Continue through all 80 sections without asking questions.\"\n\nThis is a substantial"}}
+{"event": {"type": "reasoningDelta", "text": " writing task, but the user has made it clear they want me to proceed without asking for clarification. I'll write a comprehensive tutorial covering all"}}
+{"event": {"type": "reasoningDelta", "text": " aspects of Rust ownership, from basics to advanced concepts.\n\nLet me structure this to cover:\n- Introduction to ownership\n- Ownership rules\n- Moving values"}}
+{"event": {"type": "reasoningDelta", "text": "\n- Copying\n- References and borrowing\n- Mutable references\n- Lifetime concepts\n- Common patterns\n- Best practices\n- Edge"}}
+{"event": {"type": "reasoningDelta", "text": " cases\n- And more...\n\nI'll make sure each section has at least 60 words and includes a code example."}}
+{"event": {"type": "textDelta", "text": "# A Comprehensive Tutorial on Rust"}}
+{"event": {"type": "textDelta", "text": " Ownership: 80 Sections\n\n## 1. Introduction to Ownership\n\nRust's ownership system is a set of rules that the compiler checks"}}
+{"event": {"type": "textDelta", "text": " at compile time. Unlike garbage collection or manual memory management, Rust uses ownership to manage memory safely without runtime overhead"}}
+{"event": {"type": "textDelta", "text": ". Understanding ownership is fundamental to writing Rust code effectively. The ownership system prevents common bugs like use-after-free"}}
+{"event": {"type": "textDelta", "text": " and double-free errors. It enables Rust to provide memory safety without needing a garbage collector, making"}}
+{"event": {"type": "textDelta", "text": " Rust both safe and efficient. This tutorial will guide you through every aspect of Rust's ownership model.\n\n```rust\nfn main() {\n    let s"}}
+{"event": {"type": "textDelta", "text": " = String::from(\"hello\");\n    println!(\"{}\", s); // s owns the String\n}\n```\n\n## 2. What is Ownership?\n\nOwnership is"}}
+{"event": {"type": "textDelta", "text": " a system where each value in Rust has a single owner at any given time. When the owner goes out of scope, the value is automatically dropped and"}}
+{"event": {"type": "textDelta", "text": " its memory is freed. This is different from other programming languages where memory management is handled differently. The compiler tracks ownership through static"}}
+{"event": {"type": "textDelta", "text": " analysis, ensuring memory safety. No runtime checks or garbage collection is needed. The ownership rules are enforced at compile time, catching many"}}
+{"event": {"type": "textDelta", "text": " errors before the program runs.\n\n```rust\nfn main() {\n    let s = String::from(\"world\"); // s owns this String\n    // s is the"}}
+{"event": {"type": "textDelta", "text": " owner of the String \"world\"\n} // s goes out of scope here, String is dropped\n```\n\n## 3. The"}}
+{"event": {"type": "textDelta", "text": " First Rule of Ownership\n\nThe first rule of ownership states that each value in Rust has exactly one owner. This means that at any point in time"}}
+{"event": {"type": "textDelta", "text": ", only one variable can own a particular piece of data on the heap. When you assign a value from one variable to another, ownership is transferred to"}}
+{"event": {"type": "textDelta", "text": " the new variable. The original variable no longer has ownership of that value. This rule ensures that memory is managed safely and prevents multiple parts of code"}}
+{"event": {"type": "textDelta", "text": " from trying to free the same memory. Understanding this rule is essential for avoiding conflicts over resource ownership.\n\n```rust\nfn main() {\n    "}}
+{"event": {"type": "textDelta", "text": "let s1 = String::from(\"hello\");\n    let s2 = s1; // ownership moves to s2\n    // println!(\"{}\", s"}}
+{"event": {"type": "textDelta", "text": "1); // error: s1 no longer owns the String\n    println!(\"{}\", s2); // this is fine\n}\n```\n\n## 4. The"}}
+{"event": {"type": "textDelta", "text": " Second Rule of Ownership\n\nThe second rule of ownership states that when the owner goes out of scope, the value will be dropped. This means memory is automatically"}}
+{"event": {"type": "textDelta", "text": " cleaned up when it's no longer needed. Rust calls a special function `drop` (similar to destruct"}}
+{"event": {"type": "textDelta", "text": "ors in C++) when a variable goes out of scope. This automatic cleanup happens for all types of values, whether they're on the stack or the heap. The rule"}}
+{"event": {"type": "textDelta", "text": " eliminates memory leaks because memory is always freed when it's no longer accessible. This is why Rust doesn't need garbage collection."}}
+{"event": {"type": "textDelta", "text": "\n\n```rust\nfn main() {\n    let s = String::from(\"hello\");\n    // s is in scope here\n    println!(\"{}\", s);\n}"}}
+{"event": {"type": "textDelta", "text": " // s goes out of scope here, drop is called automatically\n```\n\n## 5. Stack vs. Heap\n\nUnderstanding the difference between stack and heap storage is crucial for understanding"}}
+{"event": {"type": "textDelta", "text": " ownership. Stack memory is automatically managed and fast, storing values of known fixed size like integers and references. Heap memory"}}
+{"event": {"type": "textDelta", "text": " stores data of unknown or variable size like Strings and collections. When a variable holding heap data goes out of"}}
+{"event": {"type": "textDelta", "text": " scope, Rust deallocates the heap memory. Stack values are automatically cleaned up when they go out of scope. The heap requires explicit management"}}
+{"event": {"type": "textDelta", "text": " through ownership to prevent memory leaks.\n\n```rust\nfn main() {\n    let x = 5; // stack: stored directly"}}
+{"event": {"type": "textDelta", "text": "\n    let s = String::from(\"hello\"); // heap: data stored on heap, reference on stack\n}\n```\n\n## 6. Move"}}
+{"event": {"type": "textDelta", "text": " Semantics\n\nMove semantics is the core behavior of Rust's ownership system. When you assign a value from one variable to another, ownership is transferred in what"}}
+{"event": {"type": "textDelta", "text": "'s called a \"move.\" The original variable can no longer be used because it no longer owns the value. This differs from copying, where"}}
+{"event": {"type": "textDelta", "text": " both variables hold independent copies of the data. Moves are efficient because they don't require copying large amounts of data. Move"}}
+{"event": {"type": "textDelta", "text": " semantics ensure that at most one variable owns a value at any given time.\n\n```rust\nfn main() {\n    let s1 = String::from(\"hello\");\n    let s2 = s"}}
+{"event": {"type": "textDelta", "text": "1; // s1 is moved to s2\n    println!(\"{}\", s2); // okay\n    // println!(\"{}\", s1); // error: s1 was"}}
+{"event": {"type": "textDelta", "text": " moved\n}\n```\n\n## 7. Copy Trait for Stack Values\n\nNot all types use move semantics. Types"}}
+{"event": {"type": "textDelta", "text": " that implement the `Copy` trait are copied instead of moved when assigned to another variable. These include simple types like integers, floats, booleans, and characters"}}
+{"event": {"type": "textDelta", "text": ". When a type implements `Copy`, assigning it to another variable creates an independent copy of the value. Both variables remain"}}
+{"event": {"type": "textDelta", "text": " valid and can be used independently. `Copy` is only valid for types whose values can be safely duplicated by just copying bits"}}
+{"event": {"type": "textDelta", "text": ".\n\n```rust\nfn main() {\n    let x = 5;\n    let y = x; // x is copied to y\n    println!(\"x: {}, y: {}\", x, y);"}}
+{"event": {"type": "textDelta", "text": " // both are still valid\n}\n```\n\n## 8. Implementing Copy for Custom Types\n\nYou can implement the `Copy` trait for your own types, but"}}
+{"event": {"type": "textDelta", "text": " only if they consist entirely of `Copy` types. If a struct contains a `String` or other"}}
+{"event": {"type": "textDelta", "text": " non-`Copy` type, it cannot be `Copy`. The `Copy` trait is usually implemented along with the `Clone` trait. `"}}
+{"event": {"type": "textDelta", "text": "Copy` is a marker trait without methods that tells the compiler the type can be safely copied bit-"}}
+{"event": {"type": "textDelta", "text": "by-bit. Most commonly, you'll derive both `Copy` and `Clone` using attributes.\n\n```rust\n#[derive(Copy, Clone"}}
+{"event": {"type": "textDelta", "text": ")]\nstruct Point {\n    x: i32,\n    y: i32,\n}\n\nfn main() {\n    let p1 = Point { x: 1, y: "}}
+{"event": {"type": "textDelta", "text": "2 };\n    let p2 = p1; // p1 is copied\n    println!(\"p1: {:?}, p2: {:?}\", p1, p2); // both valid"}}
+{"event": {"type": "textDelta", "text": "\n}\n```\n\n## 9. Clone: Explicit Deep Copy\n\nWhile `Copy` is implicit and cheap, `Clone`"}}
+{"event": {"type": "textDelta", "text": " is explicit and can be expensive. The `Clone` trait allows you to create a deep copy of a value. For types like `String`,"}}
+{"event": {"type": "textDelta", "text": " cloning duplicates all the data on the heap, which takes time and memory. You must explicitly call"}}
+{"event": {"type": "textDelta", "text": " `.clone()` to clone a value. This makes expensive operations visible in your code. Cloning is useful"}}
+{"event": {"type": "textDelta", "text": " when you want multiple independent copies of a value.\n\n```rust\nfn main() {\n    let s1 = String::from(\"hello\");\n    let s2 = s"}}
+{"event": {"type": "textDelta", "text": "1.clone(); // explicit deep copy\n    println!(\"s1: {}, s2: {}\", s1, s2); // both are valid\n}\n```\n\n## 10"}}
+{"event": {"type": "textDelta", "text": ". Function Parameters and Ownership\n\nWhen you pass a value to a function, ownership is transferred to the function's parameter. After the function returns, ownership is no longer accessible"}}
+{"event": {"type": "textDelta", "text": " in the calling code unless the function returns ownership back. This is part of move semantics: ass"}}
+{"event": {"type": "textDelta", "text": "igning a value to a function parameter is like assigning it to any other variable. Large values on the heap will"}}
+{"event": {"type": "textDelta", "text": " have their ownership moved into the function. If the function doesn't return the value, it will be dropped at the end of the function.\n\n```"}}
+{"event": {"type": "textDelta", "text": "rust\nfn take_ownership(s: String) {\n    println!(\"{}\", s);\n} // s is dropped here\n\nfn main() {\n    let s"}}
+{"event": {"type": "textDelta", "text": " = String::from(\"hello\");\n    take_ownership(s); // ownership moves to function\n    // println!(\"{}\", s); // error: s is no longer accessible\n}"}}
+{"event": {"type": "textDelta", "text": "\n```\n\n## 11. Function Return Values and Ownership\n\nFunctions can return ownership to the caller by returning a value. The return value's ownership is transferred to whatever receives"}}
+{"event": {"type": "textDelta", "text": " it in the calling code. This allows functions to transfer ownership back after processing. Returning values is a way to give ownership back"}}
+{"event": {"type": "textDelta", "text": " to the caller. A function can take ownership of a parameter and return ownership of a modified value. This is an important pattern for functions"}}
+{"event": {"type": "textDelta", "text": " that need to work with owned values.\n\n```rust\nfn give_ownership() -> String {\n    String::from(\"hello\")\n}\n\nfn main() {\n    let s"}}
+{"event": {"type": "textDelta", "text": " = give_ownership(); // ownership transferred to s\n    println!(\"{}\", s);\n}\n```\n\n## 12. Introduction to References\n\nReferences allow you to refer to a"}}
+{"event": {"type": "textDelta", "text": " value without taking ownership of it. A reference is created using the `&` operator. References are immutable by default, meaning you can't modify"}}
+{"event": {"type": "textDelta", "text": " the value through a reference. References are addresses in memory pointing to owned data. When a reference goes out of scope, nothing happens because"}}
+{"event": {"type": "textDelta", "text": " the reference doesn't own the value. References enable passing values to functions without transferring ownership.\n\n```rust\nfn main() {"}}
+{"event": {"type": "textDelta", "text": "\n    let s = String::from(\"hello\");\n    let r = &s; // create a reference to s\n    println!(\"{}\", r); // dereference the reference"}}
+{"event": {"type": "textDelta", "text": "\n}\n```\n\n## 13. Borrowing: Temporary References\n\nBorrowing is the process of creating a reference to a value you don't own."}}
+{"event": {"type": "textDelta", "text": " When you borrow a value, you're temporarily allowing another part of code to read that value. The borrowed reference"}}
+{"event": {"type": "textDelta", "text": " is only valid as long as the original owner keeps the value alive. Borrowing is cheaper than moving because no data is copied."}}
+{"event": {"type": "textDelta", "text": " Borrowing is immutable by default, preventing accidental modifications.\n\n```rust\nfn print_string(s: &String) {\n    println!(\"{}\", s);\n}"}}
+{"event": {"type": "textDelta", "text": "\n\nfn main() {\n    let s = String::from(\"hello\");\n    print_string(&s); // borrow s\n    println!(\"{}\", s); // s still"}}
+{"event": {"type": "textDelta", "text": " owns the String\n}\n```\n\n## 14. Multiple Immutable References\n\nYou can create multiple immutable references to the same value at the"}}
+{"event": {"type": "textDelta", "text": " same time. This is safe because none of the references can modify the value. The rule states that you can have many immutable references to"}}
+{"event": {"type": "textDelta", "text": " a value, or one mutable reference, but not both. Multiple readers of the same data"}}
+{"event": {"type": "textDelta", "text": " is safe and encouraged. This is a fundamental rule that prevents data races at compile time.\n\n```"}}
+{"event": {"type": "textDelta", "text": "rust\nfn main() {\n    let s = String::from(\"hello\");\n    let r1 = &s;\n    let r2 = &s;\n    let r3 ="}}
+{"event": {"type": "textDelta", "text": " &s;\n    println!(\"{}, {}, {}\", r1, r2, r3); // all valid\n}\n```\n\n## 15. Mutable References\n\nMutable references allow"}}
+{"event": {"type": "textDelta", "text": " you to modify the value you're borrowing. A mutable reference is created using `&mut`. You can only have one mutable reference to a value at a time in"}}
+{"event": {"type": "textDelta", "text": " a given scope. This ensures that modifications through the reference won't surprise other parts of code. Mutable"}}
+{"event": {"type": "textDelta", "text": " references are less common than immutable references but essential for many algorithms. The compiler prevents data races by ensuring exclusive m"}}
+{"event": {"type": "textDelta", "text": "utable access.\n\n```rust\nfn main() {\n    let mut s = String::from(\"hello\");\n    let r = &mut s;\n    r.push_str(\" world\");"}}
+{"event": {"type": "textDelta", "text": "\n    println!(\"{}\", r);\n}\n```\n\n## 16. The Borrowing Rules\n\nThe borrowing rules are simple but powerful"}}
+{"event": {"type": "textDelta", "text": ". You can have either any number of immutable references, or exactly one mutable reference at a time. You cannot have both mutable and immutable references at"}}
+{"event": {"type": "textDelta", "text": " the same time. The compiler enforces these rules statically, preventing data races at compile time. Violating these rules results in a compile error"}}
+{"event": {"type": "textDelta", "text": ". These rules are checked using the concept of scopes and lifetimes.\n\n```rust\nfn main() {\n    let mut s = String::"}}
+{"event": {"type": "textDelta", "text": "from(\"hello\");\n    let r1 = &s;\n    let r2 = &s;\n    // let r3 = &mut s; // error: can"}}
+{"event": {"type": "textDelta", "text": "'t borrow as mutable while immutable borrows exist\n    println!(\"{}, {}\", r1, r2);\n    let"}}
+{"event": {"type": "textDelta", "text": " r3 = &mut s; // now okay, immutable refs are no longer used\n    r3.push_"}}
+{"event": {"type": "textDelta", "text": "str(\" world\");\n    println!(\"{}\", r3);\n}\n```\n\n## 17. Lifetimes: What Are They?\n\nLifetimes are a concept that"}}
+{"event": {"type": "textDelta", "text": " tracks how long references are valid. Every reference in Rust has a lifetime, which is the scope in which the"}}
+{"event": {"type": "textDelta", "text": " reference is valid. The compiler uses lifetimes to ensure that references never outlive the data they point to. Lifetimes are often implicit and"}}
+{"event": {"type": "textDelta", "text": " don't need to be written explicitly. When they can't be inferred, you must annotate them with `'"}}
+{"event": {"type": "textDelta", "text": "a`, `'b`, etc. Lifetimes are a compile-time feature that doesn't affect runtime performance.\n\n```rust\nfn main()"}}
+{"event": {"type": "textDelta", "text": " {\n    let s = String::from(\"hello\");\n    {\n        let r = &s; // r is borrowed here\n        println!(\"{}\", r);\n    } // r's"}}
+{"event": {"type": "textDelta", "text": " lifetime ends here\n    println!(\"{}\", s); // s is still valid\n}\n```\n\n## 18. Explicit Lifetime Annotations\n\nWhen the compiler can't in"}}
+{"event": {"type": "textDelta", "text": "fer lifetimes automatically, you must annotate them explicitly. Lifetime annotations use single quotes followed by a name like"}}
+{"event": {"type": "textDelta", "text": " `'a`. The syntax `&'a String` means \"a reference to a String with lifetime 'a\"."}}
+{"event": {"type": "textDelta", "text": " Lifetime annotations appear in function signatures and struct definitions. They don't change how long a value actually lives. They tell"}}
+{"event": {"type": "textDelta", "text": " the compiler to verify that the actual lifetimes at runtime satisfy the constraints.\n\n```rust\nfn longest<'a>(s1: &'a"}}
+{"event": {"type": "textDelta", "text": " str, s2: &'a str) -> &'a str {\n    if s1.len() > s2.len() { s1 } else { s2 "}}
+{"event": {"type": "textDelta", "text": "}\n}\n\nfn main() {\n    let s1 = \"hello\";\n    let s2 = \"world\";\n    println!(\"{}\", longest(s1, s2));"}}
+{"event": {"type": "textDelta", "text": "\n}\n```\n\n## 19. Lifetime Elision\n\nRust has rules called \"lifetime elision\" that allow you to om"}}
+{"event": {"type": "textDelta", "text": "it lifetime annotations in common cases. If there's only one input reference, its lifetime is assumed to be the output lifetime. If there"}}
+{"event": {"type": "textDelta", "text": "'s a `self` parameter, its lifetime is the output lifetime. These rules were designed to make common patterns erg"}}
+{"event": {"type": "textDelta", "text": "onomic while still requiring annotations when needed. Lifetime elision makes function signatures cleaner and easier to read.\n\n```rust\nfn"}}
+{"event": {"type": "textDelta", "text": " first_word(s: &str) -> &str {\n    // lifetime is elided here\n    let bytes = s.as_bytes();"}}
+{"event": {"type": "textDelta", "text": "\n    for (i, &item) in bytes.iter().enumerate() {\n        if item == b' ' {\n            return &s[0..i];\n        }\n    "}}
+{"event": {"type": "textDelta", "text": "}\n    &s[..]\n}\n\nfn main() {\n    println!(\"{}\", first_word(\"hello world\"));\n}\n```\n\n## 20. Lif"}}
+{"event": {"type": "textDelta", "text": "etimes in Structs\n\nStructs can contain references, but those references must have lifetime annotations. If a struct contains a reference,"}}
+{"event": {"type": "textDelta", "text": " you must specify how long that reference is valid. This prevents creating structs with dangling references. A struct with a reference is associated"}}
+{"event": {"type": "textDelta", "text": " with the lifetime of that reference. This ensures that the struct can't outlive the data it references.\n\n```rust\nstruct Text"}}
+{"event": {"type": "textDelta", "text": "Wrapper<'a> {\n    text: &'a str,\n}\n\nfn main() {\n    let s = String::from(\"hello\");\n    let"}}
+{"event": {"type": "textDelta", "text": " wrapper = TextWrapper { text: &s };\n    println!(\"{}\", wrapper.text);\n} // s is dropped here, wrapper is no longer valid\n```\n\n## 21. Lif"}}
+{"event": {"type": "textDelta", "text": "etimes in Methods\n\nMethods in impl blocks can also have lifetime annotations. If a method returns a reference, its lifetime must be connected to a reference"}}
+{"event": {"type": "textDelta", "text": " parameter or `self`. The `self` parameter has an implicit lifetime that determines how long the returned"}}
+{"event": {"type": "textDelta", "text": " reference is valid. Methods often return references with the lifetime of `self`. This ensures that methods can't return"}}
+{"event": {"type": "textDelta", "text": " references that outlive the object.\n\n```rust\nimpl<'a> TextWrapper<'a> {\n    fn get_text(&self) -> &'"}}
+{"event": {"type": "textDelta", "text": "a str {\n        self.text\n    }\n}\n\nfn main() {\n    let s = String::from(\"hello\");\n    let wrapper = TextWrapper { text: &s };\n    let"}}
+{"event": {"type": "textDelta", "text": " text = wrapper.get_text();\n    println!(\"{}\", text);\n}\n```\n\n## 22. Static Lifetimes\n\nThe `'static` lifetime means a"}}
+{"event": {"type": "textDelta", "text": " reference is valid for the entire duration of the program. String literals have `'static` lifetime because they're hardcoded into the binary. Any reference with"}}
+{"event": {"type": "textDelta", "text": " a `'static` lifetime can never be a dangling pointer. Only very specific values like string"}}
+{"event": {"type": "textDelta", "text": " literals and other compile-time constants have static lifetimes. A reference with `'static` lifetime can be stored in static variables."}}
+{"event": {"type": "textDelta", "text": "\n\n```rust\nfn main() {\n    let s: &'static str = \"hello\"; // string literals have 'static lifetime\n    println!(\"{}\", s"}}
+{"event": {"type": "textDelta", "text": ");\n}\n\nstatic GREETING: &str = \"hello, world!\";\n\nfn main2() {\n    println!(\"{}\", GREETING);"}}
+{"event": {"type": "textDelta", "text": "\n}\n```\n\n## 23. Dereference Operator\n\nThe dereference operator `*` allows you to access the value a reference points to. For references"}}
+{"event": {"type": "textDelta", "text": " to simple types, you typically don't need to dereference explicitly because of automatic dereferencing."}}
+{"event": {"type": "textDelta", "text": " For references to complex types or when you need to modify the value, dereferencing is necessary. The dereference operator has lower precedence than method"}}
+{"event": {"type": "textDelta", "text": " calls, so `ref.method()` is equivalent to `(*ref).method()`.\n\n```rust\nfn main() {\n    let x = 5;"}}
+{"event": {"type": "textDelta", "text": "\n    let r = &x;\n    println!(\"x: {}, r: {}\", x, *r); // *r dereferences to "}}
+{"event": {"type": "textDelta", "text": "5\n}\n\nfn main2() {\n    let mut s = String::from(\"hello\");\n    let r = &mut s;\n    r.push_str(\" world\");"}}
+{"event": {"type": "textDelta", "text": "\n    println!(\"{}\", r);\n}\n```\n\n## 24. Automatic Dereferencing\n\nRust automatically dereferences references in many contexts, making code cle"}}
+{"event": {"type": "textDelta", "text": "aner and easier to write. When you call a method on a reference, Rust automatically dereferences it as many times as necessary. Automatic"}}
+{"event": {"type": "textDelta", "text": " dereferencing makes working with references feel natural and doesn't require constant use of the `*` operator. This feature is called \"de"}}
+{"event": {"type": "textDelta", "text": "ref coercion\" and applies in method calls and function arguments. It makes references nearly as convenient to use as owned"}}
+{"event": {"type": "textDelta", "text": " values.\n\n```rust\nfn main() {\n    let s = String::from(\"hello\");\n    let r = &s;\n    // Both of these work due"}}
+{"event": {"type": "textDelta", "text": " to automatic dereferencing\n    println!(\"{}\", r.len());\n    println!(\"{}\", (*r).len());\n}\n```\n\n## 25. References to References"}}
+{"event": {"type": "textDelta", "text": "\n\nYou can create references to references, creating multiple levels of indirection. A reference to a reference is created by taking the address of an existing reference using"}}
+{"event": {"type": "textDelta", "text": " `&`. Dereferencing a reference to a reference requires using the `*` operator multiple times or relying on automatic dereferencing. Multiple"}}
+{"event": {"type": "textDelta", "text": " levels of references are rarely used in practice but can be useful in some situations. Rust handles them correctly"}}
+{"event": {"type": "textDelta", "text": " through its type system.\n\n```rust\nfn main() {\n    let x = 5;\n    let r1 = &x;\n    let"}}
+{"event": {"type": "textDelta", "text": " r2 = &r1;\n    println!(\"x: {}, r1: {}, r2: {}\", x, *r1, **r2);\n}\n```\n\n## 26"}}
+{"event": {"type": "textDelta", "text": ". Slices: References to Collections\n\nSlices are references to a contiguous sequence of elements in a collection. Unlike ow"}}
+{"event": {"type": "textDelta", "text": "ning a String or Vec, a slice borrows a portion of a collection. String slices `&str` and"}}
+{"event": {"type": "textDelta", "text": " vector slices `&[T]` are common examples. Slices are created using range syntax like `&s[0..5]`"}}
+{"event": {"type": "textDelta", "text": " to get a slice of the first five elements. Slices are fat pointers that contain both the address and length of the data."}}
+{"event": {"type": "textDelta", "text": " Slices are immutable references that prevent accidental modification of the collection.\n\n```rust\nfn main() {\n    let s = \"hello world\";\n    let hello"}}
+{"event": {"type": "textDelta", "text": " = &s[0..5];\n    let world = &s[6..11];\n    println!(\"{} {}\", hello, world);\n}"}}
+{"event": {"type": "textDelta", "text": "\n\nfn main2() {\n    let v = vec![1, 2, 3, 4, 5];\n    let slice = &v[1..4];\n    println!(\"{:"}}
+{"event": {"type": "textDelta", "text": "?}\", slice); // [2, 3, 4]\n}\n```\n\n## 27. Mutable Slices\n\nMutable slices allow you to b"}}
+{"event": {"type": "textDelta", "text": "orrow a portion of a collection and modify its elements. A mutable slice is created using `&mut collection[range]` syntax. You can modify elements"}}
+{"event": {"type": "textDelta", "text": " through a mutable slice without affecting other parts of the collection. Mutable slices follow the same borrowing rules as mutable references: only one"}}
+{"event": {"type": "textDelta", "text": " mutable borrow at a time. Mutable slices are useful for operations like sorting or modifying elements in bulk"}}
+{"event": {"type": "textDelta", "text": ".\n\n```rust\nfn main() {\n    let mut v = vec![1, 2, 3, 4, 5];\n    let slice = &mut v[1..4"}}
+{"event": {"type": "textDelta", "text": "];\n    slice[0] = 10;\n    println!(\"{:?}\", v); // [1, 10, 3, 4, 5]\n}\n```"}}
+{"event": {"type": "textDelta", "text": "\n\n## 28. Ownership and Functions Revisited\n\nUnderstanding how ownership works with functions is crucial for writing correct Rust code. Each function owns its parameters during execution"}}
+{"event": {"type": "textDelta", "text": ". When a function returns, ownership of the return value is transferred to the caller. If a function needs to work with a value without"}}
+{"event": {"type": "textDelta", "text": " taking ownership, you pass a reference instead. This design encourages thinking about who should own each piece"}}
+{"event": {"type": "textDelta", "text": " of data. It makes memory management explicit and predictable.\n\n```rust\nfn takes_ownership(s: String) {\n    println!(\"{}\", s);\n}\n\nfn"}}
+{"event": {"type": "textDelta", "text": " borrows(s: &String) {\n    println!(\"{}\", s);\n}\n\nfn main() {\n    let s = String::from(\"hello\");\n    takes_ownership(s);"}}
+{"event": {"type": "textDelta", "text": " // s is moved\n    // println!(\"{}\", s); // error\n\n    let s = String::from(\"world\");\n    borrows(&s); // s is borrowed"}}
+{"event": {"type": "textDelta", "text": "\n    println!(\"{}\", s); // s is still valid\n}\n```\n\n## 29. Returning Ownership from Functions\n\nFunctions often need to return ownership of data to the caller. This"}}
+{"event": {"type": "textDelta", "text": " can be done by returning the value directly or by taking and returning references. When a function takes ownership and returns something, you"}}
+{"event": {"type": "textDelta", "text": " can choose what to return. Some functions transform data and return the result. Others return the input to"}}
+{"event": {"type": "textDelta", "text": " allow the caller to use it further.\n\n```rust\nfn add_world(mut s: String) -> String {\n    s.push"}}
+{"event": {"type": "textDelta", "text": "_str(\" world\");\n    s\n}\n\nfn main() {\n    let s = String::from(\"hello\");\n    let s = add_world(s); // ownership returned"}}
+{"event": {"type": "textDelta", "text": "\n    println!(\"{}\", s);\n}\n```\n\n## 30. Ownership Patterns: Working with Multiple Values\n\nWhen working with multiple owned"}}
+{"event": {"type": "textDelta", "text": " values, ownership becomes more complex. You might have tuples containing owned values, vectors of owned values, or structs with owned fields"}}
+{"event": {"type": "textDelta", "text": ". Ownership rules still apply: each value has exactly one owner. When the owner is moved or dropped, all"}}
+{"event": {"type": "textDelta", "text": " owned values are moved or dropped as well. This ensures that cleanup happens correctly for nested structures.\n\n```rust\nfn main() {\n    let s1 = String::from(\"hello"}}
+{"event": {"type": "textDelta", "text": "\");\n    let s2 = String::from(\"world\");\n    let tuple = (s1, s2);\n    println!(\"{}, {}\", tuple.0, tuple.1);\n    "}}
+{"event": {"type": "textDelta", "text": "// s1 and s2 are no longer accessible, moved into tuple\n}\n```\n\n## 31. Vectors"}}
+{"event": {"type": "textDelta", "text": " and Ownership\n\nVectors own their elements, which are stored on the heap. When a vector is dropped, all its elements are also"}}
+{"event": {"type": "textDelta", "text": " dropped. Each element in a vector is owned by the vector. You can move values into a vector, but once there, their ownership belongs"}}
+{"event": {"type": "textDelta", "text": " to the vector. You can borrow elements from a vector as immutable or mutable references. Vectors automatically grow as needed to accommodate new elements.\n\n```rust"}}
+{"event": {"type": "textDelta", "text": "\nfn main() {\n    let v = vec![String::from(\"a\"), String::from(\"b\")];\n    // v owns both strings\n    for s in &"}}
+{"event": {"type": "textDelta", "text": "v {\n        println!(\"{}\", s);\n    }\n} // when v is dropped, both strings are dropped\n```\n\n## 32. Iterating Over Owned Collections"}}
+{"event": {"type": "textDelta", "text": "\n\nDifferent ways of iterating over collections interact differently with ownership. Using `for x in vec` consumes the vector and"}}
+{"event": {"type": "textDelta", "text": " its elements. Using `for x in &vec` borrows the vector and yields immutable references. Using `for x in &mut vec` borrows mut"}}
+{"event": {"type": "textDelta", "text": "ably and yields mutable references. The choice affects whether you can use the collection after the loop. This flexibility allows optimizing for different use cases"}}
+{"event": {"type": "textDelta", "text": ".\n\n```rust\nfn main() {\n    let v = vec![1, 2, 3];\n    \n    for x in &v { // b"}}
+{"event": {"type": "textDelta", "text": "orrow immutably\n        println!(\"{}\", x);\n    }\n    println!(\"{:?}\", v); // v is still accessible\n    \n    for"}}
+{"event": {"type": "textDelta", "text": " x in v { // consume v\n        println!(\"{}\", x);\n    }\n    // println!(\"{:?}\", v); // error: v is consumed"}}
+{"event": {"type": "textDelta", "text": "\n}\n```\n\n## 33. Moving Out of Collections\n\nSometimes you need to extract ownership from a collection. Using pattern matching with"}}
+{"event": {"type": "textDelta", "text": " `move` or consuming iterators allows taking ownership of elements. The `Vec::into_iter()` method consumes the vector and yields"}}
+{"event": {"type": "textDelta", "text": " owned values. The `Vec::iter()` method yields immutable references. The `Vec::iter_mut()` method yields mutable references. Choosing the right method"}}
+{"event": {"type": "textDelta", "text": " depends on whether you need to take ownership.\n\n```rust\nfn main() {\n    let v = vec![String::from(\"a\"), String::from(\"b\")];\n    for s"}}
+{"event": {"type": "textDelta", "text": " in v { // v is consumed\n        println!(\"{}\", s);\n    }\n}\n```\n\n## 34. Ownership in Collections with References"}}
+{"event": {"type": "textDelta", "text": "\n\nIf a collection contains references, those references must be valid for as long as the collection exists. This is enforced through lifetimes in"}}
+{"event": {"type": "textDelta", "text": " the collection's type. A `Vec<&'a str>` can only hold"}}
+{"event": {"type": "textDelta", "text": " references valid for at least `'a`. This prevents creating collections with dangling references. The compiler"}}
+{"event": {"type": "textDelta", "text": " verifies that all references in a collection are valid.\n\n```rust\nfn main() {\n    let s1 = String::from(\"hello\");\n    let s"}}
+{"event": {"type": "textDelta", "text": "2 = String::from(\"world\");\n    let v: Vec<&String> = vec![&s1, &s2];\n    println!(\"{:"}}
+{"event": {"type": "textDelta", "text": "?}\", v);\n} // s1 and s2 are dropped here\n```\n\n## 35. Smart Pointers: Box\n\n`Box` is a"}}
+{"event": {"type": "textDelta", "text": " smart pointer that allocates values on the heap and owns them. Boxing a value moves it from the stack to the heap. When the `Box` is"}}
+{"event": {"type": "textDelta", "text": " dropped, the boxed value is also dropped. `Box` is useful for trait objects, recursive types, and when you need a known fixed-"}}
+{"event": {"type": "textDelta", "text": "size pointer to heap data. `Box` implements `Deref`, allowing automatic dereferencing."}}
+{"event": {"type": "textDelta", "text": "\n\n```rust\nfn main() {\n    let b = Box::new(5);\n    println!(\"{}\", *b);\n    println!(\"{}\", b); // deref co"}}
+{"event": {"type": "textDelta", "text": "ercion makes this work\n}\n\nenum List {\n    Cons(i32, Box<List>),\n    Nil,\n}\n\nfn"}}
+{"event": {"type": "textDelta", "text": " main2() {\n    let list = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Nil))));\n}\n```\n\n## 36. Reference"}}
+{"event": {"type": "textDelta", "text": " Counting with Rc\n\n`Rc` (Reference Counted Pointer) allows multiple ownership of the same value. When you"}}
+{"event": {"type": "textDelta", "text": " clone an `Rc`, you get a new pointer to the same data, and the reference count increases. When an `Rc`"}}
+{"event": {"type": "textDelta", "text": " is dropped, the reference count decreases. When the count reaches zero, the data is dropped. `Rc` is useful when you need multiple"}}
+{"event": {"type": "textDelta", "text": " owners of heap data. `Rc` is single-threaded; for multi-threaded code, use `Arc`.\n\n```rust"}}
+{"event": {"type": "textDelta", "text": "\nuse std::rc::Rc;\n\nfn main() {\n    let s = Rc::new(String::from(\"hello\"));\n    let s2 = Rc::clone"}}
+{"event": {"type": "textDelta", "text": "(&s);\n    let s3 = Rc::clone(&s);\n    println!(\"strong count: {}\", Rc::strong_count(&s));"}}
+{"event": {"type": "textDelta", "text": " // 3\n}\n```\n\n## 37. Interior Mutability with RefCell\n\n`RefCell` allows you to mutate values inside an immutable reference"}}
+{"event": {"type": "textDelta", "text": " through interior mutability. Borrowing rules are checked at runtime instead of compile time. `RefCell` should be used only"}}
+{"event": {"type": "textDelta", "text": " when compile-time borrow checking is overly restrictive. Runtime borrow checking panics if rules are violated. `RefCell` is useful for cached"}}
+{"event": {"type": "textDelta", "text": " values or other patterns where compile-time checking is insufficient.\n\n```rust\nuse std::cell::RefCell;\n\nfn main() {\n    let x = RefCell::"}}
+{"event": {"type": "textDelta", "text": "new(5);\n    *x.borrow_mut() = 10;\n    println!(\"{}\", x.borrow());\n}\n```\n\n## 38. Combining Rc"}}
+{"event": {"type": "textDelta", "text": " and RefCell\n\nCombining `Rc` and `RefCell` allows multiple ownership with interior mutability. `Rc<RefCell<T>>` pattern enables multiple m"}}
+{"event": {"type": "textDelta", "text": "utable owners. This is useful for shared mutable state in single-threaded code. Each owner can mutably borrow the value"}}
+{"event": {"type": "textDelta", "text": " through `borrow_mut()`. Runtime checks ensure that only one mutable borrow exists at a time.\n\n```rust\nuse std::rc::"}}
+{"event": {"type": "textDelta", "text": "Rc;\nuse std::cell::RefCell;\n\nfn main() {\n    let s = Rc::new(RefCell::new(String::from(\"hello\")));\n    let s2 = Rc::"}}
+{"event": {"type": "textDelta", "text": "clone(&s);\n    s2.borrow_mut().push_str(\" world\");\n    println!(\"{}\", s.borrow());\n}\n```\n\n## 39. Atomic Reference"}}
+{"event": {"type": "textDelta", "text": " Counting with Arc\n\n`Arc` (Atomic Reference Counted Pointer) is the thread-safe version of `Rc`. It allows multiple threads"}}
+{"event": {"type": "textDelta", "text": " to own the same value. Cloning an `Arc` increments an atomic reference count. `Arc` uses atomic operations ensuring"}}
+{"event": {"type": "textDelta", "text": " thread safety. When the reference count reaches zero, the data is dropped. `Arc` is essential for multi-threaded Rust programs.\n\n```rust\nuse std::sync::Arc"}}
+{"event": {"type": "textDelta", "text": ";\nuse std::thread;\n\nfn main() {\n    let s = Arc::new(String::from(\"hello\"));\n    let s2 = Arc::clone(&s);\n    thread"}}
+{"event": {"type": "textDelta", "text": "::spawn(move || {\n        println!(\"{}\", s2);\n    });\n    println!(\"{}\", s);\n}\n```\n\n## 40. Combining"}}
+{"event": {"type": "textDelta", "text": " Arc and Mutex\n\n`Arc<Mutex<T>>` allows multiple threads to share mutable access to data. Each thread owns an"}}
+{"event": {"type": "textDelta", "text": " `Arc` pointing to the same `Mutex`. Only one thread can hold the lock at a time, preventing data races. This pattern is essential"}}
+{"event": {"type": "textDelta", "text": " for thread-safe shared mutable state. The `Mutex` provides exclusive access, while `Arc` enables multiple ownership.\n\n```rust"}}
+{"event": {"type": "textDelta", "text": "\nuse std::sync::{Arc, Mutex};\nuse std::thread;\n\nfn main() {\n    let counter = Arc::new(Mutex::new(0));\n    let counter"}}
+{"event": {"type": "textDelta", "text": "2 = Arc::clone(&counter);\n    thread::spawn(move || {\n        *counter2.lock().unwrap() += 1;\n    });\n    *counter.lock()."}}
+{"event": {"type": "textDelta", "text": "unwrap() += 1;\n}\n```\n\n## 41. Ownership and Match Expressions\n\nMatch expressions interact with ownership in interesting ways."}}
+{"event": {"type": "textDelta", "text": " Matching on a value moves or borrows depending on the pattern. Matching on an immutable reference"}}
+{"event": {"type": "textDelta", "text": " yields immutable references to fields. Matching on a mutable reference yields mutable references to fields. Matching on an owned value consumes it and"}}
+{"event": {"type": "textDelta", "text": " allows destructuring. This gives fine-grained control over ownership in pattern matching.\n\n```rust\nfn main() {\n    let x = Some(String::from"}}
+{"event": {"type": "textDelta", "text": "(\"hello\"));\n    match &x {\n        Some(s) => println!(\"{}\", s),\n        None => println!(\"none\"),\n    }\n    println"}}
+{"event": {"type": "textDelta", "text": "!(\"{:?}\", x); // x is still accessible\n}\n```\n\n## 42. Destructuring and Ownership\n\nDestructuring allows you to extract values from"}}
+{"event": {"type": "textDelta", "text": " complex types. When destructuring owned values, ownership is transferred to the bindings. When destructuring references, you get references to the fields. The"}}
+{"event": {"type": "textDelta", "text": " `ref` keyword in patterns creates references instead of moving. The `ref mut` keyword creates mutable references."}}
+{"event": {"type": "textDelta", "text": " Destructuring makes working with complex types convenient.\n\n```rust\nfn main() {\n    let point = (1, 2, 3);"}}
+{"event": {"type": "textDelta", "text": "\n    let (x, y, z) = point; // point is moved\n    println!(\"{}, {}, {}\", x, y, z);\n\n    let s = Some(String::from"}}
+{"event": {"type": "textDelta", "text": "(\"hello\"));\n    match s {\n        Some(ref text) => println!(\"{}\", text),\n        None => println!(\"none\"),\n    }\n    println!(\"{:"}}
+{"event": {"type": "textDelta", "text": "?}\", s); // s is still accessible\n}\n```\n\n## 43. Partial Moves\n\nIn some cases, you can move part of a value while"}}
+{"event": {"type": "textDelta", "text": " leaving other parts intact. If you move a field out of a struct, you can still access other fields. This only works if other fields implement `Copy`"}}
+{"event": {"type": "textDelta", "text": " or if you're careful about use-after-move. Partial moves give flexibility but require careful attention to ensure safety. Not"}}
+{"event": {"type": "textDelta", "text": " all types support partial moves.\n\n```rust\nfn main() {\n    let s = (String::from(\"hello\"), 5);\n    let (text, num) ="}}
+{"event": {"type": "textDelta", "text": " s; // s is moved\n    // Can't use s anymore because text was moved\n}\n\n// With tuple"}}
+{"event": {"type": "textDelta", "text": " unpacking:\nstruct Point {\n    x: i32,\n    y: String,\n}\n\nfn main2() {\n    let p"}}
+{"event": {"type": "textDelta", "text": " = Point { x: 1, y: String::from(\"a\") };\n    let Point { x, y } = p; // p is moved\n}\n```\n\n## 44. N"}}
+{"event": {"type": "textDelta", "text": "LL: Non-Lexical Lifetimes\n\nRust uses non-lexical lifetimes (NLL),"}}
+{"event": {"type": "textDelta", "text": " meaning lifetimes are based on actual usage rather than scopes. A reference's lifetime ends when it's last"}}
+{"event": {"type": "textDelta", "text": " used, not when it goes out of scope. This makes code more flexible and allows patterns that would otherwise be rejected. NLL makes"}}
+{"event": {"type": "textDelta", "text": " many patterns naturally work without explicit lifetime annotations. It's an important feature that makes Rust feel less restrictive."}}
+{"event": {"type": "textDelta", "text": "\n\n```rust\nfn main() {\n    let mut s = String::from(\"hello\");\n    let r = &s;\n    println!(\"{}\", r); // r's lifetime ends here"}}
+{"event": {"type": "textDelta", "text": "\n    let r2 = &mut s; // now allowed\n    r2.push_str(\" world\");\n}\n```\n\n## 45."}}
+{"event": {"type": "textDelta", "text": " Reborrowing\n\nReborrowing allows you to create a new reference from an existing reference. When you pass a reference to a function that takes a reference"}}
+{"event": {"type": "textDelta", "text": ", reborrowing happens implicitly. Reborrowing allows nested borrows without violating borrowing rules. This is useful for temporary"}}
+{"event": {"type": "textDelta", "text": " borrowed values in function arguments. Reborrowing makes working with references seamless.\n\n```rust\nfn print_len(s: &"}}
+{"event": {"type": "textDelta", "text": "str) {\n    println!(\"{}\", s.len());\n}\n\nfn main() {\n    let s = String::from(\"hello\");\n    let r = &s;\n    print_len(r"}}
+{"event": {"type": "textDelta", "text": "); // reborrow happens implicitly\n}\n```\n\n## 46. Splitting Borrows\n\nYou can sometimes split a mutable b"}}
+{"event": {"type": "textDelta", "text": "orrow into multiple mutable borrows of different fields. The compiler understands that borrows of different parts of a struct don"}}
+{"event": {"type": "textDelta", "text": "'t conflict. This allows having multiple mutable references to different fields simultaneously. Splitting works because the fields don't overlap"}}
+{"event": {"type": "textDelta", "text": " in memory. This gives you more flexibility with mutable borrows.\n\n```rust\nfn main() {\n    struct Point { x: i32, y: i"}}
+{"event": {"type": "textDelta", "text": "32 }\n    let mut p = Point { x: 1, y: 2 };\n    let x_ref = &mut p.x;\n    let y_ref = &"}}
+{"event": {"type": "textDelta", "text": "mut p.y;\n    *x_ref += 1;\n    *y_ref += 1;\n    println!(\"{}, {}\", p.x, p.y);\n}\n```"}}
+{"event": {"type": "textDelta", "text": "\n\n## 47. Ownership and Closures\n\nClosures capture variables from their environment, which affects ownership"}}
+{"event": {"type": "textDelta", "text": ". By default, closures capture by immutable reference. The `move` keyword makes closures take ownership of captured variables. Capturing"}}
+{"event": {"type": "textDelta", "text": " by mutable reference allows modification. The compiler infers which capturing mode to use based on how variables are used. This"}}
+{"event": {"type": "textDelta", "text": " makes closures flexible and optimized by default.\n\n```rust\nfn main() {\n    let x = String::from(\"hello\");\n    let c1"}}
+{"event": {"type": "textDelta", "text": " = || println!(\"{}\", x); // capture by reference\n    c1();\n    println!(\"{}\", x); // x still accessible"}}
+{"event": {"type": "textDelta", "text": "\n\n    let x = String::from(\"hello\");\n    let c2 = move || println!(\"{}\", x); // take ownership\n    c2();\n    // println"}}
+{"event": {"type": "textDelta", "text": "!(\"{}\", x); // error: x is moved\n}\n```\n\n## 48. Closures and Trait Bounds\n\nClosures implement the `Fn`,"}}
+{"event": {"type": "textDelta", "text": " `FnMut`, or `FnOnce` trait depending on how they capture. `Fn` closures capture by immutable reference and"}}
+{"event": {"type": "textDelta", "text": " can be called multiple times. `FnMut` closures capture by mutable reference and can be called multiple times. `FnOnce` closures take ownership and can only"}}
+{"event": {"type": "textDelta", "text": " be called once. These traits allow higher-order functions to work with closures. The compiler chooses the most restrictive trait that works"}}
+{"event": {"type": "textDelta", "text": ".\n\n```rust\nfn apply<F>(f: F, x: i32) -> i32\nwhere\n    F: Fn(i32) -> i32,\n{\n    f(x"}}
+{"event": {"type": "textDelta", "text": ")\n}\n\nfn main() {\n    let add_one = |x| x + 1;\n    println!(\"{}\", apply(add_one, 5));\n}\n```"}}
+{"event": {"type": "textDelta", "text": "\n\n## 49. Leaking Memory: Intentional and Unintentional\n\nRust's ownership system prevents most memory leaks, but they"}}
+{"event": {"type": "textDelta", "text": "'re still possible through cycles and `Box::leak`. Creating a reference cycle with `Rc`"}}
+{"event": {"type": "textDelta", "text": " can cause memory leaks. `Box::leak` intentionally converts a `Box` to a `'static` reference, le"}}
+{"event": {"type": "textDelta", "text": "aking memory. Most memory leaks in Rust are deliberate optimizations. Rust makes accidental memory leaks nearly impossible through its"}}
+{"event": {"type": "textDelta", "text": " type system.\n\n```rust\nuse std::mem;\n\nfn main() {\n    let b = Box::new(5);\n    let r: &'static i"}}
+{"event": {"type": "textDelta", "text": "32 = Box::leak(b);\n    println!(\"{}\", r);\n}\n```\n\n## 50. Ownership and Error Handling\n\nOwnership interacts with error handling"}}
+{"event": {"type": "textDelta", "text": " in important ways. Functions can transfer ownership of values in the error case. Result<T, E> gives ownership of either"}}
+{"event": {"type": "textDelta", "text": " the success or error value. The `?` operator propagates ownership of error values up the call stack. Error handling patterns"}}
+{"event": {"type": "textDelta", "text": " must respect ownership rules. This makes error handling explicit and safe.\n\n```rust\nfn parse_int(s: &str) -> Result<i32,"}}
+{"event": {"type": "textDelta", "text": " String> {\n    s.parse().map_err(|_| String::from(\"parse error\"))\n}\n\nfn main() {\n    match parse_int(\"42\") {"}}
+{"event": {"type": "textDelta", "text": "\n        Ok(n) => println!(\"{}\", n),\n        Err(e) => println!(\"error: {}\", e),\n    }\n}\n```\n\n## 51. Implementing Drop"}}
+{"event": {"type": "textDelta", "text": " Manually\n\nYou can implement the `Drop` trait to run custom code when values are dropped. The `drop` method is called automatically when a value goes out of scope."}}
+{"event": {"type": "textDelta", "text": " This is useful for cleanup like closing files or releasing resources. Most types don't need custom `Drop` implementations. The standard library handles"}}
+{"event": {"type": "textDelta", "text": " dropping for most types automatically.\n\n```rust\nstruct MyType {\n    name: String,\n}\n\nimpl Drop for MyType {\n    fn drop(&mut self)"}}
+{"event": {"type": "textDelta", "text": " {\n        println!(\"dropping: {}\", self.name);\n    }\n}\n\nfn main() {\n    let m = MyType { name: String::from(\"hello\") };\n    "}}
+{"event": {"type": "textDelta", "text": "println!(\"before drop\");\n} // m is dropped here\n```\n\n## 52. Early Drops with std::mem::drop\n\nSometimes"}}
+{"event": {"type": "textDelta", "text": " you need to drop a value before it goes out of scope. The `std::mem::drop` function takes ownership of a value and immediately drops it. This"}}
+{"event": {"type": "textDelta", "text": " is useful when you want to release resources early. Explicitly calling `drop` makes your intentions clear to other developers. This is different"}}
+{"event": {"type": "textDelta", "text": " from consuming the value in other ways.\n\n```rust\nfn main() {\n    let s = String::from(\"hello\");\n    println!(\"{}\", s);"}}
+{"event": {"type": "textDelta", "text": "\n    drop(s);\n    // println!(\"{}\", s); // error: s is dropped\n}\n```\n\n## 53. Ownership and Trait Objects\n\nTrait"}}
+{"event": {"type": "textDelta", "text": " objects enable dynamic dispatch and require ownership or references. A `Box<dyn Trait>"}}
+{"event": {"type": "textDelta", "text": "` owns the concrete type and allows calling trait methods. A `&dyn Trait` reference borrows the concrete type"}}
+{"event": {"type": "textDelta", "text": " through the trait interface. Trait objects work with ownership just like regular values. Using trait objects trades some performance for flexibility.\n\n```rust\ntrait Animal {\n    fn"}}
+{"event": {"type": "textDelta", "text": " speak(&self);\n}\n\nstruct Dog;\nimpl Animal for Dog {\n    fn speak(&self) { println!(\"woof\"); }\n}\n\nfn main() {"}}
+{"event": {"type": "textDelta", "text": "\n    let animal: Box<dyn Animal> = Box::new(Dog);\n    animal.speak();\n}\n```\n\n## 54. Ownership in Collections with"}}
+{"event": {"type": "textDelta", "text": " Trait Objects\n\nCollections of trait objects require careful lifetime management. A `Vec<Box<dyn Trait>>` owns a vector of boxed trait objects."}}
+{"event": {"type": "textDelta", "text": " The vector is responsible for dropping the trait objects when it's dropped. This works seamlessly with Rust's ownership system. The compiler ensures that objects aren"}}
+{"event": {"type": "textDelta", "text": "'t used after being dropped.\n\n```rust\ntrait Shape {\n    fn area(&self) -> f64;\n}\n\nstruct Circle { radius: f64"}}
+{"event": {"type": "textDelta", "text": " }\nimpl Shape for Circle {\n    fn area(&self) -> f64 { 3.14 * self.radius * self.radius }\n}\n\nfn main() {\n    let shapes"}}
+{"event": {"type": "textDelta", "text": ": Vec<Box<dyn Shape>> = vec![Box::new(Circle { radius: 1.0 })];\n    println!(\"{}\", shapes[0].area());\n}"}}
+{"event": {"type": "textDelta", "text": "\n```\n\n## 55. Ownership and Lifetime Bounds\n\nGeneric types can have lifetime bounds that relate lifetimes to other parameters"}}
+{"event": {"type": "textDelta", "text": ". `T: 'a` means \"T can only contain references with lifetime 'a"}}
+{"event": {"type": "textDelta", "text": " or longer\". Lifetime bounds ensure that owned values don't contain references that outlive them. This is important for sound"}}
+{"event": {"type": "textDelta", "text": "ness of programs with mixed ownership. The compiler verifies lifetime bounds automatically.\n\n```rust\nfn takes_ref<'a,"}}
+{"event": {"type": "textDelta", "text": " T: 'a>(t: &T) -> &T {\n    t\n}\n\nfn main() {\n    let s = String::from(\"hello\");\n    let r = takes"}}
+{"event": {"type": "textDelta", "text": "_ref(&s);\n    println!(\"{}\", r);\n}\n```\n\n## 56. RAII Pattern (Resource Acquisition Is Initialization)\n\nThe RAII"}}
+{"event": {"type": "textDelta", "text": " pattern ties resource management to object lifetimes. When a value is created, resources are acquired. When the value is dropped, resources are"}}
+{"event": {"type": "textDelta", "text": " released. Rust's ownership system naturally implements RAII. File handles, database connections, and locks are acquired and released automatically. RAII makes resource management safe"}}
+{"event": {"type": "textDelta", "text": " and automatic.\n\n```rust\nuse std::fs::File;\n\nfn main() {\n    {\n        let _file = File::create(\"test.txt\");"}}
+{"event": {"type": "textDelta", "text": "\n        // file is open here\n    } // file is automatically closed here\n}\n```\n\n## 57. Ownership and Builder"}}
+{"event": {"type": "textDelta", "text": " Pattern\n\nThe builder pattern works naturally with Rust's ownership system. Builders take ownership of the value being built and return ownership of the built result. This ensures"}}
+{"event": {"type": "textDelta", "text": " safe construction of complex objects. Builder methods typically take `self` and return `Self` or"}}
+{"event": {"type": "textDelta", "text": " another type. The ownership flow makes builder code clear and safe.\n\n```rust\nstruct Query {\n    sql: String,\n}\n\nimpl Query"}}
+{"event": {"type": "textDelta", "text": " {\n    fn new() -> Self {\n        Query { sql: String::new() }\n    }\n    \n    fn select(mut self, fields: &"}}
+{"event": {"type": "textDelta", "text": "str) -> Self {\n        self.sql = format!(\"SELECT {}\", fields);\n        self\n    }\n}\n\nfn main() {\n    let q = Query::new()."}}
+{"event": {"type": "textDelta", "text": "select(\"id, name\");\n}\n```\n\n## 58. Ownership and Strings\n\nStrings in Rust have complex ownership semantics to consider. `"}}
+{"event": {"type": "textDelta", "text": "String` owns its data and can be modified. `&str` is a borrowed string slice that can reference `String` or"}}
+{"event": {"type": "textDelta", "text": " string literals. String slices are immutable and don't own data. Functions should accept `&str` to be"}}
+{"event": {"type": "textDelta", "text": " flexible about what strings they accept. This design encourages borrowing over ownership transfers.\n\n```rust\nfn print_string(s"}}
+{"event": {"type": "textDelta", "text": ": &str) {\n    println!(\"{}\", s);\n}\n\nfn main() {\n    let s = String::from(\"hello\");\n    print_string(&s);\n    let"}}
+{"event": {"type": "textDelta", "text": " s2 = \"hello\";\n    print_string(s2);\n}\n```\n\n## 59. Ownership and String Slicing\n\nString slices allow borrow"}}
+{"event": {"type": "textDelta", "text": "ing portions of strings. Slicing works with byte indices, so you must be careful with multi"}}
+{"event": {"type": "textDelta", "text": "-byte characters. Slicing is zero-copy: it doesn't allocate new memory. Slices are immutable references preventing modification"}}
+{"event": {"type": "textDelta", "text": ". The compiler ensures that slice indices are valid.\n\n```rust\nfn main() {\n    let s = \"hello world\";\n    let hello = &"}}
+{"event": {"type": "textDelta", "text": "s[0..5];\n    let world = &s[6..11];\n    println!(\"{} {}\", hello, world);\n}\n```\n\n## 60. Ownership and Collections"}}
+{"event": {"type": "textDelta", "text": " Overview\n\nDifferent collection types handle ownership differently. `Vec<T>` owns elements and stores them on the heap. `HashMap<K, V>` owns"}}
+{"event": {"type": "textDelta", "text": " keys and values. `BTreeMap<K, V>` owns keys and values in sorted order. Collections implement `Drop` to clean up all"}}
+{"event": {"type": "textDelta", "text": " elements when dropped. The compiler tracks ownership through the collection types.\n\n```rust\nfn main() {\n    let mut map = std::collections::HashMap"}}
+{"event": {"type": "textDelta", "text": "::new();\n    map.insert(String::from(\"key\"), String::from(\"value\"));\n    // map owns both the"}}
+{"event": {"type": "textDelta", "text": " key and value\n}\n```\n\n## 61. Ownership and Iterators\n\nIterators in Rust interact with ownership in several ways. `iter()` yields immutable references without"}}
+{"event": {"type": "textDelta", "text": " taking ownership. `iter_mut()` yields mutable references without taking ownership. `into_iter()` takes ownership and yields owned"}}
+{"event": {"type": "textDelta", "text": " values. Choosing the right iterator affects whether you can use the collection afterward. Iterators are lazy and compos"}}
+{"event": {"type": "textDelta", "text": "able.\n\n```rust\nfn main() {\n    let v = vec![1, 2, 3];\n    let squared: Vec<_> = v.iter().map("}}
+{"event": {"type": "textDelta", "text": "|x| x * x).collect();\n    println!(\"{:?}\", v); // v still accessible\n    \n    let v = vec![1"}}
+{"event": {"type": "textDelta", "text": ", 2, 3];\n    let doubled: Vec<_> = v.into_iter().map(|x| x * 2).collect();\n    // println"}}
+{"event": {"type": "textDelta", "text": "!(\"{:?}\", v); // error: v is consumed\n}\n```\n\n## 62. Ownership and Adapter Functions\n\nAdapter functions transform collections"}}
+{"event": {"type": "textDelta", "text": " while respecting ownership. Functions like `map`, `filter`, and `fold` consume iterators and return transformed results. These functions enable"}}
+{"event": {"type": "textDelta", "text": " functional-style programming in Rust. Adapters are composable and lazy, making them efficient. Adapters interact properly with"}}
+{"event": {"type": "textDelta", "text": " Rust's ownership system.\n\n```rust\nfn main() {\n    let v = vec![1, 2, 3, 4, 5];\n    let result:"}}
+{"event": {"type": "textDelta", "text": " i32 = v.iter()\n        .filter(|x| x % 2 == 0)\n        .map(|x| x * x"}}
+{"event": {"type": "textDelta", "text": ")\n        .sum();\n    println!(\"{}\", result); // 4 + 16 = 20\n}\n```\n\n## 63. Ownership and Type"}}
+{"event": {"type": "textDelta", "text": " System Interactions\n\nRust's type system enforces ownership rules at compile time. Each type has ownership semantics determining whether it's `Copy`, takes"}}
+{"event": {"type": "textDelta", "text": " ownership, or requires references. Generic types inherit ownership semantics from type parameters. Trait bounds can constrain ownership requirements"}}
+{"event": {"type": "textDelta", "text": ". The type system makes ownership explicit and verifiable.\n\n```rust\nfn takes_string(s: String) {\n    println!(\"{}\", s);\n}\n\nfn takes"}}
+{"event": {"type": "textDelta", "text": "_debug<T: std::fmt::Debug>(t: T) {\n    println!(\"{:?}\", t);\n}\n\nfn main() {\n    let s = String::from(\""}}
+{"event": {"type": "textDelta", "text": "hello\");\n    takes_string(s);\n    \n    let n = 42;\n    takes_debug(n);\n}\n```\n\n## 64. Ownership and Generics\n\nGeneric"}}
+{"event": {"type": "textDelta", "text": " functions and types work with ownership just like concrete ones. Generic type parameters can be `Copy` or require owned types. Generic functions"}}
+{"event": {"type": "textDelta", "text": " can take ownership, references, or mutable references. Trait bounds specify ownership requirements for generic parameters."}}
+{"event": {"type": "textDelta", "text": " Generics enable code reuse while respecting ownership rules.\n\n```rust\nfn first<T>(v: &[T]) -> Option<&"}}
+{"event": {"type": "textDelta", "text": "T> {\n    v.first()\n}\n\nfn main() {\n    let v = vec![1, 2, 3];\n    println!(\"{:?}\", first(&v));"}}
+{"event": {"type": "textDelta", "text": "\n}\n```\n\n## 65. Ownership and Associated Types\n\nAssociated types in traits can represent owned or borrowed data"}}
+{"event": {"type": "textDelta", "text": ". A trait can specify associated types that are owned or referenced. Implementers choose the"}}
+{"event": {"type": "textDelta", "text": " concrete type for associated types. This allows flexible ownership semantics in trait implementations. Associated types enable patterns that would be difficult with"}}
+{"event": {"type": "textDelta", "text": " just generic parameters.\n\n```rust\ntrait Container {\n    type Item;\n    fn get(&self) -> Self::Item;\n}\n\nimpl Container"}}
+{"event": {"type": "textDelta", "text": " for Vec<i32> {\n    type Item = i32;\n    fn get(&self) -> i32 {\n        self.get(0).copied().unwrap_or"}}
+{"event": {"type": "textDelta", "text": "(0)\n    }\n}\n```\n\n## 66. Ownership and Where Clauses\n\nWhere clauses can specify complex ownership requirements. You can express constraints like \"T must live"}}
+{"event": {"type": "textDelta", "text": " at least as long as 'a\". Where clauses make generic ownership requirements explicit and understandable. Complex"}}
+{"event": {"type": "textDelta", "text": " ownership relationships are better expressed in where clauses than inline. Where clauses enable advanced generic patterns.\n\n```rust\nfn function"}}
+{"event": {"type": "textDelta", "text": "<'a, T>(r: &'a T) -> &'a str\nwhere\n    T: std::fmt::Display + "}}
+{"event": {"type": "textDelta", "text": "'a,\n{\n    \"hello\"\n}\n\nfn main() {\n    let s = String::from(\"world\");\n    println!(\"{}\", function(&s));\n}\n```\n\n## 67"}}
+{"event": {"type": "textDelta", "text": ". Ownership and Default Trait\n\nThe `Default` trait defines default values for types. Default implementations can involve owned types"}}
+{"event": {"type": "textDelta", "text": " or references. Implementing `Default` allows types to be created with no arguments. Default values can be useful for initialization. The trait"}}
+{"event": {"type": "textDelta", "text": " integrates well with ownership semantics.\n\n```rust\nstruct Config {\n    name: String,\n    value: i32,\n}\n\nimpl Default for Config {\n    fn default()"}}
+{"event": {"type": "textDelta", "text": " -> Self {\n        Config {\n            name: String::from(\"default\"),\n            value: 0,\n        }\n    }\n}\n\nfn main() {\n    let config = Config::default"}}
+{"event": {"type": "textDelta", "text": "();\n}\n```\n\n## 68. Ownership and From/Into Traits\n\nThe `From` and `Into` traits enable type conversions while"}}
+{"event": {"type": "textDelta", "text": " handling ownership. `From<T>` converts an owned value to another type. `Into<T>` converts a value into another"}}
+{"event": {"type": "textDelta", "text": " type. These traits are inverses of each other. Conversions can move ownership or clone data depending on the types."}}
+{"event": {"type": "textDelta", "text": " The traits integrate smoothly with the ownership system.\n\n```rust\nimpl From<&str> for String {\n    fn from(s: &str) -> String {\n        String"}}
+{"event": {"type": "textDelta", "text": "::from(s)\n    }\n}\n\nfn main() {\n    let s: String = \"hello\".into();\n    println!(\"{}\", s);\n}\n```\n\n## 69"}}
+{"event": {"type": "textDelta", "text": ". Ownership and Deref Trait\n\nThe `Deref` trait enables dereferencing smart pointers and custom types. Implementing `Deref` allows derefer"}}
+{"event": {"type": "textDelta", "text": "encing with the `*` operator. Deref enables automatic dereferencing in many contexts. Deref coercion makes working"}}
+{"event": {"type": "textDelta", "text": " with smart pointers convenient. The trait enables custom dereference behavior.\n\n```rust\nuse std::ops::Deref;\n\nstruct MyString"}}
+{"event": {"type": "textDelta", "text": "(String);\n\nimpl Deref for MyString {\n    type Target = String;\n    fn deref(&self) -> &String {\n        &self.0\n    }\n}"}}
+{"event": {"type": "textDelta", "text": "\n\nfn main() {\n    let ms = MyString(String::from(\"hello\"));\n    println!(\"{}\", ms.len());\n}\n```\n\n## 70. Ownership"}}
+{"event": {"type": "textDelta", "text": " and DerefMut Trait\n\nThe `DerefMut` trait enables mutable dereferencing of smart pointers. Implementing `DerefMut` allows dereferencing with the"}}
+{"event": {"type": "textDelta", "text": " `*` operator for mutation. DerefMut requires Deref to also be implemented. Mutable dereferencing enables mutation"}}
+{"event": {"type": "textDelta", "text": " through smart pointers. The trait integrates with Rust's borrow checker.\n\n```rust\nuse std::ops::{Deref, DerefMut};\n\nstruct"}}
+{"event": {"type": "textDelta", "text": " MyValue(i32);\n\nimpl Deref for MyValue {\n    type Target = i32;\n    fn deref(&self) -> &i32 { &self.0"}}
+{"event": {"type": "textDelta", "text": " }\n}\n\nimpl DerefMut for MyValue {\n    fn deref_mut(&mut self) -> &mut i32 { &mut self.0 }\n}\n\nfn main() {\n    "}}
+{"event": {"type": "textDelta", "text": "let mut mv = MyValue(5);\n    *mv = 10;\n    println!(\"{}\", *mv);\n}\n```\n\n## 71. Ownership and AsRef/AsMut"}}
+{"event": {"type": "textDelta", "text": " Traits\n\nThe `AsRef` and `AsMut` traits provide flexible borrowing conversions. `AsRef<T>` converts to a reference of"}}
+{"event": {"type": "textDelta", "text": " type T. Functions can accept `impl AsRef<str>` to accept both `&str` and `String"}}
+{"event": {"type": "textDelta", "text": "`. These traits enable flexible APIs. The traits work with the ownership system.\n\n```rust\nfn takes_str<S: AsRef<str>>(s"}}
+{"event": {"type": "textDelta", "text": ": S) {\n    println!(\"{}\", s.as_ref());\n}\n\nfn main() {\n    let s1 = String::from(\"hello\");\n    takes_str(&s1);"}}
+{"event": {"type": "textDelta", "text": "\n    \n    let s2 = \"world\";\n    takes_str(s2);\n}\n```\n\n## 72. Ownership and Borrow Trait\n\nThe `"}}
+{"event": {"type": "textDelta", "text": "Borrow` trait provides borrowing similar to `AsRef`. `Borrow<T>` enables borrowing as type T. B"}}
+{"event": {"type": "textDelta", "text": "orrow is primarily used for key-based lookups in collections. Using `Borrow` allows different"}}
+{"event": {"type": "textDelta", "text": " key types in maps. The trait respects ownership constraints.\n\n```rust\nuse std::collections::HashMap;\nuse std::borrow::B"}}
+{"event": {"type": "textDelta", "text": "orrow;\n\nfn main() {\n    let mut map = HashMap::new();\n    map.insert(String::from(\"key\"), 42);\n    \n    let key = \""}}
+{"event": {"type": "textDelta", "text": "key\"; // &str\n    println!(\"{}\", map.get(key).unwrap()); // works due to Borrow"}}
+{"event": {"type": "textDelta", "text": "\n}\n```\n\n## 73. Ownership and Pin/Unpin\n\n`Pin` ensures that a value won't be moved"}}
+{"event": {"type": "textDelta", "text": " in memory. Pinned values can't be moved even if ownership is transferred. `Pin` is required for creating"}}
+{"event": {"type": "textDelta", "text": " self-referential structs and async functions. Most types are `Unpin`, meaning they can be safely moved. Pin is"}}
+{"event": {"type": "textDelta", "text": " advanced and rarely needed in everyday code.\n\n```rust\nuse std::pin::Pin;\n\nfn main() {\n    let v = vec"}}
+{"event": {"type": "textDelta", "text": "![1, 2, 3];\n    let pinned = Pin::new(&v);\n    // pinned prevents v from being moved\n}"}}
+{"event": {"type": "textDelta", "text": "\n```\n\n## 74. Ownership and Async/Await\n\nAsync code complicates ownership with futures and lifetimes."}}
+{"event": {"type": "textDelta", "text": " Futures must capture owned values or borrows valid for the future's lifetime. The `'"}}
+{"event": {"type": "textDelta", "text": "static` lifetime is common in async code. Async blocks capture variables from their environment. Lifetimes in async code require"}}
+{"event": {"type": "textDelta", "text": " careful consideration.\n\n```rust\nasync fn fetch_data(s: String) -> String {\n    println!(\"{}\", s);\n    s"}}
+{"event": {"type": "textDelta", "text": "\n}\n\nfn main() {\n    let s = String::from(\"hello\");\n    let future = fetch_data(s);\n}\n```\n\n## 75."}}
+{"event": {"type": "textDelta", "text": " Ownership and Thread Safety\n\nOwnership interacts with thread safety through `Send` and `Sync` traits. Values must be `"}}
+{"event": {"type": "textDelta", "text": "Send` to move between threads. Values must be `Sync` for shared access from multiple threads. Most types are automatically `Send` and `Sync`. Some"}}
+{"event": {"type": "textDelta", "text": " types like `Rc` are neither. The compiler enforces thread safety through these traits.\n\n```rust\nuse std::thread"}}
+{"event": {"type": "textDelta", "text": ";\nuse std::sync::Arc;\n\nfn main() {\n    let v = Arc::new(vec![1, 2, 3]);\n    let v2 = Arc"}}
+{"event": {"type": "textDelta", "text": "::clone(&v);\n    \n    thread::spawn(move || {\n        println!(\"{:?}\", v2);\n    });\n    println!(\"{:"}}
+{"event": {"type": "textDelta", "text": "?}\", v);\n}\n```\n\n## 76. Ownership Anti-patterns\n\nSeveral patterns in Rust go against ownership principles. Excessive cl"}}
+{"event": {"type": "textDelta", "text": "oning can indicate ownership problems. Creating cycles with `Rc` causes memory leaks. Overly complicated lifetime annotations may indicate design"}}
+{"event": {"type": "textDelta", "text": " issues. Using `unsafe` to bypass borrowing rules hides problems. Recognizing anti-patterns helps write better Rust code.\n\n```rust\n//"}}
+{"event": {"type": "textDelta", "text": " Anti-pattern: excessive cloning\nfn bad_pattern(s: String) -> String {\n    let s2 = s."}}
+{"event": {"type": "textDelta", "text": "clone();\n    s2\n}\n\n// Better: just take ownership\nfn good_pattern(s: String) -> String {\n    s\n}\n\nfn"}}
+{"event": {"type": "textDelta", "text": " main() {\n    let s = String::from(\"hello\");\n    let result = good_pattern(s);\n    println!(\"{}\", result);\n}\n```\n\n## 77."}}
+{"event": {"type": "textDelta", "text": " Ownership Best Practices\n\nSeveral practices help write idiomatic Rust code. Prefer taking `&str` over `&"}}
+{"event": {"type": "textDelta", "text": "String` in function parameters. Prefer returning references over taking ownership. Use `impl Trait`"}}
+{"event": {"type": "textDelta", "text": " to avoid exposing complex lifetime annotations. Avoid unnecessary `clone()` calls. Design APIs that make ownership"}}
+{"event": {"type": "textDelta", "text": " clear. These practices make code more flexible and efficient.\n\n```rust\n// Better API\nfn first_word(s: &str)"}}
+{"event": {"type": "textDelta", "text": " -> &str {\n    let bytes = s.as_bytes();\n    for (i, &item) in bytes.iter().enumerate() {\n        if item == b'"}}
+{"event": {"type": "textDelta", "text": " ' { return &s[0..i]; }\n    }\n    s\n}\n\nfn main() {\n    let s = String::from(\"hello world"}}
+{"event": {"type": "textDelta", "text": "\");\n    println!(\"{}\", first_word(&s));\n}\n```\n\n## 78. Ownership and Future Improvements\n\nRust's ownership system continues to"}}
+{"event": {"type": "textDelta", "text": " evolve. Lifetime improvements like GATs (Generic Associated Types) enable more expressive code. Trait refinements allow more complex"}}
+{"event": {"type": "textDelta", "text": " ownership patterns. The `for<'a>` syntax enables higher-rank trait bounds. Research into linear"}}
+{"event": {"type": "textDelta", "text": " types may influence future versions. The ownership system remains Rust's most distinctive feature.\n\n```rust\n// Example of advanced ownership pattern"}}
+{"event": {"type": "textDelta", "text": "\ntrait LoanedValue<'a> {\n    type Borrowed: 'a;\n    fn borrow(&'"}}
+{"event": {"type": "textDelta", "text": "a self) -> Self::Borrowed;\n}\n\nfn main() {\n    println!(\"Rust ownership continues"}}
+{"event": {"type": "textDelta", "text": " to evolve!\");\n}\n```\n\n## 79. Ownership Mindset\n\nThinking about ownership becomes natural with practice. Every value"}}
+{"event": {"type": "textDelta", "text": " should have a clear owner responsible for cleanup. Functions should make ownership semantics explicit in their signatures. Ownership enables"}}
+{"event": {"type": "textDelta", "text": " fearless concurrency and memory safety. Understanding ownership is the key to mastering Rust. Developing an ownership mindset takes practice but is essential."}}
+{"event": {"type": "textDelta", "text": "\n\n```rust\n// Think about ownership at design time\nstruct Database {\n    connection: String, // owns connection string"}}
+{"event": {"type": "textDelta", "text": "\n}\n\nimpl Database {\n    fn new(url: &str) -> Self {\n        Database { connection: String::from(url) }\n    }\n    \n    fn query"}}
+{"event": {"type": "textDelta", "text": "(&self, sql: &str) -> String {\n        format!(\"Querying: {}\", sql)\n    }\n}\n\nfn main() {\n    let db = Database::new"}}
+{"event": {"type": "textDelta", "text": "(\"localhost\");\n    println!(\"{}\", db.query(\"SELECT *\"));\n}\n```\n\n## 80. Conclusion: Ownership Mastery\n\nMas"}}
+{"event": {"type": "textDelta", "text": "tering Rust's ownership system unlocks the language's full potential. Ownership enables memory safety without garbage collection. The rules"}}
+{"event": {"type": "textDelta", "text": " are simple but powerful: each value has one owner, move ownership when needed, and borrow when possible. Ownership prevents entire classes of bugs at"}}
+{"event": {"type": "textDelta", "text": " compile time. With practice, ownership becomes intuitive and empowering. Congratulations on completing this comprehensive ownership tutorial!\n\n```rust\n// The journey of ownership mastery"}}
+{"event": {"type": "textDelta", "text": "\nfn main() {\n    let message = String::from(\"You now understand Rust ownership!\");\n    println!(\"{}\", message);\n    //"}}
+{"event": {"type": "textDelta", "text": " When main ends, message is safely dropped\n}\n```"}}
+{"event": {"type": "done", "status": "completed"}}

--- a/scripts/macos-profile-window.swift
+++ b/scripts/macos-profile-window.swift
@@ -1,0 +1,43 @@
+// Foreground/window validation for the native resource replay. Fails closed
+// on a locked display so suspended rendering cannot look like a CPU win.
+import Cocoa
+import ApplicationServices
+
+func fail(_ message: String) -> Never {
+    fputs("\(message)\n", stderr)
+    exit(1)
+}
+
+let session = CGSessionCopyCurrentDictionary() as? [String: Any] ?? [:]
+if session["CGSSessionScreenIsLocked"] as? Bool == true {
+    fail("Unlock the Mac before profiling native window rendering")
+}
+if CGDisplayIsAsleep(CGMainDisplayID()) != 0 {
+    fail("Wake the display before profiling native window rendering")
+}
+if CommandLine.arguments.count == 1 { exit(0) }
+guard let pid = Int32(CommandLine.arguments[1]),
+      let app = NSRunningApplication(processIdentifier: pid) else { fail("Missing app process") }
+if CommandLine.arguments.dropFirst(2).first == "--check" {
+    guard app.isActive else { fail("Profiled app is no longer foreground; discard this run") }
+    let rows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] ?? []
+    guard rows.contains(where: { ($0[kCGWindowOwnerPID as String] as? Int32) == pid
+        && ($0[kCGWindowLayer as String] as? Int) == 0
+        && ($0[kCGWindowAlpha as String] as? Double ?? 0) > 0 }) else {
+        fail("Profiled window is not onscreen; discard this run")
+    }
+    exit(0)
+}
+guard AXIsProcessTrusted() else { fail("Window profiling requires existing Accessibility access") }
+app.activate(options: [.activateAllWindows])
+let element = AXUIElementCreateApplication(pid)
+var value: CFTypeRef?
+guard AXUIElementCopyAttributeValue(element, kAXWindowsAttribute as CFString, &value) == .success,
+      let windows = value as? [AXUIElement], windows.count == 1 else { fail("Expected one app window") }
+let window = windows[0]
+var size = CGSize(width: 1320, height: 880)
+guard let sizeValue = AXValueCreate(.cgSize, &size),
+      AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeValue) == .success,
+      AXUIElementPerformAction(window, kAXRaiseAction as CFString) == .success else {
+    fail("Could not size and raise the profiled window")
+}

--- a/scripts/macos-resource-stat.c
+++ b/scripts/macos-resource-stat.c
@@ -1,0 +1,28 @@
+// Native process counters for resource-profile.mjs. CPU time uses Mach ticks;
+// footprint includes charged compressed/GPU memory that RSS alone misses.
+#include <libproc.h>
+#include <mach/mach_time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+
+int main(int argc, char **argv) {
+    mach_timebase_info_data_t timebase;
+    mach_timebase_info(&timebase);
+    printf("[");
+    int emitted = 0;
+    for (int i = 1; i < argc; i++) {
+        int pid = atoi(argv[i]);
+        struct rusage_info_v4 usage = {0};
+        if (pid <= 0 || proc_pid_rusage(pid, RUSAGE_INFO_V4, (rusage_info_t *)&usage)) continue;
+        double seconds = (double)(usage.ri_user_time + usage.ri_system_time)
+            * timebase.numer / timebase.denom / 1e9;
+        printf("%s{\"pid\":%d,\"cpuSeconds\":%.9f,\"rssMiB\":%.6f,"
+               "\"footprintMiB\":%.6f,\"lifetimePeakFootprintMiB\":%.6f,"
+               "\"idleWakeups\":%llu}",
+               emitted++ ? "," : "", pid, seconds,
+               usage.ri_resident_size / 1048576.0, usage.ri_phys_footprint / 1048576.0,
+               usage.ri_lifetime_max_phys_footprint / 1048576.0, usage.ri_pkg_idle_wkups);
+    }
+    puts("]");
+}

--- a/scripts/markdown-profile.rs
+++ b/scripts/markdown-profile.rs
@@ -1,0 +1,62 @@
+// Included by profile-markdown.sh after selecting baseline/current parser modules.
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use std::time::Instant;
+
+struct Meter;
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+static TOTAL: AtomicUsize = AtomicUsize::new(0);
+static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[global_allocator]
+static ALLOCATOR: Meter = Meter;
+
+unsafe impl GlobalAlloc for Meter {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            let live = LIVE.fetch_add(layout.size(), Relaxed) + layout.size();
+            PEAK.fetch_max(live, Relaxed);
+            TOTAL.fetch_add(layout.size(), Relaxed);
+            COUNT.fetch_add(1, Relaxed);
+        }
+        ptr
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Relaxed);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+    let source = std::fs::read_to_string(&args[1]).unwrap();
+    let baseline_live = LIVE.load(Relaxed);
+    TOTAL.store(0, Relaxed);
+    COUNT.store(0, Relaxed);
+    PEAK.store(baseline_live, Relaxed);
+    let start = Instant::now();
+    let mut parser = markdown::parser::IncrementalParser::new();
+    let mut previous_frame = None;
+    let mut end = 0;
+    let mut commits = 0;
+    while end < source.len() {
+        end = (end + 160).min(source.len());
+        while !source.is_char_boundary(end) { end += 1; }
+        parser.set_text(&source[..end]);
+        let next = parser.display_tree();
+        // A renderer still owns the old frame while the new tree is derived.
+        std::hint::black_box(&previous_frame);
+        previous_frame = Some(next);
+        commits += 1;
+    }
+    let elapsed = start.elapsed();
+    let retained = LIVE.load(Relaxed) - baseline_live;
+    let total = TOTAL.load(Relaxed);
+    let peak = PEAK.load(Relaxed) - baseline_live;
+    let count = COUNT.load(Relaxed);
+    assert_eq!(parser.tree(), &markdown::parser::parse_full(&source));
+    println!("{{\"source_bytes\":{},\"commits\":{},\"elapsed_ms\":{},\"allocated_bytes\":{},\"allocations\":{},\"peak_live_bytes\":{},\"retained_bytes\":{}}}",
+        source.len(), commits, elapsed.as_secs_f64() * 1000.0, total, count, peak, retained);
+}

--- a/scripts/profile-markdown.sh
+++ b/scripts/profile-markdown.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Compare allocation churn using identical real captured markdown.
+# First build zeron-ui to populate deps; no extra crates are needed.
+# Usage: profile-markdown.sh TARGET/debug/deps TEXT_FILE [GIT_REF]
+# Omit GIT_REF for working-tree code. Output is JSON; bytes are allocator
+# requests/live heap, not RSS. The parser is compiled optimized in both runs.
+set -euo pipefail
+root=$(cd "$(dirname "$0")/.." && pwd)
+deps=$(realpath "$1")
+source_text=$(realpath "$2")
+bench_dir=$(mktemp -d)
+trap 'rm -rf "$bench_dir"' EXIT
+for module in parser mend; do
+  if [[ -n "${3:-}" ]]; then
+    git -C "$root" show "$3:crates/ui/src/markdown/$module.rs" > "$bench_dir/$module.rs"
+  else
+    cp "$root/crates/ui/src/markdown/$module.rs" "$bench_dir/$module.rs"
+  fi
+done
+cat > "$bench_dir/main.rs" <<EOF
+mod markdown {
+    #[path = "$bench_dir/mend.rs"] pub mod mend;
+    #[path = "$bench_dir/parser.rs"] pub mod parser;
+}
+include!("$root/scripts/markdown-profile.rs");
+EOF
+cmark=$(ls -t "$deps"/libpulldown_cmark-*.rlib | head -1)
+rustc --edition=2024 -O -Awarnings -L "dependency=$deps" \
+  --extern "pulldown_cmark=$cmark" "$bench_dir/main.rs" -o "$bench_dir/profile"
+"$bench_dir/profile" "$source_text"

--- a/scripts/replay-claude.py
+++ b/scripts/replay-claude.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Replay text/reasoning from a real Zeron Claude journal at a fixed cadence.
+
+Set CLAUDE_CODE_EXECUTABLE to this file and ZERON_REPLAY_JOURNAL to the JSONL
+captured by resource-profile.mjs. This is a deterministic adapter replay, not
+a live API run. Tool workloads must use the real harness or integration tests.
+ZERON_REPLAY_DELAY_MS defaults to 40; no network or API calls are made.
+"""
+import json
+import os
+import sys
+import time
+
+if not any(flag in sys.argv for flag in ("--print", "-p")):
+    print("2.1.228 (resource profile replay)")
+    sys.exit(0)
+
+with open(os.environ["ZERON_REPLAY_JOURNAL"]) as source:
+    events = [json.loads(line)["event"] for line in source if line.strip()]
+if not any(e["type"] == "done" and e["status"] == "completed" for e in events):
+    raise ValueError("Replay requires a successfully completed journal")
+if any(e["type"] in ("toolCall", "toolResult", "subagent", "error") for e in events):
+    raise ValueError("Only text/reasoning journals are supported")
+if not sys.stdin.readline():
+    sys.exit(1)
+
+
+def emit(frame):
+    print(json.dumps(frame), flush=True)
+
+
+emit({"type": "system", "subtype": "init", "model": "haiku", "tools": [],
+      "cwd": os.getcwd(), "session_id": "resource-profile-replay"})
+delay = float(os.environ.get("ZERON_REPLAY_DELAY_MS", "40")) / 1000
+for event in events:
+    kind = event["type"]
+    if kind not in ("textDelta", "reasoningDelta"):
+        continue
+    text = event["text"]
+    delta = {"type": "text_delta", "text": text} if kind == "textDelta" else {
+        "type": "thinking_delta", "thinking": text}
+    emit({"type": "stream_event", "parent_tool_use_id": None,
+          "event": {"type": "content_block_delta", "delta": delta}})
+    time.sleep(delay)
+emit({"type": "result", "subtype": "success", "is_error": False,
+      "session_id": "resource-profile-replay", "result": ""})
+# Match the live CLI's persistent stdin lifecycle until the engine retires it.
+for _ in sys.stdin:
+    pass

--- a/scripts/replay-claude.py
+++ b/scripts/replay-claude.py
@@ -4,7 +4,8 @@
 Set CLAUDE_CODE_EXECUTABLE to this file and ZERON_REPLAY_JOURNAL to the JSONL
 captured by resource-profile.mjs. This is a deterministic adapter replay, not
 a live API run. Tool workloads must use the real harness or integration tests.
-ZERON_REPLAY_DELAY_MS defaults to 40; no network or API calls are made.
+ZERON_REPLAY_DELAY_MS defaults to 40; ZERON_REPLAY_REPEAT defaults to 1.
+No network or API calls are made. Repetition is a synthetic stress workload.
 """
 import json
 import os
@@ -32,16 +33,20 @@ def emit(frame):
 emit({"type": "system", "subtype": "init", "model": "haiku", "tools": [],
       "cwd": os.getcwd(), "session_id": "resource-profile-replay"})
 delay = float(os.environ.get("ZERON_REPLAY_DELAY_MS", "40")) / 1000
-for event in events:
-    kind = event["type"]
-    if kind not in ("textDelta", "reasoningDelta"):
-        continue
-    text = event["text"]
-    delta = {"type": "text_delta", "text": text} if kind == "textDelta" else {
-        "type": "thinking_delta", "thinking": text}
-    emit({"type": "stream_event", "parent_tool_use_id": None,
-          "event": {"type": "content_block_delta", "delta": delta}})
-    time.sleep(delay)
+repeats = int(os.environ.get("ZERON_REPLAY_REPEAT", "1"))
+if repeats < 1:
+    raise ValueError("ZERON_REPLAY_REPEAT must be positive")
+for _ in range(repeats):
+    for event in events:
+        kind = event["type"]
+        if kind not in ("textDelta", "reasoningDelta"):
+            continue
+        text = event["text"]
+        delta = {"type": "text_delta", "text": text} if kind == "textDelta" else {
+            "type": "thinking_delta", "thinking": text}
+        emit({"type": "stream_event", "parent_tool_use_id": None,
+              "event": {"type": "content_block_delta", "delta": delta}})
+        time.sleep(delay)
 emit({"type": "result", "subtype": "success", "is_error": False,
       "session_id": "resource-profile-replay", "result": ""})
 # Match the live CLI's persistent stdin lifecycle until the engine retires it.

--- a/scripts/resource-profile.mjs
+++ b/scripts/resource-profile.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Linux end-to-end resource profile. Node >=22; no npm dependencies.
+// Linux/macOS end-to-end resource profile. Node >=22; no npm dependencies.
 // Usage: node scripts/resource-profile.mjs BINARY OUTPUT_DIR [claude-code|mock]
 // DISPLAY must name a working X server; unset WAYLAND_DISPLAY for Xvfb.
 // Uses isolated local data and a real harness (Haiku by default). This costs
@@ -10,12 +10,24 @@ import { resolve } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { createServer } from 'node:net';
+import { fileURLToPath } from 'node:url';
+
+const macOS = process.platform === 'darwin';
+const nativeWindowSource = fileURLToPath(new URL('./macos-profile-window.swift', import.meta.url));
+if (macOS && process.env.ZERON_PROFILE_SUBMIT_UI === '1')
+  throw Error('Composer submission profiling currently requires Linux/X11; use RPC submission on macOS');
+if (macOS) execFileSync('swift', [nativeWindowSource]);
 
 const [binaryArg, outputArg, harness = 'claude-code'] = process.argv.slice(2);
 if (!binaryArg || !outputArg) throw Error('Usage: resource-profile.mjs BINARY OUTPUT_DIR [claude-code|mock]');
 const binary = resolve(binaryArg), output = resolve(outputArg);
 if (existsSync(output)) throw Error('Use a new output directory for an isolated run');
 mkdirSync(output, { recursive: true });
+const nativeStat = `${output}/macos-resource-stat`;
+const nativeWindow = `${output}/macos-profile-window`;
+if (macOS) execFileSync('xcrun', ['clang', '-O2', '-Wall', '-Wextra',
+  fileURLToPath(new URL('./macos-resource-stat.c', import.meta.url)), '-o', nativeStat]);
+if (macOS) execFileSync('swiftc', ['-O', nativeWindowSource, '-o', nativeWindow]);
 // Shared Cargo targets can be replaced by another worktree mid-profile.
 // Both processes must execute the exact same immutable build throughout.
 const profiledBinary = `${output}/zeron-profiled`;
@@ -56,6 +68,7 @@ let phase = 'startup', id = 0, transcript = [], streamError;
 const hz = Number(execFileSync('getconf', ['CLK_TCK'], { encoding: 'utf8' }).trim());
 function stat(pid) {
   try {
+    if (macOS) return JSON.parse(execFileSync(nativeStat, [String(pid)], { encoding: 'utf8' }))[0] ?? null;
     const stat = readFileSync(`/proc/${pid}/stat`, 'utf8').split(') ')[1].split(' ');
     const main = readFileSync(`/proc/${pid}/task/${pid}/stat`, 'utf8').split(') ')[1].split(' ');
     const status = readFileSync(`/proc/${pid}/status`, 'utf8');
@@ -71,6 +84,12 @@ function stat(pid) {
 }
 function descendants(pid) {
   try {
+    if (macOS) {
+      const rows = execFileSync('ps', ['-axo', 'pid=,ppid='], { encoding: 'utf8' })
+        .trim().split('\n').map(line => line.trim().split(/\s+/).map(Number));
+      const walk = parent => rows.filter(row => row[1] === parent).flatMap(([child]) => [child, ...walk(child)]);
+      return walk(pid);
+    }
     // A Tokio worker can own the subprocess: inspect all task children.
     const tasks = readdirSync(`/proc/${pid}/task`);
     const children = new Set(tasks.flatMap(t => {
@@ -133,26 +152,38 @@ try {
     config: { harness, model: harness === 'mock' ? 'fable-5' : 'claude-haiku-4-5', reasoning: null, sandbox: 'workspace-write' } });
   await call('Mutate', { op: 'renameChat', chatId, title: 'Resource profile' });
   pending.set(++id, { reject: e => { streamError = e; }, item: frame => {
-    frames.push({ at: Date.now(), frame }); apply(frame);
+    // apply() reuses reset/upsert objects as the mutable transcript. Capture
+    // first so later append frames cannot rewrite earlier replay records.
+    frames.push({ at: Date.now(), frame: structuredClone(frame) }); apply(frame);
   } });
   ws.send(JSON.stringify({ id, method: 'WatchDocMessages', params: { chatId } }));
   const locator = createHash('sha256').update(`Local\0device:${deviceId}`).digest('hex').slice(0, 16);
   const ui = start([`zeron://open/chat/${chatId}?workspace=${locator}`], 'ui', { ZERON_DATA_DIR: `${output}/ui` });
+  writeFileSync(`${output}/pids.json`, JSON.stringify({engine: engine.pid, ui: ui.pid}));
+  // Native windows activate themselves. Let the initial layout/splash settle.
+  if (macOS) {
+    await sleep(2000);
+    execFileSync(nativeWindow, [String(ui.pid)]);
+  }
   // Xvfb has no window manager to send the initial configure/focus events.
   // Force first paint before measuring (otherwise a mapped, transparent
   // window can consume no rendering CPU for the entire workload).
-  if (process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+  if (!macOS && process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
     await sleep(2000);
     const windows = execFileSync('xdotool', ['search', '--class', '^zeron$'], { encoding: 'utf8' }).trim().split('\n');
     if (windows.length !== 1) throw Error('Use a dedicated X display with exactly one Zeron window');
     execFileSync('xdotool', ['windowraise', windows[0], 'windowsize', windows[0], '1280', '800', 'windowfocus', windows[0]]);
   }
   sampler = setInterval(() => {
+    if (macOS) {
+      try { execFileSync(nativeWindow, [String(ui.pid), '--check'], { stdio: 'pipe' }); }
+      catch { streamError = Error('Native window became inactive, hidden or locked during profiling; discard this run'); }
+    }
     samples.push({ at: Date.now(), phase, engine: stat(engine.pid), ui: stat(ui.pid),
       harness: descendants(engine.pid).map(stat).filter(Boolean) });
   }, 500);
   phase = 'idle';
-  await sleep(10000);
+  await sleep(Number(process.env.ZERON_PROFILE_PRE_IDLE_MS ?? 10000));
   if (ui.exitCode != null) throw Error('UI exited; inspect ui.log');
   phase = 'stream';
   const prompt = process.env.ZERON_PROFILE_PROMPT ??
@@ -184,9 +215,12 @@ try {
   if (!complete) throw Error(`Turn did not complete within ${timeoutMs / 1000} seconds`);
   phase = 'settled';
   await sleep(Number(process.env.ZERON_PROFILE_IDLE_MS ?? 15000));
+  if (streamError) throw streamError;
+  if (macOS) execFileSync(nativeWindow);
   const reply = transcript.filter(e => e.role === 'assistant').flatMap(e => e.parts)
     .filter(p => p.kind === 'text' || p.kind === 'reasoning').map(p => p.text).join('\n\n');
   const summary = { binary, binarySha256, harness, mode: process.env.ZERON_REPLAY_JOURNAL ? 'replay' : 'live',
+    platform: process.platform, arch: process.arch,
     renderThreads: process.env.LP_NUM_THREADS ?? 'default', frameStats: env.ZERON_FRAME_STATS,
     submission: process.env.ZERON_PROFILE_SUBMIT_UI === '1' ? 'composer' : 'rpc', prompt,
     replySha256: createHash('sha256').update(reply).digest('hex'), replyBytes: Buffer.byteLength(reply),
@@ -198,12 +232,15 @@ try {
       const valid = rows.filter(r => r[name]);
       const first = valid[0], last = valid.at(-1);
       summary.phases[p][name] = {
+        ...(macOS ? { peakFootprintMiB: Math.max(...valid.map(r => r[name].footprintMiB)),
+          endFootprintMiB: last[name].footprintMiB,
+          lifetimePeakFootprintMiB: last[name].lifetimePeakFootprintMiB } : {}),
         ...(first[name].pssMiB == null ? {} : {
           peakPssMiB: Math.max(...valid.map(r => r[name].pssMiB)), endPssMiB: last[name].pssMiB,
         }), peakRssMiB: Math.max(...valid.map(r => r[name].rssMiB)),
         endRssMiB: last[name].rssMiB,
         cpuPercent: 100000 * (last[name].cpuSeconds - first[name].cpuSeconds) / (last.at - first.at),
-        mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at) };
+        ...(macOS ? {} : { mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at) }) };
     }
   }
   // Report the last ten seconds separately from the completion transition.
@@ -213,9 +250,10 @@ try {
   for (const name of ['engine', 'ui']) {
     const first = quiet[0], last = quiet.at(-1);
     summary.postCompletionTail[name] = {
+      ...(macOS ? { endFootprintMiB: last[name].footprintMiB } : {}),
       endRssMiB: last[name].rssMiB,
       cpuPercent: 100000 * (last[name].cpuSeconds - first[name].cpuSeconds) / (last.at - first.at),
-      mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at),
+      ...(macOS ? {} : { mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at) }),
     };
   }
   writeFileSync(`${output}/summary.json`, JSON.stringify(summary, null, 2));

--- a/scripts/resource-profile.mjs
+++ b/scripts/resource-profile.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// Linux end-to-end resource profile. Node >=22; no npm dependencies.
+// Usage: node scripts/resource-profile.mjs BINARY OUTPUT_DIR [claude-code|mock]
+// DISPLAY must name a working X server; unset WAYLAND_DISPLAY for Xvfb.
+// Uses isolated local data and a real harness (Haiku by default). This costs
+// one API turn. RSS/CPU for the CLI child are reported separately from Zeron.
+import { spawn, execFileSync } from 'node:child_process';
+import { mkdirSync, openSync, readFileSync, writeFileSync, existsSync, readdirSync, copyFileSync, createReadStream } from 'node:fs';
+import { resolve } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { createServer } from 'node:net';
+
+const [binaryArg, outputArg, harness = 'claude-code'] = process.argv.slice(2);
+if (!binaryArg || !outputArg) throw Error('Usage: resource-profile.mjs BINARY OUTPUT_DIR [claude-code|mock]');
+const binary = resolve(binaryArg), output = resolve(outputArg);
+if (existsSync(output)) throw Error('Use a new output directory for an isolated run');
+mkdirSync(output, { recursive: true });
+// Shared Cargo targets can be replaced by another worktree mid-profile.
+// Both processes must execute the exact same immutable build throughout.
+const profiledBinary = `${output}/zeron-profiled`;
+copyFileSync(binary, profiledBinary);
+const binaryHash = createHash('sha256');
+for await (const chunk of createReadStream(profiledBinary)) binaryHash.update(chunk);
+const binarySha256 = binaryHash.digest('hex');
+const cwd = `${output}/project`;
+mkdirSync(cwd);
+execFileSync('git', ['init', '-q', cwd]);
+mkdirSync(`${output}/ui`);
+writeFileSync(`${output}/ui/composer-defaults.json`, JSON.stringify({
+  harness, modelByHarness: { [harness]: {
+    id: harness === 'mock' ? 'fable-5' : 'claude-haiku-4-5', label: harness === 'mock' ? 'Fable 5' : 'Haiku',
+  } },
+  modelLabels: { 'claude-haiku-4-5': 'Haiku' }, reasoning: null,
+}));
+const server = createServer();
+await new Promise(r => server.listen(0, '127.0.0.1', r));
+const port = server.address().port;
+await new Promise(r => server.close(r));
+const env = { ...process.env, ZERON_IPC_PORT: String(port), ZERON_DATA_DIR: `${output}/engine`,
+  ZERON_HARNESS: harness, ZERON_FRAME_STATS: process.env.ZERON_FRAME_STATS ?? '1', RUST_LOG: 'warn',
+  ZERON_MOCK_CHARS: '24', ZERON_MOCK_DELAY_MS: '20' };
+delete env.ZERON_EDGE_TOKEN;
+delete env.ZERON_ORG_ID;
+const processes = [];
+function start(args, name, extra = {}) {
+  const log = openSync(`${output}/${name}.log`, 'w');
+  const child = spawn(profiledBinary, args, { env: { ...env, ...extra }, detached: true, stdio: ['ignore', log, log] });
+  processes.push(child);
+  return child;
+}
+const engine = start(['headless'], 'engine');
+let ws, sampler;
+const samples = [], frames = [], pending = new Map();
+let phase = 'startup', id = 0, transcript = [], streamError;
+const hz = Number(execFileSync('getconf', ['CLK_TCK'], { encoding: 'utf8' }).trim());
+function stat(pid) {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8').split(') ')[1].split(' ');
+    const main = readFileSync(`/proc/${pid}/task/${pid}/stat`, 'utf8').split(') ')[1].split(' ');
+    const status = readFileSync(`/proc/${pid}/status`, 'utf8');
+    return { pid, cpuSeconds: (Number(stat[11]) + Number(stat[12])) / hz,
+      mainCpuSeconds: (Number(main[11]) + Number(main[12])) / hz,
+      rssMiB: Number(status.match(/VmRSS:\s+(\d+)/)?.[1] ?? 0) / 1024,
+      threads: Number(status.match(/Threads:\s+(\d+)/)?.[1] ?? 0) };
+  } catch { return null; }
+}
+function descendants(pid) {
+  try {
+    // A Tokio worker can own the subprocess: inspect all task children.
+    const tasks = readdirSync(`/proc/${pid}/task`);
+    const children = new Set(tasks.flatMap(t => {
+      try { return readFileSync(`/proc/${pid}/task/${t}/children`, 'utf8').trim().split(/\s+/).filter(Boolean).map(Number); }
+      catch { return []; }
+    }));
+    return [...children].flatMap(p => [p, ...descendants(p)]);
+  } catch { return []; }
+}
+function apply(frame) {
+  if (frame.reset) { transcript = frame.reset; return; }
+  for (const remove of frame.remove ?? []) transcript = transcript.filter(e => e.id !== remove);
+  for (const { entry, after } of frame.upsert ?? []) {
+    transcript = transcript.filter(e => e.id !== entry.id);
+    transcript.splice(after == null ? 0 : transcript.findIndex(e => e.id === after) + 1, 0, entry);
+  }
+  for (const append of frame.append ?? []) {
+    const entry = transcript.find(e => e.id === append.entry);
+    if (!entry) throw Error('Append without entry');
+    const part = entry.parts.find(p => p.id === append.part);
+    if (!part || typeof part.text !== 'string') throw Error('Append without text part');
+    part.text += append.text;
+    if (Buffer.byteLength(part.text) !== append.len) throw Error('Append length mismatch');
+  }
+  if (transcript.length !== frame.count) throw Error('Transcript count mismatch');
+}
+try {
+  for (let attempt = 0; attempt < 120; attempt++) {
+    if (engine.exitCode != null) throw Error('Engine exited; inspect engine.log');
+    try {
+      ws = new WebSocket(`ws://127.0.0.1:${port}`);
+      await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
+      break;
+    } catch { await sleep(250); }
+  }
+  if (ws?.readyState !== WebSocket.OPEN) throw Error('IPC startup timed out');
+  ws.onmessage = event => {
+    const frame = JSON.parse(event.data);
+    const request = pending.get(frame.id);
+    if ('err' in frame) { request?.reject(Error(JSON.stringify(frame.err))); return; }
+    if ('ok' in frame) { pending.delete(frame.id); request?.resolve(frame.ok); }
+    if ('item' in frame) {
+      try { request?.item?.(frame.item); } catch (error) { streamError = error; }
+    }
+  };
+  const call = (method, params) => new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(Error(`${method} timed out`)), 30000);
+    timer.unref();
+    pending.set(++id, {
+      resolve: value => { clearTimeout(timer); resolve(value); },
+      reject: error => { clearTimeout(timer); reject(error); },
+    });
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+  await call('EngineReady', {});
+  const { deviceId } = await call('LocalDevice', {});
+  const spaceId = randomUUID(), chatId = randomUUID();
+  await call('Mutate', { op: 'createSpace', spaceId, deviceId, path: cwd });
+  await call('Mutate', { op: 'createChat', chatId, spaceId,
+    config: { harness, model: harness === 'mock' ? 'fable-5' : 'claude-haiku-4-5', reasoning: null, sandbox: 'workspace-write' } });
+  await call('Mutate', { op: 'renameChat', chatId, title: 'Resource profile' });
+  pending.set(++id, { reject: e => { streamError = e; }, item: frame => {
+    frames.push({ at: Date.now(), frame }); apply(frame);
+  } });
+  ws.send(JSON.stringify({ id, method: 'WatchDocMessages', params: { chatId } }));
+  const locator = createHash('sha256').update(`Local\0device:${deviceId}`).digest('hex').slice(0, 16);
+  const ui = start([`zeron://open/chat/${chatId}?workspace=${locator}`], 'ui', { ZERON_DATA_DIR: `${output}/ui` });
+  // Xvfb has no window manager to send the initial configure/focus events.
+  // Force first paint before measuring (otherwise a mapped, transparent
+  // window can consume no rendering CPU for the entire workload).
+  if (process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    await sleep(2000);
+    const windows = execFileSync('xdotool', ['search', '--class', '^zeron$'], { encoding: 'utf8' }).trim().split('\n');
+    if (windows.length !== 1) throw Error('Use a dedicated X display with exactly one Zeron window');
+    execFileSync('xdotool', ['windowraise', windows[0], 'windowsize', windows[0], '1280', '800', 'windowfocus', windows[0]]);
+  }
+  sampler = setInterval(() => {
+    samples.push({ at: Date.now(), phase, engine: stat(engine.pid), ui: stat(ui.pid),
+      harness: descendants(engine.pid).map(stat).filter(Boolean) });
+  }, 500);
+  phase = 'idle';
+  await sleep(10000);
+  if (ui.exitCode != null) throw Error('UI exited; inspect ui.log');
+  phase = 'stream';
+  const prompt = process.env.ZERON_PROFILE_PROMPT ??
+    'Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.';
+  if (process.env.ZERON_PROFILE_SUBMIT_UI === '1') {
+    // Functional mode exercises the composer's own-turn scroll anchoring.
+    // Use a dedicated display; the driver focused the app's composer above.
+    execFileSync('xdotool', ['type', '--clearmodifiers', '--delay', '0', '--', prompt]);
+    execFileSync('xdotool', ['key', 'Return']);
+  } else {
+    await call('QueueCommand', { chatId, command: { kind: 'run', messageId: randomUUID(), request: {
+      prompt, model: harness === 'mock' ? null : 'haiku', reasoning: null, modelOptions: {}, cwd,
+      sandbox: 'workspace-write', autoApprove: true, resume: null,
+    } } });
+  }
+  const timeoutMs = Number(process.env.ZERON_PROFILE_TIMEOUT_MS ?? 240000);
+  const deadline = Date.now() + timeoutMs;
+  let complete = false;
+  while (Date.now() < deadline) {
+    await sleep(500);
+    if (streamError) throw streamError;
+    const assistants = transcript.filter(e => e.role === 'assistant');
+    if (assistants.length && assistants.at(-1).status !== 'streaming') {
+      if (assistants.at(-1).status !== 'complete') throw Error('Harness turn did not complete successfully');
+      complete = true; break;
+    }
+    if (ui.exitCode != null || engine.exitCode != null) throw Error('Profiled process exited');
+  }
+  if (!complete) throw Error(`Turn did not complete within ${timeoutMs / 1000} seconds`);
+  phase = 'settled';
+  await sleep(Number(process.env.ZERON_PROFILE_IDLE_MS ?? 15000));
+  const reply = transcript.filter(e => e.role === 'assistant').flatMap(e => e.parts)
+    .filter(p => p.kind === 'text' || p.kind === 'reasoning').map(p => p.text).join('\n\n');
+  const summary = { binary, binarySha256, harness, mode: process.env.ZERON_REPLAY_JOURNAL ? 'replay' : 'live',
+    renderThreads: process.env.LP_NUM_THREADS ?? 'default', frameStats: env.ZERON_FRAME_STATS,
+    submission: process.env.ZERON_PROFILE_SUBMIT_UI === '1' ? 'composer' : 'rpc', prompt,
+    replySha256: createHash('sha256').update(reply).digest('hex'), replyBytes: Buffer.byteLength(reply),
+    transcriptBytes: Buffer.byteLength(JSON.stringify(transcript)), frames: frames.length, phases: {} };
+  for (const p of ['idle', 'stream', 'settled']) {
+    const rows = samples.filter(s => s.phase === p);
+    summary.phases[p] = { durationSeconds: (rows.at(-1).at - rows[0].at) / 1000 };
+    for (const name of ['engine', 'ui']) {
+      const valid = rows.filter(r => r[name]);
+      const first = valid[0], last = valid.at(-1);
+      summary.phases[p][name] = { peakRssMiB: Math.max(...valid.map(r => r[name].rssMiB)),
+        endRssMiB: last[name].rssMiB,
+        cpuPercent: 100000 * (last[name].cpuSeconds - first[name].cpuSeconds) / (last.at - first.at),
+        mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at) };
+    }
+  }
+  // Report the last ten seconds separately from the completion transition.
+  const settled = samples.filter(s => s.phase === 'settled');
+  const quiet = settled.filter(s => s.at >= settled.at(-1).at - 10000);
+  summary.postCompletionTail = { durationSeconds: (quiet.at(-1).at - quiet[0].at) / 1000 };
+  for (const name of ['engine', 'ui']) {
+    const first = quiet[0], last = quiet.at(-1);
+    summary.postCompletionTail[name] = {
+      endRssMiB: last[name].rssMiB,
+      cpuPercent: 100000 * (last[name].cpuSeconds - first[name].cpuSeconds) / (last.at - first.at),
+      mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at),
+    };
+  }
+  writeFileSync(`${output}/summary.json`, JSON.stringify(summary, null, 2));
+  console.log(JSON.stringify(summary, null, 2));
+  // Optional machine-specific regression budgets. Do not bake software-GPU
+  // numbers into a universal desktop threshold.
+  for (const name of ['engine', 'ui']) {
+    const budget = process.env[`ZERON_MAX_${name.toUpperCase()}_RSS_MIB`];
+    if (budget == null) continue;
+    const limit = Number(budget);
+    if (!Number.isFinite(limit) || limit <= 0) throw Error(`Invalid ${name} RSS budget`);
+    const peak = Math.max(...Object.values(summary.phases).map(p => p[name].peakRssMiB));
+    if (peak > limit) throw Error(`${name} peak RSS ${peak.toFixed(1)} MiB exceeds ${limit} MiB`);
+  }
+  // Keep a verified conversation open for manual interaction checks without
+  // counting those interactions in the measured phases.
+  clearInterval(sampler);
+  if (process.env.ZERON_PROFILE_HOLD_MS) await sleep(Number(process.env.ZERON_PROFILE_HOLD_MS));
+} finally {
+  clearInterval(sampler);
+  writeFileSync(`${output}/samples.json`, JSON.stringify(samples));
+  writeFileSync(`${output}/frames.json`, JSON.stringify(frames));
+  writeFileSync(`${output}/transcript.json`, JSON.stringify(transcript));
+  ws?.close();
+  for (const child of processes.reverse()) {
+    try { process.kill(-child.pid, 'SIGTERM'); } catch { /* already exited */ }
+  }
+}

--- a/scripts/resource-profile.mjs
+++ b/scripts/resource-profile.mjs
@@ -177,7 +177,10 @@ try {
   sampler = setInterval(() => {
     if (macOS) {
       try { execFileSync(nativeWindow, [String(ui.pid), '--check'], { stdio: 'pipe' }); }
-      catch { streamError = Error('Native window became inactive, hidden or locked during profiling; discard this run'); }
+      catch (error) {
+        const reason = error.stderr?.toString().trim() || error.message;
+        streamError = Error(`Native window validation failed: ${reason}`);
+      }
     }
     samples.push({ at: Date.now(), phase, engine: stat(engine.pid), ui: stat(ui.pid),
       harness: descendants(engine.pid).map(stat).filter(Boolean) });

--- a/scripts/resource-profile.mjs
+++ b/scripts/resource-profile.mjs
@@ -59,7 +59,11 @@ function stat(pid) {
     const stat = readFileSync(`/proc/${pid}/stat`, 'utf8').split(') ')[1].split(' ');
     const main = readFileSync(`/proc/${pid}/task/${pid}/stat`, 'utf8').split(') ')[1].split(' ');
     const status = readFileSync(`/proc/${pid}/status`, 'utf8');
-    return { pid, cpuSeconds: (Number(stat[11]) + Number(stat[12])) / hz,
+    // Optional proportional memory avoids counting shared mappings twice.
+    const pss = process.env.ZERON_PROFILE_PSS === '1'
+      ? { pssMiB: Number(readFileSync(`/proc/${pid}/smaps_rollup`, 'utf8').match(/^Pss:\s+(\d+)/m)?.[1] ?? 0) / 1024 }
+      : {};
+    return { pid, ...pss, cpuSeconds: (Number(stat[11]) + Number(stat[12])) / hz,
       mainCpuSeconds: (Number(main[11]) + Number(main[12])) / hz,
       rssMiB: Number(status.match(/VmRSS:\s+(\d+)/)?.[1] ?? 0) / 1024,
       threads: Number(status.match(/Threads:\s+(\d+)/)?.[1] ?? 0) };
@@ -193,7 +197,10 @@ try {
     for (const name of ['engine', 'ui']) {
       const valid = rows.filter(r => r[name]);
       const first = valid[0], last = valid.at(-1);
-      summary.phases[p][name] = { peakRssMiB: Math.max(...valid.map(r => r[name].rssMiB)),
+      summary.phases[p][name] = {
+        ...(first[name].pssMiB == null ? {} : {
+          peakPssMiB: Math.max(...valid.map(r => r[name].pssMiB)), endPssMiB: last[name].pssMiB,
+        }), peakRssMiB: Math.max(...valid.map(r => r[name].rssMiB)),
         endRssMiB: last[name].rssMiB,
         cpuPercent: 100000 * (last[name].cpuSeconds - first[name].cpuSeconds) / (last.at - first.at),
         mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at) };


### PR DESCRIPTION
Streaming spent substantial CPU drawing large backgrounds with the general quad shader. Provider catalogs and repeated transcript copies inflated memory, and completed long replies could keep the scroll spring repainting. This reduces those costs while retaining the existing rendering and interaction behavior.

Application changes share transcript and Markdown snapshots, stream a lean provider catalog, cache syntax queries and sidebar rendering, bound viewport caches, and park the spring on a stable final-item anchor. The GPUI dependency is pinned to [zeronsh/zui at 0003b923](https://github.com/zeronsh/zui/commit/0003b923354ea8938b2d0cadbd17ef93108e2ae5). Its changes reduce blur work and specialize solid/opaque fills. Software adapters also split large plain interiors from complex edges; physical GPUs keep their original batch structure. Borders, corners, gradients, fades and clipping retain the general path wherever needed.

Repeated release measurements against old Zeron (`f1d4bad`, v0.2.37), using identical captured Haiku output through the real engine, Claude adapter, RPC and desktop. UI + engine totals, four software-rendering workers, two runs per build in forward and reverse order:

| Metric | Old Zeron | Final | Change |
| --- | ---: | ---: | ---: |
| Idle CPU | 27.41% | 7.49% | −72.7% |
| Streaming CPU | 265.57% | 158.57% | −40.3% |
| Post-completion CPU | 24.34% | 9.14% | −62.5% |
| Idle peak RSS | 330.92 MiB | 206.11 MiB | −37.7% |
| Streaming peak RSS | 358.73 MiB | 235.24 MiB | −34.4% |
| Streaming peak proportional memory | 301.38 MiB | 177.19 MiB | −41.2% |

CPU uses **100% per core**. Post-completion values use the last ten seconds of a 45-second observation. With one worker, repeated short-stream CPU fell **113.51% → 100.64%**, and peak RSS **359.39 → 233.21 MiB**. The single 10× long-transcript check reduced post-completion CPU **92.77% → 8.30%** and streaming peak RSS **398.13 → 256.27 MiB**. These are Linux software-Vulkan measurements, not native Metal measurements. OpenCode automatic model discovery is included. The additional fill pipelines cost a few MiB relative to the intermediate optimized renderer; the report records that tradeoff.

978 application tests passed during this optimization work; the 592 UI tests were rerun against the final zui pin. All 28 zui renderer/text/atlas tests pass, including 1,888 byte-identical offscreen image comparisons covering fractional clipping, translucent overlaps, borders, corners, fades, target formats and alpha modes. A fresh composer-submitted Haiku 4.5 turn completed a shell-tool call and a 20-section reply. Sidebar, scroll-away/return, selected-text copy/paste, resizing and the model menu were checked in the real window. Script and diff checks passed. Four existing application tests remain ignored; this does not claim every workspace integration target ran.

[Full report, raw summaries and reproduction commands](https://github.com/zeronsh/comet/blob/zeron/optimize-zeron-resource-usage/docs/performance-resource-usage.md) include source/executable/reply hashes, profiling attribution and the sanitized replay fixture.

Native macOS follow-up adds a transcript content revision and caches the primary transcript scene, so sidebar animation and caret frames can reuse unchanged transcript layout/paint. Explicit shell notifications, content updates, scrolling and geometry changes still invalidate it. The native frame loop gates clean-window main-queue callbacks; Metal uses per-frame autorelease pools and bounded blur scratch/kernel caches. Blur shaders, Gaussian sigma, clipping and animation clocks are preserved.

Foreground release replay on an Apple Silicon Mac (macOS 26.0.1, 1320×880 logical pixels at 2× scale), comparing the earlier PR head `f10ef38c` with the updated application. One valid baseline run and two updated runs; identical recorded text/reasoning, real engine/adapter/RPC, no simultaneous builds or sampling profilers:

| Native macOS metric | Earlier PR head | Updated, two runs |
| --- | ---: | ---: |
| Empty-chat UI CPU | 1.25% | 0.59–0.61% |
| Streaming UI CPU | 15.16% | 12.48–13.31% |
| Streaming UI + engine CPU | 16.06% | 13.26–14.09% |
| Empty-chat peak UI physical footprint | 306.38 MiB | 302.11–303.50 MiB |
| Streaming peak UI physical footprint | 328.84 MiB | 323.11–325.99 MiB |

Mean native streaming UI CPU is 12.90% (about 15% lower than the earlier PR head); memory savings in this workload are modest. Updated 10-second settled observations average 0.83–0.87% UI CPU. Native physical footprint and Linux RSS are different metrics and should not be compared directly. The driver rejects locked/asleep displays and lost-foreground measurements. These short replay results do not establish a universal memory floor or prove every reported idle memory swing is fixed.

A larger stress replay produced the same 210,502-byte reply in both runs at four times the provider cadence. Streaming UI CPU was 13.03–15.34%, with 328.74–329.75 MiB peak physical footprint. The first ten seconds after completion included additional work; the final ten seconds of a 30-second observation settled to 0.80% UI CPU at 332.41 MiB. The report includes both runs' raw counters. This is a larger-reply check, not a matched baseline comparison or proof of long-duration memory stability.

Native validation: 593 UI tests, 207 GPUI tests and 15 macOS tests pass. The completed native transcript image is pixel-identical before/after. Reused versus freshly rendered scenes also match after settling, sidebar hide/restore, scrolling, text selection, composer typing and model-menu dismissal. The animated loading menu is checked for unchanged pixels outside its bounds, with complete images retained for visual inspection; the isolated replay does not select a live provider model. The optional replay verifier exercises those comparisons outside timed phases. Release build, script and diff checks pass. Typing/selection across multiple panes, display reconnection and long-duration mixed-use validation remain limited.

The earlier isolated offscreen replay showed no meaningful CPU/memory improvement before the final transcript scene-cache change; that result is retained separately in the report. A precompiled-shader experiment did not meaningfully improve native memory and was not retained. [Native macOS report, raw counters and reproduction](https://github.com/zeronsh/comet/blob/zeron/optimize-zeron-resource-usage/docs/performance-macos.md).

Release preparation for v0.2.38 integrates current main, including long-user-message collapse. The combined code passed all 596 UI tests and the native replay's cached/fresh comparisons for settling, sidebar transitions, scrolling, selection, typing and menu dismissal. Workspace and lockfile versions are 0.2.38. The release workflow now requires successful macOS packaging alongside both Linux architectures before publishing the release and updater manifest. Historical profiling results above retain their original source identities.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791176482&installation_model_id=425430&pr_number=255&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F255&signature=6682bcd786959150d2e4e4d9d105e472f85c67bc994d4d52937dfeb14676b7c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->