### PR TITLE
Release v0.2.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "zeron"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -9443,7 +9443,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-doc"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "chrono",
  "loro",
@@ -9457,7 +9457,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-engine"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9493,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-harness"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-proto"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "chrono",
  "serde",
@@ -9524,7 +9524,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-rpc"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9543,7 +9543,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-sync"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -9566,7 +9566,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-syntax"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "thiserror 2.0.20",
  "tree-sitter",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-theme"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-ui"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-update"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.38"
+version = "0.2.39"
 edition = "2024"
 license = "MIT"
 publish = false


### PR DESCRIPTION
Bump the workspace and lockfile to v0.2.39 to release #257: smooth runway scrolling on send/completion and working downward scrolling after background streaming/refocus.

The fixes passed all 602 release UI tests and eight matched performance replays against optimized main. This change only updates the 11 workspace package versions; locked Cargo metadata and diff checks pass.

After merge, tag v0.2.39 to build Linux x86_64/aarch64 and macOS Apple silicon artifacts and publish the release plus updater manifest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791227035&installation_model_id=425430&pr_number=258&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F258&signature=aa86b43fa23f88b3ce01ea1ee0f736482475dbdcb728553e88c1d91b4eb7a3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->