### PR TITLE
Use the organization GPUI component fork for v0.2.49

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "gpui-base"
 version = "0.5.2"
-source = "git+https://github.com/jsgrrchg/gpui-component?rev=c5dca15e20b9d697c41ef173239d432e5de30ced#c5dca15e20b9d697c41ef173239d432e5de30ced"
+source = "git+https://github.com/zeronsh/gpui-component?rev=c5dca15e20b9d697c41ef173239d432e5de30ced#c5dca15e20b9d697c41ef173239d432e5de30ced"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -9591,7 +9591,7 @@ dependencies = [
 
 [[package]]
 name = "zeron"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "clap",
@@ -9610,7 +9610,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-doc"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "chrono",
  "loro",
@@ -9624,7 +9624,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-engine"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9660,7 +9660,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-harness"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-proto"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "chrono",
  "serde",
@@ -9691,7 +9691,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-rpc"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9710,7 +9710,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-sync"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -9733,7 +9733,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-syntax"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "thiserror 2.0.20",
  "tree-sitter",
@@ -9767,7 +9767,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-theme"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "clap",
@@ -9782,7 +9782,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-ui"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -9823,7 +9823,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-update"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.48"
+version = "0.2.49"
 edition = "2024"
 license = "MIT"
 publish = false
@@ -70,7 +70,7 @@ gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "de9f26e0dfc115e
     "runtime_shaders",
 ] }
 gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "de9f26e0dfc115ea97a7f08077163fa757241837" }
-gpui-base = { git = "https://github.com/jsgrrchg/gpui-component", rev = "c5dca15e20b9d697c41ef173239d432e5de30ced" }
+gpui-base = { git = "https://github.com/zeronsh/gpui-component", rev = "c5dca15e20b9d697c41ef173239d432e5de30ced" }
 
 # diffs
 similar = "2"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -13,11 +13,11 @@ Zeron bundles the following syntax-highlighting components. Unless noted otherwi
 | Tree-sitter TOML, Markdown, YAML, Swift, SQL, Lua, Nix, Make and Containerfile grammars and queries | pinned in `Cargo.lock` | MIT-compatible; see each crate | Crate repositories recorded in `Cargo.lock` |
 | Tree-sitter Kotlin grammar | 1.1.0 | MIT | https://github.com/tree-sitter-grammars/tree-sitter-kotlin |
 
-Zeron also uses the following editor foundations from the pinned `jsgrrchg/gpui-component` fork. The fork aligns these crates with the same GPUI revision used by Comet.
+Zeron also uses the following editor foundations from the pinned `zeronsh/gpui-component` fork. The fork aligns these crates with the same GPUI revision used by Comet.
 
 | Component | Version | License | Source |
 | --- | --- | --- | --- |
-| gpui-base | 0.5.2 (`c5dca15`) | Apache-2.0 | https://github.com/jsgrrchg/gpui-component |
+| gpui-base | 0.5.2 (`c5dca15`) | Apache-2.0 | https://github.com/zeronsh/gpui-component |
 | Ropey | 2.0.0-beta.1 | MIT | https://github.com/cessen/ropey |
 
 Zeron's own source code is licensed under the terms in `LICENSE`. Bundled third-party components retain their respective licenses and notices.


### PR DESCRIPTION
Resolve `gpui-base` from `zeronsh/gpui-component` at the existing `c5dca15e20b9d697c41ef173239d432e5de30ced` revision. Update the third-party notice and prepare v0.2.49.

The fork preserves the exact source tree and the lockfile keeps every dependency version unchanged. This release also includes the file-sidebar activation fix merged in #276.

Validation: locked Cargo metadata resolves the organization fork; all 739 UI tests passed. GitHub Linux/macOS CI is running.
