### PR TITLE
Follow up on macOS CPU and memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,12 +682,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -888,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1006,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1126,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1207,6 +1261,15 @@ name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1398,10 +1461,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1548,7 +1656,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1559,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2446,12 +2554,13 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "accesskit",
  "anyhow",
  "async-channel",
  "async-task",
+ "backtrace",
  "bindgen",
  "bitflags 2.13.1",
  "block",
@@ -2465,6 +2574,7 @@ dependencies = [
  "core-graphics 0.24.0",
  "core-text",
  "core-video",
+ "criterion",
  "ctor",
  "derive_more",
  "embed-resource",
@@ -2476,6 +2586,7 @@ dependencies = [
  "gpui_macros",
  "gpui_shared_string",
  "gpui_util",
+ "hdrhistogram",
  "heapless 0.9.3",
  "http_client",
  "image",
@@ -2495,6 +2606,7 @@ dependencies = [
  "pollster 0.4.0",
  "postage",
  "profiling",
+ "proptest",
  "rand 0.9.5",
  "raw-window-handle",
  "refineable",
@@ -2528,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2580,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2629,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2640,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2653,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "schemars",
  "serde",
@@ -2663,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2674,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "log",
@@ -2684,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2708,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2737,7 +2849,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -2853,6 +2965,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
+dependencies = [
+ "base64",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom 8.0.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -2982,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3259,7 +3385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -3382,6 +3508,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3533,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -4014,7 +4160,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4137,7 +4283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
@@ -4710,6 +4856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "open"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4823,7 +4975,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "collections",
  "serde",
@@ -4981,6 +5133,34 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -5220,6 +5400,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "git+https://github.com/proptest-rs/proptest?rev=3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b#3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "num-traits",
+ "proptest-macro",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-macro"
+version = "0.5.0"
+source = "git+https://github.com/proptest-rs/proptest?rev=3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b#3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b"
+dependencies = [
+ "convert_case 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5285,6 +5495,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -5476,6 +5692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5540,7 +5765,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -5664,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "derive_refineable",
 ]
@@ -5920,6 +6145,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "rustybuzz"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5955,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6568,7 +6805,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -6883,7 +7120,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -6961,6 +7198,16 @@ checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -7598,6 +7845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7735,7 +7988,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "perf",
  "quote",
@@ -7852,6 +8105,15 @@ dependencies = [
  "log",
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -8153,8 +8415,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
  "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
@@ -8215,7 +8477,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.1",
  "block2 0.6.2",
  "bytemuck",
@@ -9365,6 +9627,7 @@ dependencies = [
  "gpui",
  "gpui_platform",
  "gpui_tokio",
+ "mimalloc",
  "objc",
  "pulldown-cmark",
  "serde",
@@ -9374,6 +9637,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "ttf-parser",
  "unicode-segmentation",
  "unicode-width",
@@ -9439,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9456,7 +9720,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9467,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=49f9abd196705eda6a27080c506295a19b5da63e#49f9abd196705eda6a27080c506295a19b5da63e"
+source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,14 +61,14 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/zeronsh/zui", rev = "49f9abd196705eda6a27080c506295a19b5da63e" }
-gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "49f9abd196705eda6a27080c506295a19b5da63e", features = [
+gpui = { git = "https://github.com/zeronsh/zui", rev = "0003b923354ea8938b2d0cadbd17ef93108e2ae5" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "0003b923354ea8938b2d0cadbd17ef93108e2ae5", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "49f9abd196705eda6a27080c506295a19b5da63e" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "0003b923354ea8938b2d0cadbd17ef93108e2ae5" }
 
 # diffs
 similar = "2"

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -5,6 +5,13 @@ edition.workspace = true
 license.workspace = true
 publish.workspace = true
 
+[features]
+resource-profile = ["gpui/bench", "gpui_platform/test-support"]
+
+[[example]]
+name = "macos-resource-profile"
+required-features = ["resource-profile"]
+
 [dependencies]
 zeron-proto.workspace = true
 similar.workspace = true
@@ -41,3 +48,5 @@ objc = "0.2"
 
 [dev-dependencies]
 tempfile.workspace = true
+mimalloc.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/ui/examples/macos-resource-profile.rs
+++ b/crates/ui/examples/macos-resource-profile.rs
@@ -1,0 +1,167 @@
+//! UI-only replay with native CoreText/Metal and real animation clocks.
+//! Input is frames.json from scripts/resource-profile.mjs. An offscreen target
+//! replaces the window compositor; this is not a whole-app CPU measurement.
+use gpui::{AppContext, Bounds, WindowBounds, WindowOptions, px, size};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    time::{Duration, Instant},
+};
+use zeron_ui::*;
+
+#[cfg(target_os = "macos")]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[derive(serde::Deserialize)]
+struct Frame {
+    at: u64,
+    frame: zeron_doc::TranscriptFrame,
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() -> anyhow::Result<()> {
+    anyhow::bail!("This profiler requires macOS")
+}
+
+#[cfg(target_os = "macos")]
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+    let args: Vec<_> = std::env::args().collect();
+    anyhow::ensure!(
+        args.len() == 3,
+        "Usage: macos-resource-profile FRAMES_JSON OUTPUT_DIR"
+    );
+    let frames: Vec<Frame> = serde_json::from_slice(&std::fs::read(&args[1])?)?;
+    anyhow::ensure!(!frames.is_empty(), "Empty replay");
+    let output = std::path::PathBuf::from(&args[2]);
+    std::fs::create_dir_all(&output)?;
+    let native = gpui_platform::current_platform(true);
+    let platform = gpui::bench_platform(
+        Some(Box::new(gpui_platform::current_headless_renderer)),
+        native.text_system(),
+    );
+    let executor = platform.background_executor();
+    let handles = Rc::new(RefCell::new(None));
+    let captured = handles.clone();
+    let data = output.clone();
+    let app = gpui::Application::with_platform(platform).with_assets(icons::Assets)
+        .run_embedded(move |cx| {
+            gpui_tokio::init(cx);
+            let settings = settings::UiSettings::default();
+            settings::init(settings.clone(), data.clone(), cx);
+            let fonts = typography::register_fonts(cx);
+            typography::init(settings.ui_font_family.clone(), settings.ui_font_size, fonts, cx);
+            theme_library::init(data.clone(), cx);
+            appearance::init(appearance::AppearanceMode::Dark, settings.theme_selection,
+                settings.accent, settings.surface, cx);
+            composer::init(cx);
+            terminal::panel::init(cx);
+            app_menus::init(cx);
+            let state = cx.new(|_| {
+                let mut state = state::AppState::new();
+                state.connection = zeron_proto::view::ConnectionStatus::Ready;
+                state.workspace_scope = Some(zeron_proto::WorkspaceScope::Local);
+                state.selected_chat = Some("profile".into());
+                state.selected_space = Some("project".into());
+                state.auto_selected = true;
+                state.chats_synced = true;
+                state.spaces_synced = true;
+                state.spaces = vec![serde_json::from_value(serde_json::json!({
+                    "id":"project", "deviceId":"local", "path":"/tmp/resource-profile",
+                    "createdAt":"2026-09-05T00:00:00Z"
+                })).unwrap()];
+                state.chats = vec![serde_json::from_value(serde_json::json!({
+                    "id":"profile", "deviceId":"local", "spaceId":"project", "title":"Resource profile",
+                    "archived":false, "createdAt":"2026-09-05T00:00:00Z",
+                    "config":{"harness":"claude-code", "model":"claude-haiku-4-5", "reasoning":null, "sandbox":"workspace-write"}
+                })).unwrap()];
+                state
+            });
+            let boot = EngineBootConfig { data_dir:data, ipc_port:0,
+                edge_url:String::new(), edge_token:None, org_id:None,
+                workos_client_id:None, default_harness:HarnessId::ClaudeCode };
+            let window = cx.open_window(WindowOptions {
+                window_bounds:Some(WindowBounds::Windowed(Bounds::new(
+                    gpui::point(px(0.),px(0.)),size(px(1320.),px(880.))))),
+                ..Default::default()
+            }, |_,cx| cx.new(|cx| shell::Shell::new(state.clone(),boot,cx))).unwrap();
+            *captured.borrow_mut() = Some((state,window));
+        });
+    let (state, window) = handles.borrow_mut().take().unwrap();
+    let dispatcher = executor.dispatcher().as_bench().unwrap();
+    let start = Instant::now();
+    let first_at = frames[0].at;
+    let mut frames = frames.into_iter().peekable();
+    let mut completed_at = None;
+    eprintln!("pid={} phase=replay", std::process::id());
+    loop {
+        objc::rc::autoreleasepool(|| {
+            let elapsed = start.elapsed().as_millis() as u64;
+            while frames.peek().is_some_and(|f| f.at - first_at <= elapsed) {
+                let frame = frames.next().unwrap();
+                app.update(|cx| {
+                    state.update(cx, |state, cx| {
+                        state.apply_transcript_frame(frame.frame).unwrap();
+                        let streaming = state
+                            .transcript
+                            .iter()
+                            .any(|entry| entry.status == Some(zeron_doc::MessageStatus::Streaming));
+                        state.apply_sessions(vec![zeron_proto::Session {
+                            chat_id: "profile".into(),
+                            device_id: "local".into(),
+                            status: if streaming {
+                                zeron_proto::SessionStatus::Working
+                            } else {
+                                zeron_proto::SessionStatus::Idle
+                            },
+                            started_at: Some(chrono::Utc::now()),
+                            updated_at: chrono::Utc::now(),
+                        }]);
+                        cx.notify();
+                    })
+                });
+            }
+            app.update(|cx| {
+                window
+                    .update(cx, |_, window, cx| {
+                        window.simulate_next_frame(cx);
+                    })
+                    .unwrap()
+            });
+            dispatcher.run_until_idle();
+            app.update(|cx| {
+                window
+                    .update(cx, |_, window, _| window.present_if_needed())
+                    .unwrap()
+            });
+        });
+        if frames.peek().is_none() && completed_at.is_none() {
+            eprintln!("phase=settled elapsed={:?}", start.elapsed());
+            completed_at = Some(Instant::now());
+            app.update(|cx| {
+                window
+                    .update(cx, |_, window, _| {
+                        window
+                            .render_to_image()
+                            .unwrap()
+                            .save(output.join("complete.png"))
+                            .unwrap();
+                    })
+                    .unwrap()
+            });
+        }
+        if completed_at.is_some_and(|t| t.elapsed() > Duration::from_secs(15)) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(8));
+    }
+    eprintln!("elapsed={:?}", start.elapsed());
+    drop(state);
+    app.update(|cx| cx.quit());
+    drop(app);
+    Ok(())
+}

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -624,6 +624,9 @@ pub struct AppState {
     /// empty transcript is otherwise indistinguishable from the pre-replay
     /// gap after selection, where optimistic echoes may already be visible.
     pub transcript_replayed: bool,
+    /// Changes only when transcript/optimistic content changes. Presence,
+    /// catalogs and other app-state notifications need no row derivation.
+    pub(crate) transcript_revision: u64,
     /// Optimistic user echoes per chat id, shown until the doc frame carrying
     /// the same message id arrives (client-minted ids make dedup exact).
     echoes: HashMap<String, Vec<SessionMessageEntry>>,
@@ -686,6 +689,7 @@ impl AppState {
             selected_chat: None,
             transcript: Vec::new(),
             transcript_replayed: false,
+            transcript_revision: 0,
             echoes: HashMap::new(),
             pending_sends: HashMap::new(),
             upload_progress: None,
@@ -760,6 +764,7 @@ impl AppState {
             // Selected chat vanished (deleted elsewhere): drop selection + transcript.
             self.selected_chat = None;
             self.transcript.clear();
+            self.transcript_revision = self.transcript_revision.wrapping_add(1);
             self.transcript_replayed = false;
             self.transcript_task = None;
         }
@@ -915,6 +920,7 @@ impl AppState {
     }
 
     pub fn apply_transcript(&mut self, entries: Vec<SessionMessageEntry>) {
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         // Doc frames supersede optimistic echoes carrying the same id.
         if let Some(chat_id) = self.selected_chat.as_deref()
             && let Some(echoes) = self.echoes.get_mut(chat_id)
@@ -932,6 +938,7 @@ impl AppState {
         &mut self,
         frame: TranscriptFrame,
     ) -> Result<(), TranscriptDesync> {
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         let is_reset = matches!(&frame, TranscriptFrame::Reset { .. });
         zeron_doc::apply_transcript_frame(&mut self.transcript, frame)?;
         if is_reset {
@@ -974,6 +981,7 @@ impl AppState {
     /// Tab closed: drop the watch task (cancels the engine-side watch and
     /// unpins the doc from the engine LRU) and the rows.
     pub fn unwatch_subagent_doc(&mut self, doc_id: &str) {
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         self.sub_watch_tasks.remove(doc_id);
         self.sub_transcripts.remove(doc_id);
     }
@@ -981,6 +989,7 @@ impl AppState {
     /// Frozen-blob path: the finished subagent's uploaded transcript, no
     /// watch needed (and any in-flight watch is superseded).
     pub fn set_subagent_snapshot(&mut self, doc_id: String, entries: Vec<SessionMessageEntry>) {
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         self.sub_watch_tasks.remove(&doc_id);
         self.sub_transcripts.insert(doc_id, entries);
     }
@@ -990,13 +999,18 @@ impl AppState {
         let echoes = self.echoes.entry(chat_id.to_string()).or_default();
         if !echoes.iter().any(|e| e.id == entry.id) {
             echoes.push(entry);
+            self.transcript_revision = self.transcript_revision.wrapping_add(1);
         }
     }
 
     /// Drop an echo (send failed — the prompt returns to the draft).
     pub fn remove_echo(&mut self, chat_id: &str, message_id: &str) {
         if let Some(echoes) = self.echoes.get_mut(chat_id) {
+            let previous_len = echoes.len();
             echoes.retain(|e| e.id != message_id);
+            if echoes.len() != previous_len {
+                self.transcript_revision = self.transcript_revision.wrapping_add(1);
+            }
         }
     }
 
@@ -1372,6 +1386,7 @@ impl AppState {
         self.chats_synced = false;
         self.spaces_synced = false;
         self.transcript.clear();
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         self.transcript_replayed = false;
         self.echoes.clear();
         self.pending_sends.clear();
@@ -1583,6 +1598,7 @@ impl AppState {
         self.selected_chat = chat_id.clone();
         self.auto_selected = true;
         self.transcript.clear();
+        self.transcript_revision = self.transcript_revision.wrapping_add(1);
         self.transcript_replayed = false;
         self.transcript_task = None;
         if let Some(id) = chat_id.as_deref() {
@@ -2048,6 +2064,7 @@ fn spawn_subagent_watch(
                 let alive = this.update(cx, |state, cx| {
                     // A stale pump racing a snapshot/unwatch finds no key.
                     if let Some(rows) = state.sub_transcripts.get_mut(&doc_id) {
+                        state.transcript_revision = state.transcript_revision.wrapping_add(1);
                         if let Err(err) = zeron_doc::apply_transcript_frame(rows, frame) {
                             tracing::warn!(%doc_id, error = %err, "resubscribing subagent watch");
                             desync = true;
@@ -2658,6 +2675,53 @@ mod tests {
             status: None,
             continuation_of: None,
         }
+    }
+
+    #[test]
+    fn transcript_revision_tracks_replay_echoes_and_subagent_content() {
+        let mut state = AppState::new();
+        state.selected_chat = Some("c".into());
+        let initial = state.transcript_revision;
+        state.apply_transfers(Vec::new());
+        state.apply_auth(AuthState::SignedOut);
+        assert_eq!(
+            state.transcript_revision, initial,
+            "unrelated notifications are inert"
+        );
+
+        state.push_echo("c", user_entry("m1"));
+        let echo = state.transcript_revision;
+        assert_ne!(echo, initial);
+        state.push_echo("c", user_entry("m1"));
+        state.remove_echo("c", "absent");
+        assert_eq!(
+            state.transcript_revision, echo,
+            "unchanged echoes do not invalidate"
+        );
+        state.apply_transcript(vec![user_entry("m1")]);
+        assert!(state.pending_echoes().is_empty());
+        assert_ne!(
+            state.transcript_revision, echo,
+            "echo-to-replay handoff invalidates"
+        );
+
+        let before_reset = state.transcript_revision;
+        state
+            .apply_transcript_frame(TranscriptFrame::Reset { reset: Vec::new() })
+            .unwrap();
+        assert!(state.transcript_replayed);
+        assert_ne!(
+            state.transcript_revision, before_reset,
+            "empty replay is authoritative"
+        );
+
+        let before_subagent = state.transcript_revision;
+        state.set_subagent_snapshot("sub".into(), vec![user_entry("nested")]);
+        assert_ne!(state.transcript_revision, before_subagent);
+        let before_close = state.transcript_revision;
+        state.unwatch_subagent_doc("sub");
+        assert!(state.sub_transcript("sub").is_empty());
+        assert_ne!(state.transcript_revision, before_close);
     }
 
     fn device(id: &str, name: &str) -> Device {

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2201,6 +2201,7 @@ pub struct Transcript {
     state: Entity<AppState>,
     list: ListState,
     rows: Vec<Row>,
+    last_source: Option<(Option<String>, TranscriptReplayState, u64)>,
     chat_id: Option<String>,
     /// `Some(doc_id)` pins this instance to a SUBAGENT doc: rows come from
     /// `AppState::sub_transcript(doc_id)` instead of the selected chat, and
@@ -2449,6 +2450,7 @@ impl Transcript {
             state,
             list,
             rows: Vec::new(),
+            last_source: None,
             // Pre-set so `sync` never sees an attach edge — an override
             // instance must not reset (or re-pin) on selection changes.
             chat_id: doc_override.clone(),
@@ -3428,6 +3430,16 @@ impl Transcript {
             }
         };
 
+        let source = (
+            selected.clone(),
+            replay,
+            self.state.read(cx).transcript_revision,
+        );
+        if self.last_source.as_ref() == Some(&source) {
+            return;
+        }
+        self.last_source = Some(source);
+
         let attached = selected != self.chat_id;
         if attached {
             // Read the incoming snapshot before inserting the outgoing one:
@@ -3684,7 +3696,13 @@ impl Transcript {
     /// Cached row build for one entry (streaming entries bypass the cache).
     fn rows_for(&mut self, entry: &SessionMessageEntry, pending: bool) -> Vec<Row> {
         let streaming = entry.status == Some(MessageStatus::Streaming);
-        let fingerprint = entry_fingerprint(entry, pending);
+        // Live entries always rebuild; don't allocate a fingerprint that the
+        // streaming path cannot use.
+        let fingerprint = if streaming {
+            0
+        } else {
+            entry_fingerprint(entry, pending)
+        };
         if !streaming
             && let Some(cached) = self.row_cache.get(&entry.id)
             && cached.fingerprint == fingerprint

--- a/docs/performance-macos.md
+++ b/docs/performance-macos.md
@@ -1,0 +1,104 @@
+# Native macOS resource follow-up
+
+This follows PR #255 at `f10ef38c`. The app pins zui `0003b923`, which gates
+unnecessary main-queue frame callbacks and bounds native Metal blur resources.
+The Linux software-Vulkan results in [the earlier report](performance-resource-usage.md)
+do not predict native Metal usage.
+
+## Changes
+
+- Transcript row derivation now has a content revision. Presence, catalog and
+  other unrelated state notifications skip rebuilding rows, while selection,
+  replay readiness, optimistic echo insertion/removal, transcript deltas and
+  subagent content invalidate the cache. Live entries also skip an unused
+  serialized fingerprint.
+- The native frame loop parks clean-window callbacks and wakes for content,
+  input or animations. It keeps the existing display clock and lifecycle
+  protections. The timing thread still runs while the window is subscribed.
+- Metal uses a per-frame autorelease pool and bounded caches for alternating
+  blur surfaces. Smaller texture buckets reduce over-allocation; window shrink
+  and idle transitions release obsolete extents. Current surfaces retain their
+  resources. Blur sigma, shaders, clipping, animation clocks and scroll behavior
+  stay unchanged.
+- The resource driver now reports native process CPU and physical footprint as
+  well as RSS. Its window helper rejects locked/asleep displays and invalidates
+  measurements if the app loses the foreground or its window disappears.
+- Replay recording clones frames before the transcript applier mutates them.
+  Otherwise later appends corrupt historical reset/upsert records.
+
+## Validation and limits
+
+593 UI tests, 207 GPUI library tests and 15 native macOS tests passed. The native
+suite covers wake after idle, animation continuation, resize, Gaussian blur
+pixels, identical cold/warm rendering, cache bounds and menu-close trimming.
+The macOS pasteboard tests share the system clipboard and are run serially.
+The optional native UI replay example uses CoreText, Metal, the real shell and
+real animation clocks; its completed transcript is rendered to `complete.png`.
+The profiling feature and its benchmark dependencies are not enabled in normal
+application builds.
+
+The Mac's display was locked during this work. Native offscreen rendering is
+valid for checking pixels and isolated rendering cost. It cannot verify native
+window presentation, desktop background blur, display pacing, interactive input
+or foreground whole-app CPU/memory savings. The user's reported memory swings
+are not yet conclusively attributed. RSS alone is insufficient for comparison
+because the native physical-footprint counter also accounts for charged
+compressed and GPU memory.
+
+Before merge, repeat foreground baseline/candidate runs and check typing,
+selection/copy, scrolling, streaming/completion, menus, resizing, occlusion and
+display reconnection with the Mac unlocked. This is a draft pending those checks.
+
+## Repeated native offscreen comparison
+
+Two sequential runs per build, ordered baseline/candidate/candidate/baseline,
+on macOS 26.0.1 (25A362), arm64 Mac16,7 with 24 GiB RAM. The synthetic shell
+replays the same protocol frames at the recorded cadence, at 1320×880 logical
+pixels and 2× scale, then waits 15 seconds. Each phase excludes its first two
+seconds. Both drivers use the same allocator and native text/Metal backends.
+The baseline adds only the profiling driver and embedded-platform launch support.
+[Raw samples and executable/trace hashes](performance/resource-macos-offscreen.json).
+
+| UI-only replay metric | PR #255 | Candidate |
+| --- | ---: | ---: |
+| CPU, 100% per core | 18.49% | 18.46% |
+| Mean of per-run peak physical footprint | 282.85 MiB | 286.69 MiB |
+
+These runs establish **no meaningful streaming CPU or memory improvement** in
+this isolated workload. It excludes native display-link dispatch and desktop
+composition and does not open alternating menus. The completed 2640×1760 app
+image is byte-identical between baseline and candidate in the first matched pair.
+The frame-gating and unused-resource cleanup benefits still require a foreground
+comparison. Do not present these results as a reduction in the reported whole-app
+streaming usage, or as a universal memory floor.
+
+## Reproduction
+
+Requires Node 22+, Rust and Xcode Command Line Tools. Foreground profiling needs
+existing Accessibility access to activate and size the isolated window. Keep
+that window foreground and the display awake for the entire run. Replay uses
+an isolated profile and the bundled sanitized fixture; it makes no model API call.
+
+```sh
+cargo build --release --locked -p zeron
+ZERON_FRAME_STATS=0 ZERON_PROFILE_IDLE_MS=45000 \
+  CLAUDE_CODE_EXECUTABLE="$PWD/scripts/replay-claude.py" \
+  ZERON_REPLAY_JOURNAL="$PWD/scripts/fixtures/resource-stream.jsonl" \
+  node scripts/resource-profile.mjs target/release/zeron /tmp/zeron-native claude-code
+
+# UI-only offscreen replay of those verified protocol frames:
+cargo build --release --locked -p zeron-ui --features resource-profile \
+  --example macos-resource-profile
+ZERON_FRAME_STATS=0 target/release/examples/macos-resource-profile \
+  /tmp/zeron-native/frames.json /tmp/zeron-native-ui
+
+# Native counter usable with either process (CPU uses 100% per core):
+xcrun clang -O2 scripts/macos-resource-stat.c -o /tmp/zeron-stat
+/tmp/zeron-stat PID
+```
+
+Compare fresh release builds in alternating order, with the same trace,
+window geometry, display scale and settings. Do not compile or run a profiler
+concurrently with timed comparisons. Engine and harness processes are reported
+separately from the UI; the offscreen example excludes both and the window
+compositor. Its polling loop must not be reported as native idle CPU.

--- a/docs/performance-resource-usage.md
+++ b/docs/performance-resource-usage.md
@@ -1,5 +1,8 @@
 # Resource profiling, 2026-09-05
 
+For the subsequent native macOS work and its validation limits, see
+[Native macOS resource follow-up](performance-macos.md).
+
 Baseline: main `f1d4bad` (v0.2.37). Final application revision: `b09b379`.
 The previous optimized build is `cff81e7`, using zui `25f1c948`; the final build
 pins [`zeronsh/zui` at `49f9abd19`](https://github.com/zeronsh/zui/commit/49f9abd196705eda6a27080c506295a19b5da63e).

--- a/docs/performance/resource-macos-offscreen.json
+++ b/docs/performance/resource-macos-offscreen.json
@@ -1,0 +1,3340 @@
+{
+  "platform": "macOS 26.0.1 (25A362), arm64, Mac16,7, 24 GiB RAM",
+  "kind": "UI-only native CoreText/Metal offscreen replay; no window compositor or engine",
+  "windowLogicalPixels": [
+    1320,
+    880
+  ],
+  "scaleFactor": 2,
+  "baselineApp": "f10ef38c39256602b984201c01817746cd58ca67",
+  "baselineZui": "49f9abd196705eda6a27080c506295a19b5da63e",
+  "candidateZui": "0003b923354ea8938b2d0cadbd17ef93108e2ae5",
+  "traceSha256": "9d13d6cc6533ef9822db4332fa5a5d6b41f68851b2993b13a27f1d9d76b44628",
+  "method": "Sequential runs, no concurrent builds. 500ms samples. First 2s of each phase excluded. Replay includes initial gap before text. Settled includes fixed 8ms polling; it is not native window idle CPU. Same profiling driver and allocator for both builds. Baseline adds only the profiling driver and embedded TestPlatform launch support.",
+  "runs": [
+    {
+      "build": "baseline",
+      "binarySha256": "5f5f722926e20a64a528f4c82c4be2bfe3f330e3b42cea689024839dd02469a6",
+      "completedPngSha256": "1239080bd0b08d77780c628a05b43fa76099fa8737d605c5689d1b72ffb3de7c",
+      "summary": {
+        "replay": {
+          "durationSeconds": 23.786408959,
+          "cpuPercent": 18.22799351711087,
+          "peakFootprintMiB": 286.532349,
+          "endFootprintMiB": 286.532349
+        },
+        "settled": {
+          "durationSeconds": 12.435139625000001,
+          "cpuPercent": 0.32687242142646866,
+          "peakFootprintMiB": 128.563667,
+          "endFootprintMiB": 92.626167
+        }
+      },
+      "samples": [
+        {
+          "at": 0.033511416,
+          "phase": "startup",
+          "pid": 20768,
+          "cpuSeconds": 0.000642875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 0.550453125,
+          "phase": "startup",
+          "pid": 20768,
+          "cpuSeconds": 0.000642875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 1.066169708,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.207116708,
+          "rssMiB": 53.984375,
+          "footprintMiB": 233.579201,
+          "lifetimePeakFootprintMiB": 233.579201,
+          "idleWakeups": 0
+        },
+        {
+          "at": 1.587742458,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.271414333,
+          "rssMiB": 53.421875,
+          "footprintMiB": 279.110474,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 2.091233125,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.308089417,
+          "rssMiB": 53.546875,
+          "footprintMiB": 279.126099,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 2.616436041,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.309638542,
+          "rssMiB": 53.5,
+          "footprintMiB": 271.860474,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 3.135988416,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.31151275,
+          "rssMiB": 53.5,
+          "footprintMiB": 69.860474,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 3.654370583,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.313466125,
+          "rssMiB": 53.5,
+          "footprintMiB": 67.422974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 4.175422708,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.315153875,
+          "rssMiB": 53.5,
+          "footprintMiB": 67.422974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 4.68751075,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.316582292,
+          "rssMiB": 53.5,
+          "footprintMiB": 67.422974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 5.198538958,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.352614708,
+          "rssMiB": 54.1875,
+          "footprintMiB": 272.063599,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 5.718412291,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.445226833,
+          "rssMiB": 57.453125,
+          "footprintMiB": 274.344849,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 6.241184583,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.573443,
+          "rssMiB": 66.46875,
+          "footprintMiB": 279.969849,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 6.762305375,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.678251333,
+          "rssMiB": 67.921875,
+          "footprintMiB": 280.563599,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 7.282080166,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.749127167,
+          "rssMiB": 68.375,
+          "footprintMiB": 281.016724,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 7.797170916,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.846818708,
+          "rssMiB": 68.859375,
+          "footprintMiB": 281.485474,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 8.315662166,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 0.952428667,
+          "rssMiB": 68.96875,
+          "footprintMiB": 281.579224,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 8.836192083,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.049371625,
+          "rssMiB": 69.359375,
+          "footprintMiB": 281.922974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 9.355992,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.149459792,
+          "rssMiB": 69.78125,
+          "footprintMiB": 282.313599,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 9.873664583,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.257006417,
+          "rssMiB": 69.875,
+          "footprintMiB": 282.376099,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 10.386000375,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.339324,
+          "rssMiB": 69.90625,
+          "footprintMiB": 282.407349,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 10.896526125,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.454356708,
+          "rssMiB": 70.296875,
+          "footprintMiB": 282.797974,
+          "lifetimePeakFootprintMiB": 284.922974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 11.409421125,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.547157542,
+          "rssMiB": 70.640625,
+          "footprintMiB": 283.141724,
+          "lifetimePeakFootprintMiB": 285.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 11.929161083,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.65513925,
+          "rssMiB": 70.71875,
+          "footprintMiB": 283.204224,
+          "lifetimePeakFootprintMiB": 285.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 12.439635,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.752278667,
+          "rssMiB": 70.78125,
+          "footprintMiB": 283.110474,
+          "lifetimePeakFootprintMiB": 285.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 12.95440525,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.866936125,
+          "rssMiB": 70.90625,
+          "footprintMiB": 283.157349,
+          "lifetimePeakFootprintMiB": 285.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 13.468577666,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 1.986906667,
+          "rssMiB": 71.234375,
+          "footprintMiB": 283.485474,
+          "lifetimePeakFootprintMiB": 285.485474,
+          "idleWakeups": 0
+        },
+        {
+          "at": 13.986001041,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.088987167,
+          "rssMiB": 71.625,
+          "footprintMiB": 283.844849,
+          "lifetimePeakFootprintMiB": 285.844849,
+          "idleWakeups": 0
+        },
+        {
+          "at": 14.503704625,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.191764042,
+          "rssMiB": 71.703125,
+          "footprintMiB": 283.876099,
+          "lifetimePeakFootprintMiB": 285.860474,
+          "idleWakeups": 0
+        },
+        {
+          "at": 15.023150458,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.291109875,
+          "rssMiB": 71.828125,
+          "footprintMiB": 283.985474,
+          "lifetimePeakFootprintMiB": 285.985474,
+          "idleWakeups": 0
+        },
+        {
+          "at": 15.5424895,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.413381792,
+          "rssMiB": 71.875,
+          "footprintMiB": 284.001099,
+          "lifetimePeakFootprintMiB": 286.001099,
+          "idleWakeups": 0
+        },
+        {
+          "at": 16.054139,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.51961525,
+          "rssMiB": 71.96875,
+          "footprintMiB": 284.079224,
+          "lifetimePeakFootprintMiB": 286.079224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 16.5703625,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.632105833,
+          "rssMiB": 72.34375,
+          "footprintMiB": 284.001099,
+          "lifetimePeakFootprintMiB": 286.079224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 17.089874,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.739234458,
+          "rssMiB": 72.515625,
+          "footprintMiB": 284.094849,
+          "lifetimePeakFootprintMiB": 286.079224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 17.605746083,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.850653583,
+          "rssMiB": 72.640625,
+          "footprintMiB": 284.188599,
+          "lifetimePeakFootprintMiB": 286.157349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 18.124720916,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 2.955461625,
+          "rssMiB": 72.65625,
+          "footprintMiB": 284.204224,
+          "lifetimePeakFootprintMiB": 286.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 18.641353041,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.050271708,
+          "rssMiB": 72.609375,
+          "footprintMiB": 284.266724,
+          "lifetimePeakFootprintMiB": 286.204224,
+          "idleWakeups": 0
+        },
+        {
+          "at": 19.155981208,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.159437583,
+          "rssMiB": 72.5,
+          "footprintMiB": 284.485474,
+          "lifetimePeakFootprintMiB": 286.422974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 19.672683458,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.257584583,
+          "rssMiB": 72.515625,
+          "footprintMiB": 284.454224,
+          "lifetimePeakFootprintMiB": 286.438599,
+          "idleWakeups": 0
+        },
+        {
+          "at": 20.190915208,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.359036208,
+          "rssMiB": 70.203125,
+          "footprintMiB": 284.719849,
+          "lifetimePeakFootprintMiB": 286.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 20.713539291,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.463870125,
+          "rssMiB": 69.734375,
+          "footprintMiB": 284.766724,
+          "lifetimePeakFootprintMiB": 286.751099,
+          "idleWakeups": 0
+        },
+        {
+          "at": 21.233471,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.575535875,
+          "rssMiB": 69.734375,
+          "footprintMiB": 284.782349,
+          "lifetimePeakFootprintMiB": 286.782349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 21.752610625,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.685464375,
+          "rssMiB": 67.953125,
+          "footprintMiB": 284.922974,
+          "lifetimePeakFootprintMiB": 286.907349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 22.26963275,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.792121958,
+          "rssMiB": 68.0,
+          "footprintMiB": 284.969849,
+          "lifetimePeakFootprintMiB": 286.969849,
+          "idleWakeups": 0
+        },
+        {
+          "at": 22.78543,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 3.892053125,
+          "rssMiB": 68.109375,
+          "footprintMiB": 284.985474,
+          "lifetimePeakFootprintMiB": 286.985474,
+          "idleWakeups": 0
+        },
+        {
+          "at": 23.297050833,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.003509375,
+          "rssMiB": 64.1875,
+          "footprintMiB": 286.172974,
+          "lifetimePeakFootprintMiB": 288.172974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 23.815236875,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.110093583,
+          "rssMiB": 63.828125,
+          "footprintMiB": 286.297974,
+          "lifetimePeakFootprintMiB": 288.297974,
+          "idleWakeups": 0
+        },
+        {
+          "at": 24.331643833,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.147101042,
+          "rssMiB": 62.109375,
+          "footprintMiB": 286.297974,
+          "lifetimePeakFootprintMiB": 288.407349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 24.846172208,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.223197542,
+          "rssMiB": 62.1875,
+          "footprintMiB": 286.516724,
+          "lifetimePeakFootprintMiB": 288.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 25.364973416,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.322203833,
+          "rssMiB": 62.21875,
+          "footprintMiB": 286.438599,
+          "lifetimePeakFootprintMiB": 288.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 25.882240875,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.421928917,
+          "rssMiB": 62.25,
+          "footprintMiB": 286.469849,
+          "lifetimePeakFootprintMiB": 288.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 26.400499666,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.532201917,
+          "rssMiB": 62.375,
+          "footprintMiB": 286.485474,
+          "lifetimePeakFootprintMiB": 288.516724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 26.922397375,
+          "phase": "replay",
+          "pid": 20768,
+          "cpuSeconds": 4.647297833,
+          "rssMiB": 62.390625,
+          "footprintMiB": 286.532349,
+          "lifetimePeakFootprintMiB": 288.532349,
+          "idleWakeups": 0
+        },
+        {
+          "at": 27.437656791,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.687379083,
+          "rssMiB": 103.515625,
+          "footprintMiB": 335.329292,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 27.951710708,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.688464042,
+          "rssMiB": 103.5,
+          "footprintMiB": 335.391792,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 28.467895916,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.690436,
+          "rssMiB": 102.765625,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 28.986392708,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.691501375,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 29.50460225,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.693314208,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 30.024527708,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.694966458,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 30.54274425,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.696776333,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 31.063910833,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.698234625,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 31.582951416,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.699848458,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 32.10613625,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.702107542,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 32.627684,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.704324333,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 33.13667075,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.706562083,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 33.652862791,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.70862425,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 34.160417708,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.710512958,
+          "rssMiB": 99.6875,
+          "footprintMiB": 128.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 34.680456208,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.712512292,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 35.19953725,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.7141695,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 35.719876666,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.716200375,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 36.241039541,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.717802542,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 36.760757458,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.719601708,
+          "rssMiB": 99.6875,
+          "footprintMiB": 120.563667,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 37.280908791,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.721655792,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 37.795757041,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.723103583,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 38.314448291,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.724424208,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 38.828890375,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.72592625,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 39.348028166,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.727218792,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 39.86949475,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.728549958,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 40.383783583,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.729939083,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 40.904615333,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.731435542,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 41.4190235,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.732680167,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        },
+        {
+          "at": 41.939741875,
+          "phase": "settled",
+          "pid": 20768,
+          "cpuSeconds": 4.73396125,
+          "rssMiB": 99.71875,
+          "footprintMiB": 92.626167,
+          "lifetimePeakFootprintMiB": 339.423042,
+          "idleWakeups": 0
+        }
+      ]
+    },
+    {
+      "build": "candidate",
+      "binarySha256": "1c97d7d8e64c28fa5c386cc734284d7e5ccee55e579c02a57df1adc954ccc19b",
+      "completedPngSha256": "1239080bd0b08d77780c628a05b43fa76099fa8737d605c5689d1b72ffb3de7c",
+      "summary": {
+        "replay": {
+          "durationSeconds": 23.312508834000006,
+          "cpuPercent": 18.263411490017067,
+          "peakFootprintMiB": 284.844849,
+          "endFootprintMiB": 284.844849
+        },
+        "settled": {
+          "durationSeconds": 12.437986917000003,
+          "cpuPercent": 0.3355677673446769,
+          "peakFootprintMiB": 126.813644,
+          "endFootprintMiB": 91.016769
+        }
+      },
+      "samples": [
+        {
+          "at": 42.467085833,
+          "phase": "startup",
+          "pid": 21514,
+          "cpuSeconds": 0.003089875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 42.97942875,
+          "phase": "startup",
+          "pid": 21514,
+          "cpuSeconds": 0.003089875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 43.495972958,
+          "phase": "startup",
+          "pid": 21514,
+          "cpuSeconds": 0.003089875,
+          "rssMiB": 0.03125,
+          "footprintMiB": 0.078194,
+          "lifetimePeakFootprintMiB": 0.093819,
+          "idleWakeups": 0
+        },
+        {
+          "at": 44.001139791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.1904685,
+          "rssMiB": 54.765625,
+          "footprintMiB": 279.204224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 44.522562458,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.26309325,
+          "rssMiB": 53.921875,
+          "footprintMiB": 279.344849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 45.033201541,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.272071542,
+          "rssMiB": 47.484375,
+          "footprintMiB": 279.360474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 45.546255791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.272684792,
+          "rssMiB": 47.5625,
+          "footprintMiB": 272.047974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 46.058633916,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.274521833,
+          "rssMiB": 47.5625,
+          "footprintMiB": 59.610474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 46.576351541,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.27592875,
+          "rssMiB": 47.5625,
+          "footprintMiB": 59.610474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 47.092097375,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.277343375,
+          "rssMiB": 47.5625,
+          "footprintMiB": 59.610474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 47.614557208,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.278938417,
+          "rssMiB": 47.5625,
+          "footprintMiB": 59.610474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 48.135640875,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.3208125,
+          "rssMiB": 50.203125,
+          "footprintMiB": 272.907349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 48.655199708,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.418238458,
+          "rssMiB": 52.421875,
+          "footprintMiB": 274.360474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 49.173301791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.559048875,
+          "rssMiB": 62.109375,
+          "footprintMiB": 280.376099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 49.693863083,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.679105292,
+          "rssMiB": 63.921875,
+          "footprintMiB": 281.172974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 50.210468625,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.780034625,
+          "rssMiB": 64.3125,
+          "footprintMiB": 281.532349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 50.72831825,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 0.89592525,
+          "rssMiB": 64.828125,
+          "footprintMiB": 282.032349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 51.243031583,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.00374075,
+          "rssMiB": 65.546875,
+          "footprintMiB": 282.672974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 51.762405291,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.109333833,
+          "rssMiB": 65.671875,
+          "footprintMiB": 282.751099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 52.281835708,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.21554525,
+          "rssMiB": 65.8125,
+          "footprintMiB": 282.860474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 52.804713333,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.318153542,
+          "rssMiB": 66.234375,
+          "footprintMiB": 283.251099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 53.319499291,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.415522417,
+          "rssMiB": 66.3125,
+          "footprintMiB": 283.329224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 53.839819,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.514042542,
+          "rssMiB": 66.75,
+          "footprintMiB": 283.719849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 54.362944625,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.615480208,
+          "rssMiB": 66.84375,
+          "footprintMiB": 283.688599,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 54.8807845,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.71991175,
+          "rssMiB": 66.875,
+          "footprintMiB": 283.594849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 55.402702166,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.830747292,
+          "rssMiB": 66.90625,
+          "footprintMiB": 283.626099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 55.918638791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 1.916299,
+          "rssMiB": 67.15625,
+          "footprintMiB": 283.860474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 56.4381615,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.013708958,
+          "rssMiB": 67.171875,
+          "footprintMiB": 283.797974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 56.955489333,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.120936417,
+          "rssMiB": 67.5625,
+          "footprintMiB": 284.188599,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 57.472667208,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.212696792,
+          "rssMiB": 67.640625,
+          "footprintMiB": 284.219849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 57.992794833,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.332261833,
+          "rssMiB": 67.6875,
+          "footprintMiB": 283.938599,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 58.504922583,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.43825925,
+          "rssMiB": 67.765625,
+          "footprintMiB": 284.001099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 59.015943333,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.538217833,
+          "rssMiB": 67.8125,
+          "footprintMiB": 283.985474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 59.532991791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.648234375,
+          "rssMiB": 67.9375,
+          "footprintMiB": 284.094849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 60.052389291,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.745352458,
+          "rssMiB": 68.0625,
+          "footprintMiB": 284.204224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 60.563573833,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.851104833,
+          "rssMiB": 68.25,
+          "footprintMiB": 284.360474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 61.078091416,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 2.942907042,
+          "rssMiB": 68.28125,
+          "footprintMiB": 284.391724,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 61.593489708,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.04112375,
+          "rssMiB": 68.328125,
+          "footprintMiB": 284.422974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 62.111160791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.152065208,
+          "rssMiB": 68.40625,
+          "footprintMiB": 284.501099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 62.6297975,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.257396417,
+          "rssMiB": 68.421875,
+          "footprintMiB": 284.516724,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 63.150677583,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.362539958,
+          "rssMiB": 68.4375,
+          "footprintMiB": 284.532349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 63.676821,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.484090042,
+          "rssMiB": 68.53125,
+          "footprintMiB": 284.626099,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 64.195272125,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.5863355,
+          "rssMiB": 68.5625,
+          "footprintMiB": 284.657349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 64.714193083,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.690784167,
+          "rssMiB": 68.578125,
+          "footprintMiB": 284.672974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 65.231091291,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.807920167,
+          "rssMiB": 68.703125,
+          "footprintMiB": 284.782349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 65.750555791,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 3.893219042,
+          "rssMiB": 68.703125,
+          "footprintMiB": 284.704224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 66.271050041,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.025864208,
+          "rssMiB": 68.703125,
+          "footprintMiB": 284.704224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 66.79092675,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.117657708,
+          "rssMiB": 68.734375,
+          "footprintMiB": 284.735474,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 67.304078375,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.205439333,
+          "rssMiB": 68.78125,
+          "footprintMiB": 284.766724,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 67.816120583,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.302901333,
+          "rssMiB": 68.796875,
+          "footprintMiB": 284.782349,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 68.335663083,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.348522833,
+          "rssMiB": 68.8125,
+          "footprintMiB": 284.797974,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 68.852326125,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.41242175,
+          "rssMiB": 68.90625,
+          "footprintMiB": 284.829224,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 69.37114275,
+          "phase": "replay",
+          "pid": 21514,
+          "cpuSeconds": 4.53218125,
+          "rssMiB": 68.921875,
+          "footprintMiB": 284.844849,
+          "lifetimePeakFootprintMiB": 287.141724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 69.87741775,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.669295,
+          "rssMiB": 110.0,
+          "footprintMiB": 335.782394,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 70.387559291,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.671401125,
+          "rssMiB": 110.0,
+          "footprintMiB": 335.688644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 70.901699708,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.673006292,
+          "rssMiB": 110.0,
+          "footprintMiB": 335.688644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 71.419760625,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.67499225,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 71.936389666,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.676796542,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 72.453209416,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.678142792,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 72.9688405,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.679819375,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 73.499560125,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.681822792,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 74.013079458,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.683687333,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 74.536325166,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.685237167,
+          "rssMiB": 110.0,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 75.054332458,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.687875542,
+          "rssMiB": 109.5625,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 75.573459791,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.689924583,
+          "rssMiB": 109.5625,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 76.090062,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.69166725,
+          "rssMiB": 109.5625,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 76.606845125,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.693390458,
+          "rssMiB": 109.5625,
+          "footprintMiB": 126.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 77.118404333,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.694644208,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 77.635287083,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.696503083,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 78.145620375,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.698101708,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 78.666431166,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.699576708,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 79.184604625,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.701444833,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 79.704917916,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.703262708,
+          "rssMiB": 109.5625,
+          "footprintMiB": 118.813644,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 80.224885458,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.706908708,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 80.739941541,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.708314667,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 81.255414458,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.709489583,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 81.778310833,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.710967333,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 82.292053166,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.712446417,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 82.804161333,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.713674667,
+          "rssMiB": 109.578125,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 83.329868208,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.71507675,
+          "rssMiB": 109.5,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 83.856980666,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.716748125,
+          "rssMiB": 109.234375,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        },
+        {
+          "at": 84.374376583,
+          "phase": "settled",
+          "pid": 21514,
+          "cpuSeconds": 4.718534417,
+          "rssMiB": 108.609375,
+          "footprintMiB": 91.016769,
+          "lifetimePeakFootprintMiB": 335.782394,
+          "idleWakeups": 0
+        }
+      ]
+    },
+    {
+      "build": "candidate",
+      "binarySha256": "1c97d7d8e64c28fa5c386cc734284d7e5ccee55e579c02a57df1adc954ccc19b",
+      "completedPngSha256": "1239080bd0b08d77780c628a05b43fa76099fa8737d605c5689d1b72ffb3de7c",
+      "summary": {
+        "replay": {
+          "durationSeconds": 23.331538916,
+          "cpuPercent": 18.665320790363936,
+          "peakFootprintMiB": 288.532394,
+          "endFootprintMiB": 288.454269
+        },
+        "settled": {
+          "durationSeconds": 12.419883374999998,
+          "cpuPercent": 0.3356942391578612,
+          "peakFootprintMiB": 122.298065,
+          "endFootprintMiB": 94.50119
+        }
+      },
+      "samples": [
+        {
+          "at": 84.897251125,
+          "phase": "startup",
+          "pid": 23071,
+          "cpuSeconds": 0.005180083,
+          "rssMiB": 0.71875,
+          "footprintMiB": 0.687614,
+          "lifetimePeakFootprintMiB": 0.687614,
+          "idleWakeups": 0
+        },
+        {
+          "at": 85.414959916,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.175996875,
+          "rssMiB": 54.921875,
+          "footprintMiB": 283.579269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 0
+        },
+        {
+          "at": 85.934481,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.271432458,
+          "rssMiB": 55.109375,
+          "footprintMiB": 283.501144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 86.443842166,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.27345475,
+          "rssMiB": 55.140625,
+          "footprintMiB": 273.751144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 86.958479333,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.274809833,
+          "rssMiB": 55.140625,
+          "footprintMiB": 79.751144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 87.480118875,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.276061958,
+          "rssMiB": 55.140625,
+          "footprintMiB": 69.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 87.998413083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.27749675,
+          "rssMiB": 55.140625,
+          "footprintMiB": 69.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 88.514963,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.2790895,
+          "rssMiB": 55.140625,
+          "footprintMiB": 69.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 89.030231666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.280430417,
+          "rssMiB": 55.140625,
+          "footprintMiB": 69.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 89.550729875,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.349731667,
+          "rssMiB": 53.65625,
+          "footprintMiB": 275.891769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 90.069174375,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.473935333,
+          "rssMiB": 62.734375,
+          "footprintMiB": 281.454269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 90.588645833,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.579888375,
+          "rssMiB": 64.859375,
+          "footprintMiB": 283.204269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 91.10004,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.679901458,
+          "rssMiB": 65.140625,
+          "footprintMiB": 282.610519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 91.613816291,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.777135208,
+          "rssMiB": 65.890625,
+          "footprintMiB": 283.329269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 92.134664666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.868670292,
+          "rssMiB": 66.375,
+          "footprintMiB": 283.782394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 92.650918,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 0.968685625,
+          "rssMiB": 66.4375,
+          "footprintMiB": 283.813644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 93.169560541,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.071347792,
+          "rssMiB": 66.8125,
+          "footprintMiB": 284.157394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 93.683503833,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.179079625,
+          "rssMiB": 67.25,
+          "footprintMiB": 284.548019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 94.223484666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.278404,
+          "rssMiB": 67.59375,
+          "footprintMiB": 284.860519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 94.73972675,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.386979875,
+          "rssMiB": 67.984375,
+          "footprintMiB": 285.251144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 95.262308041,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.513258625,
+          "rssMiB": 68.09375,
+          "footprintMiB": 285.360519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 95.786134333,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.614407375,
+          "rssMiB": 67.8125,
+          "footprintMiB": 285.735519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 96.307091,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.73093325,
+          "rssMiB": 67.671875,
+          "footprintMiB": 285.626144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 96.825367083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.8302025,
+          "rssMiB": 67.703125,
+          "footprintMiB": 285.610519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 97.346767833,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 1.920027583,
+          "rssMiB": 68.0,
+          "footprintMiB": 285.907394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 97.863932083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.028053458,
+          "rssMiB": 68.390625,
+          "footprintMiB": 286.298019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 98.383885625,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.134918125,
+          "rssMiB": 68.421875,
+          "footprintMiB": 286.313644,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 98.894777875,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.248787417,
+          "rssMiB": 68.515625,
+          "footprintMiB": 286.079269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 99.414188666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.353373167,
+          "rssMiB": 68.546875,
+          "footprintMiB": 286.079269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 99.928624416,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.467906167,
+          "rssMiB": 68.65625,
+          "footprintMiB": 286.157394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 1
+        },
+        {
+          "at": 100.448054625,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.586555708,
+          "rssMiB": 67.046875,
+          "footprintMiB": 286.532394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 100.96013825,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.681576958,
+          "rssMiB": 66.78125,
+          "footprintMiB": 286.641769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 101.476905375,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.791988667,
+          "rssMiB": 67.03125,
+          "footprintMiB": 286.782394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 101.997747083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.88543075,
+          "rssMiB": 67.078125,
+          "footprintMiB": 286.829269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 102.515105541,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 2.982136125,
+          "rssMiB": 67.125,
+          "footprintMiB": 286.876144,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 103.03269125,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.076883417,
+          "rssMiB": 67.1875,
+          "footprintMiB": 286.891769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 103.560954833,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.198256,
+          "rssMiB": 65.53125,
+          "footprintMiB": 287.548019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 104.076143375,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.284363167,
+          "rssMiB": 62.46875,
+          "footprintMiB": 288.204269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 104.591727166,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.372216375,
+          "rssMiB": 62.53125,
+          "footprintMiB": 288.329269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 105.121678666,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.454920375,
+          "rssMiB": 60.0,
+          "footprintMiB": 288.469894,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 105.637431083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.573610917,
+          "rssMiB": 60.046875,
+          "footprintMiB": 288.485519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 106.150792458,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.676510042,
+          "rssMiB": 60.1875,
+          "footprintMiB": 288.532394,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 106.664995291,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.782049417,
+          "rssMiB": 60.34375,
+          "footprintMiB": 288.329269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 107.18523725,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.870260375,
+          "rssMiB": 60.375,
+          "footprintMiB": 288.329269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 107.705839875,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 3.98257575,
+          "rssMiB": 60.515625,
+          "footprintMiB": 288.360519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 108.224598458,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.073466375,
+          "rssMiB": 60.5625,
+          "footprintMiB": 288.360519,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 108.735529791,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.183010708,
+          "rssMiB": 60.65625,
+          "footprintMiB": 288.391769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 109.252967291,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.285995708,
+          "rssMiB": 60.703125,
+          "footprintMiB": 288.391769,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 109.772677416,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.408499875,
+          "rssMiB": 60.8125,
+          "footprintMiB": 288.423019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 110.291622083,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.523863,
+          "rssMiB": 60.96875,
+          "footprintMiB": 288.423019,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 110.811657791,
+          "phase": "replay",
+          "pid": 23071,
+          "cpuSeconds": 4.630968542,
+          "rssMiB": 61.0,
+          "footprintMiB": 288.454269,
+          "lifetimePeakFootprintMiB": 293.266724,
+          "idleWakeups": 2
+        },
+        {
+          "at": 111.330659791,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.726418667,
+          "rssMiB": 102.578125,
+          "footprintMiB": 337.173065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 111.85069075,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.728305042,
+          "rssMiB": 102.578125,
+          "footprintMiB": 337.173065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 112.367757458,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.729689375,
+          "rssMiB": 102.578125,
+          "footprintMiB": 130.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 112.887178541,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.73160725,
+          "rssMiB": 102.578125,
+          "footprintMiB": 130.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 113.406372,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.7336755,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 113.927990708,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.7354315,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 114.437070416,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.737403417,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 114.947087,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.739408958,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 115.46436025,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.741626708,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 115.981970958,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.743473333,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 116.501486958,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.745678292,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 117.012386041,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.7470895,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 117.528358625,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.748723083,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 118.046945458,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.750524667,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 118.567232458,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.752433958,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 119.086454958,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.754260667,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 119.606207041,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.756337542,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 120.121412125,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.757920583,
+          "rssMiB": 102.578125,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 120.642519541,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.759760708,
+          "rssMiB": 102.390625,
+          "footprintMiB": 122.298065,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 121.155048791,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.762684125,
+          "rssMiB": 102.40625,
+          "footprintMiB": 104.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 121.674247,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.764058458,
+          "rssMiB": 102.40625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 122.192893916,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.765479417,
+          "rssMiB": 102.40625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 122.700664416,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.766881,
+          "rssMiB": 102.34375,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 123.222999791,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.767596167,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 123.741344375,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.769085958,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 124.260619708,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.770333042,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 124.784037166,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.771862583,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 125.306831166,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.773528458,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        },
+        {
+          "at": 125.826255375,
+          "phase": "settled",
+          "pid": 23071,
+          "cpuSeconds": 4.775368333,
+          "rssMiB": 102.15625,
+          "footprintMiB": 94.50119,
+          "lifetimePeakFootprintMiB": 341.266815,
+          "idleWakeups": 2
+        }
+      ]
+    },
+    {
+      "build": "baseline",
+      "binarySha256": "5f5f722926e20a64a528f4c82c4be2bfe3f330e3b42cea689024839dd02469a6",
+      "completedPngSha256": "1239080bd0b08d77780c628a05b43fa76099fa8737d605c5689d1b72ffb3de7c",
+      "summary": {
+        "replay": {
+          "durationSeconds": 23.320005166999977,
+          "cpuPercent": 18.75516147478907,
+          "peakFootprintMiB": 279.172951,
+          "endFootprintMiB": 279.126076
+        },
+        "settled": {
+          "durationSeconds": 12.423877540999996,
+          "cpuPercent": 0.3303541174207052,
+          "peakFootprintMiB": 123.094849,
+          "endFootprintMiB": 87.594849
+        }
+      },
+      "samples": [
+        {
+          "at": 126.343401958,
+          "phase": "startup",
+          "pid": 23703,
+          "cpuSeconds": 0.005699125,
+          "rssMiB": 0.234375,
+          "footprintMiB": 0.234489,
+          "lifetimePeakFootprintMiB": 0.281364,
+          "idleWakeups": 0
+        },
+        {
+          "at": 126.863115666,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.190809375,
+          "rssMiB": 53.40625,
+          "footprintMiB": 265.469826,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 127.379541708,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.2498075,
+          "rssMiB": 53.59375,
+          "footprintMiB": 265.391701,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 127.898172958,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.25162,
+          "rssMiB": 53.640625,
+          "footprintMiB": 265.391701,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 128.414551291,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.252972458,
+          "rssMiB": 53.640625,
+          "footprintMiB": 71.391701,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 128.925446541,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.254739917,
+          "rssMiB": 53.640625,
+          "footprintMiB": 60.954201,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 129.445065208,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.256020583,
+          "rssMiB": 53.640625,
+          "footprintMiB": 60.954201,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 129.962670833,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.257509417,
+          "rssMiB": 53.640625,
+          "footprintMiB": 60.954201,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 130.481042333,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.258870458,
+          "rssMiB": 53.640625,
+          "footprintMiB": 60.954201,
+          "lifetimePeakFootprintMiB": 267.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 130.9994045,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.317633417,
+          "rssMiB": 56.765625,
+          "footprintMiB": 267.235451,
+          "lifetimePeakFootprintMiB": 268.235451,
+          "idleWakeups": 0
+        },
+        {
+          "at": 131.516188416,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.422578,
+          "rssMiB": 64.34375,
+          "footprintMiB": 271.922951,
+          "lifetimePeakFootprintMiB": 273.938576,
+          "idleWakeups": 0
+        },
+        {
+          "at": 132.03555725,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.534398333,
+          "rssMiB": 66.75,
+          "footprintMiB": 273.047951,
+          "lifetimePeakFootprintMiB": 275.047951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 132.546594583,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.62432725,
+          "rssMiB": 67.015625,
+          "footprintMiB": 273.297951,
+          "lifetimePeakFootprintMiB": 275.047951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 133.064618333,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.729441208,
+          "rssMiB": 67.640625,
+          "footprintMiB": 273.922951,
+          "lifetimePeakFootprintMiB": 275.297951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 133.583109416,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.835874,
+          "rssMiB": 68.484375,
+          "footprintMiB": 274.735451,
+          "lifetimePeakFootprintMiB": 276.735451,
+          "idleWakeups": 0
+        },
+        {
+          "at": 134.099132916,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 0.929528375,
+          "rssMiB": 68.53125,
+          "footprintMiB": 274.766701,
+          "lifetimePeakFootprintMiB": 276.735451,
+          "idleWakeups": 0
+        },
+        {
+          "at": 134.61562075,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.034768167,
+          "rssMiB": 68.703125,
+          "footprintMiB": 274.907326,
+          "lifetimePeakFootprintMiB": 276.860451,
+          "idleWakeups": 0
+        },
+        {
+          "at": 135.133568583,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.12009125,
+          "rssMiB": 68.734375,
+          "footprintMiB": 274.922951,
+          "lifetimePeakFootprintMiB": 276.922951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 135.657015166,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.236382708,
+          "rssMiB": 62.984375,
+          "footprintMiB": 276.063576,
+          "lifetimePeakFootprintMiB": 278.063576,
+          "idleWakeups": 0
+        },
+        {
+          "at": 136.169728833,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.352127125,
+          "rssMiB": 63.390625,
+          "footprintMiB": 276.469826,
+          "lifetimePeakFootprintMiB": 278.469826,
+          "idleWakeups": 0
+        },
+        {
+          "at": 136.702389958,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.455347542,
+          "rssMiB": 63.28125,
+          "footprintMiB": 276.626076,
+          "lifetimePeakFootprintMiB": 278.547951,
+          "idleWakeups": 0
+        },
+        {
+          "at": 137.215838666,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.564007792,
+          "rssMiB": 62.828125,
+          "footprintMiB": 276.532326,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 137.732871958,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.664437625,
+          "rssMiB": 63.0625,
+          "footprintMiB": 276.641701,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 138.25279975,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.777995458,
+          "rssMiB": 63.125,
+          "footprintMiB": 276.516701,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 138.770178416,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.876524458,
+          "rssMiB": 63.171875,
+          "footprintMiB": 276.563576,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 139.288323166,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 1.990286708,
+          "rssMiB": 63.59375,
+          "footprintMiB": 276.922951,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 139.8072385,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.101478917,
+          "rssMiB": 64.296875,
+          "footprintMiB": 277.532326,
+          "lifetimePeakFootprintMiB": 278.641701,
+          "idleWakeups": 0
+        },
+        {
+          "at": 140.328029,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.205518917,
+          "rssMiB": 64.359375,
+          "footprintMiB": 277.563576,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 0
+        },
+        {
+          "at": 140.843137625,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.321206417,
+          "rssMiB": 64.453125,
+          "footprintMiB": 277.266701,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 0
+        },
+        {
+          "at": 141.359628708,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.433442833,
+          "rssMiB": 64.578125,
+          "footprintMiB": 277.313576,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 0
+        },
+        {
+          "at": 141.877922833,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.534781583,
+          "rssMiB": 64.640625,
+          "footprintMiB": 277.360451,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 4
+        },
+        {
+          "at": 142.393014458,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.646229333,
+          "rssMiB": 64.703125,
+          "footprintMiB": 277.422951,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 4
+        },
+        {
+          "at": 142.9171455,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.757348083,
+          "rssMiB": 64.84375,
+          "footprintMiB": 277.547951,
+          "lifetimePeakFootprintMiB": 279.532326,
+          "idleWakeups": 4
+        },
+        {
+          "at": 143.435577791,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.863168458,
+          "rssMiB": 64.96875,
+          "footprintMiB": 277.610451,
+          "lifetimePeakFootprintMiB": 279.626076,
+          "idleWakeups": 4
+        },
+        {
+          "at": 143.95495425,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 2.9549945,
+          "rssMiB": 64.984375,
+          "footprintMiB": 277.610451,
+          "lifetimePeakFootprintMiB": 279.626076,
+          "idleWakeups": 4
+        },
+        {
+          "at": 144.473705291,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.0609745,
+          "rssMiB": 65.09375,
+          "footprintMiB": 277.719826,
+          "lifetimePeakFootprintMiB": 279.626076,
+          "idleWakeups": 4
+        },
+        {
+          "at": 144.9932565,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.170017042,
+          "rssMiB": 65.15625,
+          "footprintMiB": 277.782326,
+          "lifetimePeakFootprintMiB": 279.782326,
+          "idleWakeups": 4
+        },
+        {
+          "at": 145.510684083,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.26506775,
+          "rssMiB": 65.25,
+          "footprintMiB": 277.860451,
+          "lifetimePeakFootprintMiB": 279.860451,
+          "idleWakeups": 4
+        },
+        {
+          "at": 146.028799583,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.352463,
+          "rssMiB": 60.390625,
+          "footprintMiB": 279.094826,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 146.548522083,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.467887792,
+          "rssMiB": 60.421875,
+          "footprintMiB": 279.126076,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 147.060821666,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.583248333,
+          "rssMiB": 60.453125,
+          "footprintMiB": 279.001076,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 147.577100458,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.67402975,
+          "rssMiB": 60.484375,
+          "footprintMiB": 279.032326,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 148.100539916,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.792103583,
+          "rssMiB": 60.640625,
+          "footprintMiB": 279.157326,
+          "lifetimePeakFootprintMiB": 281.094826,
+          "idleWakeups": 4
+        },
+        {
+          "at": 148.624720208,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.893535833,
+          "rssMiB": 60.671875,
+          "footprintMiB": 279.172951,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 149.142225833,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 3.992702375,
+          "rssMiB": 60.734375,
+          "footprintMiB": 279.063576,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 149.662251875,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.095055667,
+          "rssMiB": 60.78125,
+          "footprintMiB": 279.110451,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 150.174314208,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.193627208,
+          "rssMiB": 60.8125,
+          "footprintMiB": 279.126076,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 150.694725333,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.306322,
+          "rssMiB": 60.96875,
+          "footprintMiB": 279.110451,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 151.205250708,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.410139042,
+          "rssMiB": 61.015625,
+          "footprintMiB": 279.141701,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 151.726,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.522660417,
+          "rssMiB": 61.15625,
+          "footprintMiB": 279.126076,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 152.245451708,
+          "phase": "replay",
+          "pid": 23703,
+          "cpuSeconds": 4.628444542,
+          "rssMiB": 61.15625,
+          "footprintMiB": 279.126076,
+          "lifetimePeakFootprintMiB": 281.172951,
+          "idleWakeups": 4
+        },
+        {
+          "at": 152.7601945,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.743183375,
+          "rssMiB": 102.875,
+          "footprintMiB": 329.954224,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 153.273564041,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.745342625,
+          "rssMiB": 102.875,
+          "footprintMiB": 329.954224,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 153.794254333,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.746548583,
+          "rssMiB": 102.84375,
+          "footprintMiB": 127.969849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 154.308340083,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.749012708,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 154.829111375,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.750561042,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 155.347716541,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.752321083,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 155.881169916,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.754273625,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 156.401448916,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.75638375,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 156.928805583,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.75844575,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 157.443779291,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.760233208,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 157.962528625,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.762282167,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 158.482125375,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.763958542,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 158.996502916,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.765658292,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 159.517976,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.767370417,
+          "rssMiB": 102.84375,
+          "footprintMiB": 123.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 160.038244,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.769197792,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 160.560993,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.771114792,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 161.075912541,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.772709708,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 161.594452833,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.774483583,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 162.105145,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.776155,
+          "rssMiB": 102.84375,
+          "footprintMiB": 115.094849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 162.623067708,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.780102333,
+          "rssMiB": 102.84375,
+          "footprintMiB": 97.297974,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 163.141683,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.781530125,
+          "rssMiB": 102.84375,
+          "footprintMiB": 87.297974,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 163.660496875,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.782788625,
+          "rssMiB": 102.84375,
+          "footprintMiB": 87.297974,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 164.165906125,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.783700625,
+          "rssMiB": 102.3125,
+          "footprintMiB": 87.297974,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 164.674999416,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.784952625,
+          "rssMiB": 61.9375,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 165.177985125,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.785651167,
+          "rssMiB": 61.890625,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 165.704633958,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.786164833,
+          "rssMiB": 61.890625,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 166.208982666,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.788147167,
+          "rssMiB": 61.890625,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 166.732567958,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.789933542,
+          "rssMiB": 61.875,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        },
+        {
+          "at": 167.252988916,
+          "phase": "settled",
+          "pid": 23703,
+          "cpuSeconds": 4.791603833,
+          "rssMiB": 61.875,
+          "footprintMiB": 87.594849,
+          "lifetimePeakFootprintMiB": 334.047974,
+          "idleWakeups": 4
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/macos-profile-window.swift
+++ b/scripts/macos-profile-window.swift
@@ -1,0 +1,43 @@
+// Foreground/window validation for the native resource replay. Fails closed
+// on a locked display so suspended rendering cannot look like a CPU win.
+import Cocoa
+import ApplicationServices
+
+func fail(_ message: String) -> Never {
+    fputs("\(message)\n", stderr)
+    exit(1)
+}
+
+let session = CGSessionCopyCurrentDictionary() as? [String: Any] ?? [:]
+if session["CGSSessionScreenIsLocked"] as? Bool == true {
+    fail("Unlock the Mac before profiling native window rendering")
+}
+if CGDisplayIsAsleep(CGMainDisplayID()) != 0 {
+    fail("Wake the display before profiling native window rendering")
+}
+if CommandLine.arguments.count == 1 { exit(0) }
+guard let pid = Int32(CommandLine.arguments[1]),
+      let app = NSRunningApplication(processIdentifier: pid) else { fail("Missing app process") }
+if CommandLine.arguments.dropFirst(2).first == "--check" {
+    guard app.isActive else { fail("Profiled app is no longer foreground; discard this run") }
+    let rows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] ?? []
+    guard rows.contains(where: { ($0[kCGWindowOwnerPID as String] as? Int32) == pid
+        && ($0[kCGWindowLayer as String] as? Int) == 0
+        && ($0[kCGWindowAlpha as String] as? Double ?? 0) > 0 }) else {
+        fail("Profiled window is not onscreen; discard this run")
+    }
+    exit(0)
+}
+guard AXIsProcessTrusted() else { fail("Window profiling requires existing Accessibility access") }
+app.activate(options: [.activateAllWindows])
+let element = AXUIElementCreateApplication(pid)
+var value: CFTypeRef?
+guard AXUIElementCopyAttributeValue(element, kAXWindowsAttribute as CFString, &value) == .success,
+      let windows = value as? [AXUIElement], windows.count == 1 else { fail("Expected one app window") }
+let window = windows[0]
+var size = CGSize(width: 1320, height: 880)
+guard let sizeValue = AXValueCreate(.cgSize, &size),
+      AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeValue) == .success,
+      AXUIElementPerformAction(window, kAXRaiseAction as CFString) == .success else {
+    fail("Could not size and raise the profiled window")
+}

--- a/scripts/macos-resource-stat.c
+++ b/scripts/macos-resource-stat.c
@@ -1,0 +1,28 @@
+// Native process counters for resource-profile.mjs. CPU time uses Mach ticks;
+// footprint includes charged compressed/GPU memory that RSS alone misses.
+#include <libproc.h>
+#include <mach/mach_time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+
+int main(int argc, char **argv) {
+    mach_timebase_info_data_t timebase;
+    mach_timebase_info(&timebase);
+    printf("[");
+    int emitted = 0;
+    for (int i = 1; i < argc; i++) {
+        int pid = atoi(argv[i]);
+        struct rusage_info_v4 usage = {0};
+        if (pid <= 0 || proc_pid_rusage(pid, RUSAGE_INFO_V4, (rusage_info_t *)&usage)) continue;
+        double seconds = (double)(usage.ri_user_time + usage.ri_system_time)
+            * timebase.numer / timebase.denom / 1e9;
+        printf("%s{\"pid\":%d,\"cpuSeconds\":%.9f,\"rssMiB\":%.6f,"
+               "\"footprintMiB\":%.6f,\"lifetimePeakFootprintMiB\":%.6f,"
+               "\"idleWakeups\":%llu}",
+               emitted++ ? "," : "", pid, seconds,
+               usage.ri_resident_size / 1048576.0, usage.ri_phys_footprint / 1048576.0,
+               usage.ri_lifetime_max_phys_footprint / 1048576.0, usage.ri_pkg_idle_wkups);
+    }
+    puts("]");
+}

--- a/scripts/resource-profile.mjs
+++ b/scripts/resource-profile.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Linux end-to-end resource profile. Node >=22; no npm dependencies.
+// Linux/macOS end-to-end resource profile. Node >=22; no npm dependencies.
 // Usage: node scripts/resource-profile.mjs BINARY OUTPUT_DIR [claude-code|mock]
 // DISPLAY must name a working X server; unset WAYLAND_DISPLAY for Xvfb.
 // Uses isolated local data and a real harness (Haiku by default). This costs
@@ -10,12 +10,24 @@ import { resolve } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { createServer } from 'node:net';
+import { fileURLToPath } from 'node:url';
+
+const macOS = process.platform === 'darwin';
+const nativeWindowSource = fileURLToPath(new URL('./macos-profile-window.swift', import.meta.url));
+if (macOS && process.env.ZERON_PROFILE_SUBMIT_UI === '1')
+  throw Error('Composer submission profiling currently requires Linux/X11; use RPC submission on macOS');
+if (macOS) execFileSync('swift', [nativeWindowSource]);
 
 const [binaryArg, outputArg, harness = 'claude-code'] = process.argv.slice(2);
 if (!binaryArg || !outputArg) throw Error('Usage: resource-profile.mjs BINARY OUTPUT_DIR [claude-code|mock]');
 const binary = resolve(binaryArg), output = resolve(outputArg);
 if (existsSync(output)) throw Error('Use a new output directory for an isolated run');
 mkdirSync(output, { recursive: true });
+const nativeStat = `${output}/macos-resource-stat`;
+const nativeWindow = `${output}/macos-profile-window`;
+if (macOS) execFileSync('xcrun', ['clang', '-O2', '-Wall', '-Wextra',
+  fileURLToPath(new URL('./macos-resource-stat.c', import.meta.url)), '-o', nativeStat]);
+if (macOS) execFileSync('swiftc', ['-O', nativeWindowSource, '-o', nativeWindow]);
 // Shared Cargo targets can be replaced by another worktree mid-profile.
 // Both processes must execute the exact same immutable build throughout.
 const profiledBinary = `${output}/zeron-profiled`;
@@ -56,6 +68,7 @@ let phase = 'startup', id = 0, transcript = [], streamError;
 const hz = Number(execFileSync('getconf', ['CLK_TCK'], { encoding: 'utf8' }).trim());
 function stat(pid) {
   try {
+    if (macOS) return JSON.parse(execFileSync(nativeStat, [String(pid)], { encoding: 'utf8' }))[0] ?? null;
     const stat = readFileSync(`/proc/${pid}/stat`, 'utf8').split(') ')[1].split(' ');
     const main = readFileSync(`/proc/${pid}/task/${pid}/stat`, 'utf8').split(') ')[1].split(' ');
     const status = readFileSync(`/proc/${pid}/status`, 'utf8');
@@ -71,6 +84,12 @@ function stat(pid) {
 }
 function descendants(pid) {
   try {
+    if (macOS) {
+      const rows = execFileSync('ps', ['-axo', 'pid=,ppid='], { encoding: 'utf8' })
+        .trim().split('\n').map(line => line.trim().split(/\s+/).map(Number));
+      const walk = parent => rows.filter(row => row[1] === parent).flatMap(([child]) => [child, ...walk(child)]);
+      return walk(pid);
+    }
     // A Tokio worker can own the subprocess: inspect all task children.
     const tasks = readdirSync(`/proc/${pid}/task`);
     const children = new Set(tasks.flatMap(t => {
@@ -133,26 +152,38 @@ try {
     config: { harness, model: harness === 'mock' ? 'fable-5' : 'claude-haiku-4-5', reasoning: null, sandbox: 'workspace-write' } });
   await call('Mutate', { op: 'renameChat', chatId, title: 'Resource profile' });
   pending.set(++id, { reject: e => { streamError = e; }, item: frame => {
-    frames.push({ at: Date.now(), frame }); apply(frame);
+    // apply() reuses reset/upsert objects as the mutable transcript. Capture
+    // first so later append frames cannot rewrite earlier replay records.
+    frames.push({ at: Date.now(), frame: structuredClone(frame) }); apply(frame);
   } });
   ws.send(JSON.stringify({ id, method: 'WatchDocMessages', params: { chatId } }));
   const locator = createHash('sha256').update(`Local\0device:${deviceId}`).digest('hex').slice(0, 16);
   const ui = start([`zeron://open/chat/${chatId}?workspace=${locator}`], 'ui', { ZERON_DATA_DIR: `${output}/ui` });
+  writeFileSync(`${output}/pids.json`, JSON.stringify({engine: engine.pid, ui: ui.pid}));
+  // Native windows activate themselves. Let the initial layout/splash settle.
+  if (macOS) {
+    await sleep(2000);
+    execFileSync(nativeWindow, [String(ui.pid)]);
+  }
   // Xvfb has no window manager to send the initial configure/focus events.
   // Force first paint before measuring (otherwise a mapped, transparent
   // window can consume no rendering CPU for the entire workload).
-  if (process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+  if (!macOS && process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
     await sleep(2000);
     const windows = execFileSync('xdotool', ['search', '--class', '^zeron$'], { encoding: 'utf8' }).trim().split('\n');
     if (windows.length !== 1) throw Error('Use a dedicated X display with exactly one Zeron window');
     execFileSync('xdotool', ['windowraise', windows[0], 'windowsize', windows[0], '1280', '800', 'windowfocus', windows[0]]);
   }
   sampler = setInterval(() => {
+    if (macOS) {
+      try { execFileSync(nativeWindow, [String(ui.pid), '--check'], { stdio: 'pipe' }); }
+      catch { streamError = Error('Native window became inactive, hidden or locked during profiling; discard this run'); }
+    }
     samples.push({ at: Date.now(), phase, engine: stat(engine.pid), ui: stat(ui.pid),
       harness: descendants(engine.pid).map(stat).filter(Boolean) });
   }, 500);
   phase = 'idle';
-  await sleep(10000);
+  await sleep(Number(process.env.ZERON_PROFILE_PRE_IDLE_MS ?? 10000));
   if (ui.exitCode != null) throw Error('UI exited; inspect ui.log');
   phase = 'stream';
   const prompt = process.env.ZERON_PROFILE_PROMPT ??
@@ -184,9 +215,12 @@ try {
   if (!complete) throw Error(`Turn did not complete within ${timeoutMs / 1000} seconds`);
   phase = 'settled';
   await sleep(Number(process.env.ZERON_PROFILE_IDLE_MS ?? 15000));
+  if (streamError) throw streamError;
+  if (macOS) execFileSync(nativeWindow);
   const reply = transcript.filter(e => e.role === 'assistant').flatMap(e => e.parts)
     .filter(p => p.kind === 'text' || p.kind === 'reasoning').map(p => p.text).join('\n\n');
   const summary = { binary, binarySha256, harness, mode: process.env.ZERON_REPLAY_JOURNAL ? 'replay' : 'live',
+    platform: process.platform, arch: process.arch,
     renderThreads: process.env.LP_NUM_THREADS ?? 'default', frameStats: env.ZERON_FRAME_STATS,
     submission: process.env.ZERON_PROFILE_SUBMIT_UI === '1' ? 'composer' : 'rpc', prompt,
     replySha256: createHash('sha256').update(reply).digest('hex'), replyBytes: Buffer.byteLength(reply),
@@ -198,12 +232,15 @@ try {
       const valid = rows.filter(r => r[name]);
       const first = valid[0], last = valid.at(-1);
       summary.phases[p][name] = {
+        ...(macOS ? { peakFootprintMiB: Math.max(...valid.map(r => r[name].footprintMiB)),
+          endFootprintMiB: last[name].footprintMiB,
+          lifetimePeakFootprintMiB: last[name].lifetimePeakFootprintMiB } : {}),
         ...(first[name].pssMiB == null ? {} : {
           peakPssMiB: Math.max(...valid.map(r => r[name].pssMiB)), endPssMiB: last[name].pssMiB,
         }), peakRssMiB: Math.max(...valid.map(r => r[name].rssMiB)),
         endRssMiB: last[name].rssMiB,
         cpuPercent: 100000 * (last[name].cpuSeconds - first[name].cpuSeconds) / (last.at - first.at),
-        mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at) };
+        ...(macOS ? {} : { mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at) }) };
     }
   }
   // Report the last ten seconds separately from the completion transition.
@@ -213,9 +250,10 @@ try {
   for (const name of ['engine', 'ui']) {
     const first = quiet[0], last = quiet.at(-1);
     summary.postCompletionTail[name] = {
+      ...(macOS ? { endFootprintMiB: last[name].footprintMiB } : {}),
       endRssMiB: last[name].rssMiB,
       cpuPercent: 100000 * (last[name].cpuSeconds - first[name].cpuSeconds) / (last.at - first.at),
-      mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at),
+      ...(macOS ? {} : { mainCpuPercent: 100000 * (last[name].mainCpuSeconds - first[name].mainCpuSeconds) / (last.at - first.at) }),
     };
   }
   writeFileSync(`${output}/summary.json`, JSON.stringify(summary, null, 2));


### PR DESCRIPTION
Follow up on #255 with native macOS frame scheduling and Metal resource lifetime fixes, plus a transcript content revision that skips row derivation on unrelated app-state notifications. The application pins zui `0003b923`, preserving existing blur shaders, Gaussian sigma, animation clocks and scroll behavior.

Adds native CPU/physical-footprint profiling, rejects invalid foreground measurements, and fixes recorded transcript frames being mutated by later appends. An optional CoreText/Metal UI replay driver supports reproducible rendering checks without an engine.

Validation: 593 UI tests, 207 GPUI tests and 15 native macOS tests pass. The completed native replay image is byte-identical before/after. Two runs per build show effectively unchanged isolated replay CPU (18.49% to 18.46%) and no consistent memory improvement (mean peak footprint 282.85 to 286.69 MiB). See `docs/performance-macos.md` and the raw samples for the method and limits.

Draft, stacked on #255. The display was locked during validation; foreground whole-app CPU/memory and interactive animation/blur checks remain. These results do not establish a reduction in reported foreground streaming usage. The graphics dependency branch is `zeronsh/zui:zeron/macos-resource-usage`; PR creation for that repository is currently blocked by the available API permissions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791203422&installation_model_id=425430&pr_number=256&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F256&signature=e0e8f52576bf68ac95306024e4723917766bb1ba01aa9ce5702897d6987aaaf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->