### PR TITLE
Tighten spacing between branch and context indicators

### DIFF
--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -6306,7 +6306,6 @@ impl Render for Composer {
                         .w_full()
                         .flex()
                         .items_center()
-                        .gap(px(8.0))
                         .child(div().flex_1().min_w_0().children(footer))
                         .child(div().pr(px(10.0)).mb(px(-8.0)).child(
                             crate::context_usage::render(usage, self.state.clone(), &theme),

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -2472,7 +2472,9 @@ impl Pickers {
                         .unwrap_or_else(|| SharedString::from("No ref")),
                     &theme,
                 ));
-            return Some(row().child(left).child(right).into_any_element());
+            // The context indicator follows this footer in the composer;
+            // its own padding supplies the spacing after the branch label.
+            return Some(row().pr_0().child(left).child(right).into_any_element());
         }
 
         // New-session draft: checkout + ref only, LEFT-aligned (device +


### PR DESCRIPTION
The branch label and context indicator had stacked spacing: 10px of right padding inside the session footer plus an 8px gap in the composer. Remove those layers so the controls sit 18 logical pixels closer together, retaining their internal padding and the context indicator's right alignment.

Validation: `cargo check --release --locked -p zeron-ui` and `git diff --check` passed.



Screenshot of the updated footer (native Linux app, isolated mock conversation with a long branch name):

![Updated branch and context indicator spacing](https://github.com/user-attachments/assets/ed203aac-f2b5-4aad-b892-c5fdf09dd91c)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791318039&installation_model_id=425430&pr_number=267&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F267&signature=64b50288c60d64e0e1447ed823bb39afe5358baa5f8fe11e5d6afa3239e1e4ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->