### PR TITLE
Fix runway sizing and restore smooth streaming follow

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,46 @@
+name: UI tests
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'crates/**'
+      - '.github/workflows/ui-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'crates/**'
+      - '.github/workflows/ui-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ui-tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: GPUI system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
+            libx11-dev libxcb1-dev libx11-xcb-dev \
+            libfontconfig1-dev libfreetype-dev libasound2-dev \
+            libvulkan-dev pkg-config cmake
+      - name: Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+      - uses: Swatinem/rust-cache@v2
+      - name: UI and headless layout regressions
+        run: cargo test --release --locked -p zeron-ui --lib -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2765,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "schemars",
  "serde",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "anyhow",
  "log",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2820,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2849,7 +2849,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3108,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4160,7 +4160,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4975,7 +4975,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "collections",
  "serde",
@@ -5889,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "derive_refineable",
 ]
@@ -6192,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6805,7 +6805,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -7988,7 +7988,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "perf",
  "quote",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9720,7 +9720,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=36ca993fb5663ae496acd1d4d19f556d6350eae8#36ca993fb5663ae496acd1d4d19f556d6350eae8"
+source = "git+https://github.com/zeronsh/zui?rev=8425850325268f7a33e6c8493145f477252616f0#8425850325268f7a33e6c8493145f477252616f0"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "zeron"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -9443,7 +9443,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-doc"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "chrono",
  "loro",
@@ -9457,7 +9457,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-engine"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9493,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-harness"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-proto"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "chrono",
  "serde",
@@ -9524,7 +9524,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-rpc"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9543,7 +9543,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-sync"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -9566,7 +9566,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-syntax"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "thiserror 2.0.20",
  "tree-sitter",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-theme"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-ui"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-update"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,14 +61,14 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/zeronsh/zui", rev = "36ca993fb5663ae496acd1d4d19f556d6350eae8" }
-gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "36ca993fb5663ae496acd1d4d19f556d6350eae8", features = [
+gpui = { git = "https://github.com/zeronsh/zui", rev = "8425850325268f7a33e6c8493145f477252616f0" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "8425850325268f7a33e6c8493145f477252616f0", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "36ca993fb5663ae496acd1d4d19f556d6350eae8" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "8425850325268f7a33e6c8493145f477252616f0" }
 
 # diffs
 similar = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.41"
+version = "0.2.42"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -194,12 +194,6 @@ const OWN_SEND_GLIDE_RETAIN: f32 = 0.85;
 /// The entry glide snaps to the absolute hold within this error.
 const OWN_SEND_GLIDE_SNAP_PX: f32 = 1.0;
 
-/// Minimum tail-row height after the preceding turn rows consume part of
-/// the viewport. This includes the tail's content and bottom chrome.
-fn own_turn_reservation(usable: f32, prefix_height: f32) -> f32 {
-    (usable - prefix_height).max(0.0)
-}
-
 /// A bounds-free guard for gliding through rows whose heights are still
 /// being measured. The provisional reservation is never a scroll target.
 fn own_turn_glide_crossed(offset: ListOffset, anchor_ix: usize, inset: f32) -> bool {
@@ -2021,8 +2015,6 @@ struct UserCollapseScroll {
 struct OwnTurnAnchor {
     chat_id: String,
     message_id: SharedString,
-    /// Minimum total height of the last row, including bottom clearance.
-    tail_min_height: f32,
     /// The step still owns the viewport (glide → hold). Any wheel/touch
     /// input releases it — the reservation stays behind as plain scrollable
     /// space, and the ordinary escape/restick rules apply from then on.
@@ -2983,14 +2975,9 @@ impl Transcript {
             .rows
             .iter()
             .position(|row| row.turn_start && row.entry_id == message_id.as_str());
-        let tail_min_height = (f32::from(self.list.viewport_bounds().size.height)
-            - Self::own_send_inset(prompt_ix.unwrap_or(self.rows.len()))
-            + OWN_SEND_SCROLL_SLACK_PX)
-            .max(0.0);
         self.own_turn = Some(OwnTurnAnchor {
             chat_id,
             message_id: SharedString::from(message_id),
-            tail_min_height,
             held: true,
             positioned: false,
             seen_prompt: prompt_ix.is_some(),
@@ -3087,8 +3074,33 @@ impl Transcript {
         self.viewport_finalize_pending = true;
     }
 
-    /// Refine the last row's minimum height, then advance the prompt glide.
-    /// Content changes within that row are absorbed during layout itself.
+    /// Install the reservation before list layout. Its height follows the
+    /// current viewport in that same pass, including window resizes.
+    fn update_runway_minimum(&mut self) {
+        if let Some(ix) = self.own_turn_anchor_ix() {
+            self.list.set_tail_reservation(Some((
+                ix,
+                px(Self::own_send_inset(ix) - OWN_SEND_SCROLL_SLACK_PX),
+            )));
+        } else if self.own_turn.is_none() {
+            self.list.set_tail_reservation(None);
+        }
+    }
+
+    fn scroll_own_turn_by(&self, delta: f32) {
+        let offset = self.list.logical_scroll_top();
+        if offset.item_ix == 0 && offset.offset_in_item < px(0.0) {
+            self.list.scroll_to(ListOffset {
+                item_ix: 0,
+                offset_in_item: offset.offset_in_item + px(delta),
+            });
+        } else {
+            self.list.scroll_by(px(delta));
+        }
+    }
+
+    /// Advance the prompt glide or hand a filled reservation to tail-follow.
+    /// Reservation sizing happens in the list layout, never in this callback.
     fn step_own_turn(&mut self, cx: &mut Context<Self>) {
         self.own_turn_kick = false;
         // Layout moves the bottom too (pad refinement, streaming growth):
@@ -3112,84 +3124,24 @@ impl Transcript {
             cx.notify();
             return;
         }
-        let Some(last_ix) = self.rows.len().checked_sub(1) else {
-            return;
-        };
         let inset = Self::own_send_inset(anchor_ix);
         if self.is_glued() {
             self.list.scroll_by(px(-viewport_height));
         }
-        let usable = viewport_height - inset + OWN_SEND_SCROLL_SLACK_PX;
-        let current = self.own_turn.as_ref().map_or(0.0, |a| a.tail_min_height);
-        // Capture geometry before invalidating the last row. In a one-row
-        // turn it is also the prompt; invalidating first loses the glide's
-        // target and used to send it chasing the provisional reservation.
         let anchor_bounds = self.list.bounds_for_item(anchor_ix);
-        let last_bounds = self.list.bounds_for_item(last_ix);
-
-        if current <= 0.0 {
-            if let Some(anchor) = self.own_turn.as_mut() {
-                anchor.tail_min_height = usable.max(0.0);
-            }
-            self.remeasure_last_row();
-            cx.notify();
-            return;
-        }
-
-        // Background output can grow past the measured window in one
-        // commit. Do not wait for the final row to become visible before
-        // releasing a filled hold: that would prevent auto-follow from ever
-        // bringing the final row into the measurement window.
-        if last_bounds.is_none()
-            && self.own_turn.as_ref().is_some_and(|anchor| anchor.held)
-            && let Some(anchor_bounds) = anchor_bounds
-            && (anchor_ix..last_ix).rev().any(|ix| {
-                self.list.bounds_for_item(ix).is_some_and(|bounds| {
-                    f32::from(bounds.bottom() - anchor_bounds.top()) >= usable
-                })
-            })
-        {
-            // The measured prefix alone fills the reservation, so removing
-            // the off-screen minimum cannot clamp the held viewport.
-            self.own_turn = None;
+        // The list consumes the reservation in the same layout that measures
+        // new rows. The height tree remains available when the prompt or tail
+        // is outside the viewport, so neither can block the handoff.
+        if self.list.tail_reservation_filled() {
+            let held = self.own_turn.take().is_some_and(|a| a.held);
             self.own_turn_last_tick = None;
-            self.remeasure_last_row();
-            self.engage_pin(cx);
-            return;
-        }
-
-        if let (Some(anchor_bounds), Some(last_bounds)) = (anchor_bounds, last_bounds) {
-            // Reserve only what the rows BEFORE the tail haven't consumed.
-            // Unlike bottom padding, min-height absorbs both tail growth and
-            // shrinkage (notably the disappearing working trailer) immediately,
-            // before GPUI can clamp an under-filled viewport and move the prompt.
-            let prefix_height = f32::from(last_bounds.top() - anchor_bounds.top());
-            let required = own_turn_reservation(usable, prefix_height);
-            let last_height = f32::from(last_bounds.size.height);
-            // A released viewport may be inside the provisional surplus. Keep
-            // enough height beneath it to avoid a clamp while refining.
-            let floor =
-                last_height - (self.distance_from_bottom() - OWN_SEND_SCROLL_SLACK_PX).max(0.0);
-            let target = required.max(floor);
-            if last_height > required + 0.5 && current <= required + 0.5 {
-                // Natural content has outgrown the minimum. Removing the
-                // constraint is height-neutral, so tail-follow can take over.
-                let held = self.own_turn.take().is_some_and(|a| a.held);
-                self.remeasure_last_row();
-                if held {
-                    self.engage_pin(cx);
-                } else {
-                    cx.notify();
-                }
-                return;
-            }
-            if (target - current).abs() > 0.5 {
-                if let Some(anchor) = self.own_turn.as_mut() {
-                    anchor.tail_min_height = target;
-                }
-                self.remeasure_last_row();
+            self.list.set_tail_reservation(None);
+            if held || self.distance_from_bottom() <= AT_BOTTOM_PX {
+                self.engage_pin(cx);
+            } else {
                 cx.notify();
             }
+            return;
         }
 
         // ---- entry glide, then absolute hold -------------------------------
@@ -3250,7 +3202,7 @@ impl Transcript {
                             self.list.scroll_by(px(err));
                             self.own_turn_last_tick = None;
                         } else {
-                            self.list.scroll_by(px(err * ease));
+                            self.scroll_own_turn_by(err * ease);
                         }
                         self.own_turn_kick = true;
                     }
@@ -3293,14 +3245,8 @@ impl Transcript {
                 // Remeasurement retains preceding row heights as hints. Read
                 // the prompt's coordinate from that same height tree rather
                 // than aiming at the provisional minimum's (larger) bottom.
-                let offset = self.list.logical_scroll_top();
                 let current = f32::from(self.list.scroll_px_offset_for_scrollbar().y);
-                self.list.scroll_to(ListOffset {
-                    item_ix: anchor_ix,
-                    offset_in_item: px(-inset),
-                });
-                let target = f32::from(self.list.scroll_px_offset_for_scrollbar().y);
-                self.list.scroll_to(offset);
+                let target = -f32::from(self.list.offset_for_item(anchor_ix)) + inset;
                 (current - target, false)
             }
         };
@@ -3346,7 +3292,7 @@ impl Transcript {
             }
             self.own_turn_last_tick = None;
         } else {
-            self.list.scroll_by(px(err * ease));
+            self.scroll_own_turn_by(err * ease);
             if own_turn_glide_crossed(self.list.logical_scroll_top(), anchor_ix, inset) {
                 land(&self.list);
             }
@@ -3732,6 +3678,20 @@ impl Transcript {
             }
         }
         self.rows = new_rows;
+        if old_last != self.rows.len().checked_sub(1) {
+            if let Some(ix) = old_last.filter(|&ix| ix < self.rows.len()) {
+                // Bottom chrome moves to the new tail too.
+                self.list.remeasure_items(ix..ix + 1);
+            }
+            if was_empty && self.own_turn.is_some() && !self.rows.is_empty() {
+                // There was no concrete row to materialize at send time.
+                // Start the echo at the bottom edge before adding its runway.
+                self.list.scroll_to(ListOffset {
+                    item_ix: 0,
+                    offset_in_item: -self.list.viewport_bounds().size.height,
+                });
+            }
+        }
         self.refresh_protected_attachments(cx);
         self.reconcile_own_turn_prompt();
         self.restore_pending_viewport(replay);
@@ -3746,27 +3706,6 @@ impl Transcript {
             self.list.scroll_to_end();
         }
         if self.own_turn.is_some() {
-            if old_last != self.rows.len().checked_sub(1) {
-                if let Some(anchor) = self.own_turn.as_mut() {
-                    anchor.tail_min_height = 0.0;
-                }
-                // Install the provisional minimum before the next layout.
-                if let Some(anchor_ix) = self.own_turn_anchor_ix() {
-                    let height = f32::from(self.list.viewport_bounds().size.height);
-                    if let Some(anchor) = self.own_turn.as_mut() {
-                        anchor.tail_min_height = (height - Self::own_send_inset(anchor_ix)
-                            + OWN_SEND_SCROLL_SLACK_PX)
-                            .max(0.0);
-                    }
-                }
-            }
-            // Appending a reply moves the runway from the previous last row to
-            // the new one. Both measurements must be invalidated because the
-            // row diff itself only knows that rows were appended at the tail.
-            if let Some(old_last) = old_last.filter(|&ix| ix < self.rows.len()) {
-                self.list.remeasure_items(old_last..old_last + 1);
-            }
-            self.remeasure_last_row();
             self.own_turn_kick = true;
         }
         if self.pinned {
@@ -4725,17 +4664,6 @@ impl Transcript {
         } else {
             0.0
         };
-        let tail_min_height = self
-            .own_turn
-            .as_ref()
-            .filter(|anchor| {
-                is_last
-                    && self
-                        .rows
-                        .iter()
-                        .any(|row| row.entry_id == anchor.message_id)
-            })
-            .map_or(0.0, |anchor| anchor.tail_min_height);
         // Live-run loader rides under the LAST row's content (above its
         // clearance pad), so it sits right beneath the working reply.
         let trailer = (ix + 1 == self.rows.len())
@@ -5018,7 +4946,6 @@ impl Transcript {
             .justify_center()
             .pt(px(top_gap))
             .pb(px(bottom_pad))
-            .min_h(px(tail_min_height))
             // Wide gutters (zeron `px-4 @3xl:px-12`) around the 46rem column.
             .px(px(48.0))
             .child(
@@ -6835,6 +6762,7 @@ impl Render for Transcript {
         // region overlay): it must float just above the composer and paint
         // OVER the bottom fade gradient, which is a later sibling of this
         // outlet — an overlay here would be tinted by the fade.
+        self.update_runway_minimum();
         let list_el = list(self.list.clone(), cx.processor(Self::render_row))
             .size_full()
             .with_sizing_behavior(gpui::ListSizingBehavior::Auto);
@@ -7157,19 +7085,6 @@ mod tests {
         assert!(!should_anchor_live_stream(true, 0.0, false));
     }
 
-    #[test]
-    fn own_turn_reservation_is_a_min_height_for_the_turn() {
-        let usable = 700.0;
-        // A short turn reserves the rest of the usable viewport below it.
-        assert_eq!(own_turn_reservation(usable, 100.0), 600.0);
-        // Growth consumes the reservation 1:1 — total held height is stable.
-        assert_eq!(own_turn_reservation(usable, 450.0), 250.0);
-        // At/past the fill line nothing is reserved (bottom spring takes
-        // over with no height jump).
-        assert_eq!(own_turn_reservation(usable, 700.0), 0.0);
-        assert_eq!(own_turn_reservation(usable, 1_200.0), 0.0);
-    }
-
     fn viewport_row(id: &str, entry_id: &str) -> Row {
         Row {
             id: id.into(),
@@ -7282,7 +7197,6 @@ mod tests {
         let own_turn = OwnTurnAnchor {
             chat_id: "chat-a".into(),
             message_id: "prompt".into(),
-            tail_min_height: 640.0,
             held: true,
             positioned: true,
             seen_prompt: true,
@@ -7305,7 +7219,6 @@ mod tests {
         else {
             panic!("an active turn must keep its runway with the viewport");
         };
-        assert_eq!(saved_turn.tail_min_height, 640.0);
         assert!(saved_turn.held);
         assert!(saved_turn.positioned);
 
@@ -7313,7 +7226,6 @@ mod tests {
             .resolve(&rows, false)
             .expect("exact queued echo survives an empty replay");
         let restored_turn = restored.own_turn.expect("valid restored runway");
-        assert_eq!(restored_turn.tail_min_height, 640.0);
         assert!(!restored_turn.held);
         assert!(!restored_turn.positioned);
         assert!(restored_turn.seen_prompt);
@@ -7337,7 +7249,6 @@ mod tests {
         let mut turn = OwnTurnAnchor {
             chat_id: "chat-a".into(),
             message_id: "prompt".into(),
-            tail_min_height: 0.0,
             held: true,
             positioned: false,
             seen_prompt: false,
@@ -7358,7 +7269,6 @@ mod tests {
         let own_turn = OwnTurnAnchor {
             chat_id: "chat-a".into(),
             message_id: "prompt".into(),
-            tail_min_height: 640.0,
             held: true,
             positioned: true,
             seen_prompt: true,
@@ -8049,6 +7959,550 @@ mod tests {
             .unwrap();
         }
 
+        // These exercise frame-by-frame geometry, including the first paint
+        // after a row append. Eventual settling alone misses visible jumps.
+        #[test]
+        fn runway_short_chat_glides_from_its_bottom_aligned_position() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    this.rows = vec![viewport_row("prompt", "prompt")];
+                    this.list.reset(1);
+                    this.rail_enabled = false;
+                    cx.notify();
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| {
+                    this.on_own_send("chat".into(), "prompt".into(), cx)
+                });
+                draw(window, cx);
+                let mut previous = transcript.read(cx).list.bounds_for_item(0).unwrap().top();
+                assert!(previous > px(400.0));
+                for _ in 0..80 {
+                    transcript.update(cx, |this, cx| {
+                        this.own_turn_last_tick = Some(Instant::now() - Duration::from_millis(17));
+                        this.step_own_turn(cx);
+                    });
+                    draw(window, cx);
+                    let top = transcript.read(cx).list.bounds_for_item(0).unwrap().top();
+                    assert!(top <= previous + px(0.5), "glide reversed");
+                    assert!(
+                        previous - top < px(150.0),
+                        "glide jumped: {previous:?} -> {top:?}"
+                    );
+                    previous = top;
+                }
+                assert!(previous.abs() < px(1.0));
+            });
+        }
+
+        fn append_runway_rows(this: &mut Transcript, count: usize, cx: &mut Context<Transcript>) {
+            let old_last = this.rows.len() - 1;
+            let mut rows = this.rows.clone();
+            for ix in 0..count {
+                rows.push(viewport_row(&format!("reply-{}", old_last + ix), "reply"));
+            }
+            // Isolate the row-splice layout boundary; the streaming tests
+            // below exercise the real row builder and sync as well.
+            this.list.splice(this.rows.len()..this.rows.len(), count);
+            this.rows = rows;
+            this.list.remeasure_items(old_last..old_last + 1);
+            this.remeasure_last_row();
+            this.own_turn_kick = true;
+            cx.notify();
+        }
+
+        #[test]
+        fn runway_append_consumes_space_before_the_first_paint() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    this.rows = vec![viewport_row("prompt", "prompt")];
+                    this.list.reset(1);
+                    this.rail_enabled = false;
+                    this.on_own_send("chat".into(), "prompt".into(), cx);
+                    this.list.scroll_to(ListOffset::default());
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| this.step_own_turn(cx));
+                draw(window, cx);
+                let before = transcript.read(cx).list.max_offset_for_scrollbar().y;
+                transcript.update(cx, |this, cx| append_runway_rows(this, 3, cx));
+                draw(window, cx);
+                let after = transcript.read(cx).list.max_offset_for_scrollbar().y;
+                assert!(
+                    (after - before).abs() <= px(1.0),
+                    "append exposed blank scroll space: {before:?} -> {after:?}"
+                );
+            });
+        }
+
+        fn feed(
+            this: &mut Transcript,
+            entries: Vec<SessionMessageEntry>,
+            cx: &mut Context<Transcript>,
+        ) {
+            this.state.update(cx, |state, _| {
+                state.selected_chat = Some("chat".into());
+                state.transcript_replayed = true;
+                state.transcript = entries;
+                state.transcript_revision += 1;
+            });
+            this.sync(cx);
+        }
+
+        fn prompt(id: &str) -> SessionMessageEntry {
+            let mut entry = assistant(
+                id,
+                MessageStatus::Complete,
+                vec![text_part("text", "Please explain this.")],
+            );
+            entry.role = MessageRole::User;
+            entry
+        }
+
+        fn tick(
+            transcript: &Entity<Transcript>,
+            window: gpui::WindowHandle<Transcript>,
+            cx: &mut gpui::App,
+        ) {
+            transcript.update(cx, |this, cx| {
+                this.own_turn_last_tick = Some(Instant::now() - Duration::from_millis(17));
+                this.spring_last_tick = Some(Instant::now() - Duration::from_millis(17));
+                if this.own_turn.is_some() {
+                    this.step_own_turn(cx);
+                }
+                if this.pinned {
+                    this.step_spring(cx);
+                }
+            });
+            draw(window, cx);
+        }
+
+        fn wheel(window: gpui::WindowHandle<Transcript>, delta: f32, cx: &mut gpui::App) {
+            cx.update_window(window.into(), |_, window, cx| {
+                window.dispatch_event(
+                    gpui::PlatformInput::ScrollWheel(gpui::ScrollWheelEvent {
+                        position: gpui::point(px(500.0), px(400.0)),
+                        delta: gpui::ScrollDelta::Pixels(gpui::point(px(0.0), px(delta))),
+                        ..Default::default()
+                    }),
+                    cx,
+                );
+            })
+            .unwrap();
+        }
+
+        #[test]
+        fn runway_first_echo_starts_a_glide_in_an_empty_chat() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    feed(this, vec![], cx);
+                    this.rail_enabled = false;
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| {
+                    this.on_own_send("chat".into(), "prompt".into(), cx)
+                });
+                draw(window, cx); // notification before the optimistic echo
+                transcript.update(cx, |this, cx| feed(this, vec![prompt("prompt")], cx));
+                draw(window, cx);
+                let mut previous = transcript.read(cx).list.bounds_for_item(0).unwrap().top();
+                assert!(
+                    previous > px(400.0),
+                    "first echo skipped its glide: {previous:?}"
+                );
+                for _ in 0..80 {
+                    tick(&transcript, window, cx);
+                    let top = transcript.read(cx).list.bounds_for_item(0).unwrap().top();
+                    assert!(top <= previous + px(0.5));
+                    assert!(previous - top < px(150.0));
+                    previous = top;
+                }
+                assert!(previous.abs() <= px(1.0));
+            });
+        }
+
+        #[test]
+        fn runway_real_stream_consumes_reservation_then_follows_until_completion() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    feed(this, vec![prompt("prompt")], cx);
+                    this.rail_enabled = false;
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| {
+                    this.on_own_send("chat".into(), "prompt".into(), cx)
+                });
+                draw(window, cx);
+                for _ in 0..80 {
+                    tick(&transcript, window, cx);
+                }
+                let mut text = String::new();
+                let mut handed_off = false;
+                for chunk in 0..30 {
+                    text.push_str(&format!("\n\nSection {chunk}. A paragraph to explain the result.\n\n```text\ncontent {chunk}\n```\n"));
+                    transcript.update(cx, |this, cx| {
+                        feed(
+                            this,
+                            vec![
+                                prompt("prompt"),
+                                assistant(
+                                    "reply",
+                                    MessageStatus::Streaming,
+                                    vec![text_part("text", &text)],
+                                ),
+                            ],
+                            cx,
+                        )
+                    });
+                    draw(window, cx); // assert the first paint, before correction
+                    let this = transcript.read(cx);
+                    if this.own_turn.is_some() && !this.list.tail_reservation_filled() {
+                        assert!(
+                            this.list.max_offset_for_scrollbar().y <= px(2.5),
+                            "provisional blank space after chunk {chunk}"
+                        );
+                    }
+                    for _ in 0..50 {
+                        tick(&transcript, window, cx);
+                    }
+                    let this = transcript.read(cx);
+                    if this.own_turn.is_none() {
+                        handed_off = true;
+                        assert!(this.pinned, "overflow lost automatic following");
+                        assert!(
+                            this.distance_from_bottom() <= 1.0,
+                            "stream stopped following at chunk {chunk}"
+                        );
+                    }
+                }
+                assert!(handed_off, "long output never retired the runway");
+                transcript.update(cx, |this, cx| {
+                    feed(
+                        this,
+                        vec![
+                            prompt("prompt"),
+                            assistant(
+                                "reply",
+                                MessageStatus::Complete,
+                                vec![text_part("text", &text)],
+                            ),
+                        ],
+                        cx,
+                    )
+                });
+                draw(window, cx);
+                for _ in 0..50 {
+                    tick(&transcript, window, cx);
+                }
+                assert!(transcript.read(cx).distance_from_bottom() <= 1.0);
+            });
+        }
+
+        #[test]
+        fn runway_wheel_down_cannot_enter_a_temporary_gap_or_reverse() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    this.rows = vec![viewport_row("prompt", "prompt")];
+                    this.list.reset(1);
+                    this.rail_enabled = false;
+                    this.on_own_send("chat".into(), "prompt".into(), cx);
+                    this.list.scroll_to(ListOffset::default());
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| append_runway_rows(this, 3, cx));
+                draw(window, cx);
+                let mut previous = px(0.0);
+                for _ in 0..20 {
+                    wheel(window, -60.0, cx);
+                    assert!(
+                        !transcript.read(cx).own_turn.as_ref().unwrap().held,
+                        "real wheel event must release the hold"
+                    );
+                    tick(&transcript, window, cx);
+                    let this = transcript.read(cx);
+                    let top = this.list.bounds_for_item(0).unwrap().top();
+                    assert!(top >= px(-2.5), "wheel entered a blank runway: {top:?}");
+                    assert!(
+                        top <= previous + px(0.5),
+                        "downward wheel reversed: {previous:?} -> {top:?}"
+                    );
+                    previous = top;
+                }
+            });
+        }
+
+        #[test]
+        fn runway_background_burst_and_downward_input_reach_the_new_tail() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    feed(this, vec![prompt("prompt")], cx);
+                    this.rail_enabled = false;
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| {
+                    this.on_own_send("chat".into(), "prompt".into(), cx)
+                });
+                draw(window, cx);
+                for _ in 0..80 {
+                    tick(&transcript, window, cx);
+                }
+                // Apply many commits with no layouts or animation frames,
+                // just as when the native window has stopped requesting them.
+                let mut text = String::new();
+                for chunk in 0..40 {
+                    text.push_str(&format!(
+                        "\n\nSection {chunk}\n\n```text\nresult {chunk}\n```\n"
+                    ));
+                    transcript.update(cx, |this, cx| {
+                        feed(
+                            this,
+                            vec![
+                                prompt("prompt"),
+                                assistant(
+                                    "reply",
+                                    MessageStatus::Streaming,
+                                    vec![text_part("text", &text)],
+                                ),
+                            ],
+                            cx,
+                        )
+                    });
+                }
+                draw(window, cx);
+                let mut previous = -transcript.read(cx).list.scroll_px_offset_for_scrollbar().y;
+                for _ in 0..100 {
+                    wheel(window, -180.0, cx);
+                    tick(&transcript, window, cx);
+                    let this = transcript.read(cx);
+                    let current = -this.list.scroll_px_offset_for_scrollbar().y;
+                    assert!(
+                        current >= previous - px(1.0),
+                        "refocus wheel snapped backward: {previous:?} -> {current:?}"
+                    );
+                    previous = current;
+                }
+                let this = transcript.read(cx);
+                assert!(this.own_turn.is_none());
+                assert!(
+                    this.distance_from_bottom() <= 1.0,
+                    "downward input never reached new output"
+                );
+                assert!(previous > px(800.0));
+            });
+        }
+
+        #[test]
+        fn runway_second_send_and_steer_keep_the_previous_viewport_until_echo() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    feed(this, vec![prompt("first")], cx);
+                    this.rail_enabled = false;
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| {
+                    this.on_own_send("chat".into(), "first".into(), cx)
+                });
+                draw(window, cx);
+                for _ in 0..80 {
+                    tick(&transcript, window, cx);
+                }
+                let mut entries = vec![prompt("first")];
+                for (ix, status) in [MessageStatus::Complete, MessageStatus::Streaming]
+                    .into_iter()
+                    .enumerate()
+                {
+                    entries.push(assistant(
+                        &format!("reply-{ix}"),
+                        status,
+                        vec![text_part("text", "A short answer.")],
+                    ));
+                    transcript.update(cx, |this, cx| feed(this, entries.clone(), cx));
+                    draw(window, cx);
+                    for _ in 0..10 {
+                        tick(&transcript, window, cx);
+                    }
+                    let before = transcript.read(cx).list.scroll_px_offset_for_scrollbar().y;
+                    let id = format!("next-{ix}");
+                    transcript.update(cx, |this, cx| {
+                        this.on_own_send("chat".into(), id.clone(), cx)
+                    });
+                    draw(window, cx); // the echoed prompt has not landed yet
+                    assert!(
+                        (transcript.read(cx).list.scroll_px_offset_for_scrollbar().y - before)
+                            .abs()
+                            <= px(1.0),
+                        "waiting for echo moved the viewport"
+                    );
+                    entries.push(prompt(&id));
+                    transcript.update(cx, |this, cx| feed(this, entries.clone(), cx));
+                    draw(window, cx);
+                    let anchor = transcript.read(cx).own_turn_anchor_ix().unwrap();
+                    let mut previous = transcript
+                        .read(cx)
+                        .list
+                        .bounds_for_item(anchor)
+                        .unwrap()
+                        .top();
+                    assert!(previous > px(Transcript::own_send_inset(anchor) + 40.0));
+                    for _ in 0..80 {
+                        tick(&transcript, window, cx);
+                        let top = transcript
+                            .read(cx)
+                            .list
+                            .bounds_for_item(anchor)
+                            .unwrap()
+                            .top();
+                        assert!(top <= previous + px(0.5), "repeat send reversed");
+                        assert!(
+                            top >= px(Transcript::own_send_inset(anchor) - 2.5),
+                            "repeat send overshot"
+                        );
+                        assert!(previous - top < px(150.0), "repeat send jumped");
+                        previous = top;
+                    }
+                }
+            });
+        }
+
+        #[test]
+        fn runway_user_scroll_up_stays_released_when_output_overflows() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    let mut entries = vec![prompt("old")];
+                    entries.push(assistant(
+                        "history",
+                        MessageStatus::Complete,
+                        vec![text_part("text", &"History paragraph.\n\n".repeat(80))],
+                    ));
+                    entries.push(prompt("prompt"));
+                    feed(this, entries, cx);
+                    this.rail_enabled = false;
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| {
+                    this.on_own_send("chat".into(), "prompt".into(), cx)
+                });
+                draw(window, cx);
+                for _ in 0..80 {
+                    tick(&transcript, window, cx);
+                }
+                wheel(window, 300.0, cx);
+                draw(window, cx);
+                assert!(!transcript.read(cx).own_turn.as_ref().unwrap().held);
+                let before = transcript.read(cx).list.logical_scroll_top();
+                transcript.update(cx, |this, cx| {
+                    let mut entries = this.state.read(cx).transcript.clone();
+                    entries.push(assistant(
+                        "reply",
+                        MessageStatus::Streaming,
+                        vec![text_part("text", &"Long streamed reply.\n\n".repeat(80))],
+                    ));
+                    feed(this, entries, cx);
+                });
+                draw(window, cx);
+                for _ in 0..80 {
+                    tick(&transcript, window, cx);
+                }
+                let this = transcript.read(cx);
+                assert!(!this.pinned, "background growth stole the user's viewport");
+                let after = this.list.logical_scroll_top();
+                assert_eq!(before.item_ix, after.item_ix);
+                assert!((before.offset_in_item - after.offset_in_item).abs() <= px(1.0));
+            });
+        }
+
+        #[test]
+        fn runway_resizes_in_the_same_layout_without_a_provisional_gap() {
+            struct SizedTranscript {
+                transcript: Entity<Transcript>,
+                height: f32,
+            }
+            impl Render for SizedTranscript {
+                fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                    div()
+                        .w_full()
+                        .h(px(self.height))
+                        .child(self.transcript.clone())
+                }
+            }
+            with_window(|transcript, _, cx| {
+                transcript.update(cx, |this, cx| {
+                    this.rows = vec![viewport_row("prompt", "prompt")];
+                    this.list.reset(1);
+                    this.rail_enabled = false;
+                    this.on_own_send("chat".into(), "prompt".into(), cx);
+                    this.list.scroll_to(ListOffset::default());
+                });
+                let window = cx
+                    .open_window(gpui::WindowOptions::default(), |_, cx| {
+                        cx.new(|_| SizedTranscript {
+                            transcript: transcript.clone(),
+                            height: 600.0,
+                        })
+                    })
+                    .unwrap();
+                for height in [600.0, 900.0, 450.0, 800.0] {
+                    window
+                        .update(cx, |root, window, cx| {
+                            root.height = height;
+                            cx.notify();
+                            window.refresh();
+                        })
+                        .unwrap();
+                    cx.update_window(window.into(), |_, window, cx| {
+                        let _ = window.draw(cx);
+                    })
+                    .unwrap();
+                    let this = transcript.read(cx);
+                    assert_eq!(this.list.viewport_bounds().size.height, px(height));
+                    assert!(
+                        (this.list.max_offset_for_scrollbar().y - px(2.0)).abs() <= px(0.5),
+                        "resize exposed blank space"
+                    );
+                    assert!(this.list.bounds_for_item(0).unwrap().top().abs() <= px(0.5));
+                }
+            });
+        }
+
+        #[test]
+        fn runway_direct_jump_to_an_unmeasured_tail_does_not_reserve_unknown_rows() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    this.rows = (0..100)
+                        .map(|ix| viewport_row(&format!("row-{ix}"), &format!("entry-{ix}")))
+                        .collect();
+                    this.list.reset(100);
+                    this.list.scroll_to(ListOffset {
+                        item_ix: 99,
+                        offset_in_item: px(0.0),
+                    });
+                    this.pinned = false;
+                    this.rail_enabled = false;
+                    cx.notify();
+                });
+                draw(window, cx);
+                let natural = transcript.read(cx).list.offset_for_item(100)
+                    - transcript.read(cx).list.offset_for_item(99);
+                transcript.update(cx, |this, cx| {
+                    this.list.reset(100); // discard all prefix height hints
+                    this.on_own_send("chat".into(), "entry-0".into(), cx);
+                    this.release_own_turn_hold();
+                    this.list.scroll_to(ListOffset {
+                        item_ix: 99,
+                        offset_in_item: px(0.0),
+                    });
+                });
+                draw(window, cx);
+                let this = transcript.read(cx);
+                assert_eq!(
+                    this.list.offset_for_item(100) - this.list.offset_for_item(99),
+                    natural,
+                    "unknown prefix rows created a blank tail"
+                );
+                assert!(this.distance_from_bottom() <= 1.0);
+            });
+        }
+
         #[test]
         fn runway_absorbs_tail_shrinkage_in_the_same_layout() {
             with_window(|transcript, window, cx| {
@@ -8211,7 +8665,6 @@ mod tests {
                     this.own_turn = Some(OwnTurnAnchor {
                         chat_id: "chat".into(),
                         message_id: "entry-0".into(),
-                        tail_min_height: 800.0,
                         held: true,
                         positioned: true,
                         seen_prompt: true,
@@ -8245,7 +8698,6 @@ mod tests {
                 this.own_turn = Some(OwnTurnAnchor {
                     chat_id: "chat".into(),
                     message_id: "prompt".into(),
-                    tail_min_height: 640.0,
                     held: true,
                     positioned: true,
                     seen_prompt: true,
@@ -8288,7 +8740,6 @@ mod tests {
                         transcript.own_turn = Some(OwnTurnAnchor {
                             chat_id: "chat".into(),
                             message_id: "prompt".into(),
-                            tail_min_height: 640.0,
                             held: true,
                             positioned: true,
                             seen_prompt: true,
@@ -8317,7 +8768,6 @@ mod tests {
                             !turn.held,
                             "an outgrown reservation must not re-engage the pin"
                         );
-                        assert_eq!(turn.tail_min_height, 640.0);
                         assert!(transcript.own_turn_last_tick.is_none());
                         assert!(!transcript.pinned);
                         assert!(!transcript.spring_kick);

--- a/docs/performance-runway-layout.md
+++ b/docs/performance-runway-layout.md
@@ -1,0 +1,93 @@
+# Runway layout regression and performance validation — PR #261
+
+The layout fix showed no material CPU or memory regression in eight matched
+Linux replays against v0.2.41 (`489a8c2`). The tested candidate is `d8c5760`,
+including that same sidebar fix. Streaming CPU changed by −0.26% on long replies
+and +0.48% on short replies. Peak RSS differed by less than 0.8 MiB in both cases.
+The short-stream UI main-thread difference was +0.29 percentage points; this
+comparison does not claim literally zero additional work or a universal speedup.
+
+The GPUI dependency changes from `36ca993` to `8425850`, whose only change is
+virtual-list reservation sizing. Renderer, scene caching, shared snapshots,
+markdown caches, and spring parking optimizations are preserved. Reservation
+layout visits the existing measured window and queries the height tree; it does
+not render the full transcript or add an idle animation loop.
+
+| Workload | Metric | v0.2.41 | Candidate |
+| --- | --- | ---: | ---: |
+| Long | Streaming CPU (%) | 136.19 | 135.83 |
+| Long | UI main-thread CPU (%) | 10.25 | 10.25 |
+| Long | Peak RSS (MiB) | 220.73 | 221.47 |
+| Long | Peak PSS (MiB) | 163.33 | 164.08 |
+| Long | Settled CPU, last 10 s (%) | 7.78 | 7.78 |
+| Short | Streaming CPU (%) | 95.83 | 96.30 |
+| Short | UI main-thread CPU (%) | 7.28 | 7.57 |
+| Short | Peak RSS (MiB) | 209.53 | 210.32 |
+| Short | Peak PSS (MiB) | 152.75 | 153.29 |
+| Short | Settled CPU, last 10 s (%) | 5.73 | 5.68 |
+
+Values average two runs per build, in main/candidate/candidate/main order for
+each workload. CPU is percent of one core. Memory sums UI and engine phase peaks,
+which may occur at different instants. All runs completed with identical reply
+hashes within each workload. The final ten settled seconds show no sustained
+idle CPU increase. Individual summaries and executable/source identities are in
+[the raw results](performance/runway-layout.json).
+
+## Functional regression coverage
+
+All **611 release-mode UI tests** passed, including ten new headless GPUI layout
+and handler tests. The initial new tests failed on v0.2.40/main: the short-chat
+animation jumped from 660 px to 0 px in one frame, and a three-row append increased
+the scroll range from 2 px to 230 px before the corrective frame.
+
+The new coverage checks:
+
+- Smooth, monotonic short-chat glides and first echoes arriving after send.
+- First-paint geometry when multiple rows consume a runway.
+- Real transcript streaming through overflow, tail-following, and completion.
+- Real wheel events at the end, without entering a gap or reversing direction.
+- Background commits without frames, followed by downward-only navigation.
+- Second sends and steering while preserving the viewport until echo arrival.
+- User scroll-up ownership while new output outgrows the reservation.
+- Viewport resizing in the same layout, without a provisional gap.
+- Direct navigation to a virtualized tail with unknown preceding row heights.
+
+Existing regressions also cover same-layout completion shrinkage, remeasurement
+during glides, off-screen overflow retirement, session restoration, and stale
+hold cancellation. The UI suite now runs in `.github/workflows/ui-tests.yml` for
+relevant pull requests and main updates.
+
+## Native recordings and measurement scope
+
+The PR has two GitHub user-attachment videos from a native Linux/X11 window:
+first send → runway → overflow following → completion → repeated downward input;
+and second send → scroll up → focus another window during streaming → refocus
+and use only downward input. They were captured before integrating the unrelated
+sidebar change; the scrolling code and GPUI list revision are identical to the
+final candidate. All tests and timed measurements above include the sidebar fix.
+
+Benchmarks used a dedicated Xvfb display, a 1280×800 foreground window, software
+Vulkan with four render workers, fresh local profiles, and composer submission.
+Compilation and recording were stopped during timed replays. This is a matched
+Linux comparison, not a native macOS/Metal benchmark or long-duration stability
+claim. Normal shared-host noise limits interpretation of small differences.
+
+## Reproduction
+
+Build each revision with `cargo build --release --locked -p zeron`, copy each
+binary to an immutable path, and run `scripts/resource-profile.mjs` sequentially
+in main/candidate/candidate/main order for each workload. Use:
+
+```sh
+DISPLAY=:108 WAYLAND_DISPLAY= LP_NUM_THREADS=4 ZERON_FRAME_STATS=0 \
+  ZERON_PROFILE_PSS=1 ZERON_PROFILE_SUBMIT_UI=1 \
+  ZERON_PROFILE_PRE_IDLE_MS=10000 ZERON_PROFILE_IDLE_MS=45000 \
+  ZERON_REPLAY_DELAY_MS=40 \
+  CLAUDE_CODE_EXECUTABLE="$PWD/scripts/replay-claude.py" \
+  ZERON_REPLAY_JOURNAL="$PWD/scripts/fixtures/resource-stream.jsonl" \
+  node scripts/resource-profile.mjs /path/to/binary /tmp/fresh-run claude-code
+```
+
+The long fixture contains 52,624 text/reasoning bytes. For the short retained
+runway, use `scripts/fixtures/runway-short-stream.jsonl`, a 400 ms delta delay,
+5 s pre-idle, and 20 s settled time. No model API calls are made.

--- a/docs/performance/runway-layout.json
+++ b/docs/performance/runway-layout.json
@@ -1,0 +1,807 @@
+{
+  "builds": {
+    "baseline": "489a8c265a0dc730911bd795e148343a235cad28",
+    "candidate": "d8c57603fd99840f9d0457014ad5c5a53dd1d5dc",
+    "baselineZui": "36ca993fb5663ae496acd1d4d19f556d6350eae8",
+    "candidateZui": "8425850325268f7a33e6c8493145f477252616f0",
+    "candidateTranscriptSha256": "ef2969a29b5cac74069dbf9b34565831bc06e8d8f02ce8cd8abf219c27f9d6f5",
+    "binaries": {
+      "main": "5b8d8723278acd9a8321319cf956b4dedea71e3d395b6c9b4ee8ac896110720c",
+      "candidate": "6d41ca9ce07283429f7f800204e926e94940d9c281f50a45900539891cf0b17e"
+    }
+  },
+  "rows": [
+    {
+      "workload": "long",
+      "metric": "Streaming CPU (%)",
+      "main": 136.19108135407606,
+      "candidate": 135.8313817330211,
+      "changePercent": -0.2641139327764108
+    },
+    {
+      "workload": "long",
+      "metric": "UI main-thread CPU (%)",
+      "main": 10.252175677036691,
+      "candidate": 10.25304164048666,
+      "changePercent": 0.008446631010317063
+    },
+    {
+      "workload": "long",
+      "metric": "Peak RSS (MiB)",
+      "main": 220.73046875,
+      "candidate": 221.46875,
+      "changePercent": 0.3344718353478271
+    },
+    {
+      "workload": "long",
+      "metric": "Peak PSS (MiB)",
+      "main": 163.32861328125,
+      "candidate": 164.08056640625,
+      "changePercent": 0.46039276884397573
+    },
+    {
+      "workload": "long",
+      "metric": "Settled CPU, last 10 s (%)",
+      "main": 7.780475865783357,
+      "candidate": 7.781305318384426,
+      "changePercent": 0.01066069242263712
+    },
+    {
+      "workload": "short",
+      "metric": "Streaming CPU (%)",
+      "main": 95.83273868988154,
+      "candidate": 96.29514245148383,
+      "changePercent": 0.48251126694671687
+    },
+    {
+      "workload": "short",
+      "metric": "UI main-thread CPU (%)",
+      "main": 7.2784358498644215,
+      "candidate": 7.566554199068871,
+      "changePercent": 3.958520142893285
+    },
+    {
+      "workload": "short",
+      "metric": "Peak RSS (MiB)",
+      "main": 209.53125,
+      "candidate": 210.318359375,
+      "changePercent": 0.37565249813571455
+    },
+    {
+      "workload": "short",
+      "metric": "Peak PSS (MiB)",
+      "main": 152.75341796875,
+      "candidate": 153.28564453125,
+      "changePercent": 0.3484220317799158
+    },
+    {
+      "workload": "short",
+      "metric": "Settled CPU, last 10 s (%)",
+      "main": 5.72991433605217,
+      "candidate": 5.6785155483009735,
+      "changePercent": -0.8970254132387168
+    }
+  ],
+  "runs": {
+    "main-long-1": {
+      "binary": "/tmp/cool-summit-runway-v2/zeron-main",
+      "binarySha256": "5b8d8723278acd9a8321319cf956b4dedea71e3d395b6c9b4ee8ac896110720c",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "linux",
+      "arch": "x64",
+      "renderThreads": "4",
+      "frameStats": "0",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 0,
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 55067,
+      "frames": 121,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.009,
+          "engine": {
+            "peakPssMiB": 24.14453125,
+            "endPssMiB": 24.14453125,
+            "peakRssMiB": 31.3203125,
+            "endRssMiB": 31.3203125,
+            "cpuPercent": 0.555000555000555,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 126.0546875,
+            "endPssMiB": 126.0478515625,
+            "peakRssMiB": 175.52734375,
+            "endRssMiB": 175.51953125,
+            "cpuPercent": 6.105006105006105,
+            "mainCpuPercent": 0.4440004440004441
+          }
+        },
+        "stream": {
+          "durationSeconds": 17.506,
+          "engine": {
+            "peakPssMiB": 26.966796875,
+            "endPssMiB": 26.9638671875,
+            "peakRssMiB": 34.41796875,
+            "endRssMiB": 34.41796875,
+            "cpuPercent": 0.799725808294299,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 137.0615234375,
+            "endPssMiB": 137.0615234375,
+            "peakRssMiB": 186.9453125,
+            "endRssMiB": 186.9453125,
+            "cpuPercent": 136.01051068205186,
+            "mainCpuPercent": 10.339312235804867
+          }
+        },
+        "settled": {
+          "durationSeconds": 44.546,
+          "engine": {
+            "peakPssMiB": 27.6787109375,
+            "endPssMiB": 27.6748046875,
+            "peakRssMiB": 35.12890625,
+            "endRssMiB": 35.12890625,
+            "cpuPercent": 0.22448704709738249,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 138.44140625,
+            "endPssMiB": 138.41015625,
+            "peakRssMiB": 188.375,
+            "endRssMiB": 188.34765625,
+            "cpuPercent": 14.16513267184484,
+            "mainCpuPercent": 0.9203968930992685
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.51,
+        "engine": {
+          "endRssMiB": 35.12890625,
+          "cpuPercent": 0.2103049421661411,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 188.34765625,
+          "cpuPercent": 7.676130389064148,
+          "mainCpuPercent": 0.4206098843322822
+        }
+      }
+    },
+    "main-long-2": {
+      "binary": "/tmp/cool-summit-runway-v2/zeron-main",
+      "binarySha256": "5b8d8723278acd9a8321319cf956b4dedea71e3d395b6c9b4ee8ac896110720c",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "linux",
+      "arch": "x64",
+      "renderThreads": "4",
+      "frameStats": "0",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 0,
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 55067,
+      "frames": 121,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.006,
+          "engine": {
+            "peakPssMiB": 22.89453125,
+            "endPssMiB": 22.89453125,
+            "peakRssMiB": 30.171875,
+            "endRssMiB": 30.171875,
+            "cpuPercent": 0.6662225183211192,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 125.8525390625,
+            "endPssMiB": 125.814453125,
+            "peakRssMiB": 175.41796875,
+            "endRssMiB": 175.36328125,
+            "cpuPercent": 5.662891405729513,
+            "mainCpuPercent": 0.3331112591605596
+          }
+        },
+        "stream": {
+          "durationSeconds": 17.511,
+          "engine": {
+            "peakPssMiB": 25.5947265625,
+            "endPssMiB": 25.5947265625,
+            "peakRssMiB": 33.125,
+            "endRssMiB": 33.125,
+            "cpuPercent": 0.7423904974016332,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 137.0341796875,
+            "endPssMiB": 136.9931640625,
+            "peakRssMiB": 186.97265625,
+            "endRssMiB": 186.921875,
+            "cpuPercent": 134.82953572040432,
+            "mainCpuPercent": 10.165039118268515
+          }
+        },
+        "settled": {
+          "durationSeconds": 44.557,
+          "engine": {
+            "peakPssMiB": 26.50390625,
+            "endPssMiB": 26.5009765625,
+            "peakRssMiB": 34.03125,
+            "endRssMiB": 34.03125,
+            "cpuPercent": 0.22443162690486343,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 138.58984375,
+            "endPssMiB": 138.5146484375,
+            "peakRssMiB": 188.59375,
+            "endRssMiB": 188.50390625,
+            "cpuPercent": 12.747716408196244,
+            "mainCpuPercent": 0.8528401822384809
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.512,
+        "engine": {
+          "endRssMiB": 34.03125,
+          "cpuPercent": 0.21026072329688833,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 188.50390625,
+          "cpuPercent": 7.464255677039538,
+          "mainCpuPercent": 0.42052144659377666
+        }
+      }
+    },
+    "candidate-long-1": {
+      "binary": "/tmp/cool-summit-runway-v2/zeron-candidate",
+      "binarySha256": "6d41ca9ce07283429f7f800204e926e94940d9c281f50a45900539891cf0b17e",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "linux",
+      "arch": "x64",
+      "renderThreads": "4",
+      "frameStats": "0",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 0,
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 55067,
+      "frames": 120,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.014,
+          "engine": {
+            "peakPssMiB": 22.990234375,
+            "endPssMiB": 22.98828125,
+            "peakRssMiB": 30.22265625,
+            "endRssMiB": 30.22265625,
+            "cpuPercent": 0.6656312402928779,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 126.11328125,
+            "endPssMiB": 126.1025390625,
+            "peakRssMiB": 175.578125,
+            "endRssMiB": 175.5703125,
+            "cpuPercent": 6.101619702684712,
+            "mainCpuPercent": 0.3328156201464389
+          }
+        },
+        "stream": {
+          "durationSeconds": 17.507,
+          "engine": {
+            "peakPssMiB": 26.658203125,
+            "endPssMiB": 26.658203125,
+            "peakRssMiB": 34.109375,
+            "endRssMiB": 34.109375,
+            "cpuPercent": 0.742560118809619,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 137.3466796875,
+            "endPssMiB": 137.326171875,
+            "peakRssMiB": 187.16015625,
+            "endRssMiB": 187.13671875,
+            "cpuPercent": 136.2312217969955,
+            "mainCpuPercent": 10.22448163591706
+          }
+        },
+        "settled": {
+          "durationSeconds": 44.554,
+          "engine": {
+            "peakPssMiB": 27.958984375,
+            "endPssMiB": 27.9580078125,
+            "peakRssMiB": 35.41015625,
+            "endRssMiB": 35.41015625,
+            "cpuPercent": 0.2244467387888854,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 137.69140625,
+            "endPssMiB": 137.69140625,
+            "peakRssMiB": 187.5625,
+            "endRssMiB": 187.5625,
+            "cpuPercent": 7.563855097185432,
+            "mainCpuPercent": 0.4488934775777712
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.512,
+        "engine": {
+          "endRssMiB": 35.41015625,
+          "cpuPercent": 0.21026072329688833,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 187.5625,
+          "cpuPercent": 7.4642556770395,
+          "mainCpuPercent": 0.5256518082422231
+        }
+      }
+    },
+    "candidate-long-2": {
+      "binary": "/tmp/cool-summit-runway-v2/zeron-candidate",
+      "binarySha256": "6d41ca9ce07283429f7f800204e926e94940d9c281f50a45900539891cf0b17e",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "linux",
+      "arch": "x64",
+      "renderThreads": "4",
+      "frameStats": "0",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 0,
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "87f610ae8e3be4c4a6eb3ce6655e2f2728e532115fd3b4c5a2db00a0e0ac73fb",
+      "replyBytes": 52624,
+      "transcriptBytes": 55067,
+      "frames": 120,
+      "phases": {
+        "idle": {
+          "durationSeconds": 9.011,
+          "engine": {
+            "peakPssMiB": 23.9052734375,
+            "endPssMiB": 23.900390625,
+            "peakRssMiB": 31.1171875,
+            "endRssMiB": 31.1171875,
+            "cpuPercent": 0.665852846520919,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 125.771484375,
+            "endPssMiB": 125.748046875,
+            "peakRssMiB": 175.28125,
+            "endRssMiB": 175.2734375,
+            "cpuPercent": 5.992675618688269,
+            "mainCpuPercent": 0.5548773721007656
+          }
+        },
+        "stream": {
+          "durationSeconds": 17.507,
+          "engine": {
+            "peakPssMiB": 27.33984375,
+            "endPssMiB": 27.33984375,
+            "peakRssMiB": 34.87890625,
+            "endRssMiB": 34.87890625,
+            "cpuPercent": 0.742560118809619,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 136.81640625,
+            "endPssMiB": 136.81640625,
+            "peakRssMiB": 186.7890625,
+            "endRssMiB": 186.7890625,
+            "cpuPercent": 133.94642143142744,
+            "mainCpuPercent": 10.281601645056263
+          }
+        },
+        "settled": {
+          "durationSeconds": 44.554,
+          "engine": {
+            "peakPssMiB": 28.021484375,
+            "endPssMiB": 28.0205078125,
+            "peakRssMiB": 35.55859375,
+            "endRssMiB": 35.55859375,
+            "cpuPercent": 0.2468914126677739,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 137.1943359375,
+            "endPssMiB": 137.1923828125,
+            "peakRssMiB": 187.22265625,
+            "endRssMiB": 187.22265625,
+            "cpuPercent": 7.496521075548772,
+            "mainCpuPercent": 0.47133815145665925
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.508,
+        "engine": {
+          "endRssMiB": 35.55859375,
+          "cpuPercent": 0.3155237694572988,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 187.22265625,
+          "cpuPercent": 7.572570466975167,
+          "mainCpuPercent": 0.5258729490954966
+        }
+      }
+    },
+    "main-short-1": {
+      "binary": "/tmp/cool-summit-runway-v2/zeron-main",
+      "binarySha256": "5b8d8723278acd9a8321319cf956b4dedea71e3d395b6c9b4ee8ac896110720c",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "linux",
+      "arch": "x64",
+      "renderThreads": "4",
+      "frameStats": "0",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 0,
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "891cc0f89ea05904a81aea52d168d62993c9f886a66e2b40736137d457c1daac",
+      "replyBytes": 412,
+      "transcriptBytes": 1081,
+      "frames": 21,
+      "phases": {
+        "idle": {
+          "durationSeconds": 4.005,
+          "engine": {
+            "peakPssMiB": 23.400390625,
+            "endPssMiB": 23.400390625,
+            "peakRssMiB": 30.55078125,
+            "endRssMiB": 30.55078125,
+            "cpuPercent": 1.2484394506866416,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 125.224609375,
+            "endPssMiB": 125.224609375,
+            "peakRssMiB": 174.625,
+            "endRssMiB": 174.625,
+            "cpuPercent": 7.490636704119848,
+            "mainCpuPercent": 0.7490636704119851
+          }
+        },
+        "stream": {
+          "durationSeconds": 7.007,
+          "engine": {
+            "peakPssMiB": 24.5400390625,
+            "endPssMiB": 24.5400390625,
+            "peakRssMiB": 31.765625,
+            "endRssMiB": 31.765625,
+            "cpuPercent": 0.4281432852861424,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 127.6005859375,
+            "endPssMiB": 127.6005859375,
+            "peakRssMiB": 177.078125,
+            "endRssMiB": 177.078125,
+            "cpuPercent": 95.19052376195233,
+            "mainCpuPercent": 7.2784358498644215
+          }
+        },
+        "settled": {
+          "durationSeconds": 19.523,
+          "engine": {
+            "peakPssMiB": 24.6611328125,
+            "endPssMiB": 24.658203125,
+            "peakRssMiB": 31.94921875,
+            "endRssMiB": 31.94921875,
+            "cpuPercent": 0.20488654407621784,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 127.8427734375,
+            "endPssMiB": 127.830078125,
+            "peakRssMiB": 177.44140625,
+            "endRssMiB": 177.43359375,
+            "cpuPercent": 5.583158326076934,
+            "mainCpuPercent": 0.4097730881524354
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.51,
+        "engine": {
+          "endRssMiB": 31.94921875,
+          "cpuPercent": 0.2103049421661411,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 177.43359375,
+          "cpuPercent": 5.573080967402727,
+          "mainCpuPercent": 0.4206098843322822
+        }
+      }
+    },
+    "main-short-2": {
+      "binary": "/tmp/cool-summit-runway-v2/zeron-main",
+      "binarySha256": "5b8d8723278acd9a8321319cf956b4dedea71e3d395b6c9b4ee8ac896110720c",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "linux",
+      "arch": "x64",
+      "renderThreads": "4",
+      "frameStats": "0",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 0,
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "891cc0f89ea05904a81aea52d168d62993c9f886a66e2b40736137d457c1daac",
+      "replyBytes": 412,
+      "transcriptBytes": 1081,
+      "frames": 21,
+      "phases": {
+        "idle": {
+          "durationSeconds": 4.005,
+          "engine": {
+            "peakPssMiB": 23.7236328125,
+            "endPssMiB": 23.7236328125,
+            "peakRssMiB": 30.96484375,
+            "endRssMiB": 30.96484375,
+            "cpuPercent": 1.4981273408239704,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 125.9873046875,
+            "endPssMiB": 125.9873046875,
+            "peakRssMiB": 175.4609375,
+            "endRssMiB": 175.4609375,
+            "cpuPercent": 7.740324594257177,
+            "mainCpuPercent": 0.49937578027465646
+          }
+        },
+        "stream": {
+          "durationSeconds": 7.007,
+          "engine": {
+            "peakPssMiB": 25.1455078125,
+            "endPssMiB": 25.142578125,
+            "peakRssMiB": 32.453125,
+            "endRssMiB": 32.453125,
+            "cpuPercent": 0.4281432852861424,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 128.220703125,
+            "endPssMiB": 128.220703125,
+            "peakRssMiB": 177.765625,
+            "endRssMiB": 177.765625,
+            "cpuPercent": 95.61866704723846,
+            "mainCpuPercent": 7.2784358498644215
+          }
+        },
+        "settled": {
+          "durationSeconds": 19.524,
+          "engine": {
+            "peakPssMiB": 25.201171875,
+            "endPssMiB": 25.19921875,
+            "peakRssMiB": 32.5078125,
+            "endRssMiB": 32.5078125,
+            "cpuPercent": 0.20487604998975625,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 128.3955078125,
+            "endPssMiB": 128.384765625,
+            "peakRssMiB": 177.99609375,
+            "endRssMiB": 177.98828125,
+            "cpuPercent": 5.429215324728541,
+            "mainCpuPercent": 0.35853308748207313
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.513,
+        "engine": {
+          "endRssMiB": 32.5078125,
+          "cpuPercent": 0.2102386208346475,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 177.98828125,
+          "cpuPercent": 5.466204141700826,
+          "mainCpuPercent": 0.420477241669295
+        }
+      }
+    },
+    "candidate-short-1": {
+      "binary": "/tmp/cool-summit-runway-v2/zeron-candidate",
+      "binarySha256": "6d41ca9ce07283429f7f800204e926e94940d9c281f50a45900539891cf0b17e",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "linux",
+      "arch": "x64",
+      "renderThreads": "4",
+      "frameStats": "0",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 0,
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "891cc0f89ea05904a81aea52d168d62993c9f886a66e2b40736137d457c1daac",
+      "replyBytes": 412,
+      "transcriptBytes": 1081,
+      "frames": 21,
+      "phases": {
+        "idle": {
+          "durationSeconds": 4.005,
+          "engine": {
+            "peakPssMiB": 23.578125,
+            "endPssMiB": 23.578125,
+            "peakRssMiB": 30.76171875,
+            "endRssMiB": 30.76171875,
+            "cpuPercent": 1.2484394506866416,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 126.4189453125,
+            "endPssMiB": 126.4189453125,
+            "peakRssMiB": 175.921875,
+            "endRssMiB": 175.921875,
+            "cpuPercent": 7.740324594257177,
+            "mainCpuPercent": 0.49937578027465646
+          }
+        },
+        "stream": {
+          "durationSeconds": 7.005,
+          "engine": {
+            "peakPssMiB": 24.455078125,
+            "endPssMiB": 24.4541015625,
+            "peakRssMiB": 31.7109375,
+            "endRssMiB": 31.7109375,
+            "cpuPercent": 0.4282655246252677,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 128.662109375,
+            "endPssMiB": 128.61328125,
+            "peakRssMiB": 178.24609375,
+            "endRssMiB": 178.19140625,
+            "cpuPercent": 97.21627408993574,
+            "mainCpuPercent": 7.708779443254818
+          }
+        },
+        "settled": {
+          "durationSeconds": 19.522,
+          "engine": {
+            "peakPssMiB": 24.4951171875,
+            "endPssMiB": 24.4931640625,
+            "peakRssMiB": 31.8125,
+            "endRssMiB": 31.8125,
+            "cpuPercent": 0.20489703923778307,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 128.8603515625,
+            "endPssMiB": 128.8505859375,
+            "peakRssMiB": 178.55859375,
+            "endRssMiB": 178.55078125,
+            "cpuPercent": 5.378547279991799,
+            "mainCpuPercent": 0.35856981866612003
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.511,
+        "engine": {
+          "endRssMiB": 31.8125,
+          "cpuPercent": 0.10514141520344873,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 178.55078125,
+          "cpuPercent": 5.677636420986217,
+          "mainCpuPercent": 0.42056566081379493
+        }
+      }
+    },
+    "candidate-short-2": {
+      "binary": "/tmp/cool-summit-runway-v2/zeron-candidate",
+      "binarySha256": "6d41ca9ce07283429f7f800204e926e94940d9c281f50a45900539891cf0b17e",
+      "harness": "claude-code",
+      "mode": "replay",
+      "platform": "linux",
+      "arch": "x64",
+      "renderThreads": "4",
+      "frameStats": "0",
+      "submission": "composer",
+      "turns": 1,
+      "backgroundChats": 0,
+      "prompt": "Do not use tools. Write a detailed tutorial of Rust ownership in exactly 80 numbered sections. Each section should have a heading, a paragraph of at least 60 words and a short Rust code example. Continue through all 80 sections without asking questions.",
+      "replySha256": "891cc0f89ea05904a81aea52d168d62993c9f886a66e2b40736137d457c1daac",
+      "replyBytes": 412,
+      "transcriptBytes": 1081,
+      "frames": 21,
+      "phases": {
+        "idle": {
+          "durationSeconds": 4.004,
+          "engine": {
+            "peakPssMiB": 25.46484375,
+            "endPssMiB": 25.46484375,
+            "peakRssMiB": 32.921875,
+            "endRssMiB": 32.921875,
+            "cpuPercent": 1.2487512487512487,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 125.7177734375,
+            "endPssMiB": 125.7177734375,
+            "peakRssMiB": 175.390625,
+            "endRssMiB": 175.390625,
+            "cpuPercent": 7.492507492507491,
+            "mainCpuPercent": 0.4995004995004993
+          }
+        },
+        "stream": {
+          "durationSeconds": 7.004,
+          "engine": {
+            "peakPssMiB": 25.4638671875,
+            "endPssMiB": 24.3125,
+            "peakRssMiB": 32.921875,
+            "endRssMiB": 31.86328125,
+            "cpuPercent": 0.42832667047401485,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 127.990234375,
+            "endPssMiB": 127.990234375,
+            "peakRssMiB": 177.7578125,
+            "endRssMiB": 177.7578125,
+            "cpuPercent": 94.5174186179326,
+            "mainCpuPercent": 7.424328954882924
+          }
+        },
+        "settled": {
+          "durationSeconds": 19.515,
+          "engine": {
+            "peakPssMiB": 24.4580078125,
+            "endPssMiB": 24.4580078125,
+            "peakRssMiB": 32.0078125,
+            "endRssMiB": 32.0078125,
+            "cpuPercent": 0.204970535485524,
+            "mainCpuPercent": 0
+          },
+          "ui": {
+            "peakPssMiB": 128.2890625,
+            "endPssMiB": 128.2822265625,
+            "peakRssMiB": 178.1171875,
+            "endRssMiB": 178.109375,
+            "cpuPercent": 5.431719190366387,
+            "mainCpuPercent": 0.4099410709710477
+          }
+        }
+      },
+      "postCompletionTail": {
+        "durationSeconds": 9.508,
+        "engine": {
+          "endRssMiB": 32.0078125,
+          "cpuPercent": 0.2103491796381996,
+          "mainCpuPercent": 0
+        },
+        "ui": {
+          "endRssMiB": 178.109375,
+          "cpuPercent": 5.363904080774082,
+          "mainCpuPercent": 0.31552376945729943
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix runway scrolling regressions: short and first sends animate to the prompt, streamed rows consume reserved space immediately, overflowing replies hand off to tail-following, and downward scrolling cannot enter a temporary blank gap. Returning to background-streamed output preserves user control.

The reservation is now calculated inside GPUI list layout, before clamping and painting. This replaces provisional tail-row minimums and their delayed correction. Negative first-row offsets are preserved during the send glide, and overflow detection no longer depends on visible prompt/tail bounds. The dependency change is isolated to the virtual list: https://github.com/zeronsh/zui/pull/1.

Validation:
- 611 release-mode UI tests passed, including ten new frame-by-frame regressions for append geometry, short-chat glide, first echo, multi-row streaming through completion, wheel input, background bursts without frames, repeated sends/steering, user-owned scrolling, resize, and unmeasured-tail navigation.
- Before the fix, new tests reproduced a 660 px single-frame send jump and 228 px of temporary extra scroll space.
- Latest sidebar fix from main is included. Eight matched composer replays against v0.2.41 found no material performance regression: long-stream CPU −0.26%, short-stream CPU +0.48%, and peak RSS differences below 0.8 MiB. All reply hashes matched within each workload.
- The existing renderer and caching optimizations are retained. These measurements are Linux/X11 with software Vulkan; native macOS performance was not remeasured.
- The UI suite now runs automatically for relevant pull requests and main updates.
- Bumps the workspace to v0.2.42 for release after merge.

| Metric | v0.2.41 | Candidate |
| --- | ---: | ---: |
| Long streaming CPU | 136.19% | 135.83% |
| Long peak RSS | 220.73 MiB | 221.47 MiB |
| Short streaming CPU | 95.83% | 96.30% |
| Short peak RSS | 209.53 MiB | 210.32 MiB |

[Full measurements, limits, and reproduction](https://github.com/zeronsh/comet/blob/zeron/runway-scroll-regressions/docs/performance-runway-layout.md).

Native Linux/X11 recordings of the runway change (GitHub user attachments):

First send, streaming past the runway, completion, and repeated downward input:

https://github.com/user-attachments/assets/2c3d6744-cc17-49ff-88f7-41ff95daaef1

Second send and background/refocus: read earlier output at 5.5 s, focus another window at 7.1 s, refocus at 19.6 s, then use only downward input:

https://github.com/user-attachments/assets/429965f3-4e5d-4d38-ae26-fe1d1894af0a
