### PR TITLE
Smooth composer resizing and fade scroll overflow

### DIFF
--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -395,7 +395,7 @@ pub fn flip_morph_step(
     reduced_motion: bool,
     route_snap: bool,
 ) -> Option<FlipMorph> {
-    if route_snap {
+    if route_snap || reduced_motion {
         return None;
     }
     if !mode_changed {
@@ -1318,6 +1318,9 @@ pub struct ComposerInput {
     drag_autoscroll_active: bool,
     /// Vertical scroll inside the input once content exceeds the max height.
     scroll_top: f32,
+    /// Visible content budget supplied by the animated composer.
+    viewport_height: Option<f32>,
+    needs_measure: bool,
     /// Normally keeps the caret visible through edits and rewraps. Manual
     /// wheel scrolling pauses it until the next caret move or edit.
     follow_cursor: bool,
@@ -1397,6 +1400,8 @@ impl ComposerInput {
             drag_generation: 0,
             drag_autoscroll_active: false,
             scroll_top: 0.0,
+            viewport_height: None,
+            needs_measure: true,
             follow_cursor: true,
             last_lines: Vec::new(),
             line_starts: vec![0],
@@ -1517,6 +1522,7 @@ impl ComposerInput {
         self.selection_reversed = false;
         self.follow_cursor = true;
         self.reset_blink();
+        self.needs_measure = true;
         cx.emit(ComposerInputEvent::Edited);
         cx.notify();
     }
@@ -1547,6 +1553,7 @@ impl ComposerInput {
         self.selection_reversed = false;
         self.follow_cursor = true;
         self.reset_blink();
+        self.needs_measure = true;
         cx.emit(ComposerInputEvent::Edited);
         cx.notify();
     }
@@ -1603,6 +1610,7 @@ impl ComposerInput {
         self.redo_stack.clear();
         self.last_edit = None;
         self.reset_blink();
+        self.needs_measure = true;
         cx.emit(ComposerInputEvent::Edited);
         cx.notify();
     }
@@ -1793,6 +1801,7 @@ impl ComposerInput {
         // Never merge a subsequent edit into a step that undo just crossed.
         self.last_edit = None;
         self.reset_blink();
+        self.needs_measure = true;
         cx.emit(ComposerInputEvent::Edited);
         cx.notify();
     }
@@ -2613,6 +2622,7 @@ impl ComposerInput {
         self.content_height = content_height.max(INPUT_LINE_HEIGHT);
         self.max_line_width = if is_placeholder { 0.0 } else { max_line_width };
         self.last_width = f32::from(width);
+        self.needs_measure = false;
         self.layout_epoch += 1;
         self.content_height
     }
@@ -2712,6 +2722,7 @@ impl EntityInputHandler for ComposerInput {
         self.marked_range.take();
         self.follow_cursor = true;
         self.reset_blink();
+        self.needs_measure = true;
         cx.emit(ComposerInputEvent::Edited);
         cx.notify();
     }
@@ -2756,6 +2767,7 @@ impl EntityInputHandler for ComposerInput {
             .unwrap_or_else(|| range.start + new_text.len()..range.start + new_text.len());
         self.follow_cursor = true;
         self.reset_blink();
+        self.needs_measure = true;
         cx.emit(ComposerInputEvent::Edited);
         cx.notify();
     }
@@ -2875,7 +2887,12 @@ impl gpui::Element for ComposerTextElement {
                     _ => px(320.0),
                 });
                 let content_height = input.update(cx, |input, cx| {
-                    input.layout_text(width, &text_style, window, cx)
+                    let previous = input.content_height;
+                    let height = input.layout_text(width, &text_style, window, cx);
+                    if (height - previous).abs() > 0.5 {
+                        cx.emit(ComposerInputEvent::ViewportChanged);
+                    }
+                    height
                 });
                 size(width, px(content_height.min(max_content)))
             });
@@ -3088,60 +3105,77 @@ impl gpui::Element for ComposerTextElement {
             )
         });
 
-        window.with_content_mask(Some(gpui::ContentMask { bounds }), |window| {
-            for quad in prepaint.mention_quads.drain(..) {
-                window.paint_quad(quad);
-            }
-            for quad in prepaint.selection_quads.drain(..) {
-                window.paint_quad(quad);
-            }
-            let mut y = bounds.top() - px(scroll);
-            for line in &lines {
-                let height = line.size(line_height).height;
-                let _ = line.paint(
-                    point(bounds.left(), y),
-                    line_height,
-                    gpui::TextAlign::Left,
-                    Some(bounds),
-                    window,
-                    cx,
-                );
-                y += height;
-            }
-            if let Some((ghost_origin, ghost)) = prepaint.ghost.take() {
-                let style = window.text_style();
-                let font_size = style.font_size.to_pixels(window.rem_size());
-                let run = TextRun {
-                    len: ghost.len(),
-                    font: style.font(),
-                    color: Theme::of(cx).text_faint,
-                    background_color: None,
-                    underline: None,
-                    strikethrough: None,
-                };
-                let line = window
-                    .text_system()
-                    .shape_line(ghost, font_size, &[run], None);
-                // (Clipping comes from the surrounding content mask.)
-                let _ = line.paint(
-                    ghost_origin,
-                    line_height,
-                    gpui::TextAlign::Left,
-                    None,
-                    window,
-                    cx,
-                );
-            }
-            // Caret only when this input is actually focused in an active
-            // window (Electron hides it on window deactivation too), and only
-            // in the "on" blink phase — solid while typing, ~500ms blink idle.
-            if self
-                .input
-                .update(cx, |input, cx| input.caret_shown(window, cx))
-                && let Some(cursor) = prepaint.cursor.take()
-            {
-                window.paint_quad(cursor);
-            }
+        // Read overflow after prepaint has clamped scrolling for this frame.
+        let max_scroll = input_max_scroll(
+            self.input.read(cx).content_height,
+            f32::from(bounds.size.height),
+        );
+        let fade = gpui::EdgeFade {
+            bounds,
+            band: px(12.0),
+            band_top: None,
+            band_bottom: None,
+            top: scroll > 1.0,
+            bottom: scroll < max_scroll - 1.0,
+            left: false,
+            right: false,
+        };
+        window.with_edge_fade(Some(fade), |window| {
+            window.with_content_mask(Some(gpui::ContentMask { bounds }), |window| {
+                for quad in prepaint.mention_quads.drain(..) {
+                    window.paint_quad(quad);
+                }
+                for quad in prepaint.selection_quads.drain(..) {
+                    window.paint_quad(quad);
+                }
+                let mut y = bounds.top() - px(scroll);
+                for line in &lines {
+                    let height = line.size(line_height).height;
+                    let _ = line.paint(
+                        point(bounds.left(), y),
+                        line_height,
+                        gpui::TextAlign::Left,
+                        Some(bounds),
+                        window,
+                        cx,
+                    );
+                    y += height;
+                }
+                if let Some((ghost_origin, ghost)) = prepaint.ghost.take() {
+                    let style = window.text_style();
+                    let font_size = style.font_size.to_pixels(window.rem_size());
+                    let run = TextRun {
+                        len: ghost.len(),
+                        font: style.font(),
+                        color: Theme::of(cx).text_faint,
+                        background_color: None,
+                        underline: None,
+                        strikethrough: None,
+                    };
+                    let line = window
+                        .text_system()
+                        .shape_line(ghost, font_size, &[run], None);
+                    // (Clipping comes from the surrounding content mask.)
+                    let _ = line.paint(
+                        ghost_origin,
+                        line_height,
+                        gpui::TextAlign::Left,
+                        None,
+                        window,
+                        cx,
+                    );
+                }
+                // Caret only when this input is actually focused in an active
+                // window (Electron hides it on window deactivation too), and only
+                // in the "on" blink phase — solid while typing, ~500ms blink idle.
+                if self
+                    .input
+                    .update(cx, |input, cx| input.caret_shown(window, cx))
+                    && let Some(cursor) = prepaint.cursor.take()
+                {
+                    window.paint_quad(cursor);
+                }
+            });
         });
         self.input.update(cx, |input, _| {
             input.last_lines = lines;
@@ -3210,7 +3244,9 @@ impl Render for ComposerInput {
                 input: cx.entity(),
                 // Internal scrolling once content exceeds the 260px textarea
                 // box minus its `pt-4 pb-1` padding.
-                max_content_height: TEXTAREA_MAX - TEXTAREA_PAD_V,
+                max_content_height: self
+                    .viewport_height
+                    .unwrap_or(TEXTAREA_MAX - TEXTAREA_PAD_V),
             })
     }
 }
@@ -3447,6 +3483,8 @@ pub struct Composer {
     /// Pill height actually rendered last frame — a committed flip morphs
     /// from here, so mid-flight reversals hand off without a jump.
     last_rendered_height: f32,
+    last_target_height: f32,
+    height_morph: Option<FlipMorph>,
     /// Monotonic clock anchor for the morph timeline.
     morph_clock: Instant,
     /// Set on every session/route change: flips committed before this instant
@@ -3569,6 +3607,8 @@ impl Composer {
             settle_task: None,
             flip_morph: None,
             last_rendered_height: 0.0,
+            last_target_height: 0.0,
+            height_morph: None,
             morph_clock: Instant::now(),
             route_snap_until: None,
             _observe: observe,
@@ -4632,6 +4672,8 @@ impl Composer {
             // been re-measured, one or two renders later, so the whole
             // window snaps (see ROUTE_SNAP_MS).
             self.flip_morph = None;
+            self.height_morph = None;
+            self.last_target_height = 0.0;
             self.last_rendered_height = 0.0;
             self.route_snap_until = Some(Instant::now() + Duration::from_millis(ROUTE_SNAP_MS));
             self.input.update(cx, |input, cx| input.set_text(draft, cx));
@@ -5790,6 +5832,21 @@ impl Render for Composer {
             self.reset_slash(None, cx);
         }
         let mode = self.button_mode(cx);
+        // Shape the current draft before sizing the pill. Waiting for the child
+        // layout leaves the parent using the previous edit's height.
+        self.input.update(cx, |input, cx| {
+            if input.needs_measure && input.last_width > 0.0 {
+                let mut style = window.text_style();
+                style.font_family = theme.font_sans.clone();
+                style.font_size = crate::typography::ui_rems(INPUT_TEXT_SIZE).into();
+                style.color = if input.content.is_empty() {
+                    theme.text_faint
+                } else {
+                    theme.text
+                };
+                input.layout_text(px(input.last_width), &style, window, cx);
+            }
+        });
         let (text_width, has_newline, content_height, last_width, epoch) = {
             let input = self.input.read(cx);
             (
@@ -6067,7 +6124,22 @@ impl Render for Composer {
             COMPACT_TOTAL_HEIGHT
         };
         let target_height = base_height + strip_h + comment_strip_h;
-        let (pill_height, morph_t, morphing) = match self.flip_morph {
+        self.height_morph = flip_morph_step(
+            self.height_morph,
+            (target_height - self.last_target_height).abs() > 0.5,
+            self.last_rendered_height,
+            now_ms,
+            motion::reduced_motion(cx),
+            route_snap,
+        );
+        self.last_target_height = target_height;
+        let pill_height = self
+            .height_morph
+            .map_or(target_height, |m| m.height(target_height, now_ms));
+        if self.height_morph.is_some() {
+            window.request_animation_frame();
+        }
+        let (_, morph_t, morphing) = match self.flip_morph {
             Some(m) if !m.done(now_ms) => {
                 (m.height(target_height, now_ms), m.progress(now_ms), true)
             }
@@ -6080,6 +6152,20 @@ impl Render for Composer {
             window.request_animation_frame();
         }
         self.last_rendered_height = pill_height;
+        let text_pt = morph_text_pad(morph_t);
+        let textarea_height =
+            (pill_height - strip_h - comment_strip_h - PILL_BORDER_V - ACTIONS_ROW_HEIGHT).max(0.0);
+        self.input.update(cx, |input, cx| {
+            let height = if expanded {
+                (textarea_height - text_pt - 4.0).max(0.0)
+            } else {
+                INPUT_LINE_HEIGHT
+            };
+            if input.viewport_height != Some(height) {
+                input.viewport_height = Some(height);
+                cx.notify();
+            }
+        });
 
         let send_button = self.render_send_button(mode, cx);
         // Attach button — opens the native image picker (the original's hidden
@@ -6144,10 +6230,10 @@ impl Render for Composer {
             // (`px-3 pb-2.5 pt-1`, h-8 chips → 46px) ABSOLUTE at the pill's
             // stationary bottom — constant screen-y through the morph, with
             // the 2.5px compact↔expanded centering delta gliding out. The
-            // text container is laid out at TARGET size (committed layout
-            // never reflows mid-tween — the caret can't jump); its top pad
-            // eases 12→16 so the first line glides from its compact resting
-            // place. The whole control cluster stays at full alpha — chips,
+            // text viewport follows the animated height so it cannot paint
+            // over the controls. Its width stays fixed (no tween rewraps);
+            // top padding eases 12→16. The whole control cluster stays at
+            // full alpha — chips,
             // attach and send are all (near-)stationary on the bottom anchor.
             let text_pt = morph_text_pad(morph_t);
             pill.h(px(pill_height))
@@ -6159,9 +6245,9 @@ impl Render for Composer {
                 .children(strip)
                 .child(
                     div()
-                        .h(px(
-                            (base_height - PILL_BORDER_V - ACTIONS_ROW_HEIGHT).max(0.0)
-                        ))
+                        .h(px(textarea_height))
+                        .flex_none()
+                        .overflow_hidden()
                         .px(px(16.0))
                         .pt(px(text_pt))
                         .pb(px(4.0))
@@ -6819,6 +6905,29 @@ mod tests {
         );
         assert_eq!(
             flip_morph_step(Some(m), false, 124.0, 300.0, false, false),
+            None
+        );
+    }
+
+    #[test]
+    fn content_resize_retargets_from_visible_height_and_settles() {
+        let start = composer_total_height(input_content_height(3));
+        let target = composer_total_height(input_content_height(6));
+        let grow = flip_morph_step(None, true, start, 0.0, false, false).unwrap();
+        let visible = grow.height(target, 60.0);
+        assert!(visible > start && visible < target);
+        // A delete during growth reverses from what is on screen, with no snap.
+        let shrink = flip_morph_step(Some(grow), true, visible, 60.0, false, false).unwrap();
+        assert_eq!(shrink.height(start, 60.0), visible);
+        assert!(shrink.height(start, 120.0) < visible);
+        assert_eq!(shrink.height(start, 240.0), start);
+        assert_eq!(
+            flip_morph_step(Some(shrink), false, start, 240.0, false, false),
+            None
+        );
+        // Toggling reduced motion also cancels an already running resize.
+        assert_eq!(
+            flip_morph_step(Some(grow), false, visible, 60.0, true, false),
             None
         );
     }

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -150,6 +150,21 @@ fn input_max_scroll(content_height: f32, viewport_height: f32) -> f32 {
     (content_height - viewport_height).max(0.0)
 }
 
+/// Only settled overflow gets a scroll fade. The animated viewport can be
+/// smaller for a few frames while an otherwise fitting draft grows into it.
+fn input_overflow_edges(
+    content_height: f32,
+    settled_height: f32,
+    visible_height: f32,
+    scroll_top: f32,
+) -> (bool, bool) {
+    if input_max_scroll(content_height, settled_height) <= 1.0 {
+        return (false, false);
+    }
+    let max_scroll = input_max_scroll(content_height, visible_height);
+    (scroll_top > 1.0, scroll_top < max_scroll - 1.0)
+}
+
 /// Apply GPUI's wheel delta to a top-origin input offset. Positive deltas mean
 /// scrolling toward the start, matching gpui's built-in list/div behavior.
 fn input_scroll_offset(
@@ -1320,6 +1335,8 @@ pub struct ComposerInput {
     scroll_top: f32,
     /// Visible content budget supplied by the animated composer.
     viewport_height: Option<f32>,
+    /// Final content budget, excluding temporary overflow during a resize.
+    settled_viewport_height: Option<f32>,
     needs_measure: bool,
     /// Normally keeps the caret visible through edits and rewraps. Manual
     /// wheel scrolling pauses it until the next caret move or edit.
@@ -1401,6 +1418,7 @@ impl ComposerInput {
             drag_autoscroll_active: false,
             scroll_top: 0.0,
             viewport_height: None,
+            settled_viewport_height: None,
             needs_measure: true,
             follow_cursor: true,
             last_lines: Vec::new(),
@@ -3105,79 +3123,60 @@ impl gpui::Element for ComposerTextElement {
             )
         });
 
-        // Read overflow after prepaint has clamped scrolling for this frame.
-        let max_scroll = input_max_scroll(
-            self.input.read(cx).content_height,
-            f32::from(bounds.size.height),
-        );
-        let fade = gpui::EdgeFade {
-            bounds,
-            // Match the sidebar/transcript ramp: a 12px band is shorter than
-            // a text row and still reads as a hard cutoff while scrolling.
-            band: px(Theme::TRANSCRIPT_FADE_BAND),
-            band_top: None,
-            band_bottom: None,
-            top: scroll > 1.0,
-            bottom: scroll < max_scroll - 1.0,
-            left: false,
-            right: false,
-        };
-        window.with_edge_fade(Some(fade), |window| {
-            window.with_content_mask(Some(gpui::ContentMask { bounds }), |window| {
-                for quad in prepaint.mention_quads.drain(..) {
-                    window.paint_quad(quad);
-                }
-                for quad in prepaint.selection_quads.drain(..) {
-                    window.paint_quad(quad);
-                }
-                let mut y = bounds.top() - px(scroll);
-                for line in &lines {
-                    let height = line.size(line_height).height;
-                    let _ = line.paint(
-                        point(bounds.left(), y),
-                        line_height,
-                        gpui::TextAlign::Left,
-                        Some(bounds),
-                        window,
-                        cx,
-                    );
-                    y += height;
-                }
-                if let Some((ghost_origin, ghost)) = prepaint.ghost.take() {
-                    let style = window.text_style();
-                    let font_size = style.font_size.to_pixels(window.rem_size());
-                    let run = TextRun {
-                        len: ghost.len(),
-                        font: style.font(),
-                        color: Theme::of(cx).text_faint,
-                        background_color: None,
-                        underline: None,
-                        strikethrough: None,
-                    };
-                    let line = window
-                        .text_system()
-                        .shape_line(ghost, font_size, &[run], None);
-                    // (Clipping comes from the surrounding content mask.)
-                    let _ = line.paint(
-                        ghost_origin,
-                        line_height,
-                        gpui::TextAlign::Left,
-                        None,
-                        window,
-                        cx,
-                    );
-                }
-                // Caret only when this input is actually focused in an active
-                // window (Electron hides it on window deactivation too), and only
-                // in the "on" blink phase — solid while typing, ~500ms blink idle.
-                if self
-                    .input
-                    .update(cx, |input, cx| input.caret_shown(window, cx))
-                    && let Some(cursor) = prepaint.cursor.take()
-                {
-                    window.paint_quad(cursor);
-                }
-            });
+        window.with_content_mask(Some(gpui::ContentMask { bounds }), |window| {
+            for quad in prepaint.mention_quads.drain(..) {
+                window.paint_quad(quad);
+            }
+            for quad in prepaint.selection_quads.drain(..) {
+                window.paint_quad(quad);
+            }
+            let mut y = bounds.top() - px(scroll);
+            for line in &lines {
+                let height = line.size(line_height).height;
+                let _ = line.paint(
+                    point(bounds.left(), y),
+                    line_height,
+                    gpui::TextAlign::Left,
+                    Some(bounds),
+                    window,
+                    cx,
+                );
+                y += height;
+            }
+            if let Some((ghost_origin, ghost)) = prepaint.ghost.take() {
+                let style = window.text_style();
+                let font_size = style.font_size.to_pixels(window.rem_size());
+                let run = TextRun {
+                    len: ghost.len(),
+                    font: style.font(),
+                    color: Theme::of(cx).text_faint,
+                    background_color: None,
+                    underline: None,
+                    strikethrough: None,
+                };
+                let line = window
+                    .text_system()
+                    .shape_line(ghost, font_size, &[run], None);
+                // (Clipping comes from the surrounding content mask.)
+                let _ = line.paint(
+                    ghost_origin,
+                    line_height,
+                    gpui::TextAlign::Left,
+                    None,
+                    window,
+                    cx,
+                );
+            }
+            // Caret only when this input is actually focused in an active
+            // window (Electron hides it on window deactivation too), and only
+            // in the "on" blink phase — solid while typing, ~500ms blink idle.
+            if self
+                .input
+                .update(cx, |input, cx| input.caret_shown(window, cx))
+                && let Some(cursor) = prepaint.cursor.take()
+            {
+                window.paint_quad(cursor);
+            }
         });
         self.input.update(cx, |input, _| {
             input.last_lines = lines;
@@ -3242,13 +3241,37 @@ impl Render for ComposerInput {
             .line_height(px(INPUT_LINE_HEIGHT))
             .text_color(text_color)
             .font_family(theme.font_sans.clone())
-            .child(ComposerTextElement {
-                input: cx.entity(),
-                // Internal scrolling once content exceeds the 260px textarea
-                // box minus its `pt-4 pb-1` padding.
-                max_content_height: self
-                    .viewport_height
-                    .unwrap_or(TEXTAREA_MAX - TEXTAREA_PAD_V),
+            .child({
+                let input = cx.entity();
+                crate::edge_fade::edge_faded(
+                    Theme::TRANSCRIPT_FADE_BAND,
+                    true,
+                    true,
+                    ComposerTextElement {
+                        input: input.clone(),
+                        max_content_height: self
+                            .viewport_height
+                            .unwrap_or(TEXTAREA_MAX - TEXTAREA_PAD_V),
+                    },
+                )
+                // Like the transcript's titlebar inset, reach zero inside the
+                // clip boundary. One text row also covers GPUI's baseline-based
+                // glyph fade sampling, so the clip cannot slice visible ink.
+                .inset_top(INPUT_LINE_HEIGHT)
+                .fade_overflow_y_with(move |cx| {
+                    let input = input.read(cx);
+                    let visible_height = input
+                        .last_bounds
+                        .map_or(0.0, |bounds| f32::from(bounds.size.height));
+                    input_overflow_edges(
+                        input.content_height,
+                        input
+                            .settled_viewport_height
+                            .unwrap_or(TEXTAREA_MAX - TEXTAREA_PAD_V),
+                        visible_height,
+                        input.scroll_top,
+                    )
+                })
             })
     }
 }
@@ -6163,8 +6186,16 @@ impl Render for Composer {
             } else {
                 INPUT_LINE_HEIGHT
             };
-            if input.viewport_height != Some(height) {
+            let settled_height = if expanded {
+                base_height - PILL_BORDER_V - ACTIONS_ROW_HEIGHT - TEXTAREA_PAD_V
+            } else {
+                INPUT_LINE_HEIGHT
+            };
+            if input.viewport_height != Some(height)
+                || input.settled_viewport_height != Some(settled_height)
+            {
                 input.viewport_height = Some(height);
+                input.settled_viewport_height = Some(settled_height);
                 cx.notify();
             }
         });
@@ -6909,6 +6940,34 @@ mod tests {
             flip_morph_step(Some(m), false, 124.0, 300.0, false, false),
             None
         );
+    }
+
+    #[test]
+    fn scroll_fade_ignores_temporary_resize_overflow() {
+        for visible_height in [0.0, 20.0, 60.0, 100.0, 160.0] {
+            let scroll = input_max_scroll(160.0, visible_height);
+            assert_eq!(
+                input_overflow_edges(160.0, 160.0, visible_height, scroll),
+                (false, false)
+            );
+        }
+        // Deleting a capped draft disables fading immediately, even while
+        // its scroll position and outer height are still settling.
+        assert_eq!(
+            input_overflow_edges(100.0, 100.0, 240.0, 80.0),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn scroll_fade_tracks_real_overflow_edges() {
+        for (scroll, top, bottom) in [(0.0, false, true), (80.0, true, true), (160.0, true, false)]
+        {
+            assert_eq!(
+                input_overflow_edges(400.0, 240.0, 240.0, scroll),
+                (top, bottom)
+            );
+        }
     }
 
     #[test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -1331,6 +1331,20 @@ pub enum ComposerInputEvent {
     PastedPaths(Vec<PathBuf>),
 }
 
+/// Shaping inputs excluding mutable viewport and selection geometry.
+#[derive(Clone, PartialEq)]
+struct InputLayoutKey {
+    width: Pixels,
+    font: gpui::Font,
+    font_size: Pixels,
+    color: gpui::Hsla,
+    chip_family: SharedString,
+    chip_color: gpui::Hsla,
+    marked_range: Option<Range<usize>>,
+    placeholder: SharedString,
+    mentions_enabled: bool,
+}
+
 /// Multiline input entity: content + selection + IME marked text + measured
 /// layout (wrapped lines) for mouse mapping and auto-grow.
 pub struct ComposerInput {
@@ -1356,6 +1370,11 @@ pub struct ComposerInput {
     resizing: bool,
     overflow_top_padding: f32,
     needs_measure: bool,
+    last_layout_key: Option<InputLayoutKey>,
+    last_notified_layout: Option<(Pixels, f32)>,
+    max_ascent: f32,
+    #[cfg(test)]
+    layout_rebuilds: usize,
     /// Normally keeps the caret visible through edits and rewraps. Manual
     /// wheel scrolling pauses it until the next caret move or edit.
     follow_cursor: bool,
@@ -1440,6 +1459,11 @@ impl ComposerInput {
             resizing: false,
             overflow_top_padding: 0.0,
             needs_measure: true,
+            last_layout_key: None,
+            last_notified_layout: None,
+            max_ascent: INPUT_TEXT_SIZE,
+            #[cfg(test)]
+            layout_rebuilds: 0,
             follow_cursor: true,
             last_lines: Vec::new(),
             line_starts: vec![0],
@@ -2566,6 +2590,29 @@ impl ComposerInput {
         window: &mut Window,
         cx: &App,
     ) -> f32 {
+        let theme = Theme::of(cx);
+        let key = InputLayoutKey {
+            width,
+            font: style.font(),
+            font_size: style.font_size.to_pixels(window.rem_size()),
+            color: style.color,
+            chip_family: theme.font_mono.clone(),
+            chip_color: theme.code_text,
+            marked_range: self.marked_range.clone(),
+            placeholder: self.placeholder.clone(),
+            mentions_enabled: self.mentions_enabled,
+        };
+        // Height-only animation, scrolling, selection and caret blinking do
+        // not change shaping. Reuse the entity's single retained layout,
+        // including the parent's early measurement of this same edit.
+        if !self.needs_measure && self.last_layout_key.as_ref() == Some(&key) {
+            self.layout_epoch += 1;
+            return self.content_height;
+        }
+        #[cfg(test)]
+        {
+            self.layout_rebuilds += 1;
+        }
         // Rebuild this even for an empty draft. Otherwise deleting the final
         // mention can leave its previous paint geometry alive while the
         // placeholder is already being shaped, tinting "Do anything" for a
@@ -2661,6 +2708,11 @@ impl ComposerInput {
             .fold(0.0, f32::max);
 
         self.display_is_placeholder = is_placeholder;
+        self.max_ascent = lines
+            .iter()
+            .map(|line| f32::from(line.unwrapped_layout.ascent))
+            .fold(INPUT_TEXT_SIZE, f32::max);
+        self.last_layout_key = Some(key);
         self.last_lines = lines;
         self.line_starts = line_starts;
         self.content_height = content_height.max(INPUT_LINE_HEIGHT);
@@ -2962,12 +3014,7 @@ impl gpui::Element for ComposerTextElement {
                     _ => px(320.0),
                 });
                 let content_height = input.update(cx, |input, cx| {
-                    let previous = input.content_height;
-                    let height = input.layout_text(width, &text_style, window, cx);
-                    if (height - previous).abs() > 0.5 {
-                        cx.emit(ComposerInputEvent::ViewportChanged);
-                    }
-                    height
+                    input.layout_text(width, &text_style, window, cx)
                 });
                 size(width, px(content_height.min(max_content)))
             });
@@ -2983,10 +3030,18 @@ impl gpui::Element for ComposerTextElement {
         window: &mut Window,
         cx: &mut App,
     ) -> Self::PrepaintState {
+        let text_style = window.text_style();
         self.input.update(cx, |input, cx| {
+            // Intrinsic measurement may try several widths in one layout.
+            // Only publish the resolved geometry, once: notifying for each
+            // provisional width starts an endless measure/notify loop.
+            input.layout_text(bounds.size.width, &text_style, window, cx);
+            let layout = (bounds.size.width, input.content_height);
+            let layout_changed = input.last_notified_layout != Some(layout);
+            input.last_notified_layout = Some(layout);
             let scrolled = input.clamp_scroll(f32::from(bounds.size.height));
             input.last_bounds = Some(bounds);
-            if scrolled {
+            if scrolled || layout_changed {
                 cx.emit(ComposerInputEvent::ViewportChanged);
             }
         });
@@ -3307,11 +3362,7 @@ impl Render for ComposerInput {
             .font_family(theme.font_sans.clone())
             .child({
                 let input = cx.entity();
-                let ascent = self
-                    .last_lines
-                    .iter()
-                    .map(|line| f32::from(line.unwrapped_layout.ascent))
-                    .fold(INPUT_TEXT_SIZE, f32::max);
+                let ascent = self.max_ascent;
                 crate::edge_fade::edge_faded(
                     INPUT_FADE_BAND,
                     true,
@@ -7015,6 +7066,117 @@ mod tests {
             flip_morph_step(Some(m), false, 124.0, 300.0, false, false),
             None
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolved_layout_does_not_keep_notifying_on_repaint() {
+        use std::cell::Cell;
+        gpui_platform::headless().run(|cx| {
+            cx.set_global(Theme::dark());
+            let handle = cx.open_window(gpui::WindowOptions::default(), |_, cx| {
+                cx.new(|cx| {
+                    let mut input = ComposerInput::new("Draft", cx);
+                    input.set_text("A long line whose wrapping differs between provisional and resolved widths.\n".repeat(100), cx);
+                    input
+                })
+            }).unwrap();
+            let changes = Rc::new(Cell::new(0));
+            let observed = changes.clone();
+            let subscription = cx.subscribe(&handle.entity(cx).unwrap(), move |_, event, _| {
+                if matches!(event, ComposerInputEvent::ViewportChanged) {
+                    observed.set(observed.get() + 1);
+                }
+            });
+            cx.spawn(async move |cx| {
+                let _subscription = subscription;
+                cx.update(|cx| {
+                    handle.update(cx, |input, _, _| input.last_notified_layout = None).unwrap();
+                    cx.update_window(handle.into(), |_, window, cx| { window.refresh(); let _ = window.draw(cx); }).unwrap();
+                });
+                let settled = changes.get();
+                assert!(settled > 0, "the first resolved layout must be published");
+                for _ in 0..30 {
+                    cx.update(|cx| {
+                        cx.update_window(handle.into(), |_, window, cx| { window.refresh(); let _ = window.draw(cx); }).unwrap();
+                    });
+                }
+                assert_eq!(changes.get(), settled, "unchanged draws must not schedule more layout");
+                cx.update(|cx| cx.quit());
+            }).detach();
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn layout_cache_reuses_resize_frames_and_invalidates_text_inputs() {
+        gpui_platform::headless().run(|cx| {
+            cx.set_global(Theme::dark());
+            let handle = cx
+                .open_window(gpui::WindowOptions::default(), |_, cx| {
+                    cx.new(|cx| ComposerInput::new("Draft", cx))
+                })
+                .unwrap();
+            handle
+                .update(cx, |input, window, cx| {
+                    input.layout_rebuilds = 0; // Exclude the window's initial placeholder paint.
+                    let mut style = window.text_style();
+                    style.font_size = px(INPUT_TEXT_SIZE).into();
+                    input.set_text(
+                        "A wrapped draft with enough text to measure.\n".repeat(100),
+                        cx,
+                    );
+                    input.layout_text(px(400.0), &style, window, cx);
+                    assert_eq!(input.layout_rebuilds, 1);
+                    let height = input.content_height;
+                    for frame in 0..120 {
+                        input.viewport_height = Some(40.0 + frame as f32);
+                        input.scroll_top = frame as f32;
+                        input.selected_range = 2..8;
+                        assert_eq!(input.layout_text(px(400.0), &style, window, cx), height);
+                    }
+                    assert_eq!(
+                        input.layout_rebuilds, 1,
+                        "resize/scroll/selection must reuse shaping"
+                    );
+                    input.set_text("Edited draft", cx);
+                    input.layout_text(px(400.0), &style, window, cx);
+                    assert_eq!(input.layout_rebuilds, 2);
+                    input.layout_text(px(200.0), &style, window, cx);
+                    assert_eq!(input.layout_rebuilds, 3, "width changes must rewrap");
+                    style.font_size = px(18.0).into();
+                    input.layout_text(px(200.0), &style, window, cx);
+                    assert_eq!(input.layout_rebuilds, 4);
+                    input.marked_range = Some(0..2);
+                    input.layout_text(px(200.0), &style, window, cx);
+                    assert_eq!(
+                        input.layout_rebuilds, 5,
+                        "IME marking must repaint decoration"
+                    );
+                    input.unmark_text(window, cx);
+                    input.layout_text(px(200.0), &style, window, cx);
+                    assert_eq!(input.layout_rebuilds, 6, "IME unmark must also invalidate");
+                    input.set_text("", cx);
+                    input.layout_text(px(200.0), &style, window, cx);
+                    input.set_placeholder("New placeholder", cx);
+                    input.layout_text(px(200.0), &style, window, cx);
+                    assert_eq!(input.layout_rebuilds, 8);
+                    style.color = gpui::rgb(0xff0000).into();
+                    input.layout_text(px(200.0), &style, window, cx);
+                    assert_eq!(input.layout_rebuilds, 9);
+                    input.enable_mentions();
+                    input.layout_text(px(200.0), &style, window, cx);
+                    assert_eq!(input.layout_rebuilds, 10);
+                    cx.set_global(Theme::light());
+                    input.layout_text(px(200.0), &style, window, cx);
+                    assert_eq!(input.layout_rebuilds, 11, "mention colors follow the theme");
+                })
+                .unwrap();
+            cx.spawn(async move |cx| {
+                cx.update(|cx| cx.quit());
+            })
+            .detach();
+        });
     }
 
     #[test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -167,6 +167,16 @@ fn input_overflow_edges(
     (scroll_top > 1.0, scroll_top < max_scroll - 1.0)
 }
 
+/// During the reveal, stop at a complete row boundary instead of slicing
+/// glyphs with a moving clip. Scrolling offsets the row grid inside the box.
+fn input_reveal_height(visible: f32, scroll: f32, line_height: f32, resizing: bool) -> f32 {
+    if !resizing {
+        return visible;
+    }
+    let row_end = ((scroll + visible + 0.001) / line_height).floor() * line_height;
+    (row_end - scroll).clamp(0.0, visible)
+}
+
 /// Apply GPUI's wheel delta to a top-origin input offset. Positive deltas mean
 /// scrolling toward the start, matching gpui's built-in list/div behavior.
 fn input_scroll_offset(
@@ -1343,6 +1353,8 @@ pub struct ComposerInput {
     viewport_height: Option<f32>,
     /// Final content budget, excluding temporary overflow during a resize.
     settled_viewport_height: Option<f32>,
+    resizing: bool,
+    overflow_top_padding: f32,
     needs_measure: bool,
     /// Normally keeps the caret visible through edits and rewraps. Manual
     /// wheel scrolling pauses it until the next caret move or edit.
@@ -1425,6 +1437,8 @@ impl ComposerInput {
             scroll_top: 0.0,
             viewport_height: None,
             settled_viewport_height: None,
+            resizing: false,
+            overflow_top_padding: 0.0,
             needs_measure: true,
             follow_cursor: true,
             last_lines: Vec::new(),
@@ -2657,6 +2671,32 @@ impl ComposerInput {
         self.content_height
     }
 
+    fn paint_bounds(&self, bounds: Bounds<Pixels>) -> Bounds<Pixels> {
+        let visible = f32::from(bounds.size.height);
+        let top_overflow = input_overflow_edges(
+            self.content_height,
+            self.settled_viewport_height.unwrap_or(visible),
+            visible,
+            self.scroll_top,
+        )
+        .0;
+        let top_padding = if top_overflow {
+            self.overflow_top_padding
+        } else {
+            0.0
+        };
+        let height = input_reveal_height(
+            visible,
+            self.scroll_top,
+            f32::from(self.line_height),
+            self.resizing,
+        );
+        Bounds::new(
+            point(bounds.left(), bounds.top() - px(top_padding)),
+            size(bounds.size.width, px(height + top_padding)),
+        )
+    }
+
     /// Keep the cursor visible when content exceeds the element height.
     fn clamp_scroll(&mut self, element_height: f32) -> bool {
         let previous = self.scroll_top;
@@ -2951,6 +2991,7 @@ impl gpui::Element for ComposerTextElement {
             }
         });
         let input = self.input.read(cx);
+        let paint_bounds = input.paint_bounds(bounds);
         let scroll = px(input.scroll_top);
         let origin = point(bounds.left(), bounds.top() - scroll);
         let selection_color = Theme::of(cx).selection;
@@ -2993,7 +3034,7 @@ impl gpui::Element for ComposerTextElement {
                     // below fallback flush so the pointer can enter the popup.
                     chip_bounds.bottom() - px(1.0)
                 };
-                let visible_bounds = chip_bounds.intersect(&bounds);
+                let visible_bounds = chip_bounds.intersect(&paint_bounds);
                 if visible_bounds.size.width == px(0.0) || visible_bounds.size.height == px(0.0) {
                     continue;
                 }
@@ -3140,61 +3181,67 @@ impl gpui::Element for ComposerTextElement {
             )
         });
 
-        window.with_content_mask(Some(gpui::ContentMask { bounds }), |window| {
-            for quad in prepaint.mention_quads.drain(..) {
-                window.paint_quad(quad);
-            }
-            for quad in prepaint.selection_quads.drain(..) {
-                window.paint_quad(quad);
-            }
-            let mut y = bounds.top() - px(scroll);
-            for line in &lines {
-                let height = line.size(line_height).height;
-                let _ = line.paint(
-                    point(bounds.left(), y),
-                    line_height,
-                    gpui::TextAlign::Left,
-                    Some(bounds),
-                    window,
-                    cx,
-                );
-                y += height;
-            }
-            if let Some((ghost_origin, ghost)) = prepaint.ghost.take() {
-                let style = window.text_style();
-                let font_size = style.font_size.to_pixels(window.rem_size());
-                let run = TextRun {
-                    len: ghost.len(),
-                    font: style.font(),
-                    color: Theme::of(cx).text_faint,
-                    background_color: None,
-                    underline: None,
-                    strikethrough: None,
-                };
-                let line = window
-                    .text_system()
-                    .shape_line(ghost, font_size, &[run], None);
-                // (Clipping comes from the surrounding content mask.)
-                let _ = line.paint(
-                    ghost_origin,
-                    line_height,
-                    gpui::TextAlign::Left,
-                    None,
-                    window,
-                    cx,
-                );
-            }
-            // Caret only when this input is actually focused in an active
-            // window (Electron hides it on window deactivation too), and only
-            // in the "on" blink phase — solid while typing, ~500ms blink idle.
-            if self
-                .input
-                .update(cx, |input, cx| input.caret_shown(window, cx))
-                && let Some(cursor) = prepaint.cursor.take()
-            {
-                window.paint_quad(cursor);
-            }
-        });
+        let paint_bounds = self.input.read(cx).paint_bounds(bounds);
+        window.with_content_mask(
+            Some(gpui::ContentMask {
+                bounds: paint_bounds,
+            }),
+            |window| {
+                for quad in prepaint.mention_quads.drain(..) {
+                    window.paint_quad(quad);
+                }
+                for quad in prepaint.selection_quads.drain(..) {
+                    window.paint_quad(quad);
+                }
+                let mut y = bounds.top() - px(scroll);
+                for line in &lines {
+                    let height = line.size(line_height).height;
+                    let _ = line.paint(
+                        point(bounds.left(), y),
+                        line_height,
+                        gpui::TextAlign::Left,
+                        Some(bounds),
+                        window,
+                        cx,
+                    );
+                    y += height;
+                }
+                if let Some((ghost_origin, ghost)) = prepaint.ghost.take() {
+                    let style = window.text_style();
+                    let font_size = style.font_size.to_pixels(window.rem_size());
+                    let run = TextRun {
+                        len: ghost.len(),
+                        font: style.font(),
+                        color: Theme::of(cx).text_faint,
+                        background_color: None,
+                        underline: None,
+                        strikethrough: None,
+                    };
+                    let line = window
+                        .text_system()
+                        .shape_line(ghost, font_size, &[run], None);
+                    // (Clipping comes from the surrounding content mask.)
+                    let _ = line.paint(
+                        ghost_origin,
+                        line_height,
+                        gpui::TextAlign::Left,
+                        None,
+                        window,
+                        cx,
+                    );
+                }
+                // Caret only when this input is actually focused in an active
+                // window (Electron hides it on window deactivation too), and only
+                // in the "on" blink phase — solid while typing, ~500ms blink idle.
+                if self
+                    .input
+                    .update(cx, |input, cx| input.caret_shown(window, cx))
+                    && let Some(cursor) = prepaint.cursor.take()
+                {
+                    window.paint_quad(cursor);
+                }
+            },
+        );
         self.input.update(cx, |input, _| {
             input.last_lines = lines;
         });
@@ -3276,10 +3323,10 @@ impl Render for ComposerInput {
                             .unwrap_or(TEXTAREA_MAX - TEXTAREA_PAD_V),
                     },
                 )
-                // Reuse the transcript's inset, but reserve only the font's
-                // ascent rather than a full text row. GPUI samples a glyph's
-                // baseline; this makes clipped ink invisible without dead space.
-                .inset_top(ascent)
+                // Fade through the existing top padding, like the transcript
+                // scrolling under its chrome. Account for GPUI's baseline
+                // sampling without consuming another inset inside the text box.
+                .inset_top(ascent - self.overflow_top_padding)
                 .fade_overflow_y_with(move |cx| {
                     let input = input.read(cx);
                     let visible_height = input
@@ -6213,9 +6260,15 @@ impl Render for Composer {
             } else {
                 INPUT_LINE_HEIGHT
             };
+            let resizing = self.height_morph.is_some();
+            let top_padding = if expanded { text_pt } else { 0.0 };
             if input.viewport_height != Some(height)
                 || input.settled_viewport_height != Some(settled_height)
+                || input.resizing != resizing
+                || input.overflow_top_padding != top_padding
             {
+                input.resizing = resizing;
+                input.overflow_top_padding = top_padding;
                 input.viewport_height = Some(height);
                 input.settled_viewport_height = Some(settled_height);
                 cx.notify();
@@ -6962,6 +7015,20 @@ mod tests {
             flip_morph_step(Some(m), false, 124.0, 300.0, false, false),
             None
         );
+    }
+
+    #[test]
+    fn resize_reveals_only_complete_rows() {
+        for visible in [0.0, 5.0, 22.0, 22.75, 30.0, 45.5, 70.0, 150.0] {
+            let height = input_reveal_height(visible, 0.0, INPUT_LINE_HEIGHT, true);
+            assert!(height <= visible);
+            assert_eq!(height % INPUT_LINE_HEIGHT, 0.0);
+        }
+        // The row grid moves with scrolling; the clip still ends between rows.
+        assert_eq!(input_reveal_height(39.0, 7.0, 20.0, true), 33.0);
+        // Normal overflow scrolling keeps its full viewport and existing fades.
+        assert_eq!(input_reveal_height(39.0, 7.0, 20.0, false), 39.0);
+        assert_eq!(input_reveal_height(100.0, 0.0, 20.0, true), 100.0);
     }
 
     #[test]

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -73,6 +73,8 @@ pub const MIN_COMPACT_INPUT_WIDTH: f32 = 200.0;
 /// Input text metrics: `text-[14px] leading-relaxed` = 14 × 1.625 = 22.75.
 pub const INPUT_LINE_HEIGHT: f32 = 22.75;
 pub const INPUT_TEXT_SIZE: f32 = 14.0;
+/// A compact ramp; the glyph-ascent inset keeps the clip edge invisible.
+const INPUT_FADE_BAND: f32 = 12.0;
 /// Single-select questions auto-advance after this long.
 pub const AUTO_ADVANCE_MS: u64 = 220;
 /// Drag-selection autoscroll runs at the display-friendly 60fps cadence.
@@ -183,7 +185,11 @@ fn input_scroll_offset_for_cursor(
     cursor_height: f32,
     content_height: f32,
     viewport_height: f32,
+    settled_height: Option<f32>,
 ) -> f32 {
+    // Resize the reveal, not the scroll position: existing text stays fixed
+    // relative to the input origin throughout the height animation.
+    let viewport_height = settled_height.unwrap_or(viewport_height);
     let mut next = current;
     if cursor_top < next {
         next = cursor_top;
@@ -2445,7 +2451,11 @@ impl ComposerInput {
         }
         let next = (self.scroll_top + delta).clamp(
             0.0,
-            input_max_scroll(self.content_height, f32::from(bounds.size.height)),
+            input_max_scroll(
+                self.content_height,
+                self.settled_viewport_height
+                    .unwrap_or(f32::from(bounds.size.height)),
+            ),
         );
         if next == self.scroll_top {
             self.drag_autoscroll_active = false;
@@ -2469,7 +2479,9 @@ impl ComposerInput {
         let Some(bounds) = self.last_bounds else {
             return;
         };
-        let viewport_height = f32::from(bounds.size.height);
+        let viewport_height = self
+            .settled_viewport_height
+            .unwrap_or(f32::from(bounds.size.height));
         let delta_y = f32::from(event.delta.pixel_delta(self.line_height).y);
         let next = input_scroll_offset(
             self.scroll_top,
@@ -2656,12 +2668,17 @@ impl ComposerInput {
                     f32::from(self.line_height),
                     self.content_height,
                     element_height,
+                    self.settled_viewport_height,
                 );
             }
         }
-        self.scroll_top = self
-            .scroll_top
-            .clamp(0.0, input_max_scroll(self.content_height, element_height));
+        self.scroll_top = self.scroll_top.clamp(
+            0.0,
+            input_max_scroll(
+                self.content_height,
+                self.settled_viewport_height.unwrap_or(element_height),
+            ),
+        );
         self.scroll_top != previous
     }
 }
@@ -3243,8 +3260,13 @@ impl Render for ComposerInput {
             .font_family(theme.font_sans.clone())
             .child({
                 let input = cx.entity();
+                let ascent = self
+                    .last_lines
+                    .iter()
+                    .map(|line| f32::from(line.unwrapped_layout.ascent))
+                    .fold(INPUT_TEXT_SIZE, f32::max);
                 crate::edge_fade::edge_faded(
-                    Theme::TRANSCRIPT_FADE_BAND,
+                    INPUT_FADE_BAND,
                     true,
                     true,
                     ComposerTextElement {
@@ -3254,10 +3276,10 @@ impl Render for ComposerInput {
                             .unwrap_or(TEXTAREA_MAX - TEXTAREA_PAD_V),
                     },
                 )
-                // Like the transcript's titlebar inset, reach zero inside the
-                // clip boundary. One text row also covers GPUI's baseline-based
-                // glyph fade sampling, so the clip cannot slice visible ink.
-                .inset_top(INPUT_LINE_HEIGHT)
+                // Reuse the transcript's inset, but reserve only the font's
+                // ascent rather than a full text row. GPUI samples a glyph's
+                // baseline; this makes clipped ink invisible without dead space.
+                .inset_top(ascent)
                 .fade_overflow_y_with(move |cx| {
                     let input = input.read(cx);
                     let visible_height = input
@@ -6883,21 +6905,21 @@ mod tests {
     fn input_scroll_reveals_only_when_caret_leaves_viewport() {
         // A visible caret preserves the user's viewport.
         assert_eq!(
-            input_scroll_offset_for_cursor(40.0, 60.0, 20.0, 300.0, 100.0),
+            input_scroll_offset_for_cursor(40.0, 60.0, 20.0, 300.0, 100.0, None),
             40.0
         );
         // Moving above or below reveals the row with the smallest adjustment.
         assert_eq!(
-            input_scroll_offset_for_cursor(80.0, 30.0, 20.0, 300.0, 100.0),
+            input_scroll_offset_for_cursor(80.0, 30.0, 20.0, 300.0, 100.0, None),
             30.0
         );
         assert_eq!(
-            input_scroll_offset_for_cursor(20.0, 130.0, 20.0, 300.0, 100.0),
+            input_scroll_offset_for_cursor(20.0, 130.0, 20.0, 300.0, 100.0, None),
             50.0
         );
         // Revealing the final row clamps exactly to the content end.
         assert_eq!(
-            input_scroll_offset_for_cursor(0.0, 290.0, 20.0, 300.0, 100.0),
+            input_scroll_offset_for_cursor(0.0, 290.0, 20.0, 300.0, 100.0, None),
             200.0
         );
     }
@@ -6939,6 +6961,32 @@ mod tests {
         assert_eq!(
             flip_morph_step(Some(m), false, 124.0, 300.0, false, false),
             None
+        );
+    }
+
+    #[test]
+    fn resize_keeps_text_anchored_to_the_input_origin() {
+        // A fitting draft grows from one row to seven. Caret-follow must
+        // never temporarily scroll earlier lines through the top clip.
+        for visible in [0.0, 22.75, 60.0, 110.0, 159.25] {
+            assert_eq!(
+                input_scroll_offset_for_cursor(0.0, 136.5, 22.75, 159.25, visible, Some(159.25),),
+                0.0
+            );
+        }
+        // A genuinely overflowing draft keeps the same caret-follow offset
+        // through every frame of the reveal, rather than chasing its height.
+        for visible in [30.0, 100.0, 180.0, 240.0] {
+            assert_eq!(
+                input_scroll_offset_for_cursor(160.0, 377.25, 22.75, 400.0, visible, Some(240.0),),
+                160.0
+            );
+        }
+        // Deleting back to a fitting draft resets scroll immediately, even
+        // while the old, larger viewport is still shrinking.
+        assert_eq!(
+            input_scroll_offset_for_cursor(160.0, 77.25, 22.75, 100.0, 240.0, Some(100.0),),
+            0.0
         );
     }
 

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -3112,7 +3112,9 @@ impl gpui::Element for ComposerTextElement {
         );
         let fade = gpui::EdgeFade {
             bounds,
-            band: px(12.0),
+            // Match the sidebar/transcript ramp: a 12px band is shorter than
+            // a text row and still reads as a hard cutoff while scrolling.
+            band: px(Theme::TRANSCRIPT_FADE_BAND),
             band_top: None,
             band_bottom: None,
             top: scroll > 1.0,

--- a/crates/ui/src/edge_fade.rs
+++ b/crates/ui/src/edge_fade.rs
@@ -25,6 +25,7 @@ pub fn edge_faded(band: f32, top: bool, bottom: bool, child: impl IntoElement) -
         left: false,
         right: false,
         scroll_y: None,
+        overflow_y: None,
         scroll_x: None,
         child: child.into_any_element(),
     }
@@ -40,6 +41,7 @@ pub struct EdgeFaded {
     left: bool,
     right: bool,
     scroll_y: Option<ScrollHandle>,
+    overflow_y: Option<Box<dyn Fn(&App) -> (bool, bool)>>,
     scroll_x: Option<ScrollHandle>,
     child: AnyElement,
 }
@@ -78,6 +80,16 @@ impl EdgeFaded {
     /// enables; the handle decides per frame.
     pub fn fade_overflow_y(mut self, handle: &ScrollHandle) -> Self {
         self.scroll_y = Some(handle.clone());
+        self
+    }
+
+    /// Paint-time overflow for custom scrollable elements that do not use a
+    /// ScrollHandle. Called after the child's prepaint has clamped scrolling.
+    pub fn fade_overflow_y_with(
+        mut self,
+        overflow: impl Fn(&App) -> (bool, bool) + 'static,
+    ) -> Self {
+        self.overflow_y = Some(Box::new(overflow));
         self
     }
 
@@ -150,6 +162,11 @@ impl Element for EdgeFaded {
             top &= scrolled > 1.0;
             bottom &= scrolled < max_scroll - 1.0;
         }
+        if let Some(overflow) = &self.overflow_y {
+            let (overflow_top, overflow_bottom) = overflow(cx);
+            top &= overflow_top;
+            bottom &= overflow_bottom;
+        }
         let (mut left, mut right) = (self.left, self.right);
         if let Some(scroll) = &self.scroll_x {
             let scrolled = -f32::from(scroll.offset().x);
@@ -159,8 +176,9 @@ impl Element for EdgeFaded {
         }
         let fade = (top || bottom || left || right).then(|| {
             let mut bounds = bounds;
-            bounds.origin.y += px(self.inset_top);
-            bounds.size.height -= px(self.inset_top);
+            let inset = px(self.inset_top).min(bounds.size.height);
+            bounds.origin.y += inset;
+            bounds.size.height -= inset;
             EdgeFade {
                 bounds,
                 band: px(self.band),

--- a/docs/performance-composer.md
+++ b/docs/performance-composer.md
@@ -1,0 +1,88 @@
+# Composer performance validation — PR #271
+
+The audit found and fixed an unbounded repaint loop in the earlier PR. Intrinsic
+layout measured the editor at a provisional 320px width and then its resolved
+width. Notifying the composer for both heights scheduled another layout forever
+once wrapping differed. With a 1,000-line draft, unfocused CPU stayed at 238% of
+one core before the fix. It now returns to 0.2%, within the baseline's 0–0.2%
+range. Notifications now originate in prepaint, only when final geometry changes.
+
+The editor also retains one shaping key alongside its existing wrapped lines.
+Height, scrolling, selection, and caret blinking can reuse that layout. Text
+edits, width, font/size, colors, placeholder, mention mode, and IME marked ranges
+invalidate it. The cache does not retain draft history. Maximum glyph ascent is
+computed with layout rather than rescanned on every render. Final prepaint
+ensures the retained layout matches the actual viewport width.
+
+## Release measurements
+
+UI-process CPU, including rendering workers; percent of one core:
+
+| Phase | Base main | Earlier PR | Fixed PR |
+| --- | ---: | ---: | ---: |
+| Empty, focused | 9.00 | 8.60 | 9.10 |
+| Typing / growing | 167.39 | 211.78 | 201.63 |
+| Normal scrolling | 29.99 | 233.47 | 29.95 |
+| Paste / resize | 218.46 | 204.94 | 213.48 |
+| 1,000-line paste | 228.66 | 230.43 | 230.32 |
+| 1,000-line scrolling | 62.39 | 239.16 | 62.02 |
+| Large draft, focused idle | 15.50 | 241.39 | 16.80 |
+| Unfocused idle | 0.10 | 237.99 | 0.20 |
+
+The fixed PR's average peak RSS was **212.37 MiB**, versus **212.74 MiB** for
+main and **212.94 MiB** for the earlier PR. Large-draft scrolling main-thread
+CPU fell from 3.36% on main to 2.48% with the fix.
+
+This is not a claim of zero animation overhead. During typing, main-thread CPU
+was 15.83%, versus 14.77% on main (+1.06 percentage points). Total process CPU
+was about 20% higher during that phase, which includes rendering the additional
+animation frames. That work is bounded by the 180ms animation and ends when it
+settles. Focused idle includes caret blinking. The unfocused samples are near
+`/proc` counter resolution; a 0.1-point difference is not meaningful.
+
+## Method and reproduction
+
+[Raw runs, executable hashes, and summaries](performance/composer-layout.json)
+compare `f9fbca6` (the PR's base main), `28e1537` (earlier PR), and the fixed
+candidate identified by source and executable SHA-256. Main and the fixed PR
+were each run twice; the earlier PR diagnostic was run once. Runs used release
+builds, immutable executable copies, fresh UI data directories, the same isolated
+mock-engine fixture, a dedicated 1280×900 Xvfb window, and `LP_NUM_THREADS=4`.
+Compilation was finished before each measurement. Linux x86_64, Rust 1.97.1.
+
+[The profiler](../scripts/profile-composer.py) drives real key, clipboard, and
+wheel events without submitting a turn. It samples RSS every 100ms and reads
+process and main-thread CPU counters at phase boundaries. The fixture has two
+seeded chats in its sidebar and no streaming activity. For each binary, use a
+fresh output directory on the dedicated display:
+
+```sh
+python3 scripts/profile-composer.py /path/to/zeron /tmp/composer-run-1 \
+  --settings /path/to/mock-ui/ui-settings.json \
+  --ipc-port 27997 --display :117
+```
+
+The sequence covers focused idle, sixteen typed lines, bidirectional scrolling,
+six alternating three/nine-line pastes, three 1,000-line pastes, long-draft
+scrolling, and focused/unfocused idle. The output includes a screenshot to check
+that the intended draft and window were exercised. Measurements exclude the
+mock daemon and input-driving processes. They are comparative Linux/Xvfb
+measurements, not macOS GPU, frame-latency, or battery-life measurements.
+
+## Regression coverage
+
+All **627 UI tests** pass. Two added Linux headless tests exercise the real editor:
+
+- 120 layout passes with changed viewport heights, scroll positions, and selection
+  reuse one shaped layout; relevant text, styling, placeholder, mention, and IME
+  changes invalidate it.
+- After publishing final geometry, 30 actual window draws emit no additional
+  layout notifications. This guards the provisional-measurement repaint loop.
+
+Existing resize, row-reveal, overflow, editing, transcript, and picker tests remain
+in the full suite. Validation commands:
+
+```sh
+cargo build --release --locked -p zeron
+cargo test --locked -p zeron-ui --lib -- --test-threads=1
+```

--- a/docs/performance/composer-layout.json
+++ b/docs/performance/composer-layout.json
@@ -1,0 +1,494 @@
+{
+  "date": "2026-09-08",
+  "baselineMain": "f9fbca6ea7526e1801169e20e6d30e51aebf72aa",
+  "beforeOptimization": "28e1537",
+  "candidate": "composer layout-cache + resolved-layout notification fix",
+  "platform": "Linux x86_64, Xvfb :117, 1280x900, LP_NUM_THREADS=4",
+  "rustc": "1.97.1 (8bab26f4f 2026-07-14)",
+  "build": "cargo build --release --locked -p zeron; immutable executable copies",
+  "scope": "UI process only; CPU percent of one core; main-thread CPU sampled separately; RSS sampled every 100ms; /proc counters at 100 ticks/s",
+  "runs": [
+    {
+      "name": "main-1",
+      "binarySha256": "ab9dc2d507536b3835ebde32cf04dd48589ec2641206144aebed941f0b8abcb8",
+      "phases": [
+        {
+          "phase": "idle_focused",
+          "seconds": 5.000263559166342,
+          "cpuPercent": 8.799536160317077,
+          "mainCpuPercent": 0.19998945818902467,
+          "peakRssMiB": 201.1328125,
+          "endRssMiB": 201.1328125
+        },
+        {
+          "phase": "typing_resize",
+          "seconds": 5.959245202597231,
+          "cpuPercent": 173.84752007661606,
+          "mainCpuPercent": 14.934777303879182,
+          "peakRssMiB": 206.1953125,
+          "endRssMiB": 206.1953125
+        },
+        {
+          "phase": "scroll",
+          "seconds": 9.07674321020022,
+          "cpuPercent": 30.517553883061733,
+          "mainCpuPercent": 0.8813733973447416,
+          "peakRssMiB": 206.1953125,
+          "endRssMiB": 205.8203125
+        },
+        {
+          "phase": "paste_resize",
+          "seconds": 3.47995494492352,
+          "cpuPercent": 217.5315519829631,
+          "mainCpuPercent": 4.310400633744318,
+          "peakRssMiB": 206.0078125,
+          "endRssMiB": 205.8203125
+        },
+        {
+          "phase": "large_paste",
+          "seconds": 1.9688164042308927,
+          "cpuPercent": 226.0241224340249,
+          "mainCpuPercent": 5.587113138818587,
+          "peakRssMiB": 212.1953125,
+          "endRssMiB": 212.1953125
+        },
+        {
+          "phase": "large_scroll",
+          "seconds": 9.068150906823575,
+          "cpuPercent": 62.8573571235,
+          "mainCpuPercent": 3.41855801899737,
+          "peakRssMiB": 212.7578125,
+          "endRssMiB": 212.7578125
+        },
+        {
+          "phase": "large_idle_focused",
+          "seconds": 5.000249783042818,
+          "cpuPercent": 15.599220715836823,
+          "mainCpuPercent": 0.7999600367095803,
+          "peakRssMiB": 212.7578125,
+          "endRssMiB": 212.5703125
+        },
+        {
+          "phase": "idle_unfocused",
+          "seconds": 5.0002551027573645,
+          "cpuPercent": 0.1999897964102584,
+          "mainCpuPercent": 0.19998979641029838,
+          "peakRssMiB": 212.5703125,
+          "endRssMiB": 212.5703125
+        }
+      ]
+    },
+    {
+      "name": "before-1",
+      "binarySha256": "713788226f9f83d3cce5ac15905edfbbc79054f64d40c5dcfbfd06633ae08832",
+      "phases": [
+        {
+          "phase": "idle_focused",
+          "seconds": 5.000198378227651,
+          "cpuPercent": 8.599658802985646,
+          "mainCpuPercent": 0.19999206518571302,
+          "peakRssMiB": 200.00390625,
+          "endRssMiB": 200.00390625
+        },
+        {
+          "phase": "typing_resize",
+          "seconds": 5.925925221759826,
+          "cpuPercent": 211.7812751655516,
+          "mainCpuPercent": 26.493753148200476,
+          "peakRssMiB": 205.44140625,
+          "endRssMiB": 205.44140625
+        },
+        {
+          "phase": "scroll",
+          "seconds": 9.071667826268822,
+          "cpuPercent": 233.47415718495654,
+          "mainCpuPercent": 5.401432342805886,
+          "peakRssMiB": 206.00390625,
+          "endRssMiB": 206.00390625
+        },
+        {
+          "phase": "paste_resize",
+          "seconds": 3.4742184868082404,
+          "cpuPercent": 204.93817608290755,
+          "mainCpuPercent": 6.620193890318645,
+          "peakRssMiB": 206.19140625,
+          "endRssMiB": 206.00390625
+        },
+        {
+          "phase": "large_paste",
+          "seconds": 1.965907318983227,
+          "cpuPercent": 230.42795335554936,
+          "mainCpuPercent": 16.277471318714312,
+          "peakRssMiB": 212.56640625,
+          "endRssMiB": 212.37890625
+        },
+        {
+          "phase": "large_scroll",
+          "seconds": 9.07743330905214,
+          "cpuPercent": 239.16452218217339,
+          "mainCpuPercent": 13.660249079037083,
+          "peakRssMiB": 212.94140625,
+          "endRssMiB": 212.75390625
+        },
+        {
+          "phase": "large_idle_focused",
+          "seconds": 5.0002614739350975,
+          "cpuPercent": 241.3873766985462,
+          "mainCpuPercent": 13.799278369676625,
+          "peakRssMiB": 212.75390625,
+          "endRssMiB": 211.81640625
+        },
+        {
+          "phase": "idle_unfocused",
+          "seconds": 5.000277273822576,
+          "cpuPercent": 237.98680249790985,
+          "mainCpuPercent": 13.399256947361305,
+          "peakRssMiB": 212.37890625,
+          "endRssMiB": 212.37890625
+        }
+      ]
+    },
+    {
+      "name": "after-1",
+      "binarySha256": "bb68fbcc7d78ba3ca4fae38d9a3966fba3b365706eb34bc80925e173848c82e5",
+      "phases": [
+        {
+          "phase": "idle_focused",
+          "seconds": 5.00031814025715,
+          "cpuPercent": 8.999427383971575,
+          "mainCpuPercent": 0.39997455039873636,
+          "peakRssMiB": 201.09765625,
+          "endRssMiB": 201.09765625
+        },
+        {
+          "phase": "typing_resize",
+          "seconds": 5.989682451356202,
+          "cpuPercent": 201.84709453608087,
+          "mainCpuPercent": 15.526699579698528,
+          "peakRssMiB": 206.1875,
+          "endRssMiB": 206.1875
+        },
+        {
+          "phase": "scroll",
+          "seconds": 9.06894272333011,
+          "cpuPercent": 29.771937946572024,
+          "mainCpuPercent": 0.7718650578740903,
+          "peakRssMiB": 206.5625,
+          "endRssMiB": 206.5625
+        },
+        {
+          "phase": "paste_resize",
+          "seconds": 3.4663270208984613,
+          "cpuPercent": 214.92490336555093,
+          "mainCpuPercent": 5.19281645715425,
+          "peakRssMiB": 206.5625,
+          "endRssMiB": 206.375
+        },
+        {
+          "phase": "large_paste",
+          "seconds": 1.964813796337694,
+          "cpuPercent": 233.60992316704568,
+          "mainCpuPercent": 5.089540809739562,
+          "peakRssMiB": 212.1875,
+          "endRssMiB": 211.8125
+        },
+        {
+          "phase": "large_scroll",
+          "seconds": 9.061849133111537,
+          "cpuPercent": 61.90789448812769,
+          "mainCpuPercent": 2.5381133212601354,
+          "peakRssMiB": 212.5625,
+          "endRssMiB": 212.5625
+        },
+        {
+          "phase": "large_idle_focused",
+          "seconds": 5.000254201237112,
+          "cpuPercent": 16.799145927264497,
+          "mainCpuPercent": 0.7999593298697423,
+          "peakRssMiB": 212.9375,
+          "endRssMiB": 212.75
+        },
+        {
+          "phase": "idle_unfocused",
+          "seconds": 5.000245986040682,
+          "cpuPercent": 0.19999016104238218,
+          "mainCpuPercent": 0.19999016104242215,
+          "peakRssMiB": 212.75,
+          "endRssMiB": 212.75
+        }
+      ]
+    },
+    {
+      "name": "after-2",
+      "binarySha256": "bb68fbcc7d78ba3ca4fae38d9a3966fba3b365706eb34bc80925e173848c82e5",
+      "phases": [
+        {
+          "phase": "idle_focused",
+          "seconds": 5.000249362085015,
+          "cpuPercent": 9.199541196645205,
+          "mainCpuPercent": 0.39998005202805226,
+          "peakRssMiB": 199.23828125,
+          "endRssMiB": 199.23828125
+        },
+        {
+          "phase": "typing_resize",
+          "seconds": 5.948086879681796,
+          "cpuPercent": 201.40929751585762,
+          "mainCpuPercent": 16.139643206612963,
+          "peakRssMiB": 204.67578125,
+          "endRssMiB": 204.48828125
+        },
+        {
+          "phase": "scroll",
+          "seconds": 9.06272948300466,
+          "cpuPercent": 30.12337513901935,
+          "mainCpuPercent": 0.7723942343338295,
+          "peakRssMiB": 205.05078125,
+          "endRssMiB": 205.05078125
+        },
+        {
+          "phase": "paste_resize",
+          "seconds": 3.471098992973566,
+          "cpuPercent": 212.03659172206298,
+          "mainCpuPercent": 5.185677514941756,
+          "peakRssMiB": 205.80078125,
+          "endRssMiB": 205.80078125
+        },
+        {
+          "phase": "large_paste",
+          "seconds": 1.9644745280966163,
+          "cpuPercent": 227.0327222985834,
+          "mainCpuPercent": 5.090419782479456,
+          "peakRssMiB": 211.80078125,
+          "endRssMiB": 211.42578125
+        },
+        {
+          "phase": "large_scroll",
+          "seconds": 9.062160599976778,
+          "cpuPercent": 62.12646463156291,
+          "mainCpuPercent": 2.427677125922528,
+          "peakRssMiB": 211.80078125,
+          "endRssMiB": 211.80078125
+        },
+        {
+          "phase": "large_idle_focused",
+          "seconds": 5.000243060756475,
+          "cpuPercent": 16.799183355557012,
+          "mainCpuPercent": 0.7999611121693858,
+          "peakRssMiB": 211.80078125,
+          "endRssMiB": 211.80078125
+        },
+        {
+          "phase": "idle_unfocused",
+          "seconds": 5.000262095127255,
+          "cpuPercent": 0.19998951674439205,
+          "mainCpuPercent": 0.0,
+          "peakRssMiB": 211.80078125,
+          "endRssMiB": 211.80078125
+        }
+      ]
+    },
+    {
+      "name": "main-2",
+      "binarySha256": "ab9dc2d507536b3835ebde32cf04dd48589ec2641206144aebed941f0b8abcb8",
+      "phases": [
+        {
+          "phase": "idle_focused",
+          "seconds": 5.000295836944133,
+          "cpuPercent": 9.199455692228065,
+          "mainCpuPercent": 0.5999645016670477,
+          "peakRssMiB": 200.71484375,
+          "endRssMiB": 200.71484375
+        },
+        {
+          "phase": "typing_resize",
+          "seconds": 5.958886589854956,
+          "cpuPercent": 160.93610535107413,
+          "mainCpuPercent": 14.600042925488479,
+          "peakRssMiB": 205.58984375,
+          "endRssMiB": 205.58984375
+        },
+        {
+          "phase": "scroll",
+          "seconds": 9.063138409983367,
+          "cpuPercent": 29.45999364920766,
+          "mainCpuPercent": 0.8826964389275687,
+          "peakRssMiB": 206.15234375,
+          "endRssMiB": 206.15234375
+        },
+        {
+          "phase": "paste_resize",
+          "seconds": 3.4686198318377137,
+          "cpuPercent": 219.3956204179383,
+          "mainCpuPercent": 4.32448660482139,
+          "peakRssMiB": 206.15234375,
+          "endRssMiB": 206.15234375
+        },
+        {
+          "phase": "large_paste",
+          "seconds": 1.9671238479204476,
+          "cpuPercent": 231.30216253593034,
+          "mainCpuPercent": 5.591920412956551,
+          "peakRssMiB": 212.71484375,
+          "endRssMiB": 212.71484375
+        },
+        {
+          "phase": "large_scroll",
+          "seconds": 9.060269671026617,
+          "cpuPercent": 61.91868679074684,
+          "mainCpuPercent": 3.3111597214303123,
+          "peakRssMiB": 212.71484375,
+          "endRssMiB": 212.52734375
+        },
+        {
+          "phase": "large_idle_focused",
+          "seconds": 5.000257855746895,
+          "cpuPercent": 15.399205845255098,
+          "mainCpuPercent": 1.1999381178120818,
+          "peakRssMiB": 212.52734375,
+          "endRssMiB": 212.33984375
+        },
+        {
+          "phase": "idle_unfocused",
+          "seconds": 5.000247416086495,
+          "cpuPercent": 0.0,
+          "mainCpuPercent": 0.19999010384623392,
+          "peakRssMiB": 212.33984375,
+          "endRssMiB": 212.33984375
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "main": {
+      "idle_focused": {
+        "cpuPercent": 8.999495926272571,
+        "mainCpuPercent": 0.3999769799280362,
+        "peakRssMiB": 200.923828125
+      },
+      "typing_resize": {
+        "cpuPercent": 167.3918127138451,
+        "mainCpuPercent": 14.76741011468383,
+        "peakRssMiB": 205.892578125
+      },
+      "scroll": {
+        "cpuPercent": 29.9887737661347,
+        "mainCpuPercent": 0.8820349181361551,
+        "peakRssMiB": 206.173828125
+      },
+      "paste_resize": {
+        "cpuPercent": 218.4635862004507,
+        "mainCpuPercent": 4.317443619282853,
+        "peakRssMiB": 206.080078125
+      },
+      "large_paste": {
+        "cpuPercent": 228.6631424849776,
+        "mainCpuPercent": 5.589516775887569,
+        "peakRssMiB": 212.455078125
+      },
+      "large_scroll": {
+        "cpuPercent": 62.38802195712342,
+        "mainCpuPercent": 3.3648588702138413,
+        "peakRssMiB": 212.736328125
+      },
+      "large_idle_focused": {
+        "cpuPercent": 15.49921328054596,
+        "mainCpuPercent": 0.999949077260831,
+        "peakRssMiB": 212.642578125
+      },
+      "idle_unfocused": {
+        "cpuPercent": 0.0999948982051292,
+        "mainCpuPercent": 0.19998995012826615,
+        "peakRssMiB": 212.455078125
+      },
+      "peakRssMiB": 212.736328125
+    },
+    "before": {
+      "idle_focused": {
+        "cpuPercent": 8.599658802985646,
+        "mainCpuPercent": 0.19999206518571302,
+        "peakRssMiB": 200.00390625
+      },
+      "typing_resize": {
+        "cpuPercent": 211.7812751655516,
+        "mainCpuPercent": 26.493753148200476,
+        "peakRssMiB": 205.44140625
+      },
+      "scroll": {
+        "cpuPercent": 233.47415718495654,
+        "mainCpuPercent": 5.401432342805886,
+        "peakRssMiB": 206.00390625
+      },
+      "paste_resize": {
+        "cpuPercent": 204.93817608290755,
+        "mainCpuPercent": 6.620193890318645,
+        "peakRssMiB": 206.19140625
+      },
+      "large_paste": {
+        "cpuPercent": 230.42795335554936,
+        "mainCpuPercent": 16.277471318714312,
+        "peakRssMiB": 212.56640625
+      },
+      "large_scroll": {
+        "cpuPercent": 239.16452218217339,
+        "mainCpuPercent": 13.660249079037083,
+        "peakRssMiB": 212.94140625
+      },
+      "large_idle_focused": {
+        "cpuPercent": 241.3873766985462,
+        "mainCpuPercent": 13.799278369676625,
+        "peakRssMiB": 212.75390625
+      },
+      "idle_unfocused": {
+        "cpuPercent": 237.98680249790985,
+        "mainCpuPercent": 13.399256947361305,
+        "peakRssMiB": 212.37890625
+      },
+      "peakRssMiB": 212.94140625
+    },
+    "after": {
+      "idle_focused": {
+        "cpuPercent": 9.09948429030839,
+        "mainCpuPercent": 0.3999773012133943,
+        "peakRssMiB": 200.16796875
+      },
+      "typing_resize": {
+        "cpuPercent": 201.62819602596926,
+        "mainCpuPercent": 15.833171393155745,
+        "peakRssMiB": 205.431640625
+      },
+      "scroll": {
+        "cpuPercent": 29.947656542795684,
+        "mainCpuPercent": 0.77212964610396,
+        "peakRssMiB": 205.806640625
+      },
+      "paste_resize": {
+        "cpuPercent": 213.48074754380696,
+        "mainCpuPercent": 5.189246986048003,
+        "peakRssMiB": 206.181640625
+      },
+      "large_paste": {
+        "cpuPercent": 230.32132273281454,
+        "mainCpuPercent": 5.089980296109509,
+        "peakRssMiB": 211.994140625
+      },
+      "large_scroll": {
+        "cpuPercent": 62.0171795598453,
+        "mainCpuPercent": 2.4828952235913317,
+        "peakRssMiB": 212.181640625
+      },
+      "large_idle_focused": {
+        "cpuPercent": 16.799164641410755,
+        "mainCpuPercent": 0.799960221019564,
+        "peakRssMiB": 212.369140625
+      },
+      "idle_unfocused": {
+        "cpuPercent": 0.19998983889338712,
+        "mainCpuPercent": 0.09999508052121107,
+        "peakRssMiB": 212.275390625
+      },
+      "peakRssMiB": 212.369140625
+    }
+  },
+  "candidateSourceSha256": "48d6842b7fb272ba7c2d028b94ed679a8235285ef1c26c4458a7faeba4cd32d5"
+}

--- a/scripts/profile-composer.py
+++ b/scripts/profile-composer.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Profile a native composer on a dedicated Linux/X11 display.
+
+Requires xdotool, xclip, ImageMagick, and an isolated mock daemon with two
+seeded chats. Pass that fixture's UI settings and IPC port. Never sends a turn.
+CPU percentages are relative to one core; the UI process includes GPU workers.
+"""
+import subprocess, os, pathlib, time, json, threading, hashlib, argparse, shutil, re
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('binary', type=pathlib.Path)
+parser.add_argument('output', type=pathlib.Path)
+parser.add_argument('--settings', required=True, type=pathlib.Path)
+parser.add_argument('--ipc-port', required=True)
+parser.add_argument('--display', required=True)
+args = parser.parse_args()
+out = args.output.resolve()
+out.mkdir(parents=True, exist_ok=False)
+name = out.name
+binary = out / 'profiled-zeron'
+shutil.copy2(args.binary, binary)
+settings = json.loads(args.settings.read_text())
+(out / 'ui-settings.json').write_text(json.dumps(settings))
+env = os.environ | {'DISPLAY': args.display, 'WAYLAND_DISPLAY': '', 'ZERON_IPC_PORT': args.ipc_port, 'ZERON_HARNESS': 'mock', 'ZERON_WORKOS_CLIENT_ID': '', 'ZERON_EDGE_URL': 'http://127.0.0.1:1', 'ZERON_DATA_DIR': str(out), 'RUST_LOG': 'warn', 'LP_NUM_THREADS': '4'}
+p = subprocess.Popen([str(binary)], env=env, stdout=open(out / 'ui.log', 'w'), stderr=subprocess.STDOUT, start_new_session=True)
+hz = os.sysconf('SC_CLK_TCK')
+
+def stat():
+    s = pathlib.Path(f'/proc/{p.pid}/stat').read_text().split(') ')[1].split()
+    m = pathlib.Path(f'/proc/{p.pid}/task/{p.pid}/stat').read_text().split(') ')[1].split()
+    return {'cpu': (int(s[11]) + int(s[12])) / hz, 'main': (int(m[11]) + int(m[12])) / hz, 'rss': int(s[21]) * os.sysconf('SC_PAGE_SIZE') / 1048576}
+
+def key(*a):
+    subprocess.run(['xdotool', *a], env=env, check=True, stdout=subprocess.DEVNULL)
+
+def paste(text):
+    subprocess.run(['xclip', '-selection', 'clipboard'], input=text.encode(), env=env, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    key('key', 'ctrl+a', 'ctrl+v')
+
+def idle():
+    time.sleep(5)
+
+def typing():
+    for i in range(16):
+        key('type', '--clearmodifiers', '--delay', '5', f'Line {i:02d}: Measuring native composer layout and resizing performance.')
+        key('key', 'shift+Return')
+        time.sleep(0.12)
+    time.sleep(0.4)
+
+def scroll():
+    key('mousemove', '720', '660')
+    for i in range(48):
+        key('click', '4' if i // 8 % 2 == 0 else '5')
+        time.sleep(0.08)
+    time.sleep(0.3)
+
+def edits():
+    key('key', 'ctrl+a', 'BackSpace')
+    time.sleep(0.4)
+    for i in range(6):
+        paste('A draft that grows and shrinks while keeping its input anchored.\n' * (3 if i % 2 == 0 else 9))
+        time.sleep(0.45)
+
+def large_paste():
+    for i in range(3):
+        paste(f'Pass {i}: A long draft exercises wrapping and cached layout during repaint.\n' * 1000)
+        time.sleep(0.6)
+results = []
+
+def phase(name, fn):
+    stop = threading.Event()
+    samples = []
+
+    def sample():
+        while not stop.wait(0.1):
+            try:
+                samples.append(stat())
+            except FileNotFoundError:
+                break
+    t = threading.Thread(target=sample)
+    t.start()
+    start = stat()
+    when = time.monotonic()
+    fn()
+    end = stat()
+    duration = time.monotonic() - when
+    stop.set()
+    t.join()
+    result = {'phase': name, 'seconds': duration, 'cpuPercent': 100 * (end['cpu'] - start['cpu']) / duration, 'mainCpuPercent': 100 * (end['main'] - start['main']) / duration, 'peakRssMiB': max((x['rss'] for x in samples + [start, end])), 'endRssMiB': end['rss']}
+    results.append(result)
+    print(json.dumps(result), flush=True)
+try:
+    time.sleep(2)
+    ids = subprocess.check_output(['xdotool', 'search', '--class', 'zeron'], env=env, text=True).splitlines()
+    wid = ids[-1]
+    key('windowmap', wid, 'windowsize', wid, '1280', '900', 'windowmove', wid, '0', '0', 'windowfocus', wid)
+    time.sleep(1)
+    key('mousemove', '110', '160', 'click', '1')
+    time.sleep(0.5)
+    key('mousemove', '500', '830', 'click', '1')
+    key('key', 'ctrl+a', 'BackSpace')
+    time.sleep(1)
+    phase('idle_focused', idle)
+    phase('typing_resize', typing)
+    phase('scroll', scroll)
+    phase('paste_resize', edits)
+    phase('large_paste', large_paste)
+    phase('large_scroll', scroll)
+    phase('large_idle_focused', idle)
+    root = re.search('Window id: (0x[0-9a-f]+)', subprocess.check_output(['xwininfo', '-root'], env=env, text=True))[1]
+    key('windowfocus', root)
+    time.sleep(0.5)
+    phase('idle_unfocused', idle)
+    subprocess.run(['import', '-window', 'root', str(out / 'final.png')], env=env, check=True)
+    (out / 'results.json').write_text(json.dumps({'name': name, 'binarySha256': hashlib.sha256(binary.read_bytes()).hexdigest(), 'phases': results}, indent=2))
+finally:
+    p.terminate()
+    p.wait(timeout=10)


### PR DESCRIPTION
The composer fades text only at edges with real scroll overflow and animates content-driven growth and shrinkage over 180ms, including mid-animation reversals.

Reuse the transcript/sidebar `edge_faded` wrapper with a compact 12px ramp. Overflow paints through the composer's existing top padding, so the baseline-corrected fade does not add apparent padding inside the editor. Paint-time overflow checks use the settled height; fitting drafts never flash a fade during resizing.

Use the settled viewport for caret-follow, wheel scrolling, and drag-scroll limits to keep existing text anchored to the input origin. During resizing, reveal complete text rows using the editor's line metrics, rather than slicing glyphs with the moving bottom boundary. New rows become visible once there is room (within the 180ms animation). Normal overflow scrolling keeps its full viewport and directional fades.

Measure edited text before choosing the parent height and constrain painting above the controls, preventing stale-height delay and overlap with the model picker. Navigation and reduced motion still snap.

Validation: `cargo build --locked -p zeron` and all 627 UI unit tests passed (`cargo test --locked -p zeron-ui --lib -- --test-threads=1`). Regressions cover complete-row reveals with fractional scroll offsets, text anchoring across resize heights, fitting versus overflowing drafts, overflow direction, deletion, and animation reversal/settling/reduced motion. Native frame inspection confirmed full-height bottom-row glyphs throughout the sampled growth sequence.

Performance audit: fixed a provisional-layout notification loop and added a bounded shaping cache. Two native release reruns return unfocused CPU to 0.2% (base main: 0–0.2%; earlier PR: 238%), with comparable scrolling CPU and peak RSS. Typing animations still add bounded rendering work: main-thread CPU averaged 15.83% versus 14.77% on main, and total process CPU was about 20% higher during typing in this Linux/Xvfb workload. Added real headless regressions for cache invalidation and settled repaint notifications. [Measurements, limitations, and reproduction](https://github.com/zeronsh/comet/blob/283b3b11845f14d18c0f8372fa8d252e21d7331c/docs/performance-composer.md).

Video: actual Linux desktop app with an isolated mock-engine demo. Shows anchored text and complete rows during growth/deletion, fades within existing top padding, directional overflow fades, and clearing the draft. Cropped to the composer; playback speed is unchanged.

https://github.com/user-attachments/assets/fd5aef37-b66a-4108-a88e-6341c70136fe
