### PR TITLE
Keep following after downward runway input and release v0.2.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "zeron"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "anyhow",
  "clap",
@@ -9443,7 +9443,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-doc"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "chrono",
  "loro",
@@ -9457,7 +9457,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-engine"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9493,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-harness"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-proto"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "chrono",
  "serde",
@@ -9524,7 +9524,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-rpc"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9543,7 +9543,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-sync"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -9566,7 +9566,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-syntax"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "thiserror 2.0.20",
  "tree-sitter",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-theme"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "anyhow",
  "clap",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-ui"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-update"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.42"
+version = "0.2.43"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -2796,6 +2796,13 @@ impl Transcript {
         self.cancel_user_hold();
         let released_own_turn = self.own_turn.as_ref().is_some_and(|anchor| anchor.held);
         self.release_own_turn_hold();
+        if self.own_turn.is_some() {
+            // Cancel any tail spring synchronously too; the deferred input
+            // decision below may re-engage it after reading the new offset.
+            self.pinned = false;
+            self.spring.reset();
+            self.spring_last_tick = None;
+        }
         // The list invokes this handler ONLY from its wheel/touch input path
         // (programmatic scroll_by/scroll_to never re-enter it), while holding
         // its internal RefCell borrow — reading the ListState back
@@ -2813,7 +2820,10 @@ impl Transcript {
                     let distance = this.distance_from_bottom();
                     let previous = this.last_scroll_distance;
                     this.last_scroll_distance = distance;
-                    this.pinned = false;
+                    // Reaching the end preserves normal tail-follow intent
+                    // without reasserting a possibly stale prompt hold.
+                    this.pinned =
+                        distance <= AT_BOTTOM_PX || Self::should_restick(distance, previous);
                     this.spring.reset();
                     this.spring_last_tick = None;
                     // Re-stick only when returning to a short turn's actual
@@ -2830,7 +2840,11 @@ impl Transcript {
                             anchor.held = true;
                             anchor.positioned = false;
                         }
+                        this.pinned = false;
                         this.own_turn_kick = true;
+                    }
+                    if this.pinned {
+                        this.wake_spring();
                     }
                     this.show_jump_button = distance > SCROLL_BUTTON_THRESHOLD_PX
                         && !this.own_turn.as_ref().is_some_and(|a| a.held);
@@ -3125,7 +3139,7 @@ impl Transcript {
             return;
         }
         let inset = Self::own_send_inset(anchor_ix);
-        if self.is_glued() {
+        if self.is_glued() && self.own_turn.as_ref().is_some_and(|anchor| anchor.held) {
             self.list.scroll_by(px(-viewport_height));
         }
         let anchor_bounds = self.list.bounds_for_item(anchor_ix);
@@ -3136,7 +3150,7 @@ impl Transcript {
             let held = self.own_turn.take().is_some_and(|a| a.held);
             self.own_turn_last_tick = None;
             self.list.set_tail_reservation(None);
-            if held || self.distance_from_bottom() <= AT_BOTTOM_PX {
+            if held || self.pinned || self.distance_from_bottom() <= AT_BOTTOM_PX {
                 self.engage_pin(cx);
             } else {
                 cx.notify();
@@ -8220,7 +8234,17 @@ mod tests {
                     );
                     tick(&transcript, window, cx);
                     let this = transcript.read(cx);
-                    let top = this.list.bounds_for_item(0).unwrap().top();
+                    let top = this
+                        .list
+                        .bounds_for_item(0)
+                        .map(|bounds| bounds.top())
+                        .unwrap_or_else(|| {
+                            // A genuine bottom pin uses GPUI's end sentinel, for
+                            // which bounds_for_item intentionally returns None.
+                            this.list.viewport_bounds().top()
+                                + this.list.offset_for_item(0)
+                                + this.list.scroll_px_offset_for_scrollbar().y
+                        });
                     assert!(top >= px(-2.5), "wheel entered a blank runway: {top:?}");
                     assert!(
                         top <= previous + px(0.5),
@@ -8500,6 +8524,126 @@ mod tests {
                     "unknown prefix rows created a blank tail"
                 );
                 assert!(this.distance_from_bottom() <= 1.0);
+            });
+        }
+
+        #[test]
+        fn runway_wheel_down_at_the_end_keeps_following_when_streaming_overflows() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    feed(this, vec![prompt("prompt")], cx);
+                    this.rail_enabled = false;
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| {
+                    this.on_own_send("chat".into(), "prompt".into(), cx)
+                });
+                draw(window, cx);
+                for _ in 0..80 {
+                    tick(&transcript, window, cx);
+                }
+                wheel(window, -60.0, cx);
+                // Let the real wheel handler's deferred ListState read finish
+                // before delivering more output, as in the native event loop.
+                cx.defer(move |cx| {
+                    assert!(
+                        transcript.read(cx).pinned,
+                        "downward input at the runway end must retain follow intent"
+                    );
+                    let mut text = String::new();
+                    for chunk in 0..20 {
+                        text.push_str(&format!(
+                            "\n\nSection {chunk}\n\n```text\ncontent {chunk}\n```\n"
+                        ));
+                        transcript.update(cx, |this, cx| {
+                            feed(
+                                this,
+                                vec![
+                                    prompt("prompt"),
+                                    assistant(
+                                        "reply",
+                                        MessageStatus::Streaming,
+                                        vec![text_part("text", &text)],
+                                    ),
+                                ],
+                                cx,
+                            )
+                        });
+                        draw(window, cx);
+                        for _ in 0..40 {
+                            tick(&transcript, window, cx);
+                        }
+                    }
+                    let this = transcript.read(cx);
+                    assert!(this.own_turn.is_none());
+                    assert!(this.pinned);
+                    assert!(
+                        this.distance_from_bottom() <= 1.0,
+                        "output stopped following after the runway filled"
+                    );
+                });
+            });
+        }
+
+        #[test]
+        fn runway_down_then_up_before_overflow_preserves_the_user_viewport() {
+            with_window(|transcript, window, cx| {
+                transcript.update(cx, |this, cx| {
+                    feed(
+                        this,
+                        vec![
+                            prompt("old"),
+                            assistant(
+                                "history",
+                                MessageStatus::Complete,
+                                vec![text_part("text", &"History.\n\n".repeat(80))],
+                            ),
+                            prompt("prompt"),
+                        ],
+                        cx,
+                    );
+                    this.rail_enabled = false;
+                });
+                draw(window, cx);
+                transcript.update(cx, |this, cx| {
+                    this.on_own_send("chat".into(), "prompt".into(), cx)
+                });
+                draw(window, cx);
+                for _ in 0..80 {
+                    tick(&transcript, window, cx);
+                }
+                wheel(window, -60.0, cx);
+                cx.defer(move |cx| {
+                    assert!(transcript.read(cx).pinned);
+                    draw(window, cx);
+                    wheel(window, 300.0, cx);
+                    assert!(
+                        !transcript.read(cx).pinned,
+                        "upward input must cancel the spring synchronously"
+                    );
+                    cx.defer(move |cx| {
+                        assert!(!transcript.read(cx).pinned);
+                        let before = transcript.read(cx).list.logical_scroll_top();
+                        transcript.update(cx, |this, cx| {
+                            let mut entries = this.state.read(cx).transcript.clone();
+                            entries.push(assistant(
+                                "reply",
+                                MessageStatus::Streaming,
+                                vec![text_part("text", &"New output.\n\n".repeat(80))],
+                            ));
+                            feed(this, entries, cx);
+                        });
+                        draw(window, cx);
+                        for _ in 0..80 {
+                            tick(&transcript, window, cx);
+                        }
+                        let this = transcript.read(cx);
+                        assert!(!this.pinned);
+                        let after = this.list.logical_scroll_top();
+                        assert_eq!(before.item_ix, after.item_ix);
+                        assert!((before.offset_in_item - after.offset_in_item).abs() <= px(1.0));
+                    });
+                });
             });
         }
 


### PR DESCRIPTION
Preserve automatic following when the user scrolls down to the end of an active runway. Previously, wheel input released the prompt hold but unconditionally cleared the tail pin; when the reply later outgrew the runway it could stop following. Reaching the end now engages ordinary tail-following without reasserting a stale prompt, and upward input cancels that spring immediately.

This completes the runway layout changes in #261 and prepares v0.2.43. The v0.2.42 release workflow was cancelled before publication when the additional regression was found.

Validation:
- All **613 release-mode UI tests passed** locally and in [GitHub CI](https://github.com/zeronsh/comet/actions/runs/33999411307).
- The new real-wheel/deferred-event test failed before the change and now verifies continued following through later streaming overflow.
- A second new test verifies that scrolling down and then up preserves the user's viewport as output grows.
- All prior first-paint layout, send, resize, overflow, completion, refocus, and navigation regressions remain covered.
- Eight final composer-submitted replays against published v0.2.41 found no material CPU/memory regression. Long streaming CPU changed by +0.35%, short streaming CPU by −0.79%, and peak RSS differences were below 0.6 MiB. All reply hashes matched within each workload.
- Renderer and cache optimizations remain intact. These are matched Linux/X11 software-Vulkan measurements; native macOS performance was not remeasured.

The original layout fix's native videos and benchmark evidence are in #261.

Additional native Linux/X11 proof on the final v0.2.43 binary: send at 1.5 s, scroll down once at 3 s while the runway is still active, then provide no further input until 31 s. The reply automatically follows through overflow and completion. The final repeated downward input checks the end stop.

https://github.com/user-attachments/assets/9bdb059e-a765-436a-a6c1-446dc17e4f0a


Final binary comparison (UI + engine unless specified):

| Workload | Metric | v0.2.41 | v0.2.43 candidate |
| --- | --- | ---: | ---: |
| long | Streaming CPU (%) | 135.03 | 135.51 |
| long | UI main-thread CPU (%) | 10.14 | 10.14 |
| long | Peak RSS (MiB) | 220.51 | 221.02 |
| long | Peak PSS (MiB) | 163.25 | 163.69 |
| long | Settled CPU, last 10 s (%) | 7.67 | 7.73 |
| short | Streaming CPU (%) | 97.92 | 97.14 |
| short | UI main-thread CPU (%) | 7.28 | 7.64 |
| short | Peak RSS (MiB) | 209.37 | 209.07 |
| short | Peak PSS (MiB) | 152.61 | 152.15 |
| short | Settled CPU, last 10 s (%) | 5.68 | 5.62 |

Two runs per build, in main/candidate/candidate/main order per workload. CPU is percent of one core. The short-stream UI main-thread difference is +0.36 percentage points; this is not a claim of literally zero extra work. Compilation and recording were stopped during measurement. [Method and fixtures](https://github.com/zeronsh/comet/blob/main/docs/performance-runway-layout.md#reproduction).

<details>
<summary>Per-run values and build identities</summary>

| Run | Streaming CPU | Peak RSS (MiB) | Peak PSS (MiB) | Quiet CPU |
| --- | ---: | ---: | ---: | ---: |
| main-long-1 | 134.01% | 220.04 | 162.76 | 7.57% |
| candidate-long-1 | 135.91% | 220.79 | 163.42 | 7.57% |
| candidate-long-2 | 135.11% | 221.25 | 163.97 | 7.89% |
| main-long-2 | 136.05% | 220.97 | 163.75 | 7.78% |
| main-short-1 | 98.63% | 209.18 | 152.50 | 5.78% |
| candidate-short-1 | 96.66% | 208.61 | 151.67 | 5.57% |
| candidate-short-2 | 97.62% | 209.54 | 152.63 | 5.67% |
| main-short-2 | 97.20% | 209.56 | 152.72 | 5.57% |

```json
{
  "baseline": "489a8c265a0dc730911bd795e148343a235cad28",
  "candidate": "a9ad222c97ff1b7a4ab5d8dbf866233feaa03d57",
  "baselineZui": "36ca993fb5663ae496acd1d4d19f556d6350eae8",
  "candidateZui": "8425850325268f7a33e6c8493145f477252616f0",
  "candidateTranscriptSha256": "11feb6bc844949526a49040bf5021be76f441f0c3e47a16ef8b52669ae7a95f6",
  "binaries": {
    "main": "5b8d8723278acd9a8321319cf956b4dedea71e3d395b6c9b4ee8ac896110720c",
    "candidate": "412fc3d9febaa0660f3783ff5d59ec077e055b43f52abf3c0851041f226937ca"
  }
}
```

</details>
