### PR TITLE
Fix macOS streaming crashes, repair stalled sync, and reduce rendering overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "zeron"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -9443,7 +9443,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-doc"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "chrono",
  "loro",
@@ -9457,7 +9457,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-engine"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9493,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-harness"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-proto"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "chrono",
  "serde",
@@ -9524,7 +9524,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-rpc"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9543,7 +9543,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-sync"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -9566,7 +9566,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-syntax"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "thiserror 2.0.20",
  "tree-sitter",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-theme"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-ui"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-update"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2765,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "schemars",
  "serde",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "anyhow",
  "log",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2820,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2849,7 +2849,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3108,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4160,7 +4160,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4975,7 +4975,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "collections",
  "serde",
@@ -5889,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "derive_refineable",
 ]
@@ -6192,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6805,7 +6805,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -7988,7 +7988,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "perf",
  "quote",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9720,7 +9720,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=0003b923354ea8938b2d0cadbd17ef93108e2ae5#0003b923354ea8938b2d0cadbd17ef93108e2ae5"
+source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,14 +61,14 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/zeronsh/zui", rev = "0003b923354ea8938b2d0cadbd17ef93108e2ae5" }
-gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "0003b923354ea8938b2d0cadbd17ef93108e2ae5", features = [
+gpui = { git = "https://github.com/zeronsh/zui", rev = "36ca993fb5663ae496acd1d4d19f556d6350eae8" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "36ca993fb5663ae496acd1d4d19f556d6350eae8", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "0003b923354ea8938b2d0cadbd17ef93108e2ae5" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "36ca993fb5663ae496acd1d4d19f556d6350eae8" }
 
 # diffs
 similar = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.39"
+version = "0.2.40"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/apps/zeron/src/main.rs
+++ b/apps/zeron/src/main.rs
@@ -149,6 +149,18 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
+    if long_running {
+        // Finder launches have no visible stderr. Mirror the panic location
+        // and backtrace into the same rotating log as engine diagnostics.
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            tracing::error!(panic = %info,
+                backtrace = %std::backtrace::Backtrace::force_capture(),
+                "application panic");
+            default_hook(info);
+        }));
+    }
+
     match cli.command {
         Some(Command::Headless) => {
             let runtime = tokio::runtime::Runtime::new()?;

--- a/crates/engine/src/chat2_host.rs
+++ b/crates/engine/src/chat2_host.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use zeron_doc::SessionDoc;
-use zeron_sync::chat_client::{ChatDocSink, CheckpointFetcher};
+use zeron_sync::chat_client::{ChatDocSink, CheckpointFetcher, RowImportOutcome};
 use zeron_sync::{DocsStore, SyncError};
 
 use crate::doc_host::EdgeConfig;
@@ -74,20 +74,19 @@ impl EngineChatSink {
 }
 
 impl ChatDocSink for EngineChatSink {
-    fn apply_row(&self, bytes: &[u8], cursor: u64) {
+    fn apply_row(&self, bytes: &[u8], cursor: u64) -> RowImportOutcome {
         let Some(doc) = self.doc.upgrade() else {
-            return;
+            return RowImportOutcome::Applied;
         };
         match doc.doc().import(bytes) {
             Ok(status) => {
                 if status.pending.is_some() {
-                    // Missing causal deps: loro parked these ops invisibly.
-                    // The client's cursor contiguity rule keeps `cursor`
-                    // honest (it never jumps a gap), so persisting is safe —
-                    // this warn is the tripwire that the 2026-08-19
-                    // empty-doc/advanced-cursor wedge shape was seen live.
+                    // Room sequence contiguity does not prove causal history
+                    // is present. Snapshot export omits parked operations;
+                    // advancing its cursor would lose them after restart.
                     tracing::warn!(chat = %self.chat_id, cursor,
-                        "chat2 sink: row parked on missing deps (gap repair should follow)");
+                        "chat2 sink: row parked on missing deps; requesting repair");
+                    return RowImportOutcome::PendingDependencies;
                 }
             }
             Err(err) => {
@@ -99,13 +98,18 @@ impl ChatDocSink for EngineChatSink {
             }
         }
         self.persist_with_cursor(cursor);
+        RowImportOutcome::Applied
     }
 
     fn apply_checkpoint(&self, bytes: &[u8], cursor: u64) -> Result<(), String> {
         let doc = self.doc.upgrade().ok_or("doc evicted")?;
-        doc.doc()
+        let status = doc
+            .doc()
             .import(bytes)
             .map_err(|e| format!("checkpoint import: {e}"))?;
+        if status.pending.is_some() {
+            return Err("checkpoint is missing causal dependencies".into());
+        }
         self.persist_with_cursor(cursor);
         Ok(())
     }
@@ -251,7 +255,6 @@ impl CheckpointFetcher for EdgeCheckpointFetcher {
     }
 }
 
-
 /// Plain-HTTPS chat pull/push (the airplane-wifi transport): GET/POST
 /// `/chat2/{id}/rows` with the same bearer auth the checkpoint fetcher uses.
 pub struct EdgeChatTransport {
@@ -304,7 +307,10 @@ impl zeron_sync::chat_client::ChatTransport for EdgeChatTransport {
                 .await
                 .map_err(|e| SyncError::WebSocket(e.to_string()))?;
             if !res.status().is_success() {
-                return Err(SyncError::Protocol(format!("chat pull http {}", res.status())));
+                return Err(SyncError::Protocol(format!(
+                    "chat pull http {}",
+                    res.status()
+                )));
             }
             let bytes = res
                 .bytes()
@@ -337,7 +343,10 @@ impl zeron_sync::chat_client::ChatTransport for EdgeChatTransport {
                 .await
                 .map_err(|e| SyncError::WebSocket(e.to_string()))?;
             if !res.status().is_success() {
-                return Err(SyncError::Protocol(format!("chat push http {}", res.status())));
+                return Err(SyncError::Protocol(format!(
+                    "chat push http {}",
+                    res.status()
+                )));
             }
             res.text()
                 .await
@@ -388,13 +397,61 @@ mod frontier_tests {
         );
         // A real, contained frontier still short-circuits the fetch — the
         // doc needs actual ops, or its own frontier is the vacuous-empty one.
-        doc.doc()
-            .get_map("meta")
-            .insert("k", "v")
-            .expect("insert");
+        doc.doc().get_map("meta").insert("k", "v").expect("insert");
         doc.doc().commit();
         let vv = doc.doc().oplog_vv().encode();
         assert!(sink.contains_frontier(&vv));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parked_rows_do_not_persist_a_cursor_until_their_history_arrives() {
+        let source = SessionDoc::init("chat").unwrap();
+        let text = source.doc().get_text("body");
+        text.insert(0, "parent").unwrap();
+        source.doc().commit();
+        let checkpoint = source.export_snapshot().unwrap();
+        let frontier = source.doc().oplog_vv();
+        text.insert(6, " child").unwrap();
+        source.doc().commit();
+        let row = source
+            .doc()
+            .export(loro::ExportMode::updates(&frontier))
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(DocsStore::open(dir.path()).unwrap());
+        let target = Arc::new(SessionDoc::from_doc(loro::LoroDoc::new()));
+        let sink = EngineChatSink::new(&target, store.clone(), "chat");
+        sink.persist_with_cursor(0);
+        assert_eq!(
+            sink.apply_row(&row, 1),
+            RowImportOutcome::PendingDependencies
+        );
+        let (_, cursor, _) = store.load_snapshot_with_cursor("chat").unwrap().unwrap();
+        assert_eq!(cursor, 0, "a restart must retry the invisible update");
+
+        sink.apply_checkpoint(&checkpoint, 0).unwrap();
+        assert_eq!(sink.apply_row(&row, 1), RowImportOutcome::Applied);
+        let (snapshot, cursor, _) = store.load_snapshot_with_cursor("chat").unwrap().unwrap();
+        assert_eq!(cursor, 1);
+        let restored = loro::LoroDoc::new();
+        restored.import(&snapshot).unwrap();
+        assert_eq!(restored.get_text("body").to_string(), "parent child");
+
+        let incomplete = Arc::new(SessionDoc::from_doc(loro::LoroDoc::new()));
+        let incomplete_sink = EngineChatSink::new(&incomplete, store.clone(), "incomplete");
+        assert!(incomplete_sink.apply_checkpoint(&row, 1).is_err());
+        assert!(
+            store
+                .load_snapshot_with_cursor("incomplete")
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -1103,16 +1103,25 @@ impl WorkspaceHostInner {
     }
 
     fn publish(&self) {
+        self.publish_lists(false);
+    }
+
+    fn publish_lists(&self, clock_tick: bool) {
         match lock(&self.reg).read_all() {
             Ok(mut state) => {
                 self.overlay_presence(&mut state.devices);
-                // send_replace, NOT send: `watch::Sender::send` drops the value when
-                // no receiver exists yet, so a stream subscribed later would start
-                // from a stale snapshot (found the hard way by the e2e smoke).
-                self.chats_tx.send_replace(state.chats);
-                self.devices_tx.send_replace(state.devices);
-                self.sessions_tx.send_replace(state.sessions);
-                self.spaces_tx.send_replace(state.spaces);
+                // Retain the latest value even with no subscribers, but don't
+                // wake every list for unrelated registry/presence changes.
+                publish_if_changed(&self.chats_tx, state.chats);
+                // The periodic presence tick also drives time-based expiry.
+                // Unrelated registry writes need no synthetic device event.
+                if clock_tick {
+                    self.devices_tx.send_replace(state.devices);
+                } else {
+                    publish_if_changed(&self.devices_tx, state.devices);
+                }
+                publish_if_changed(&self.sessions_tx, state.sessions);
+                publish_if_changed(&self.spaces_tx, state.spaces);
             }
             Err(err) => {
                 tracing::warn!(error = %err, "registry read failed");
@@ -1407,10 +1416,21 @@ async fn workspace_task(weak: Weak<WorkspaceHostInner>, mut changed_rx: watch::R
                 // Re-publish on the same cadence: remote heartbeats decay when a
                 // device goes silent, and watchers (the UI online dot, "host
                 // offline" hints) need a tick to observe that staleness.
-                inner.publish();
+                inner.publish_lists(true);
             }
         }
     }
+}
+
+fn publish_if_changed<T: PartialEq>(sender: &watch::Sender<T>, value: T) {
+    sender.send_if_modified(|current| {
+        if *current == value {
+            false
+        } else {
+            *current = value;
+            true
+        }
+    });
 }
 
 fn device_name_on_boot(existing_name: Option<&str>, detected_name: &str) -> String {
@@ -1546,6 +1566,62 @@ impl zeron_sync::RegistryTransport for WsDerivedRegistryTransport {
 #[cfg(test)]
 mod tests {
     use super::{device_name_on_boot, linked_worktree_root};
+
+    #[tokio::test]
+    async fn presence_publish_keeps_unchanged_lists_quiet_and_late_subscribers_current() {
+        use super::*;
+
+        let dir = tempfile::tempdir().unwrap();
+        let host = WorkspaceHost::open(
+            Arc::new(DocsStore::open(dir.path()).unwrap()),
+            WorkspaceHostConfig {
+                device_id: "test-device".into(),
+                device_name: "Test device".into(),
+                platform: "macos".into(),
+                org_id: "test-org".into(),
+                user_id: "test-user".into(),
+                edge: None,
+            },
+        )
+        .unwrap();
+        let chats = host.watch_chats();
+        let sessions = host.watch_session_rows();
+        let mut spaces = host.watch_spaces();
+        let devices = host.watch_devices();
+
+        host.inner.publish();
+        assert!(!chats.has_changed().unwrap());
+        assert!(!sessions.has_changed().unwrap());
+        assert!(!spaces.has_changed().unwrap());
+        assert!(!devices.has_changed().unwrap());
+        host.inner.publish_lists(true);
+        assert!(
+            devices.has_changed().unwrap(),
+            "presence expiry still ticks"
+        );
+        assert!(!chats.has_changed().unwrap());
+        assert!(!sessions.has_changed().unwrap());
+        assert!(!spaces.has_changed().unwrap());
+
+        host.create_space("space", "test-device", "/project", None, false)
+            .unwrap();
+        host.inner.publish();
+        assert!(
+            spaces.has_changed().unwrap(),
+            "real changes must wake readers"
+        );
+        assert_eq!(spaces.borrow_and_update()[0].id, "space");
+        assert!(!chats.has_changed().unwrap());
+        assert!(!sessions.has_changed().unwrap());
+        drop(spaces);
+
+        host.rename_space("space", Some("Renamed")).unwrap();
+        host.inner.publish();
+        assert_eq!(
+            host.watch_spaces().borrow()[0].name.as_deref(),
+            Some("Renamed")
+        );
+    }
 
     #[test]
     fn boot_repairs_the_legacy_unknown_device_sentinel() {

--- a/crates/sync/examples/chat2_live.rs
+++ b/crates/sync/examples/chat2_live.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use futures::future::BoxFuture;
 use loro::{ExportMode, LoroDoc, VersionVector};
 use zeron_sync::SyncError;
-use zeron_sync::chat_client::{ChatClient, ChatDocSink, CheckpointFetcher};
+use zeron_sync::chat_client::{ChatClient, ChatDocSink, CheckpointFetcher, RowImportOutcome};
 
 struct DocSink {
     doc: Mutex<LoroDoc>,
@@ -24,11 +24,14 @@ struct DocSink {
 }
 
 impl ChatDocSink for DocSink {
-    fn apply_row(&self, bytes: &[u8], cursor: u64) {
+    fn apply_row(&self, bytes: &[u8], cursor: u64) -> RowImportOutcome {
         let doc = self.doc.lock().unwrap();
-        doc.import(bytes).expect("row import");
+        if doc.import(bytes).expect("row import").pending.is_some() {
+            return RowImportOutcome::PendingDependencies;
+        }
         self.cursor.store(cursor, Relaxed);
         self.rows_applied.fetch_add(1, Relaxed);
+        RowImportOutcome::Applied
     }
     fn apply_checkpoint(&self, bytes: &[u8], cursor: u64) -> Result<(), String> {
         let doc = self.doc.lock().unwrap();

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -106,12 +106,21 @@ pub enum ChatEvent {
 
 // ── engine-facing traits ────────────────────────────────────────────────────
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowImportOutcome {
+    Applied,
+    /// The update is buffered in memory until missing causal history arrives.
+    /// It is not represented in an exported snapshot yet.
+    PendingDependencies,
+}
+
 /// Where remote bytes land. The engine implements this over its doc handle;
 /// every method persists doc content AND the room cursor in one transaction
 /// (`DocsStore::save_snapshot_with_cursor`) so they can never diverge.
 pub trait ChatDocSink: Send + Sync + 'static {
-    /// Import one remote update row; `cursor` is the row's seq.
-    fn apply_row(&self, bytes: &[u8], cursor: u64);
+    /// Import one remote update row with a proposed contiguous cursor. A
+    /// pending import must not persist that cursor; the client repairs it.
+    fn apply_row(&self, bytes: &[u8], cursor: u64) -> RowImportOutcome;
     /// Replace/merge from a checkpoint blob; `cursor` is its checkpointSeq.
     fn apply_checkpoint(&self, bytes: &[u8], cursor: u64) -> Result<(), String>;
     /// Client-side precision (replaces the server VV diff): is the server
@@ -299,6 +308,39 @@ struct Shared {
     /// wedge); instead this flag asks the session loop for a rowsReq
     /// backfill from the honest cursor.
     gap_repair: bool,
+    /// Contiguous room rows can still lack CRDT dependencies. Re-fetch the
+    /// checkpoint even if its advertised frontier appears locally contained.
+    needs_checkpoint: bool,
+    /// Prevent an overlapping HTTP/socket catch-up from clearing a newer gap.
+    causal_gap_generation: u64,
+}
+
+fn apply_remote_row(shared: &Mutex<Shared>, sink: &dyn ChatDocSink, bytes: &[u8], seq: u64) {
+    let cursor = {
+        let mut shared = lock(shared);
+        if seq > shared.cursor.saturating_add(1) {
+            shared.gap_repair = true;
+            shared.cursor
+        } else {
+            shared.cursor.max(seq)
+        }
+    };
+    // Import may fire document subscriptions, so never hold the client lock
+    // across the sink call.
+    let outcome = sink.apply_row(bytes, cursor);
+    let mut shared = lock(shared);
+    match outcome {
+        RowImportOutcome::Applied => shared.cursor = shared.cursor.max(cursor),
+        RowImportOutcome::PendingDependencies => {
+            shared.needs_checkpoint = true;
+            shared.causal_gap_generation = shared.causal_gap_generation.wrapping_add(1);
+            tracing::warn!(
+                seq,
+                cursor = shared.cursor,
+                "chat2: missing causal history; holding cursor and refreshing checkpoint"
+            );
+        }
+    }
 }
 
 /// `zeron sync` surface (plan: cursor / headSeq / floorLag / pendingPushes).
@@ -904,8 +946,12 @@ impl Actor {
         // ── catch-up: checkpoint precision + row backfill ───────────────────
         // Same presence rule as `plan_catch_up`: SIZE, not seq — a seeded
         // room's checkpoint covers seq 0 (see the decision-table test).
-        let contained =
-            state.checkpoint_size == 0 || self.sink.contains_frontier(&state_frame.payload);
+        let (repair_causal_history, repair_generation) = {
+            let shared = lock(&self.shared);
+            (shared.needs_checkpoint, shared.causal_gap_generation)
+        };
+        let contained = state.checkpoint_size == 0
+            || (!repair_causal_history && self.sink.contains_frontier(&state_frame.payload));
         let plan = plan_catch_up(cursor, &state, contained);
         let after = match plan {
             CatchUpPlan::RowsOnly { after } => after,
@@ -931,7 +977,7 @@ impl Actor {
                 after,
                 // First backfill of this process redownloads own rows (see
                 // `Actor::resumed`); reconnects skip them.
-                exclude_own: self.resumed,
+                exclude_own: self.resumed && !repair_causal_history,
             },
             &[],
         );
@@ -998,6 +1044,14 @@ impl Actor {
             drop(shared);
             let _ = self.events.send(ChatEvent::Applied);
         }
+        // A new full catch-up may resolve a prior causal gap. Imports below
+        // re-arm repair if any history is still missing.
+        {
+            let mut shared = lock(&self.shared);
+            if shared.causal_gap_generation == repair_generation {
+                shared.needs_checkpoint = false;
+            }
+        }
         // Frames buffered during the fetch replay first, then the live socket
         // finishes the backfill — one pass, same ROWS_DONE terminator either
         // way.
@@ -1049,7 +1103,9 @@ impl Actor {
         if let Some(ready) = ready.take() {
             let _ = ready.send(Ok(()));
         }
-        let _ = self.events.send(ChatEvent::CaughtUp { head_seq });
+        if !lock(&self.shared).needs_checkpoint {
+            let _ = self.events.send(ChatEvent::CaughtUp { head_seq });
+        }
 
         // ── steady state ────────────────────────────────────────────────────
         let mut last_frame = tokio::time::Instant::now();
@@ -1262,11 +1318,14 @@ impl Actor {
                     serde_json::from_value::<wire::StateHeader>(state_frame.header.clone())
                 {
                     lock(&shared).server = Some(state);
-                    let contained =
-                        state.checkpoint_size == 0 || sink.contains_frontier(&state_frame.payload);
-                    if let CatchUpPlan::CheckpointThenRows { after } =
-                        plan_catch_up(cursor, &state, contained)
-                    {
+                    let (repair_causal_history, repair_generation) = {
+                        let shared = lock(&shared);
+                        (shared.needs_checkpoint, shared.causal_gap_generation)
+                    };
+                    let contained = state.checkpoint_size == 0
+                        || (!repair_causal_history && sink.contains_frontier(&state_frame.payload));
+                    let plan = plan_catch_up(cursor, &state, contained);
+                    if let CatchUpPlan::CheckpointThenRows { .. } = plan {
                         let fetched =
                             tokio::time::timeout(CHECKPOINT_FETCH_DEADLINE, fetcher.fetch()).await;
                         match fetched {
@@ -1275,9 +1334,6 @@ impl Actor {
                                     busy.store(false, Relaxed);
                                     return;
                                 }
-                                let mut sh = lock(&shared);
-                                sh.cursor = sh.cursor.max(after);
-                                drop(sh);
                                 let _ = events.send(ChatEvent::Applied);
                             }
                             _ => {
@@ -1285,6 +1341,22 @@ impl Actor {
                                 return;
                             }
                         }
+                    }
+                    let after = match plan {
+                        CatchUpPlan::RowsOnly { after }
+                        | CatchUpPlan::CheckpointThenRows { after } => after,
+                    };
+                    // A contained checkpoint covers the trimmed rows too;
+                    // otherwise the first post-checkpoint row looks like a
+                    // permanent sequence gap in the HTTPS fallback.
+                    let mut sh = lock(&shared);
+                    sh.cursor = if sh.cursor > state.head_seq {
+                        after
+                    } else {
+                        sh.cursor.max(after)
+                    };
+                    if sh.causal_gap_generation == repair_generation {
+                        sh.needs_checkpoint = false;
                     }
                 }
             }
@@ -1300,17 +1372,7 @@ impl Actor {
                         // contiguous — but hold the rule anyway: a jump
                         // (trimmed log, server surprise) must not stamp the
                         // cursor over rows the doc never saw.
-                        let effective = {
-                            let mut sh = lock(&shared);
-                            if row.seq <= sh.cursor + 1 {
-                                sh.cursor = sh.cursor.max(row.seq);
-                            } else {
-                                tracing::warn!(seq = row.seq, cursor = sh.cursor,
-                                    "chat2: pull row gap; holding cursor");
-                            }
-                            sh.cursor
-                        };
-                        sink.apply_row(&frame.payload, effective);
+                        apply_remote_row(&shared, sink.as_ref(), &frame.payload, row.seq);
                         applied = true;
                     }
                     frame_type::ROWS_DONE => {}
@@ -1332,6 +1394,12 @@ impl Actor {
         const MAX_GAP_REPAIRS_PER_SESSION: u32 = 3;
         let (repair, after) = {
             let mut shared = lock(&self.shared);
+            if shared.needs_checkpoint {
+                // A row backfill cannot restore dependencies already trimmed
+                // into the checkpoint. Redial through the bounded backoff and
+                // bypass frontier precision on the next catch-up.
+                return false;
+            }
             (std::mem::take(&mut shared.gap_repair), shared.cursor)
         };
         if !repair {
@@ -1342,7 +1410,11 @@ impl Actor {
             tracing::warn!("chat2: gap repairs exhausted; redialing for a full catch-up");
             return false;
         }
-        tracing::info!(after, attempt = *repairs, "chat2: backfilling over a row gap");
+        tracing::info!(
+            after,
+            attempt = *repairs,
+            "chat2: backfilling over a row gap"
+        );
         let req = wire::encode(
             frame_type::ROWS_REQ,
             &wire::RowsReqHeader {
@@ -1393,21 +1465,7 @@ impl Actor {
                 // gap means rows we never received (live broadcast mid-join)
                 // — apply the bytes (loro parks dependents harmlessly), keep
                 // the honest cursor, and ask for a backfill repair.
-                let effective = {
-                    let mut shared = lock(&self.shared);
-                    if row.seq > shared.cursor + 1 {
-                        shared.gap_repair = true;
-                        tracing::warn!(
-                            seq = row.seq,
-                            cursor = shared.cursor,
-                            "chat2: row gap detected; holding cursor and requesting backfill"
-                        );
-                    } else {
-                        shared.cursor = shared.cursor.max(row.seq);
-                    }
-                    shared.cursor
-                };
-                self.sink.apply_row(&frame.payload, effective);
+                apply_remote_row(&self.shared, self.sink.as_ref(), &frame.payload, row.seq);
                 let _ = self.events.send(ChatEvent::Applied);
             }
             frame_type::ACK => {

--- a/crates/sync/src/chat_client/tests.rs
+++ b/crates/sync/src/chat_client/tests.rs
@@ -50,17 +50,27 @@ struct RecordingSink {
     checkpoints: Mutex<Vec<(Vec<u8>, u64)>>,
     cursor_advances: Mutex<Vec<u64>>,
     frontier_contained: std::sync::atomic::AtomicBool,
+    pending_until_checkpoint: std::sync::atomic::AtomicBool,
     /// Global apply order across rows and checkpoints — the overlap test
     /// pins "checkpoint imports before any row that buffered during it".
     ops: Mutex<Vec<String>>,
 }
 
 impl ChatDocSink for RecordingSink {
-    fn apply_row(&self, bytes: &[u8], cursor: u64) {
+    fn apply_row(&self, bytes: &[u8], cursor: u64) -> RowImportOutcome {
+        if self
+            .pending_until_checkpoint
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return RowImportOutcome::PendingDependencies;
+        }
         lock(&self.rows).push((bytes.to_vec(), cursor));
         lock(&self.ops).push(format!("row@{cursor}"));
+        RowImportOutcome::Applied
     }
     fn apply_checkpoint(&self, bytes: &[u8], cursor: u64) -> Result<(), String> {
+        self.pending_until_checkpoint
+            .store(false, std::sync::atomic::Ordering::Relaxed);
         lock(&self.checkpoints).push((bytes.to_vec(), cursor));
         lock(&self.ops).push(format!("ckpt@{cursor}"));
         Ok(())
@@ -1356,4 +1366,168 @@ async fn checkpointless_amnesty_refetches_from_zero() {
     assert_eq!(client.stats().cursor, 3);
     drop(end);
     client.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn causal_gap_refetches_checkpoint_without_skipping_parked_row() {
+    use std::sync::atomic::Ordering::Relaxed;
+    let (first_pipe, mut first_end) = pipe_pair();
+    let (second_pipe, mut second_end) = pipe_pair();
+    let sink = Arc::new(RecordingSink::default());
+    sink.frontier_contained.store(true, Relaxed);
+    sink.pending_until_checkpoint.store(true, Relaxed);
+    let (fetch, calls) = fetcher(b"complete-history");
+    let server = tokio::spawn(async move {
+        let state = serde_json::json!({"headSeq": 5, "seqFloor": 5,
+            "checkpointSeq": 5, "checkpointSize": 1000, "rowCount": 0, "rowBytes": 0});
+        serve_join(&mut first_end, state.clone(), b"frontier", vec![], false).await;
+        send(
+            &first_end,
+            frame_type::ROW,
+            serde_json::json!({"seq": 6, "device": "dev-b", "batchId": "b6"}),
+            b"dependent-row",
+        )
+        .await;
+        let hello = expect_kind(&mut second_end, frame_type::HELLO).await;
+        assert_eq!(
+            hello.header["cursor"], 5,
+            "parked row must not advance cursor"
+        );
+        let mut state = state;
+        state["headSeq"] = 6.into();
+        send(&second_end, frame_type::STATE, state, b"frontier").await;
+        let rows = expect_kind(&mut second_end, frame_type::ROWS_REQ).await;
+        assert_eq!(rows.header["after"], 5);
+        assert_eq!(
+            rows.header["excludeOwn"], false,
+            "repair includes every writer"
+        );
+        send(
+            &second_end,
+            frame_type::ROW,
+            serde_json::json!({"seq": 6, "device": "dev-b", "batchId": "b6"}),
+            b"dependent-row",
+        )
+        .await;
+        send(
+            &second_end,
+            frame_type::ROWS_DONE,
+            serde_json::json!({"headSeq": 6}),
+            &[],
+        )
+        .await;
+        (first_end, second_end)
+    });
+    let client = ChatClient::connect_with_tuned(
+        connector(vec![first_pipe, second_pipe]),
+        sink.clone(),
+        fetch,
+        "dev-a",
+        5,
+        ChatTuning::default(),
+    )
+    .await
+    .unwrap();
+    let ends = server.await.unwrap();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while client.stats().cursor != 6 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "causal repair stalled"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        calls.load(Relaxed),
+        1,
+        "fetch despite the contained frontier"
+    );
+    assert_eq!(*lock(&sink.ops), vec!["ckpt@5", "row@6"]);
+    drop(ends);
+    client.shutdown().await;
+}
+
+struct FixedHttpRows {
+    body: Vec<u8>,
+    requests: Mutex<Vec<u64>>,
+}
+impl ChatTransport for FixedHttpRows {
+    fn fetch_rows(&self, after: u64) -> BoxFuture<'static, Result<Vec<u8>, SyncError>> {
+        lock(&self.requests).push(after);
+        let body = self.body.clone();
+        Box::pin(async move { Ok(body) })
+    }
+    fn push(&self, _: String, _: Vec<u8>) -> BoxFuture<'static, Result<String, SyncError>> {
+        Box::pin(async { panic!("read-only recovery must not push") })
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn http_catchup_crosses_a_contained_checkpoint_and_repairs_causal_gaps() {
+    use std::sync::atomic::Ordering::Relaxed;
+    for pending_dependencies in [false, true] {
+        let sink = Arc::new(RecordingSink::default());
+        sink.frontier_contained.store(true, Relaxed);
+        sink.pending_until_checkpoint
+            .store(pending_dependencies, Relaxed);
+        let (fetch, calls) = fetcher(b"complete-history");
+        let frames = [
+            encode(
+                frame_type::STATE,
+                &serde_json::json!({"headSeq": 6, "seqFloor": 5,
+                "checkpointSeq": 5, "checkpointSize": 1000, "rowCount": 1, "rowBytes": 20}),
+                b"frontier",
+            ),
+            encode(
+                frame_type::ROW,
+                &serde_json::json!({"seq": 6, "device": "dev-b", "batchId": "b6"}),
+                b"row",
+            ),
+            encode(
+                frame_type::ROWS_DONE,
+                &serde_json::json!({"headSeq": 6}),
+                &[],
+            ),
+        ];
+        let mut body = Vec::new();
+        for frame in frames {
+            body.extend_from_slice(&(frame.len() as u32).to_le_bytes());
+            body.extend_from_slice(&frame);
+        }
+        let transport = Arc::new(FixedHttpRows {
+            body,
+            requests: Mutex::new(Vec::new()),
+        });
+        let client = ChatClient::connect_with_transport(
+            connector(vec![]),
+            sink.clone(),
+            fetch,
+            "dev-a",
+            1,
+            ChatTuning::default(),
+            Some(transport.clone()),
+        )
+        .await
+        .unwrap();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while client.stats().cursor != 6 {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "HTTP recovery stalled"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(calls.load(Relaxed), u64::from(pending_dependencies));
+        assert_eq!(lock(&transport.requests)[0], 1);
+        assert_eq!(lock(&sink.rows).last().unwrap().1, 6);
+        if pending_dependencies {
+            assert_eq!(
+                lock(&transport.requests)[1],
+                5,
+                "retry starts before the parked row"
+            );
+            assert_eq!(lock(&sink.ops)[0], "ckpt@5");
+        }
+        client.shutdown().await;
+    }
 }

--- a/crates/ui/examples/macos-resource-profile.rs
+++ b/crates/ui/examples/macos-resource-profile.rs
@@ -79,6 +79,14 @@ fn main() -> anyhow::Result<()> {
                     "archived":false, "createdAt":"2026-09-05T00:00:00Z",
                     "config":{"harness":"claude-code", "model":"claude-haiku-4-5", "reasoning":null, "sandbox":"workspace-write"}
                 })).unwrap()];
+                let background_chats = std::env::var("ZERON_PROFILE_BACKGROUND_CHATS")
+                    .ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(0);
+                for index in 0..background_chats {
+                    let mut chat = state.chats[0].clone();
+                    chat.id = format!("background-{index}");
+                    chat.title = Some(format!("Background conversation {}", index + 1));
+                    state.chats.push(chat);
+                }
                 state
             });
             let boot = EngineBootConfig { data_dir:data, ipc_port:0,
@@ -92,6 +100,11 @@ fn main() -> anyhow::Result<()> {
             *captured.borrow_mut() = Some((state,window));
         });
     let (state, window) = handles.borrow_mut().take().unwrap();
+    let notifications = Rc::new(std::cell::Cell::new(0usize));
+    let observed = notifications.clone();
+    let _notification_probe = app.update(|cx| cx.observe(&state, move |_, _| {
+        observed.set(observed.get() + 1);
+    }));
     let dispatcher = executor.dispatcher().as_bench().unwrap();
     let start = Instant::now();
     let first_at = frames[0].at;
@@ -103,9 +116,13 @@ fn main() -> anyhow::Result<()> {
             let elapsed = start.elapsed().as_millis() as u64;
             while frames.peek().is_some_and(|f| f.at - first_at <= elapsed) {
                 let frame = frames.next().unwrap();
+                let text_only = matches!(&frame.frame, zeron_doc::TranscriptFrame::Delta {
+                    upsert, append, remove, ..
+                } if upsert.is_empty() && remove.is_empty() && !append.is_empty());
+                let before = notifications.get();
                 app.update(|cx| {
                     state.update(cx, |state, cx| {
-                        state.apply_transcript_frame(frame.frame).unwrap();
+                        state.receive_transcript_frame(frame.frame, cx).unwrap();
                         let streaming = state
                             .transcript
                             .iter()
@@ -121,9 +138,12 @@ fn main() -> anyhow::Result<()> {
                             started_at: Some(chrono::Utc::now()),
                             updated_at: chrono::Utc::now(),
                         }]);
-                        cx.notify();
                     })
                 });
+                if text_only {
+                    assert_eq!(notifications.get(), before,
+                        "text growth must not notify unrelated app-state observers");
+                }
             }
             app.update(|cx| {
                 window

--- a/crates/ui/src/loaders.rs
+++ b/crates/ui/src/loaders.rs
@@ -9,8 +9,8 @@
 //! cell to its rest state automatically (gpui `reduce_motion`).
 
 use gpui::{
-    AnyElement, App, EntityId, IntoElement, ParentElement, PathBuilder, SharedString, Styled,
-    canvas, div, point, px,
+    AnyElement, App, AppContext, Context, Entity, EntityId, IntoElement, ParentElement,
+    PathBuilder, Render, RenderOnce, SharedString, Styled, Window, canvas, div, point, px,
 };
 
 use crate::motion::{self, GRADIENT_SPIN, PULSE_STAGGER, SPLASH_OUT, ZERON_PULSE};
@@ -176,6 +176,67 @@ fn mini_spinner_tinted(
     key: impl Into<SharedString>,
     cell_px: f32,
     row_tints: [gpui::Hsla; 3],
+    _view: EntityId,
+    _cx: &mut App,
+) -> impl IntoElement {
+    MiniSpinner {
+        key: key.into(),
+        cell_px,
+        row_tints,
+    }
+}
+
+#[derive(IntoElement)]
+struct MiniSpinner {
+    key: SharedString,
+    cell_px: f32,
+    row_tints: [gpui::Hsla; 3],
+}
+
+impl RenderOnce for MiniSpinner {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        // Keep pulse invalidation separate from container state changes so
+        // cached sibling rows can be reused while these six cells animate.
+        let view = window.with_global_id(self.key.into(), |id, window| {
+            window.with_element_state(id, |previous: Option<Entity<MiniSpinnerView>>, _| {
+                let view = previous.unwrap_or_else(|| {
+                    cx.new(|_| MiniSpinnerView {
+                        cell_px: self.cell_px,
+                        row_tints: self.row_tints,
+                    })
+                });
+                view.update(cx, |view, cx| {
+                    if view.cell_px != self.cell_px || view.row_tints != self.row_tints {
+                        view.cell_px = self.cell_px;
+                        view.row_tints = self.row_tints;
+                        cx.notify();
+                    }
+                });
+                (view.clone(), view)
+            })
+        });
+        view.cached(
+            gpui::StyleRefinement::default()
+                .w(px(self.cell_px * 2.5))
+                .h(px(self.cell_px * 4.0)),
+        )
+    }
+}
+
+struct MiniSpinnerView {
+    cell_px: f32,
+    row_tints: [gpui::Hsla; 3],
+}
+
+impl Render for MiniSpinnerView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        mini_spinner_cells(self.cell_px, self.row_tints, cx.entity_id(), cx)
+    }
+}
+
+fn mini_spinner_cells(
+    cell_px: f32,
+    row_tints: [gpui::Hsla; 3],
     view: EntityId,
     cx: &mut App,
 ) -> impl IntoElement {
@@ -185,7 +246,6 @@ fn mini_spinner_tinted(
     /// (0,0) → (0,1) → (1,1) → (2,1) → (2,0) → (1,0).
     const RING: [[usize; COLS]; ROWS] = [[0, 1], [5, 2], [4, 3]];
     const RING_LEN: f32 = (COLS * ROWS) as f32;
-    let _key = key.into();
     let delta = motion::pulse_delta(&GRADIENT_SPIN, view, cx);
     div()
         .flex()

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -999,6 +999,94 @@ impl Render for SidebarPane {
     }
 }
 
+#[derive(Clone, PartialEq)]
+struct ChatRowProps {
+    id: String,
+    title: SharedString,
+    time_ago: SharedString,
+    space_name: SharedString,
+    branch: Option<SharedString>,
+    change_request: Option<zeron_proto::ChangeRequestSummary>,
+    harness: Option<zeron_proto::HarnessId>,
+    status: zeron_proto::ChatIndicator,
+    selected: bool,
+    archived: bool,
+    jump_label: Option<SharedString>,
+}
+
+#[derive(IntoElement)]
+struct CachedChatRow {
+    shell: gpui::WeakEntity<Shell>,
+    props: ChatRowProps,
+}
+
+impl gpui::RenderOnce for CachedChatRow {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let height = chat_row_height(
+            self.props.branch.is_some(),
+            self.props.change_request.is_some(),
+        );
+        let key: SharedString = format!("sidebar-row-{}", self.props.id).into();
+        let view = window.with_global_id(key.into(), |id, window| {
+            window.with_element_state(id, |previous: Option<Entity<ChatRowView>>, _| {
+                let view = previous.unwrap_or_else(|| {
+                    cx.new(|cx| ChatRowView {
+                        shell: self.shell.clone(),
+                        props: self.props.clone(),
+                        _shell_changes: self
+                            .shell
+                            .upgrade()
+                            .map(|shell| cx.observe(&shell, |_, _, cx| cx.notify())),
+                    })
+                });
+                view.update(cx, |view, cx| {
+                    if view.props != self.props {
+                        view.props = self.props;
+                        cx.notify();
+                    }
+                });
+                (view.clone(), view)
+            })
+        });
+        view.cached(gpui::StyleRefinement::default().w_full().h(px(height)))
+    }
+}
+
+struct ChatRowView {
+    shell: gpui::WeakEntity<Shell>,
+    props: ChatRowProps,
+    _shell_changes: Option<Subscription>,
+}
+
+impl Render for ChatRowView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(shell) = self.shell.upgrade() else {
+            return div().into_any_element();
+        };
+        let props = self.props.clone();
+        let animation_view = cx.entity_id();
+        shell.update(cx, |shell, cx| {
+            let theme = Theme::of(cx).clone();
+            shell.render_chat_row_inner(
+                props.id,
+                props.title,
+                props.time_ago,
+                props.space_name,
+                props.branch,
+                props.change_request,
+                props.harness,
+                props.status,
+                props.selected,
+                props.archived,
+                props.jump_label,
+                animation_view,
+                &theme,
+                cx,
+            )
+        })
+    }
+}
+
 pub struct Shell {
     state: Entity<AppState>,
     sidebar_pane: Entity<SidebarPane>,
@@ -3865,6 +3953,47 @@ impl Shell {
         // nine chips appear together instead of leaving a hole on whichever
         // row is busy or under the pointer.
         jump_label: Option<SharedString>,
+        _theme: &Theme,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        CachedChatRow {
+            shell: cx.weak_entity(),
+            props: ChatRowProps {
+                id,
+                title,
+                time_ago,
+                space_name,
+                branch,
+                change_request,
+                harness,
+                status,
+                selected,
+                archived,
+                jump_label,
+            },
+        }
+        .into_any_element()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn render_chat_row_inner(
+        &self,
+        id: String,
+        title: SharedString,
+        time_ago: SharedString,
+        space_name: SharedString,
+        branch: Option<SharedString>,
+        change_request: Option<zeron_proto::ChangeRequestSummary>,
+        harness: Option<zeron_proto::HarnessId>,
+        status: zeron_proto::ChatIndicator,
+        selected: bool,
+        archived: bool,
+        // This row's jump combo while the hint overlay is up. It takes the
+        // corner outright — above hover and above the status word — so all
+        // nine chips appear together instead of leaving a hole on whichever
+        // row is busy or under the pointer.
+        jump_label: Option<SharedString>,
+        animation_view: gpui::EntityId,
         theme: &Theme,
         cx: &mut Context<Self>,
     ) -> AnyElement {
@@ -3991,7 +4120,7 @@ impl Shell {
                             format!("chat-working-{id}"),
                             2.0,
                             theme.glyph,
-                            self.sidebar_pane.entity_id(),
+                            animation_view,
                             cx,
                         )
                         .into_any_element()

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -666,6 +666,20 @@ pub struct AppState {
     sub_watch_tasks: HashMap<String, Task<()>>,
 }
 
+/// Text/reasoning growth changes the transcript without changing session
+/// status, tools, navigation, or composer state. Keep those frames local to
+/// the affected transcript instead of rebuilding every app-state observer.
+pub(crate) struct TranscriptTextChanged {
+    pub doc_id: String,
+}
+
+impl gpui::EventEmitter<TranscriptTextChanged> for AppState {}
+
+fn is_text_append(frame: &TranscriptFrame) -> bool {
+    matches!(frame, TranscriptFrame::Delta { upsert, append, remove, .. }
+        if upsert.is_empty() && remove.is_empty() && !append.is_empty())
+}
+
 impl Default for AppState {
     fn default() -> Self {
         Self::new()
@@ -952,6 +966,30 @@ impl AppState {
         }
         self.ack_pending_send_from_transcript();
         Ok(())
+    }
+
+    /// Apply an incoming frame and invalidate only its affected presentation.
+    pub fn receive_transcript_frame(
+        &mut self,
+        frame: TranscriptFrame,
+        cx: &mut Context<Self>,
+    ) -> Result<(), TranscriptDesync> {
+        let text_doc = self
+            .selected_chat
+            .as_ref()
+            .filter(|id| {
+                is_text_append(&frame)
+                    && !self.pending_sends.contains_key(*id)
+                    && self.pending_echoes().is_empty()
+            })
+            .cloned();
+        let result = self.apply_transcript_frame(frame);
+        if let Some(doc_id) = text_doc.filter(|_| result.is_ok()) {
+            cx.emit(TranscriptTextChanged { doc_id });
+        } else {
+            cx.notify();
+        }
+        result
     }
 
     /// A subagent doc's current transcript copy (empty until its watch's
@@ -1998,11 +2036,10 @@ fn spawn_transcript_watch(
                 let alive = this.update(cx, |state, cx| {
                     // Guard against a stale pump racing a newer selection.
                     if state.selected_chat.as_deref() == Some(chat_id.as_str()) {
-                        if let Err(err) = state.apply_transcript_frame(frame) {
+                        if let Err(err) = state.receive_transcript_frame(frame, cx) {
                             tracing::warn!(%chat_id, error = %err, "resubscribing transcript");
                             desync = true;
                         }
-                        cx.notify();
                     }
                 });
                 if alive.is_err() {
@@ -2064,12 +2101,19 @@ fn spawn_subagent_watch(
                 let alive = this.update(cx, |state, cx| {
                     // A stale pump racing a snapshot/unwatch finds no key.
                     if let Some(rows) = state.sub_transcripts.get_mut(&doc_id) {
+                        let text_only = is_text_append(&frame);
                         state.transcript_revision = state.transcript_revision.wrapping_add(1);
                         if let Err(err) = zeron_doc::apply_transcript_frame(rows, frame) {
                             tracing::warn!(%doc_id, error = %err, "resubscribing subagent watch");
                             desync = true;
                         }
-                        cx.notify();
+                        if text_only && !desync {
+                            cx.emit(TranscriptTextChanged {
+                                doc_id: doc_id.clone(),
+                            });
+                        } else {
+                            cx.notify();
+                        }
                     }
                 });
                 if alive.is_err() {

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2429,6 +2429,7 @@ pub struct Transcript {
     blob_fetch_order: HashMap<SharedString, u64>,
     blob_fetch_counter: u64,
     _observe: Subscription,
+    _text_changes: Subscription,
 }
 
 /// One sidecar blob fetch's lifecycle.
@@ -2509,6 +2510,18 @@ impl Transcript {
             .ok();
         });
         let observe = cx.observe(&state, |this: &mut Self, _, cx| this.sync(cx));
+        let text_changes = cx.subscribe(
+            &state,
+            |this: &mut Self, state, event: &crate::state::TranscriptTextChanged, cx| {
+                let doc_id = this
+                    .doc_override
+                    .as_deref()
+                    .or_else(|| state.read(cx).selected_chat.as_deref());
+                if doc_id == Some(event.doc_id.as_str()) {
+                    this.sync(cx);
+                }
+            },
+        );
         // The rail is sized for the conversation column; a narrow right-pane
         // tab has no width gate driving it, so override instances skip it.
         let rail_enabled = doc_override.is_none();
@@ -2587,6 +2600,7 @@ impl Transcript {
             blob_fetch_order: HashMap::new(),
             blob_fetch_counter: 0,
             _observe: observe,
+            _text_changes: text_changes,
         };
         this.sync(cx);
         this

--- a/docs/performance-macos-stability.md
+++ b/docs/performance-macos-stability.md
@@ -62,9 +62,16 @@ render timings for this workload, not a guarantee about every display or GPU.
 ## Idle memory interpretation
 
 An approximately one-minute sample of the installed v0.2.39 app reproduced physical
-footprint changes from 186 to 416 MiB. Heap allocation stayed near 11 MiB; paired
+footprint changes from 186 to 416 MiB. Tracked malloc-zone allocations stayed near 11 MiB; paired
 footprint reports attributed most of the difference to owned, unmapped graphics
 memory, about 11 versus 221 MiB. Most main-thread samples were asleep.
+
+The malloc-zone figure is not a complete inventory of Rust allocator memory.
+In the candidate's 371 MiB sample, `vmmap` reported about 222 MiB of owned
+unmapped memory, 75 MiB of dirty/swapped IOAccelerator memory and 36 MiB of
+IOSurface memory. The paired installed-build footprint reports identify the large
+changing unmapped category as graphics memory. Its individual allocation owners
+have not yet been established.
 
 That evidence does not show a 230 MiB Rust heap leak. Nor does it identify every
 driver/compositor allocation responsible for the changing charge. The drawable

--- a/docs/performance-macos-stability.md
+++ b/docs/performance-macos-stability.md
@@ -1,0 +1,152 @@
+# macOS streaming stability follow-up
+
+This follow-up starts from v0.2.39 (`d97f4c2`). It fixes a reproduced native
+scrolling abort and recovery defects found while investigating stuck sends.
+It also reduces redundant UI work and the Metal window drawable pool. Animation
+timelines, text effects, blur passes, resolution and motion settings are unchanged.
+
+## Reproduced crash
+
+The v0.2.39 main-thread abort resolves to `ListState::scroll_by` in the renderer
+dependency: `list.rs:583`, `cannot seek backward`. The native composer reproduction
+reaches it through `Transcript::step_own_turn` during consecutive short replies.
+
+A prompt can be anchored below the viewport top, giving its list item a negative
+offset. A forward animation step can then still target a position before the tree
+cursor's current item. Choosing `seek_forward` from the direction of the animation
+is incorrect. The renderer now compares the target with the cursor's actual item
+start, using a full seek when needed. A regression test reproduces the old panic
+and checks movement in both directions across the item boundary.
+
+Finder-launched panics now include their location and backtrace in the existing
+rotating app log. This supplements macOS reports whose release stacks lack symbols.
+
+## Stuck-send recovery
+
+Observed logs contained updates parked on missing causal history. A contiguous
+server row number does not establish that a CRDT update's dependencies exist.
+Previously the client could persist an advanced cursor even though snapshot export
+omitted the parked update, allowing a restart to skip it indefinitely.
+
+Pending imports now hold the cursor and request a full catch-up, including a fresh
+checkpoint even when its advertised frontier appears contained. Recovery includes
+the device's own rows and uses the existing reconnect backoff. Overlapping HTTP and
+WebSocket catch-ups cannot clear a newer repair request. Incomplete checkpoints are
+rejected before persistence. The HTTP fallback also advances across a contained
+checkpoint's trimmed prefix before applying its remaining rows.
+
+Tests cover WebSocket repair, HTTP repair, the contained-checkpoint boundary, and
+actual Loro/SQLite persistence followed by a restart. These fixes cover identified
+failure modes; a server that lacks the necessary history or an unavailable model
+provider can still prevent a turn from completing.
+
+## Resource changes
+
+- Unchanged workspace lists no longer wake their subscribers. The existing
+  periodic device tick remains, so time-based presence expiry still updates.
+- Pure text/reasoning appends notify the affected transcript. Structural changes,
+  pending-send acknowledgements, tool changes and errors still notify app state.
+- Sidebar rows and small loaders retain their rendered views. Changes to row
+  properties, navigation, hover and settings invalidate them normally.
+- Metal windows use two drawable buffers instead of three. This removes a
+  full-resolution surface from the pool; it does not change shader quality or
+  remove a blur effect. See Apple's [drawable pool documentation](https://developer.apple.com/documentation/quartzcore/cametallayer/maximumdrawablecount).
+
+The buffer experiment used the same instrumented executable with either pool
+size. Two buffers saved about 29 MiB in the populated streaming test. Steady-state
+95th-percentile acquisition waits rose from roughly 0.03 ms to 2.4–2.7 ms, while
+95th-percentile acquisition plus encoding remained below 3 ms. The measured
+transcript render cadence remained about 42 renders/s in both cases. These are
+render timings for this workload, not a guarantee about every display or GPU.
+
+## Idle memory interpretation
+
+An approximately one-minute sample of the installed v0.2.39 app reproduced physical
+footprint changes from 186 to 416 MiB. Heap allocation stayed near 11 MiB; paired
+footprint reports attributed most of the difference to owned, unmapped graphics
+memory, about 11 versus 221 MiB. Most main-thread samples were asleep.
+
+That evidence does not show a 230 MiB Rust heap leak. Nor does it identify every
+driver/compositor allocation responsible for the changing charge. The drawable
+reduction lowers measured graphics memory, but does not establish that macOS will
+stop changing the app's reported footprint. Virtual address-space totals in a
+crash report are not physical memory usage.
+
+A later 65-second foreground sample of the candidate using the real synced profile
+averaged 1.40% CPU and stayed between 362 and 372 MiB. The earlier installed-build
+sample averaged 1.88% CPU, but its median footprint was lower (199 versus 371 MiB).
+These diagnostic samples were not a controlled pair with identical focus and
+graphics residency. They do not establish an across-the-board idle memory win.
+
+## Native measurements and validation
+
+M4 Pro, 24 GiB, macOS 26.0.1, 1320×880-point foreground window at 2× scale,
+50 additional idle conversations. Normal-rate values average two runs per build;
+the faster workload has one run per build. Binaries were built in release mode
+with symbols retained. No build or test ran alongside these measurements.
+
+| Streaming metric | v0.2.39 normal | Candidate normal | v0.2.39 fast | Candidate fast |
+| --- | ---: | ---: | ---: | ---: |
+| UI average CPU, % of one core | 18.24 | 16.91 | 19.04 | 18.29 |
+| Engine average CPU, % of one core | 0.61 | 0.61 | 0.87 | 0.88 |
+| UI peak physical footprint, MiB | 330.42 | 307.21 | 334.24 | 311.27 |
+| Engine peak physical footprint, MiB | 28.14 | 25.50 | 28.55 | 30.70 |
+| UI peak two-second CPU, % of one core | 20.79 | 18.81 | 19.89 | 19.00 |
+
+The normal-rate UI CPU reduction is about 7%; the faster workload's is about 4%.
+UI peak footprint falls about 23 MiB in each. Engine memory varies between runs;
+its faster-workload peak increased about 2 MiB. This is a modest resource gain
+alongside concrete stability fixes, not evidence of universal performance limits.
+The total app cost includes both processes. Their separate memory peaks need not
+occur at the same instant.
+
+All completed replies have identical hashes within each workload. The public
+[per-run summaries](performance/macos-stability.json) retain executable hashes,
+phase durations, both processes' measurements and reply hashes. Native replay
+results must not be extrapolated to every provider's chunking, cloud profile,
+background workload or long-running session.
+
+Validation also passed:
+
+- 32 sync, 129 engine and 596 UI library tests. Git fixture tests ran with global
+  URL rewrites disabled (`GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1`).
+- 208 GPUI and 18 macOS renderer library tests, including blur pixel checks.
+- Eight consecutive short replies and three consecutive long replies through
+  native composer input, without the reproduced abort or a stuck turn. These
+  functional runs overlapped compilation and are excluded from the resource table.
+- Eight cached-versus-fresh visual checks with 50 background conversations:
+  settled, sidebar hidden/restored, scrolled, selected, typed, model menu and menu
+  dismissed. The menu comparison excludes only its animated loading region.
+
+A live-provider check returned explicit authentication errors because the local
+Claude CLI needs sign-in again. It is excluded from successful-turn validation.
+The profiling driver now rejects error parts even when the containing transcript
+entry has settled to `complete`. A final focus-transition diagnostic lost
+foreground focus and was discarded, rather than counted as a resource result.
+
+## Reproduction
+
+Build with `cargo build --release --locked -p zeron`, and copy each binary to an
+immutable path before profiling. Use an unlocked, awake display with no concurrent
+build or test workload. The native helper sizes the foreground window to 1320×880
+points and rejects focus loss. Default dark appearance and animations are enabled.
+
+```sh
+CLAUDE_CODE_EXECUTABLE="$PWD/scripts/replay-claude.py" \
+ZERON_REPLAY_JOURNAL="$PWD/scripts/fixtures/resource-stream.jsonl" \
+ZERON_PROFILE_BACKGROUND_CHATS=50 ZERON_PROFILE_SUBMIT_UI=1 \
+ZERON_PROFILE_PROMPT='Replay fixture.' \
+node scripts/resource-profile.mjs /path/to/zeron /tmp/fresh-profile claude-code
+```
+
+The fixture emits 52,624 combined text/reasoning bytes with a 40 ms delta delay.
+For faster streaming, set `ZERON_REPLAY_REPEAT=4 ZERON_REPLAY_DELAY_MS=10`.
+For the crash regression, select `runway-short-stream.jsonl`, set the delay to
+400 ms and `ZERON_PROFILE_TURNS=8`. Submission uses actual native composer key
+events and verifies the exact prompt and successful completion of every turn.
+
+The profiler measures UI and engine separately, sampling native CPU time and
+physical footprint every 500 ms. CPU is percent of one core. Phase averages must
+not be compared directly with an instantaneous Activity Monitor peak. Replays use
+the real engine, RPC and CLI adapter, but make no model API calls and do not
+simulate every cloud/network failure.

--- a/docs/performance-macos.md
+++ b/docs/performance-macos.md
@@ -1,5 +1,10 @@
 # Native macOS resource follow-up
 
+For the subsequent v0.2.39 native scrolling crash, stuck-send recovery and
+populated-chat measurements, see the [stability follow-up](performance-macos-stability.md).
+The measurements below predate those regressions and do not establish stability
+for consecutive native composer sends.
+
 This follows PR #255 at `f10ef38c`. The app pins zui `0003b923`, which gates
 unnecessary main-queue frame callbacks and bounds native Metal blur resources.
 The Linux software-Vulkan results in [the earlier report](performance-resource-usage.md)

--- a/docs/performance/macos-stability.json
+++ b/docs/performance/macos-stability.json
@@ -1,0 +1,595 @@
+{
+  "baselineCommit": "d97f4c2ba2c6ff1595acd204f4a76082d1468794",
+  "rendererCommit": "36ca993fb5663ae496acd1d4d19f556d6350eae8",
+  "hardware": "M4 Pro, 24 GiB, Mac16,7",
+  "os": "macOS 26.0.1 (25A362)",
+  "windowPoints": [
+    1320,
+    880
+  ],
+  "scaleFactor": 2,
+  "runs": [
+    {
+      "binarySha256": "73ba5007ca9461d386e9b3fd10c4a13349efb5bb27ab3e05d8c8323315955434",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "darwin",
+      "arch": "arm64",
+      "renderThreads": "default",
+      "frameStats": "1",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 50,
+      "prompt": "Replay fixture.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 54829,
+      "frames": 151,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.018,
+          "engine": {
+            "peakFootprintMiB": 23.891518,
+            "endFootprintMiB": 23.891518,
+            "lifetimePeakFootprintMiB": 23.891518,
+            "peakRssMiB": 34.65625,
+            "endRssMiB": 34.4375,
+            "cpuPercent": 0.02931266356176531,
+            "peakTwoSecondCpuPercent": 0.08113568956994564
+          },
+          "ui": {
+            "peakFootprintMiB": 308.344757,
+            "endFootprintMiB": 303.329132,
+            "lifetimePeakFootprintMiB": 347.094757,
+            "peakRssMiB": 102.546875,
+            "endRssMiB": 102.546875,
+            "cpuPercent": 0.6622237081392764,
+            "peakTwoSecondCpuPercent": 1.0849148129675803
+          }
+        },
+        "stream": {
+          "durationSeconds": 19.549,
+          "engine": {
+            "peakFootprintMiB": 27.204018,
+            "endFootprintMiB": 27.204018,
+            "lifetimePeakFootprintMiB": 27.204018,
+            "peakRssMiB": 47.671875,
+            "endRssMiB": 47.671875,
+            "cpuPercent": 0.5998936416184972,
+            "peakTwoSecondCpuPercent": 1.2776613273453097
+          },
+          "ui": {
+            "peakFootprintMiB": 330.06353,
+            "endFootprintMiB": 330.047905,
+            "lifetimePeakFootprintMiB": 347.094757,
+            "peakRssMiB": 131.25,
+            "endRssMiB": 131.25,
+            "cpuPercent": 17.97159978515525,
+            "peakTwoSecondCpuPercent": 20.360686976047905
+          }
+        },
+        "settled": {
+          "durationSeconds": 14.552,
+          "engine": {
+            "peakFootprintMiB": 28.266518,
+            "endFootprintMiB": 28.266518,
+            "lifetimePeakFootprintMiB": 28.266518,
+            "peakRssMiB": 49.140625,
+            "endRssMiB": 45.375,
+            "cpuPercent": 0.06726910390324349,
+            "peakTwoSecondCpuPercent": 0.22880859413810167
+          },
+          "ui": {
+            "peakFootprintMiB": 330.813553,
+            "endFootprintMiB": 330.813553,
+            "lifetimePeakFootprintMiB": 347.094757,
+            "peakRssMiB": 132.171875,
+            "endRssMiB": 132.125,
+            "cpuPercent": 1.0732210349092899,
+            "peakTwoSecondCpuPercent": 1.7759559600997554
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.534,
+        "engine": {
+          "endFootprintMiB": 28.266518,
+          "endRssMiB": 45.375,
+          "cpuPercent": 0.048525445773022806
+        },
+        "ui": {
+          "endFootprintMiB": 330.813553,
+          "endRssMiB": 132.125,
+          "cpuPercent": 1.1330335221313192
+        }
+      },
+      "build": "v0.2.39",
+      "workload": "normal"
+    },
+    {
+      "binarySha256": "73ba5007ca9461d386e9b3fd10c4a13349efb5bb27ab3e05d8c8323315955434",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "darwin",
+      "arch": "arm64",
+      "renderThreads": "default",
+      "frameStats": "1",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 50,
+      "prompt": "Replay fixture.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 54829,
+      "frames": 151,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.036,
+          "engine": {
+            "peakFootprintMiB": 26.985291,
+            "endFootprintMiB": 25.063416,
+            "lifetimePeakFootprintMiB": 27.016541,
+            "peakRssMiB": 36.671875,
+            "endRssMiB": 25.34375,
+            "cpuPercent": 0.06182861885790172,
+            "peakTwoSecondCpuPercent": 0.11815149105367752
+          },
+          "ui": {
+            "peakFootprintMiB": 309.09478,
+            "endFootprintMiB": 304.09478,
+            "lifetimePeakFootprintMiB": 348.110382,
+            "peakRssMiB": 101.921875,
+            "endRssMiB": 92.4375,
+            "cpuPercent": 0.7121758410801244,
+            "peakTwoSecondCpuPercent": 1.1197100349475788
+          }
+        },
+        "stream": {
+          "durationSeconds": 19.533,
+          "engine": {
+            "peakFootprintMiB": 29.079041,
+            "endFootprintMiB": 29.079041,
+            "lifetimePeakFootprintMiB": 29.079041,
+            "peakRssMiB": 43.046875,
+            "endRssMiB": 43.046875,
+            "cpuPercent": 0.6173716684585061,
+            "peakTwoSecondCpuPercent": 1.3996370333499257
+          },
+          "ui": {
+            "peakFootprintMiB": 330.782303,
+            "endFootprintMiB": 330.782303,
+            "lifetimePeakFootprintMiB": 348.110382,
+            "peakRssMiB": 127.015625,
+            "endRssMiB": 127.015625,
+            "cpuPercent": 18.51762423590846,
+            "peakTwoSecondCpuPercent": 21.225371229467395
+          }
+        },
+        "settled": {
+          "durationSeconds": 14.531,
+          "engine": {
+            "peakFootprintMiB": 29.438416,
+            "endFootprintMiB": 29.438416,
+            "lifetimePeakFootprintMiB": 29.438416,
+            "peakRssMiB": 45.15625,
+            "endRssMiB": 45.125,
+            "cpuPercent": 0.08448231367421374,
+            "peakTwoSecondCpuPercent": 0.23202071892161663
+          },
+          "ui": {
+            "peakFootprintMiB": 331.501076,
+            "endFootprintMiB": 331.235451,
+            "lifetimePeakFootprintMiB": 348.110382,
+            "peakRssMiB": 128.25,
+            "endRssMiB": 127.375,
+            "cpuPercent": 0.9121765535751141,
+            "peakTwoSecondCpuPercent": 1.5138757242757408
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.517,
+        "engine": {
+          "endFootprintMiB": 29.438416,
+          "endRssMiB": 45.125,
+          "cpuPercent": 0.07467120941473163
+        },
+        "ui": {
+          "endFootprintMiB": 331.235451,
+          "endRssMiB": 127.375,
+          "cpuPercent": 1.068479205632023
+        }
+      },
+      "build": "v0.2.39",
+      "workload": "normal"
+    },
+    {
+      "binarySha256": "487e657b3154f30ee0cdb0078f55c80c2c51ce6dbc0e7fc1a02bae29bcabf0b4",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "darwin",
+      "arch": "arm64",
+      "renderThreads": "default",
+      "frameStats": "1",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 50,
+      "prompt": "Replay fixture.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 54829,
+      "frames": 151,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.042,
+          "engine": {
+            "peakFootprintMiB": 25.157143,
+            "endFootprintMiB": 23.922768,
+            "lifetimePeakFootprintMiB": 25.282143,
+            "peakRssMiB": 36.40625,
+            "endRssMiB": 30.21875,
+            "cpuPercent": 0.04794385091793855,
+            "peakTwoSecondCpuPercent": 0.09424374999999971
+          },
+          "ui": {
+            "peakFootprintMiB": 298.750984,
+            "endFootprintMiB": 298.704109,
+            "lifetimePeakFootprintMiB": 316.907234,
+            "peakRssMiB": 101.21875,
+            "endRssMiB": 101.109375,
+            "cpuPercent": 0.7073656270736565,
+            "peakTwoSecondCpuPercent": 1.035233682634732
+          }
+        },
+        "stream": {
+          "durationSeconds": 19.542,
+          "engine": {
+            "peakFootprintMiB": 24.625893,
+            "endFootprintMiB": 24.625893,
+            "lifetimePeakFootprintMiB": 25.563393,
+            "peakRssMiB": 41.15625,
+            "endRssMiB": 41.15625,
+            "cpuPercent": 0.607785794698598,
+            "peakTwoSecondCpuPercent": 1.3802348129675814
+          },
+          "ui": {
+            "peakFootprintMiB": 307.391678,
+            "endFootprintMiB": 307.391678,
+            "lifetimePeakFootprintMiB": 316.907234,
+            "peakRssMiB": 126.453125,
+            "endRssMiB": 126.453125,
+            "cpuPercent": 16.575827704431482,
+            "peakTwoSecondCpuPercent": 19.164050274314214
+          }
+        },
+        "settled": {
+          "durationSeconds": 14.533,
+          "engine": {
+            "peakFootprintMiB": 27.141518,
+            "endFootprintMiB": 27.141518,
+            "lifetimePeakFootprintMiB": 27.141518,
+            "peakRssMiB": 38.75,
+            "endRssMiB": 36.40625,
+            "cpuPercent": 0.06853941374802176,
+            "peakTwoSecondCpuPercent": 0.11828572003218009
+          },
+          "ui": {
+            "peakFootprintMiB": 310.610451,
+            "endFootprintMiB": 310.001076,
+            "lifetimePeakFootprintMiB": 316.907234,
+            "peakRssMiB": 123.625,
+            "endRssMiB": 122.046875,
+            "cpuPercent": 0.7882293745269376,
+            "peakTwoSecondCpuPercent": 0.986444339152122
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.528,
+        "engine": {
+          "endFootprintMiB": 27.141518,
+          "endRssMiB": 36.40625,
+          "cpuPercent": 0.04038666036943741
+        },
+        "ui": {
+          "endFootprintMiB": 310.001076,
+          "endRssMiB": 122.046875,
+          "cpuPercent": 0.8331636649874025
+        }
+      },
+      "build": "candidate",
+      "workload": "normal"
+    },
+    {
+      "binarySha256": "928ea3fabc5f3b127463aad7bb2a0c9a29684214a17e684357515d5138b12c19",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "darwin",
+      "arch": "arm64",
+      "renderThreads": "default",
+      "frameStats": "1",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 50,
+      "prompt": "Replay fixture.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 54829,
+      "frames": 151,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.034,
+          "engine": {
+            "peakFootprintMiB": 26.735291,
+            "endFootprintMiB": 26.641541,
+            "lifetimePeakFootprintMiB": 26.735291,
+            "peakRssMiB": 35.671875,
+            "endRssMiB": 29.796875,
+            "cpuPercent": 0.04198214522913438,
+            "peakTwoSecondCpuPercent": 0.08460233134920618
+          },
+          "ui": {
+            "peakFootprintMiB": 298.438484,
+            "endFootprintMiB": 298.360359,
+            "lifetimePeakFootprintMiB": 334.500984,
+            "peakRssMiB": 101.796875,
+            "endRssMiB": 101.625,
+            "cpuPercent": 0.5885137591321675,
+            "peakTwoSecondCpuPercent": 0.7755530439121748
+          }
+        },
+        "stream": {
+          "durationSeconds": 19.522,
+          "engine": {
+            "peakFootprintMiB": 26.375916,
+            "endFootprintMiB": 25.563416,
+            "lifetimePeakFootprintMiB": 26.735291,
+            "peakRssMiB": 42.09375,
+            "endRssMiB": 42.09375,
+            "cpuPercent": 0.6115696393812109,
+            "peakTwoSecondCpuPercent": 0.7596848530144491
+          },
+          "ui": {
+            "peakFootprintMiB": 307.03228,
+            "endFootprintMiB": 307.03228,
+            "lifetimePeakFootprintMiB": 334.500984,
+            "peakRssMiB": 129.8125,
+            "endRssMiB": 129.8125,
+            "cpuPercent": 17.240564281323635,
+            "peakTwoSecondCpuPercent": 18.463919380619377
+          }
+        },
+        "settled": {
+          "durationSeconds": 14.532,
+          "engine": {
+            "peakFootprintMiB": 27.688416,
+            "endFootprintMiB": 27.688416,
+            "lifetimePeakFootprintMiB": 27.688416,
+            "peakRssMiB": 45.65625,
+            "endRssMiB": 45.65625,
+            "cpuPercent": 0.07925755573905874,
+            "peakTwoSecondCpuPercent": 0.24826350947158565
+          },
+          "ui": {
+            "peakFootprintMiB": 307.969803,
+            "endFootprintMiB": 307.719803,
+            "lifetimePeakFootprintMiB": 334.500984,
+            "peakRssMiB": 131.125,
+            "endRssMiB": 131.125,
+            "cpuPercent": 1.0147608175061924,
+            "peakTwoSecondCpuPercent": 1.3899975087195087
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.518,
+        "engine": {
+          "endFootprintMiB": 27.688416,
+          "endRssMiB": 45.65625,
+          "cpuPercent": 0.06231306997268349
+        },
+        "ui": {
+          "endFootprintMiB": 307.719803,
+          "endRssMiB": 131.125,
+          "cpuPercent": 0.9589059361210388
+        }
+      },
+      "build": "candidate",
+      "workload": "normal"
+    },
+    {
+      "binarySha256": "73ba5007ca9461d386e9b3fd10c4a13349efb5bb27ab3e05d8c8323315955434",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "darwin",
+      "arch": "arm64",
+      "renderThreads": "default",
+      "frameStats": "1",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 50,
+      "prompt": "Replay fixture.",
+      "replySha256": "cb96ce276ed79aa8d791fc796f56ccf586b29e73d54acc911b42aacf30236f8f",
+      "replyBytes": 210502,
+      "transcriptBytes": 218149,
+      "frames": 179,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.037,
+          "engine": {
+            "peakFootprintMiB": 27.282143,
+            "endFootprintMiB": 26.141518,
+            "lifetimePeakFootprintMiB": 27.282143,
+            "peakRssMiB": 37.515625,
+            "endRssMiB": 30.140625,
+            "cpuPercent": 0.033253114971782724,
+            "peakTwoSecondCpuPercent": 0.08401776674938007
+          },
+          "ui": {
+            "peakFootprintMiB": 308.329132,
+            "endFootprintMiB": 303.141632,
+            "lifetimePeakFootprintMiB": 347.297882,
+            "peakRssMiB": 101.890625,
+            "endRssMiB": 101.890625,
+            "cpuPercent": 0.6946050569879382,
+            "peakTwoSecondCpuPercent": 1.143658715139442
+          }
+        },
+        "stream": {
+          "durationSeconds": 21.53,
+          "engine": {
+            "peakFootprintMiB": 28.547768,
+            "endFootprintMiB": 27.813393,
+            "lifetimePeakFootprintMiB": 28.625893,
+            "peakRssMiB": 55.609375,
+            "endRssMiB": 55.609375,
+            "cpuPercent": 0.8672586716209941,
+            "peakTwoSecondCpuPercent": 1.0480175736395412
+          },
+          "ui": {
+            "peakFootprintMiB": 334.235451,
+            "endFootprintMiB": 333.907326,
+            "lifetimePeakFootprintMiB": 347.297882,
+            "peakRssMiB": 136.8125,
+            "endRssMiB": 136.8125,
+            "cpuPercent": 19.03858298653042,
+            "peakTwoSecondCpuPercent": 19.890009195402314
+          }
+        },
+        "settled": {
+          "durationSeconds": 14.537,
+          "engine": {
+            "peakFootprintMiB": 30.360268,
+            "endFootprintMiB": 30.360268,
+            "lifetimePeakFootprintMiB": 30.360268,
+            "peakRssMiB": 59.578125,
+            "endRssMiB": 59.578125,
+            "cpuPercent": 0.06252694503680269,
+            "peakTwoSecondCpuPercent": 0.16479312063808554
+          },
+          "ui": {
+            "peakFootprintMiB": 334.579224,
+            "endFootprintMiB": 333.610474,
+            "lifetimePeakFootprintMiB": 347.297882,
+            "peakRssMiB": 137.78125,
+            "endRssMiB": 137.75,
+            "cpuPercent": 0.8881320079796334,
+            "peakTwoSecondCpuPercent": 1.2441201097804504
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.512,
+        "engine": {
+          "endFootprintMiB": 30.360268,
+          "endRssMiB": 59.578125,
+          "cpuPercent": 0.056135229184188194
+        },
+        "ui": {
+          "endFootprintMiB": 333.610474,
+          "endRssMiB": 137.75,
+          "cpuPercent": 0.8541552775441511
+        }
+      },
+      "build": "v0.2.39",
+      "workload": "fast"
+    },
+    {
+      "binarySha256": "928ea3fabc5f3b127463aad7bb2a0c9a29684214a17e684357515d5138b12c19",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "darwin",
+      "arch": "arm64",
+      "renderThreads": "default",
+      "frameStats": "1",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 50,
+      "prompt": "Replay fixture.",
+      "replySha256": "cb96ce276ed79aa8d791fc796f56ccf586b29e73d54acc911b42aacf30236f8f",
+      "replyBytes": 210502,
+      "transcriptBytes": 218149,
+      "frames": 178,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.032,
+          "engine": {
+            "peakFootprintMiB": 20.688416,
+            "endFootprintMiB": 20.250916,
+            "lifetimePeakFootprintMiB": 24.688416,
+            "peakRssMiB": 35.859375,
+            "endRssMiB": 29.71875,
+            "cpuPercent": 0.0463181908768822,
+            "peakTwoSecondCpuPercent": 0.09264584999999978
+          },
+          "ui": {
+            "peakFootprintMiB": 298.844757,
+            "endFootprintMiB": 298.813507,
+            "lifetimePeakFootprintMiB": 317.016632,
+            "peakRssMiB": 102.28125,
+            "endRssMiB": 102.109375,
+            "cpuPercent": 0.6225102413640394,
+            "peakTwoSecondCpuPercent": 1.2295922161626178
+          }
+        },
+        "stream": {
+          "durationSeconds": 21.542,
+          "engine": {
+            "peakFootprintMiB": 30.704041,
+            "endFootprintMiB": 28.266541,
+            "lifetimePeakFootprintMiB": 31.063416,
+            "peakRssMiB": 51.390625,
+            "endRssMiB": 51.390625,
+            "cpuPercent": 0.8754622736978922,
+            "peakTwoSecondCpuPercent": 0.9855405797101447
+          },
+          "ui": {
+            "peakFootprintMiB": 311.266701,
+            "endFootprintMiB": 311.126076,
+            "lifetimePeakFootprintMiB": 317.016632,
+            "peakRssMiB": 136.875,
+            "endRssMiB": 136.875,
+            "cpuPercent": 18.287930168972238,
+            "peakTwoSecondCpuPercent": 18.998321730482335
+          }
+        },
+        "settled": {
+          "durationSeconds": 14.543,
+          "engine": {
+            "peakFootprintMiB": 31.329041,
+            "endFootprintMiB": 31.329041,
+            "lifetimePeakFootprintMiB": 31.329041,
+            "peakRssMiB": 55.515625,
+            "endRssMiB": 55.515625,
+            "cpuPercent": 0.0815469641752046,
+            "peakTwoSecondCpuPercent": 0.20040773839241202
+          },
+          "ui": {
+            "peakFootprintMiB": 312.376099,
+            "endFootprintMiB": 312.219849,
+            "lifetimePeakFootprintMiB": 317.016632,
+            "peakRssMiB": 138.40625,
+            "endRssMiB": 138.40625,
+            "cpuPercent": 0.9328388228013466,
+            "peakTwoSecondCpuPercent": 1.245192307692305
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.527,
+        "engine": {
+          "endFootprintMiB": 31.329041,
+          "endRssMiB": 55.515625,
+          "cpuPercent": 0.07708355201007644
+        },
+        "ui": {
+          "endFootprintMiB": 312.219849,
+          "endRssMiB": 138.40625,
+          "cpuPercent": 0.8596191455862252
+        }
+      },
+      "build": "candidate",
+      "workload": "fast"
+    }
+  ]
+}

--- a/scripts/macos-profile-window.swift
+++ b/scripts/macos-profile-window.swift
@@ -18,6 +18,40 @@ if CGDisplayIsAsleep(CGMainDisplayID()) != 0 {
 if CommandLine.arguments.count == 1 { exit(0) }
 guard let pid = Int32(CommandLine.arguments[1]),
       let app = NSRunningApplication(processIdentifier: pid) else { fail("Missing app process") }
+if CommandLine.arguments.dropFirst(2).first == "--submit" {
+    guard CommandLine.arguments.count == 4,
+          let prompt = try? String(contentsOfFile: CommandLine.arguments[3], encoding: .utf8),
+          AXIsProcessTrusted(), app.isActive else {
+        fail("Composer submission requires a prompt file and the focused profiled app")
+    }
+    // Target this process explicitly and retain the foreground guard for
+    // every event. Unicode key events leave the user's clipboard untouched.
+    for character in prompt {
+        guard app.isActive else { fail("App lost focus during composer submission") }
+        let units = Array(String(character).utf16)
+        guard let down = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+              let up = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) else {
+            fail("Could not create composer input event")
+        }
+        down.flags = []
+        up.flags = []
+        down.keyboardSetUnicodeString(stringLength: units.count, unicodeString: units)
+        up.keyboardSetUnicodeString(stringLength: units.count, unicodeString: units)
+        down.postToPid(pid)
+        up.postToPid(pid)
+        Thread.sleep(forTimeInterval: 0.015)
+    }
+    guard app.isActive else { fail("App lost focus before submitting") }
+    Thread.sleep(forTimeInterval: 0.05)
+    for pressed in [true, false] {
+        guard let event = CGEvent(keyboardEventSource: nil, virtualKey: 36, keyDown: pressed) else {
+            fail("Could not create submit event")
+        }
+        event.flags = []
+        event.postToPid(pid)
+    }
+    exit(0)
+}
 if CommandLine.arguments.dropFirst(2).first == "--check" {
     guard app.isActive else { fail("Profiled app is no longer foreground; discard this run") }
     let rows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] ?? []

--- a/scripts/replay-claude.py
+++ b/scripts/replay-claude.py
@@ -22,10 +22,6 @@ if not any(e["type"] == "done" and e["status"] == "completed" for e in events):
     raise ValueError("Replay requires a successfully completed journal")
 if any(e["type"] in ("toolCall", "toolResult", "subagent", "error") for e in events):
     raise ValueError("Only text/reasoning journals are supported")
-if not sys.stdin.readline():
-    sys.exit(1)
-
-
 def emit(frame):
     print(json.dumps(frame), flush=True)
 
@@ -36,19 +32,21 @@ delay = float(os.environ.get("ZERON_REPLAY_DELAY_MS", "40")) / 1000
 repeats = int(os.environ.get("ZERON_REPLAY_REPEAT", "1"))
 if repeats < 1:
     raise ValueError("ZERON_REPLAY_REPEAT must be positive")
-for _ in range(repeats):
-    for event in events:
-        kind = event["type"]
-        if kind not in ("textDelta", "reasoningDelta"):
-            continue
-        text = event["text"]
-        delta = {"type": "text_delta", "text": text} if kind == "textDelta" else {
-            "type": "thinking_delta", "thinking": text}
-        emit({"type": "stream_event", "parent_tool_use_id": None,
-              "event": {"type": "content_block_delta", "delta": delta}})
-        time.sleep(delay)
-emit({"type": "result", "subtype": "success", "is_error": False,
-      "session_id": "resource-profile-replay", "result": ""})
-# Match the live CLI's persistent stdin lifecycle until the engine retires it.
-for _ in sys.stdin:
-    pass
+# The adapter keeps one CLI alive across turns. Replay each prompt so native
+# composer tests can exercise sends into an already populated transcript.
+for request in sys.stdin:
+    if not request.strip():
+        continue
+    for _ in range(repeats):
+        for event in events:
+            kind = event["type"]
+            if kind not in ("textDelta", "reasoningDelta"):
+                continue
+            text = event["text"]
+            delta = {"type": "text_delta", "text": text} if kind == "textDelta" else {
+                "type": "thinking_delta", "thinking": text}
+            emit({"type": "stream_event", "parent_tool_use_id": None,
+                  "event": {"type": "content_block_delta", "delta": delta}})
+            time.sleep(delay)
+    emit({"type": "result", "subtype": "success", "is_error": False,
+          "session_id": "resource-profile-replay", "result": ""})

--- a/scripts/resource-profile.mjs
+++ b/scripts/resource-profile.mjs
@@ -14,8 +14,6 @@ import { fileURLToPath } from 'node:url';
 
 const macOS = process.platform === 'darwin';
 const nativeWindowSource = fileURLToPath(new URL('./macos-profile-window.swift', import.meta.url));
-if (macOS && process.env.ZERON_PROFILE_SUBMIT_UI === '1')
-  throw Error('Composer submission profiling currently requires Linux/X11; use RPC submission on macOS');
 if (macOS) execFileSync('swift', [nativeWindowSource]);
 
 const [binaryArg, outputArg, harness = 'claude-code'] = process.argv.slice(2);
@@ -151,6 +149,13 @@ try {
   await call('Mutate', { op: 'createChat', chatId, spaceId,
     config: { harness, model: harness === 'mock' ? 'fable-5' : 'claude-haiku-4-5', reasoning: null, sandbox: 'workspace-write' } });
   await call('Mutate', { op: 'renameChat', chatId, title: 'Resource profile' });
+  const backgroundChats = Number(process.env.ZERON_PROFILE_BACKGROUND_CHATS ?? 0);
+  if (!Number.isSafeInteger(backgroundChats) || backgroundChats < 0) throw Error('Invalid background chat count');
+  for (let index = 0; index < backgroundChats; index++) {
+    const backgroundId = randomUUID();
+    await call('Mutate', { op: 'createChat', chatId: backgroundId, spaceId });
+    await call('Mutate', { op: 'renameChat', chatId: backgroundId, title: `Background conversation ${index + 1}` });
+  }
   pending.set(++id, { reject: e => { streamError = e; }, item: frame => {
     // apply() reuses reset/upsert objects as the mutable transcript. Capture
     // first so later append frames cannot rewrite earlier replay records.
@@ -191,31 +196,51 @@ try {
   phase = 'stream';
   const prompt = process.env.ZERON_PROFILE_PROMPT ??
     'Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.';
-  if (process.env.ZERON_PROFILE_SUBMIT_UI === '1') {
-    // Functional mode exercises the composer's own-turn scroll anchoring.
-    // Use a dedicated display; the driver focused the app's composer above.
-    execFileSync('xdotool', ['type', '--clearmodifiers', '--delay', '0', '--', prompt]);
-    execFileSync('xdotool', ['key', 'Return']);
-  } else {
-    await call('QueueCommand', { chatId, command: { kind: 'run', messageId: randomUUID(), request: {
-      prompt, model: harness === 'mock' ? null : 'haiku', reasoning: null, modelOptions: {}, cwd,
-      sandbox: 'workspace-write', autoApprove: true, resume: null,
-    } } });
-  }
-  const timeoutMs = Number(process.env.ZERON_PROFILE_TIMEOUT_MS ?? 240000);
-  const deadline = Date.now() + timeoutMs;
-  let complete = false;
-  while (Date.now() < deadline) {
-    await sleep(500);
-    if (streamError) throw streamError;
-    const assistants = transcript.filter(e => e.role === 'assistant');
-    if (assistants.length && assistants.at(-1).status !== 'streaming') {
-      if (assistants.at(-1).status !== 'complete') throw Error('Harness turn did not complete successfully');
-      complete = true; break;
+  const turns = Number(process.env.ZERON_PROFILE_TURNS ?? 1);
+  if (!Number.isSafeInteger(turns) || turns < 1) throw Error('ZERON_PROFILE_TURNS must be a positive integer');
+  for (let turn = 0; turn < turns; turn++) {
+    const priorAssistants = new Set(transcript.filter(e => e.role === 'assistant').map(e => e.id));
+    if (process.env.ZERON_PROFILE_SUBMIT_UI === '1') {
+      // Functional mode exercises the composer's own-turn scroll anchoring.
+      // Use a dedicated display; the driver focused the app's composer above.
+      if (macOS) {
+        const promptFile = `${output}/prompt.txt`;
+        writeFileSync(promptFile, prompt);
+        execFileSync(nativeWindow, [String(ui.pid), '--submit', promptFile]);
+      } else {
+        execFileSync('xdotool', ['type', '--clearmodifiers', '--delay', '0', '--', prompt]);
+        execFileSync('xdotool', ['key', 'Return']);
+      }
+    } else {
+      await call('QueueCommand', { chatId, command: { kind: 'run', messageId: randomUUID(), request: {
+        prompt, model: harness === 'mock' ? null : 'haiku', reasoning: null, modelOptions: {}, cwd,
+        sandbox: 'workspace-write', autoApprove: true, resume: null,
+      } } });
     }
-    if (ui.exitCode != null || engine.exitCode != null) throw Error('Profiled process exited');
+    const timeoutMs = Number(process.env.ZERON_PROFILE_TIMEOUT_MS ?? 240000);
+    const deadline = Date.now() + timeoutMs;
+    let complete = false;
+    while (Date.now() < deadline) {
+      await sleep(500);
+      if (streamError) throw streamError;
+      const assistants = transcript.filter(e => e.role === 'assistant' && !priorAssistants.has(e.id));
+      if (assistants.length && assistants.at(-1).status !== 'streaming') {
+        if (assistants.at(-1).status !== 'complete') throw Error('Harness turn did not complete successfully');
+        if (assistants.some(e => e.parts.some(p => p.kind === 'error'))) {
+          throw Error('Harness turn returned an error part');
+        }
+        complete = true; break;
+      }
+      if (ui.exitCode != null || engine.exitCode != null) throw Error('Profiled process exited');
+    }
+    if (!complete) throw Error(`Turn did not complete within ${timeoutMs / 1000} seconds`);
+    if (process.env.ZERON_PROFILE_SUBMIT_UI === '1') {
+      const sent = transcript.filter(e => e.role === 'user').at(-1)?.parts
+        .filter(p => p.kind === 'text').map(p => p.text).join('');
+      if (sent !== prompt) throw Error('Composer input did not submit the exact requested prompt');
+    }
+    if (turn + 1 < turns) await sleep(500);
   }
-  if (!complete) throw Error(`Turn did not complete within ${timeoutMs / 1000} seconds`);
   phase = 'settled';
   await sleep(Number(process.env.ZERON_PROFILE_IDLE_MS ?? 15000));
   if (streamError) throw streamError;
@@ -225,7 +250,7 @@ try {
   const summary = { binary, binarySha256, harness, mode: process.env.ZERON_REPLAY_JOURNAL ? 'replay' : 'live',
     platform: process.platform, arch: process.arch,
     renderThreads: process.env.LP_NUM_THREADS ?? 'default', frameStats: env.ZERON_FRAME_STATS,
-    submission: process.env.ZERON_PROFILE_SUBMIT_UI === '1' ? 'composer' : 'rpc', prompt,
+    submission: process.env.ZERON_PROFILE_SUBMIT_UI === '1' ? 'composer' : 'rpc', turns, backgroundChats, prompt,
     replySha256: createHash('sha256').update(reply).digest('hex'), replyBytes: Buffer.byteLength(reply),
     transcriptBytes: Buffer.byteLength(JSON.stringify(transcript)), frames: frames.length, phases: {} };
   for (const p of ['idle', 'stream', 'settled']) {


### PR DESCRIPTION
Consecutive native composer sends in v0.2.39 can abort in `ListState::scroll_by` while a prompt has a negative item offset. Pin the renderer fix that chooses its tree seek from the target position, and retain panic locations/backtraces in the existing app log.

Repair another stuck-send failure mode: CRDT rows parked on missing causal history must not advance a persisted cursor. Re-fetch the checkpoint and replay all required rows with bounded reconnect backoff, protect overlapping repair attempts, reject incomplete checkpoints, and cross contained checkpoint prefixes correctly in the HTTP fallback.

Reduce redundant workspace notifications and isolate text append/loader/sidebar-row rendering. The renderer uses two Metal drawables. Animation timelines, resolution and blur passes are unchanged.

Native M4 Pro measurements, 50 background conversations, actual composer submission:

| Streaming UI metric | v0.2.39 | Candidate |
| --- | ---: | ---: |
| Normal-rate average CPU, two runs/build | 18.24% | 16.91% |
| Normal-rate peak physical footprint | 330.42 MiB | 307.21 MiB |
| Faster-stream average CPU, one run/build | 19.04% | 18.29% |
| Faster-stream peak physical footprint | 334.24 MiB | 311.27 MiB |

CPU gains are modest (about 4–7%). Engine CPU remained about the same; the report includes both processes and per-run summaries. A real-profile idle sample stayed around 362–372 MiB at 1.40% average CPU. The earlier installed-build sample swung between 186–416 MiB and had a lower median, so this does not establish universally lower idle memory. Most of the observed swing was charged graphics memory while heap allocation stayed near 11 MiB.

Validation: 32 sync + 129 engine + 596 UI tests, and 208 GPUI + 18 macOS renderer tests pass. Eight consecutive short and three consecutive long native composer replies completed without the reproduced abort or stuck turn. Eight cached/fresh interaction and pixel checks passed. Matched buffer-count instrumentation retained the render cadence and kept steady acquisition+encoding p95 below 3 ms. A live-provider check returned explicit expired-authentication errors and is excluded from successful streaming validation; the driver now rejects settled error parts.

Full methods, limitations, hashes and results: [report](docs/performance-macos-stability.md), [per-run data](docs/performance/macos-stability.json). Renderer commit: https://github.com/zeronsh/zui/commit/36ca993fb5663ae496acd1d4d19f556d6350eae8.

This follows the already-merged performance and runway PRs. The installed app bundle has not been replaced and this change has not been released.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791237640&installation_model_id=425430&pr_number=259&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F259&signature=35c462efa6b8a6b16cba60a0f43ee4156f0126d119b40865726db361fb32cb98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->