### PR TITLE
Fix sidebar row sizing regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "zeron"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "clap",
@@ -9443,7 +9443,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-doc"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "chrono",
  "loro",
@@ -9457,7 +9457,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-engine"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9493,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-harness"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-proto"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "chrono",
  "serde",
@@ -9524,7 +9524,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-rpc"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9543,7 +9543,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-sync"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -9566,7 +9566,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-syntax"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "thiserror 2.0.20",
  "tree-sitter",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-theme"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "clap",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-ui"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-update"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.40"
+version = "0.2.41"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/crates/ui/examples/macos-resource-profile.rs
+++ b/crates/ui/examples/macos-resource-profile.rs
@@ -87,6 +87,25 @@ fn main() -> anyhow::Result<()> {
                     chat.title = Some(format!("Background conversation {}", index + 1));
                     state.chats.push(chat);
                 }
+                if std::env::var_os("ZERON_VERIFY_SIDEBAR_ROWS").is_some() {
+                    state.chats[0].title = Some("Short".into());
+                    state.chats[0].branch = Some("main".into());
+                    for (index, chat) in state.chats.iter_mut().skip(1).enumerate() {
+                        chat.title = Some(if index == 0 { "Brief".into() } else {
+                            "A deliberately long conversation title that must truncate inside the sidebar".into()
+                        });
+                        chat.branch = Some(if index == 0 { "main".into() } else {
+                            "feature/a-deliberately-long-branch-name-that-must-also-truncate".into()
+                        });
+                    }
+                    for chat in &mut state.chats {
+                        chat.source_context = Some(zeron_proto::ConversationSourceContext {
+                            checkout_id: "layout-checkout".into(), repo_root: "/tmp/resource-profile".into(),
+                            cwd: "/tmp/resource-profile".into(), branch: chat.branch.clone().unwrap(),
+                            head_sha: None, observed_at: chrono::Utc::now(),
+                        });
+                    }
+                }
                 state
             });
             let boot = EngineBootConfig { data_dir:data, ipc_port:0,
@@ -184,6 +203,9 @@ fn main() -> anyhow::Result<()> {
     // measured phases; screenshot readback and forced refreshes add work.
     if std::env::var_os("ZERON_VERIFY_CACHE").is_some() {
         let mut scenarios = vec!["settled", "sidebar-hidden", "sidebar-restored", "scrolled"];
+        if std::env::var_os("ZERON_VERIFY_SIDEBAR_ROWS").is_some() {
+            scenarios.extend(["sidebar-hover-short", "sidebar-hover-long"]);
+        }
         // These hit coordinates target the bundled 80-section fixture. General
         // frame replays can still use the cache checks above on their own.
         if std::env::var_os("ZERON_VERIFY_INTERACTIONS").is_some() {
@@ -225,6 +247,12 @@ fn main() -> anyhow::Result<()> {
                             assert!(markdown::selection::selected_text().is_some_and(|text| text.len() > 20),
                                 "The fixed 80-section fixture must support dragging across text after scene reuse");
                         }
+                        "sidebar-hover-short" | "sidebar-hover-long" => {
+                            window.dispatch_event(gpui::PlatformInput::MouseMove(gpui::MouseMoveEvent {
+                                position: gpui::point(px(100.), px(if scenario == "sidebar-hover-short" { 115. } else { 180. })),
+                                ..Default::default()
+                            }), cx);
+                        }
                         "typed" => {
                             click(window, cx, 550., 839.);
                             for key in ["c", "a", "c", "h", "e", "space", "c", "h", "e", "c", "k"] {
@@ -263,6 +291,27 @@ fn main() -> anyhow::Result<()> {
             });
             cached.save(output.join(format!("{scenario}-cached.png")))?;
             fresh.save(output.join(format!("{scenario}-fresh.png")))?;
+            if std::env::var_os("ZERON_VERIFY_SIDEBAR_ROWS").is_some()
+                && scenario != "sidebar-hidden"
+            {
+                // This fixture uses a 256-point sidebar at 2x scale. Check
+                // actual geometry, not just equality with another render of
+                // the same potentially broken layout. Text must leave the
+                // right padding clear and selected/hovered fills must span it.
+                let mut painted = 0;
+                for y in 180..800 {
+                    let left = cached.get_pixel(20, y).0;
+                    if left[0] >= 30 && left[0] <= 60
+                        && left[0] == left[1] && left[1] == left[2]
+                    {
+                        anyhow::ensure!(cached.get_pixel(491, y).0 == left,
+                            "Sidebar row does not fill its width at y={y}: {scenario}");
+                        painted += 1;
+                    }
+                }
+                anyhow::ensure!(painted > 40, "Selected sidebar row missing: {scenario}");
+                eprintln!("sidebar row widths match: {scenario}");
+            }
             if scenario == "model-menu" {
                 // With no engine catalog the menu animates its loading bars.
                 // Their phase advances between readbacks; compare the rest of

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -999,94 +999,6 @@ impl Render for SidebarPane {
     }
 }
 
-#[derive(Clone, PartialEq)]
-struct ChatRowProps {
-    id: String,
-    title: SharedString,
-    time_ago: SharedString,
-    space_name: SharedString,
-    branch: Option<SharedString>,
-    change_request: Option<zeron_proto::ChangeRequestSummary>,
-    harness: Option<zeron_proto::HarnessId>,
-    status: zeron_proto::ChatIndicator,
-    selected: bool,
-    archived: bool,
-    jump_label: Option<SharedString>,
-}
-
-#[derive(IntoElement)]
-struct CachedChatRow {
-    shell: gpui::WeakEntity<Shell>,
-    props: ChatRowProps,
-}
-
-impl gpui::RenderOnce for CachedChatRow {
-    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let height = chat_row_height(
-            self.props.branch.is_some(),
-            self.props.change_request.is_some(),
-        );
-        let key: SharedString = format!("sidebar-row-{}", self.props.id).into();
-        let view = window.with_global_id(key.into(), |id, window| {
-            window.with_element_state(id, |previous: Option<Entity<ChatRowView>>, _| {
-                let view = previous.unwrap_or_else(|| {
-                    cx.new(|cx| ChatRowView {
-                        shell: self.shell.clone(),
-                        props: self.props.clone(),
-                        _shell_changes: self
-                            .shell
-                            .upgrade()
-                            .map(|shell| cx.observe(&shell, |_, _, cx| cx.notify())),
-                    })
-                });
-                view.update(cx, |view, cx| {
-                    if view.props != self.props {
-                        view.props = self.props;
-                        cx.notify();
-                    }
-                });
-                (view.clone(), view)
-            })
-        });
-        view.cached(gpui::StyleRefinement::default().w_full().h(px(height)))
-    }
-}
-
-struct ChatRowView {
-    shell: gpui::WeakEntity<Shell>,
-    props: ChatRowProps,
-    _shell_changes: Option<Subscription>,
-}
-
-impl Render for ChatRowView {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let Some(shell) = self.shell.upgrade() else {
-            return div().into_any_element();
-        };
-        let props = self.props.clone();
-        let animation_view = cx.entity_id();
-        shell.update(cx, |shell, cx| {
-            let theme = Theme::of(cx).clone();
-            shell.render_chat_row_inner(
-                props.id,
-                props.title,
-                props.time_ago,
-                props.space_name,
-                props.branch,
-                props.change_request,
-                props.harness,
-                props.status,
-                props.selected,
-                props.archived,
-                props.jump_label,
-                animation_view,
-                &theme,
-                cx,
-            )
-        })
-    }
-}
-
 pub struct Shell {
     state: Entity<AppState>,
     sidebar_pane: Entity<SidebarPane>,
@@ -3953,47 +3865,6 @@ impl Shell {
         // nine chips appear together instead of leaving a hole on whichever
         // row is busy or under the pointer.
         jump_label: Option<SharedString>,
-        _theme: &Theme,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
-        CachedChatRow {
-            shell: cx.weak_entity(),
-            props: ChatRowProps {
-                id,
-                title,
-                time_ago,
-                space_name,
-                branch,
-                change_request,
-                harness,
-                status,
-                selected,
-                archived,
-                jump_label,
-            },
-        }
-        .into_any_element()
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn render_chat_row_inner(
-        &self,
-        id: String,
-        title: SharedString,
-        time_ago: SharedString,
-        space_name: SharedString,
-        branch: Option<SharedString>,
-        change_request: Option<zeron_proto::ChangeRequestSummary>,
-        harness: Option<zeron_proto::HarnessId>,
-        status: zeron_proto::ChatIndicator,
-        selected: bool,
-        archived: bool,
-        // This row's jump combo while the hint overlay is up. It takes the
-        // corner outright — above hover and above the status word — so all
-        // nine chips appear together instead of leaving a hole on whichever
-        // row is busy or under the pointer.
-        jump_label: Option<SharedString>,
-        animation_view: gpui::EntityId,
         theme: &Theme,
         cx: &mut Context<Self>,
     ) -> AnyElement {
@@ -4120,7 +3991,7 @@ impl Shell {
                             format!("chat-working-{id}"),
                             2.0,
                             theme.glyph,
-                            animation_view,
+                            self.sidebar_pane.entity_id(),
                             cx,
                         )
                         .into_any_element()

--- a/docs/performance-macos-stability.md
+++ b/docs/performance-macos-stability.md
@@ -1,5 +1,12 @@
 # macOS streaming stability follow-up
 
+v0.2.41 removes the sidebar conversation-row cache introduced here because it
+broke row widths and text truncation. The measurements below describe v0.2.40;
+they are not performance claims for the hotfix. The crash, sync-recovery and
+Metal drawable fixes remain. The earlier cached/fresh pixel checks did not catch
+the incorrect geometry shared by both renders; sidebar layout checks now include
+short and long titles/branches with selected and hovered rows.
+
 This follow-up starts from v0.2.39 (`d97f4c2`). It fixes a reproduced native
 scrolling abort and recovery defects found while investigating stuck sends.
 It also reduces redundant UI work and the Metal window drawable pool. Animation


### PR DESCRIPTION
Restore the sidebar layout after v0.2.40: short conversation rows fill the sidebar again, and long titles and branch names truncate within their rows.

Remove the conversation-row cache and restore the previous renderer. Keep the streaming crash, sync recovery and Metal drawable fixes. Some sidebar CPU savings are rolled back to restore correct behavior; the earlier performance numbers are explicitly scoped to v0.2.40.

Validation:
- 596 UI tests pass.
- Release-mode sidebar fixture covers short/long titles and branches, selection, hover, scrolling, and hide/restore.
- Geometry assertions check selected/hovered row widths independently of cached/fresh render equality.

Bump the workspace to v0.2.41 for the hotfix release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791240246&installation_model_id=425430&pr_number=260&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F260&signature=f3f2bc344553e2778a196c4186998ed591749565109f29ddcbd62f7c061466db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->