### PR TITLE
Remove GPL tracing dependencies and release v0.2.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2765,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "schemars",
  "serde",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "anyhow",
  "gpui",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "anyhow",
  "log",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2820,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2849,7 +2849,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3108,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4160,7 +4160,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4975,7 +4975,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "collections",
  "serde",
@@ -5889,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "derive_refineable",
 ]
@@ -6192,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "async-task",
  "backtrace",
@@ -6805,13 +6805,11 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "heapless 0.9.3",
  "log",
  "rayon",
- "tracing",
- "ztracing",
 ]
 
 [[package]]
@@ -7988,7 +7986,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
+source = "git+https://github.com/zeronsh/zui?rev=de9f26e0dfc115ea97a7f08077163fa757241837#de9f26e0dfc115ea97a7f08077163fa757241837"
 dependencies = [
  "perf",
  "quote",
@@ -9424,7 +9422,7 @@ dependencies = [
 
 [[package]]
 name = "zeron"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "anyhow",
  "clap",
@@ -9443,7 +9441,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-doc"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "chrono",
  "loro",
@@ -9457,7 +9455,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-engine"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9493,7 +9491,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-harness"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9514,7 +9512,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-proto"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "chrono",
  "serde",
@@ -9524,7 +9522,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-rpc"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9543,7 +9541,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-sync"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -9566,7 +9564,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-syntax"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "thiserror 2.0.20",
  "tree-sitter",
@@ -9600,7 +9598,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-theme"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "anyhow",
  "clap",
@@ -9615,7 +9613,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-ui"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -9654,7 +9652,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-update"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "anyhow",
  "futures",
@@ -9701,37 +9699,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zlog"
-version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
-dependencies = [
- "anyhow",
- "chrono",
- "collections",
- "log",
-]
-
-[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
-
-[[package]]
-name = "ztracing"
-version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
-dependencies = [
- "tracing",
- "tracing-subscriber",
- "zlog",
- "ztracing_macro",
-]
-
-[[package]]
-name = "ztracing_macro"
-version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=a1efdb9b7a4fb97824330af4bf49170a3deef986#a1efdb9b7a4fb97824330af4bf49170a3deef986"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.45"
+version = "0.2.46"
 edition = "2024"
 license = "MIT"
 publish = false
@@ -41,6 +41,7 @@ loro-protocol = "0.3"
 
 # gpui — zeronsh/zui, extracted from wingleeio/zed e2ddcc6 with identical
 # crate sources; adds bounded blur passes and shared Gaussian weights.
+# Removes the GPL tracing crates from sum_tree while preserving frame recovery.
 # Preserved fork history: upstream f14fea9 + commits on
 # `comet/edge-fade-horizontal` (tip of `comet/line-wrap-closing-punctuation`
 # + 5d1f83d horizontal per-pixel EdgeFade for quads/images; rebase when bumping the
@@ -61,14 +62,14 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/zeronsh/zui", rev = "a1efdb9b7a4fb97824330af4bf49170a3deef986" }
-gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "a1efdb9b7a4fb97824330af4bf49170a3deef986", features = [
+gpui = { git = "https://github.com/zeronsh/zui", rev = "de9f26e0dfc115ea97a7f08077163fa757241837" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "de9f26e0dfc115ea97a7f08077163fa757241837", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "a1efdb9b7a4fb97824330af4bf49170a3deef986" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "de9f26e0dfc115ea97a7f08077163fa757241837" }
 
 # diffs
 similar = "2"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -13,7 +13,8 @@ Zeron bundles the following syntax-highlighting components. Unless noted otherwi
 | Tree-sitter TOML, Markdown, YAML, Swift, SQL, Lua, Nix, Make and Containerfile grammars and queries | pinned in `Cargo.lock` | MIT-compatible; see each crate | Crate repositories recorded in `Cargo.lock` |
 | Tree-sitter Kotlin grammar | 1.1.0 | MIT | https://github.com/tree-sitter-grammars/tree-sitter-kotlin |
 
-The full Zeron distribution remains licensed under the terms in `LICENSE`.
+Zeron's own source code is licensed under the terms in `LICENSE`. Bundled
+third-party components retain their respective licenses and notices.
 
 ## Bundled theme palette adaptations
 


### PR DESCRIPTION
Zeron pulled GPL-3.0-or-later crates into its desktop dependency graph through `gpui → sum_tree → ztracing`. Pin ZUI to `de9f26e`, which removes the profiling annotations and the `ztracing`, `ztracing_macro`, and `zlog` crates, and uses `env_logger` for sum-tree tests. Existing macOS frame recovery fixes are preserved.

Bump the workspace to v0.2.46 and clarify that bundled dependencies retain their own licenses.

Validation: all 10 sum-tree tests pass; `cargo check --locked -p zeron` passes; resolved metadata for all 910 packages contains none of the removed crates, the GPL `path` crate, or GPL-only license declarations. All 652 UI regression tests pass (`cargo test --release --locked -p zeron-ui --lib -- --test-threads=1`). GitHub also runs Linux UI and macOS frame-recovery checks.

Fixes #272.
