### PR TITLE
Always queue active-turn messages and remove steering controls

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -7,6 +7,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - 'crates/**'
+      - 'apps/ios/**'
       - '.github/workflows/ui-tests.yml'
   push:
     branches: [main]
@@ -15,6 +16,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - 'crates/**'
+      - 'apps/ios/**'
       - '.github/workflows/ui-tests.yml'
   workflow_dispatch:
 
@@ -87,3 +89,35 @@ jobs:
       - name: Native frame-source recovery regression
         working-directory: frame-source-tests
         run: cargo test --release --locked -p gpui_macos --test frame_source_recovery
+
+  ios-tests:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select an available iPhone simulator
+        run: |
+          python3 - <<'PYTHON'
+          import json, os, subprocess
+          devices = json.loads(subprocess.check_output(["xcrun", "simctl", "list", "devices", "available", "--json"]))["devices"]
+          iphones = [device for runtime, group in devices.items() if "iOS" in runtime
+                     for device in group if device["name"].startswith("iPhone")]
+          if not iphones:
+              raise SystemExit("No iPhone simulator is installed")
+          with open(os.environ["GITHUB_ENV"], "a") as env:
+              env.write("IOS_SIMULATOR_ID=" + iphones[0]["udid"] + "\n")
+          PYTHON
+      - name: Run iOS unit tests
+        working-directory: apps/ios
+        run: |
+          xcodebuild -project Zeron.xcodeproj -scheme Zeron \
+            -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_ID" \
+            -resultBundlePath "$RUNNER_TEMP/ios-tests.xcresult" \
+            -only-testing:ZeronTests CODE_SIGNING_ALLOWED=NO test
+      - name: Upload iOS test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-results
+          path: ${{ runner.temp }}/ios-tests.xcresult
+          if-no-files-found: ignore

--- a/apps/ios/Zeron/Composer/ComposerView.swift
+++ b/apps/ios/Zeron/Composer/ComposerView.swift
@@ -1,8 +1,8 @@
 // Composer — the floating glass shell in the t3 mobile composer's shape: a
 // collapsed capsule (editor + send circle) that morphs into an expanded card
 // with a toolbar ROW below it (attach circle · scrolling chips · pinned send)
-// when the editor takes focus. Carries the desktop's Send→Steer→Stop
-// semantics: live run + text = steer (same up-arrow), live run + empty = stop.
+// when the editor takes focus. A live run plus text queues the message;
+// a live run with an empty composer offers Stop.
 //
 // Expansion is focus-driven like t3's, with the old deterministic content
 // triggers kept as a floor (attachments, newline, >26 chars) — content-size
@@ -240,8 +240,6 @@ struct ComposerView: View {
     let chat: Chat
     let runLive: Bool
 
-    @AppStorage("activeTurnSendBehavior") private var activeTurnBehavior: ActiveTurnSendBehavior = .queue
-    @State private var midTurnSteering: Bool?
     @State private var text = ""
     @State private var attachments: [StagedAttachment] = []
     @State private var pickerItems: [PhotosPickerItem] = []
@@ -329,7 +327,6 @@ struct ComposerView: View {
                            editingId: editingQueuedId,
                            onEdit: { item in Task { await beginQueueEdit(item) } },
                            onCancelEdit: { Task { await cancelQueueEdit() } },
-                           midTurnSteering: midTurnSteering,
                            supportsActions: supportsQueueActions,
                            onAction: performQueueAction)
             }
@@ -353,7 +350,7 @@ struct ComposerView: View {
                 placeholder: editingQueuedId == nil ? "Message" : "Edit queued message",
                 sendEnabled: true,
                 sendLabel: editingQueuedId != nil ? "Save queued message"
-                    : (runLive && activeTurnBehavior == .queue ? "Queue message" : "Send message"),
+                    : (runLive ? "Queue message" : "Send message"),
                 allowEmptySend: editingQueuedId != nil,
                 showStop: runLive,
                 busy: uploading || queueEditBusy,
@@ -372,20 +369,6 @@ struct ComposerView: View {
                 if let branch = chat.branch?.trimmingCharacters(in: .whitespacesAndNewlines),
                    !branch.isEmpty {
                     BranchContextChip(branch: branch)
-                }
-                if model.hostSupportsMessageQueue(chat) {
-                    Menu {
-                        Picker("Messages during an active turn", selection: $activeTurnBehavior) {
-                            ForEach(ActiveTurnSendBehavior.allCases, id: \.self) { behavior in
-                                Text(behavior.label).tag(behavior)
-                            }
-                        }
-                    } label: {
-                        Text(activeTurnBehavior.label)
-                            .font(Theme.sans(12, weight: .medium))
-                            .foregroundStyle(Theme.textMuted)
-                    }
-                    .accessibilityLabel("Messages during an active turn: \(activeTurnBehavior.label)")
                 }
                 ComposerChip(label: currentModel.label, badgeHarness: harness) {
                     showModelPicker = true
@@ -441,12 +424,6 @@ struct ComposerView: View {
         .task(id: "\(chat.id)/\(harness)") {
             guard let space = model.space(for: chat) else { return }
             catalogs[harness] = await model.listModels(space: space, harness: harness)
-        }
-        .task(id: "\(chat.deviceId)/\(harness)/\(model.deviceOnline(chat.deviceId))") {
-            midTurnSteering = nil
-            let descriptors = await model.workspace?.listHarnesses(deviceId: chat.deviceId)
-            guard !Task.isCancelled else { return }
-            midTurnSteering = descriptors?.first(where: { $0.id == harness })?.midTurnSteering
         }
         .task(id: queueEdit?.terminal == true ? nil : queueEditLease?.leaseId) {
             guard let lease = queueEditLease, queueEdit?.terminal != true else { return }
@@ -620,6 +597,10 @@ struct ComposerView: View {
         let submittedText = text
         let prompt = submittedText.trimmingCharacters(in: .whitespacesAndNewlines)
         let staged = attachments
+        guard !runLive || model.hostSupportsMessageQueue(chat, attachments: !staged.isEmpty) else {
+            uploadError = "Update the chat's engine to queue messages during a response."
+            return
+        }
         guard !prompt.isEmpty || !staged.isEmpty else { return }
 
         if staged.isEmpty {
@@ -687,22 +668,12 @@ struct ComposerView: View {
     }
 
     private func deliver(content: String, paths: [String]) {
-        // Mid-turn, the message joins the queue rather than racing the turn:
-        // whether it then steers into this turn or waits for the next one is
-        // the host's call (DocHost::drain_queue). It sits in the panel above
-        // meanwhile, editable, which beats a bubble that looks sent.
+        // All active-turn messages wait in the shared queue.
         if runLive {
-            if model.hostSupportsMessageQueue(chat, attachments: !paths.isEmpty) {
-                let queueText = model.hostSupportsCleanQueueAttachmentText(chat)
-                    ? MessageQueue.visibleText(content, attachments: paths)
-                    : content
-                store.enqueueMessage(text: queueText, attachments: paths, holdForTurnEnd: activeTurnBehavior.holdForTurnEnd)
-            } else {
-                // Same-version upstream and older hosts retain the proven
-                // durable command path instead of receiving an unknown queue
-                // document shape or RPC.
-                store.sendSteer(prompt: content)
-            }
+            let queueText = model.hostSupportsCleanQueueAttachmentText(chat)
+                ? MessageQueue.visibleText(content, attachments: paths)
+                : content
+            store.enqueueMessage(text: queueText, attachments: paths, holdForTurnEnd: true)
         } else {
             store.sendRun(prompt: content, chat: chat, attachments: paths)
         }
@@ -716,7 +687,7 @@ struct ComposerView: View {
         guard editingQueuedId == nil, !queueEditBusy, !uploading,
               let head = store.queue.first,
               let action = MessageQueue.primaryAction(
-                for: head, midTurnSteering: midTurnSteering,
+                for: head,
                 supportsActions: supportsQueueActions,
                 pending: store.queueActionsPending.contains(head.id)) else { return }
         performQueueAction(head, action)

--- a/apps/ios/Zeron/Composer/QueuePanelView.swift
+++ b/apps/ios/Zeron/Composer/QueuePanelView.swift
@@ -14,7 +14,6 @@ struct QueuePanel: View {
     var editingId: String?
     var onEdit: (QueuedMessage) -> Void
     var onCancelEdit: () -> Void
-    var midTurnSteering: Bool?
     var supportsActions: Bool
     var onAction: (QueuedMessage, QueueAction) -> Void
 
@@ -112,7 +111,7 @@ struct QueuePanel: View {
                           editing: Bool) -> some View {
         let pending = store.queueActionsPending.contains(item.id)
         let gated = item.deliveryGate != nil || pending
-        let primary = MessageQueue.primaryAction(for: item, midTurnSteering: midTurnSteering,
+        let primary = MessageQueue.primaryAction(for: item,
                                                  supportsActions: supportsActions, pending: pending)
         let lockedByOther: Bool = {
             if case .editing = item.deliveryGate { return !editing }
@@ -139,7 +138,7 @@ struct QueuePanel: View {
                 Button(primary.label) { onAction(item, primary) }
                     .font(Theme.sans(11, weight: .medium))
                     .buttonStyle(.plain)
-                    .accessibilityLabel(primary == .steer ? "Steer without interrupting" : "Send now, interrupting the response")
+                    .accessibilityLabel("Send now, interrupting the response")
             }
             iconButton("trash", label: "Remove", enabled: supportsActions && !pending,
                        tone: Theme.textFaint) {

--- a/apps/ios/Zeron/Models/MessageQueue.swift
+++ b/apps/ios/Zeron/Models/MessageQueue.swift
@@ -114,25 +114,16 @@ enum MessageQueue {
     }
 }
 
-/// Preserve the phone's existing policy unless the user opts into steering.
-enum ActiveTurnSendBehavior: String, CaseIterable {
-    case queue, steer
-    var label: String { self == .queue ? "Queue" : "Steer" }
-    var holdForTurnEnd: Bool { self == .queue }
-}
-
 enum QueueAction: Equatable {
-    case steer, sendNow, remove
+    case sendNow, remove
     var method: String {
         switch self {
-        case .steer: return "SteerQueuedMessageNow"
         case .sendNow: return "SendQueuedMessageNow"
         case .remove: return "RemoveQueuedMessage"
         }
     }
     var label: String {
         switch self {
-        case .steer: return "Steer"
         case .sendNow: return "Send now"
         case .remove: return "Remove"
         }
@@ -148,10 +139,9 @@ struct QueueActionReply: Decodable {
 }
 
 extension MessageQueue {
-    static func primaryAction(for item: QueuedMessage, midTurnSteering: Bool?,
+    static func primaryAction(for item: QueuedMessage,
                               supportsActions: Bool, pending: Bool) -> QueueAction? {
-        guard supportsActions, !pending, item.deliveryGate == nil,
-              let midTurnSteering else { return nil }
-        return midTurnSteering && item.attachments.isEmpty ? .steer : .sendNow
+        guard supportsActions, !pending, item.deliveryGate == nil else { return nil }
+        return .sendNow
     }
 }

--- a/apps/ios/ZeronTests/MessageQueueTests.swift
+++ b/apps/ios/ZeronTests/MessageQueueTests.swift
@@ -128,19 +128,17 @@ final class MessageQueueTests: XCTestCase {
         XCTAssertTrue(store.queueActionsPending.isEmpty)
     }
 
-    func testSteerAndSendUseDistinctHostMethodsAndLeaveProjectionToSync() async throws {
+    func testSendNowUsesHostMethodAndLeavesProjectionToSync() async throws {
         let store = store()
         let id = try XCTUnwrap(store.enqueueMessage(text: "hello"))
-        for (action, method) in [(QueueAction.steer, "SteerQueuedMessageNow"), (.sendNow, "SendQueuedMessageNow")] {
-            let sent = await store.performQueueAction(id: id, action: action) { actual, _ in
-                XCTAssertEqual(actual, method)
-                return QueueActionReply(sent: true)
-            }
-            XCTAssertTrue(sent)
-            XCTAssertEqual(texts(store), ["hello"])
-            XCTAssertNil(store.queueActionError)
+        let delivered = await store.performQueueAction(id: id, action: .sendNow) { method, _ in
+            XCTAssertEqual(method, "SendQueuedMessageNow")
+            return QueueActionReply(sent: true)
         }
-        let sent = await store.performQueueAction(id: id, action: .steer) { _, _ in
+        XCTAssertTrue(delivered)
+        XCTAssertEqual(texts(store), ["hello"])
+        XCTAssertNil(store.queueActionError)
+        let sent = await store.performQueueAction(id: id, action: .sendNow) { _, _ in
             throw RelayError.hostOffline
         }
         XCTAssertFalse(sent)
@@ -149,23 +147,19 @@ final class MessageQueueTests: XCTestCase {
 
     func testPrimaryActionRespectsCapabilitiesAttachmentsAndDeliveryGates() {
         var item = QueuedMessage(id: "q", text: "hello")
-        func action(_ steering: Bool?, supported: Bool = true, pending: Bool = false) -> QueueAction? {
-            MessageQueue.primaryAction(for: item, midTurnSteering: steering,
+        func action(supported: Bool = true, pending: Bool = false) -> QueueAction? {
+            MessageQueue.primaryAction(for: item,
                                        supportsActions: supported, pending: pending)
         }
-        XCTAssertEqual(action(true), .steer)
-        XCTAssertEqual(action(false), .sendNow)
-        XCTAssertNil(action(nil))
-        XCTAssertNil(action(true, supported: false))
-        XCTAssertNil(action(true, pending: true))
+        XCTAssertEqual(action(), .sendNow)
+        XCTAssertNil(action(supported: false))
+        XCTAssertNil(action(pending: true))
         item.attachments = ["uploads/image.png"]
-        XCTAssertEqual(action(true), .sendNow)
+        XCTAssertEqual(action(), .sendNow)
         item.deliveryGate = .reviewRequired(ownerDeviceId: "mac")
-        XCTAssertNil(action(true))
+        XCTAssertNil(action())
         item.deliveryGate = .editing(ownerDeviceId: "mac", expiresAtMs: 60_000)
-        XCTAssertNil(action(false))
-        XCTAssertTrue(ActiveTurnSendBehavior.queue.holdForTurnEnd)
-        XCTAssertFalse(ActiveTurnSendBehavior.steer.holdForTurnEnd)
+        XCTAssertNil(action())
     }
 
     func testProtectedRowsCannotBeDeliveredEvenThroughDirectStoreCall() async throws {
@@ -177,13 +171,11 @@ final class MessageQueueTests: XCTestCase {
         ]))
         store.doc.commit()
         store.refreshQueue()
-        for action in [QueueAction.steer, .sendNow] {
-            let sent = await store.performQueueAction(id: id, action: action) { _, _ in
-                XCTFail("protected rows must not dispatch")
-                return QueueActionReply(sent: true)
-            }
-            XCTAssertFalse(sent)
+        let sent = await store.performQueueAction(id: id, action: .sendNow) { _, _ in
+            XCTFail("protected rows must not dispatch")
+            return QueueActionReply(sent: true)
         }
+        XCTAssertFalse(sent)
         XCTAssertEqual(texts(store), ["protected"])
     }
 

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -2910,8 +2910,7 @@ impl DocHost {
     /// put them.
     ///
     /// - Idle: send the head as the next turn (and loop — the agent is free).
-    /// - Working, agent takes mid-turn input: steer it in.
-    /// - Working, anything else: hold. The turn-end watcher comes back for it.
+    /// - Turn in flight: hold. The turn-end watcher comes back for it.
     ///
     /// One at a time by design: each send changes the status this reads.
     pub async fn drain_queue(&self, handle: &Arc<ChatDocHandle>) {
@@ -2966,21 +2965,10 @@ impl DocHost {
             // the turn too, and the composer queues on the same reading. Taking
             // `AwaitingInput` for idle would send the follow-up as a fresh turn
             // and abandon the question.
-            let busy = sessions.turn_in_flight(&handle.chat_id);
-            let send = if busy {
-                // Attachments never steer: the steer path carries a prompt and
-                // nothing else, so a message with files must wait for a turn
-                // that can inline them rather than lose them.
-                let steer_now = !head.hold_for_turn_end
-                    && head.attachments.is_empty()
-                    && sessions.steers_mid_turn(self.harness_for(&handle.chat_id));
-                if !steer_now {
-                    return; // held until the turn ends
-                }
-                QueueSend::Steer
-            } else {
-                QueueSend::NextTurn
-            };
+            if sessions.turn_in_flight(&handle.chat_id) {
+                return; // All queued messages wait, including rows from older clients.
+            }
+            let send = QueueSend::NextTurn;
             // Take it only once we know it is going out — a row that stays in
             // the queue on a failed send is recoverable; a vanished one is not.
             let Ok(Some(item)) = handle.doc.take_queued(&head.id) else {
@@ -2993,9 +2981,6 @@ impl DocHost {
                 let _ = handle.doc.insert_queued(0, &item);
                 handle.publish_queue();
                 return;
-            }
-            if busy {
-                return; // steered into a live turn; the rest waits for its end
             }
         }
     }

--- a/crates/engine/tests/message_queue.rs
+++ b/crates/engine/tests/message_queue.rs
@@ -5,7 +5,7 @@
 //! - idle agent → the queue drains immediately, in order;
 //! - busy agent that only takes input at a turn boundary → the queue HOLDS,
 //!   and flushes when the turn ends;
-//! - busy agent that takes input mid-turn → steered in;
+//! - busy agent, including one that takes input mid-turn → held until turn end;
 //! - "send now" → interrupts whatever is running.
 
 use std::sync::{Arc, Mutex};
@@ -556,40 +556,51 @@ async fn a_steer_command_holds_for_an_agent_that_takes_no_mid_turn_prompt() {
     core.shutdown().await;
 }
 
-/// An agent that takes mid-turn input: the message goes straight into the
-/// running turn, and the queue stays empty.
+/// Even agents that support mid-turn input deliver queue rows one turn at a time.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn steer_sends_into_a_live_turn_when_the_agent_takes_mid_turn_input() {
+async fn queued_text_waits_for_a_steerable_turn_even_with_legacy_policy() {
     let (core, harness, prompts) = setup(SteeringMode::StepBoundary).await;
-
     core.doc_host
         .queue_message(CHAT, "opening", Vec::new())
-        .expect("queue opening");
+        .unwrap();
     wait_for(
         || prompts.lock().unwrap().iter().any(|p| p == "opening"),
-        "the first turn to start",
+        "first turn",
     )
     .await;
 
+    // Omitted and explicitly false policies from old clients must both wait.
     core.doc_host
-        .queue_message(CHAT, "mid-turn", Vec::new())
-        .expect("queue mid-turn");
+        .queue_message(CHAT, "first queued", Vec::new())
+        .unwrap();
+    core.doc_host
+        .queue_message_with_behavior(CHAT, "second queued", Vec::new(), false)
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert_eq!(queue_texts(&core), vec!["first queued", "second queued"]);
+    assert_eq!(user_messages(&core), vec!["opening"]);
 
-    // Steered messages are written to the transcript by the steer path, and the
-    // queue lets go of them straight away.
+    harness.finish.send(()).unwrap();
     wait_for(
-        || user_messages(&core).iter().any(|m| m == "mid-turn"),
-        "the steered message to reach the transcript",
+        || user_messages(&core).iter().any(|m| m == "first queued"),
+        "first queued turn",
+    )
+    .await;
+    assert_eq!(queue_texts(&core), vec!["second queued"]);
+    assert!(!user_messages(&core).iter().any(|m| m == "second queued"));
+    harness.finish.send(()).unwrap();
+    wait_for(
+        || user_messages(&core).iter().any(|m| m == "second queued"),
+        "second queued turn",
     )
     .await;
     assert!(queue_texts(&core).is_empty());
-
     let _ = harness.finish.send(());
     core.shutdown().await;
 }
 
-/// The user can opt out of automatic steering even for a step-boundary agent,
-/// then explicitly steer a selected row without interrupting the turn.
+/// The legacy explicit-steer RPC remains compatible with older clients;
+/// current clients offer only Send now.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn held_policy_keeps_a_steerable_message_visible_until_steer_now() {
     let (core, harness, prompts) = setup(SteeringMode::StepBoundary).await;

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -1,5 +1,5 @@
 //! The composer: a hand-rolled multiline text input (adapted from gpui's
-//! `examples/input.rs`), the compact↔expanded flip, the Send/Steer/Stop morph,
+//! `examples/input.rs`), the compact↔expanded flip, the Send/Queue/Stop morph,
 //! optimistic send with failure recovery, per-chat drafts, and the question
 //! wizard that replaces the composer while a run awaits input.
 //!
@@ -34,7 +34,7 @@ use zeron_rpc::{RpcError, methods};
 use crate::attachments::{self, StagedAttachment};
 use crate::motion;
 use crate::pickers::Pickers;
-use crate::settings::{ActiveTurnSendBehavior, ComposerSendBehavior, platform_combo};
+use crate::settings::{ComposerSendBehavior, platform_combo};
 use crate::state::{AppState, Indicator};
 use crate::theme::Theme;
 
@@ -460,15 +460,15 @@ const QUEUED_ATTACHMENTS_MIN: (u64, u64, u64) = (0, 2, 12);
 pub enum SendButtonMode {
     /// No live run: plain send.
     Send,
-    /// Live steerable run with text typed: "Send (steers the current run)".
-    Steer,
+    /// Live run with text typed: queue for the next turn.
+    Queue,
     /// Live run, nothing typed: red stop square.
     Stop,
 }
 
 /// What the composer holds that a send could carry. A staged image or diff
 /// comment counts: both synthesize their own prompt body, so either alone is
-/// a legal send — and during a live run has to read as Steer, not Stop.
+/// a legal send — and during a live run has to read as Queue, not Stop.
 pub fn composer_has_content(text: &str, attachments: usize, comments: usize) -> bool {
     !text.trim().is_empty() || attachments > 0 || comments > 0
 }
@@ -490,7 +490,7 @@ fn modified_submit_target(has_content: bool) -> ModifiedSubmitTarget {
 pub fn send_button_mode(run_live: bool, has_text: bool) -> SendButtonMode {
     match (run_live, has_text) {
         (false, _) => SendButtonMode::Send,
-        (true, true) => SendButtonMode::Steer,
+        (true, true) => SendButtonMode::Queue,
         (true, false) => SendButtonMode::Stop,
     }
 }
@@ -3832,9 +3832,7 @@ fn mention_error_message(err: &RpcError) -> SharedString {
             "The session's device runs an older zeron — update it to search its files".into()
         }
         RpcError::Transport(_) | RpcError::Closed => "The session's device is unreachable".into(),
-        RpcError::BadParams(_) | RpcError::Failed(_) => {
-            "File search failed".into()
-        }
+        RpcError::BadParams(_) | RpcError::Failed(_) => "File search failed".into(),
     }
 }
 
@@ -5392,11 +5390,8 @@ impl Composer {
             _ if no_content => {}
             _ if self.send_blocked(cx) => {}
             SendButtonMode::Send => self.send(text, false, cx),
-            // Busy: the message joins the queue rather than racing the turn.
-            // Whether it then steers straight into that turn or waits for the
-            // next one is the engine's call (`DocHost::drain_queue`) — the
-            // composer only says "here, take this".
-            SendButtonMode::Steer => self.send(text, true, cx),
+            // Busy: keep the message queued until the current turn ends.
+            SendButtonMode::Queue => self.send(text, true, cx),
         }
     }
 
@@ -5481,6 +5476,21 @@ impl Composer {
         };
         let space_id = space.as_ref().map(|s| s.id.clone());
         let space_path = space.as_ref().map(|s| s.path.clone());
+        if queue && !is_new {
+            let capability = if self.staged().is_empty() {
+                capabilities::MESSAGE_QUEUE_V1
+            } else {
+                capabilities::MESSAGE_QUEUE_ATTACHMENTS_V1
+            };
+            if !engine.engine_info().supports(capability)
+                || !self.state.read(cx).chat_host_supports(&chat_id, capability)
+            {
+                self.failure =
+                    Some("Update the chat's engine to queue messages during a response.".into());
+                cx.notify();
+                return;
+            }
+        }
         // Snapshot-and-clear NOW (use-attachments.ts takeAttachments): the
         // strip empties the instant you hit send; a failure hands the files
         // back into the chat's stash.
@@ -5504,22 +5514,9 @@ impl Composer {
         self.preview = None;
         let message_id = uuid::Uuid::new_v4().to_string();
         let created_at = chrono::Utc::now().timestamp_millis();
-        // New chats always start a Run. Existing busy chats use the personal
-        // cut's visible/editable message queue only when both the UI's engine
-        // and the chat host explicitly advertise it. Same-version upstream
-        // builds do not, so they retain the legacy durable Steer command.
-        let queue_requested = queue && !is_new;
-        let queue_capability = if staged.is_empty() {
-            capabilities::MESSAGE_QUEUE_V1
-        } else {
-            capabilities::MESSAGE_QUEUE_ATTACHMENTS_V1
-        };
-        let queue = queue_requested
-            && engine.engine_info().supports(queue_capability)
-            && self
-                .state
-                .read(cx)
-                .chat_host_supports(&chat_id, queue_capability);
+        // Existing busy chats always queue; compatibility was checked before
+        // taking the draft, attachments, or review comments.
+        let queue = queue && !is_new;
         let clean_queue_attachment_text = staged.is_empty()
             || (engine
                 .engine_info()
@@ -5528,7 +5525,6 @@ impl Composer {
                     &chat_id,
                     capabilities::MESSAGE_QUEUE_CLEAN_ATTACHMENT_TEXT_V1,
                 ));
-        let legacy_steer = queue_requested && !queue;
 
         // Queued-attachment flow (durable-by-design): stage the bytes on the
         // LOCAL engine, queue the command immediately with `pending://` refs,
@@ -5632,9 +5628,6 @@ impl Composer {
         };
         // A queued message is not in the transcript yet — the queue panel is
         // its echo, and it gets a real bubble when the host sends it.
-        let hold_for_turn_end = queue
-            && crate::settings::current(cx).active_turn_send_behavior
-                == ActiveTurnSendBehavior::Queue;
         self.state.update(cx, |s, cx| {
             if is_new {
                 s.select_chat(Some(chat_id.clone()), cx);
@@ -5934,7 +5927,7 @@ impl Composer {
                         "chatId": chat_id,
                         "text": queue_text,
                         "attachments": attachment_paths,
-                        "holdForTurnEnd": hold_for_turn_end,
+                        "holdForTurnEnd": true,
                     });
                     let reply = engine
                         .client()
@@ -5949,28 +5942,21 @@ impl Composer {
                     return Ok(Some(queue_id.to_string()));
                 }
 
-                let command = if legacy_steer {
-                    SessionCommandPayload::Steer {
+                let command = SessionCommandPayload::Run {
+                    request: RunRequest {
                         prompt: content.clone(),
-                        message_id: Some(message_id.clone()),
-                    }
-                } else {
-                    SessionCommandPayload::Run {
-                        request: RunRequest {
-                            prompt: content.clone(),
-                            harness: resolved.harness,
-                            model: resolved.model.clone(),
-                            reasoning: resolved.reasoning,
-                            model_options: resolved.model_options.clone(),
-                            cwd,
-                            sandbox: SandboxLevel::WorkspaceWrite,
-                            auto_approve: false,
-                            resume: None,
-                            attachments: attachment_paths,
-                            worktree: run_worktree,
-                        },
-                        message_id: message_id.clone(),
-                    }
+                        harness: resolved.harness,
+                        model: resolved.model.clone(),
+                        reasoning: resolved.reasoning,
+                        model_options: resolved.model_options.clone(),
+                        cwd,
+                        sandbox: SandboxLevel::WorkspaceWrite,
+                        auto_approve: false,
+                        resume: None,
+                        attachments: attachment_paths,
+                        worktree: run_worktree,
+                    },
+                    message_id: message_id.clone(),
                 };
                 let command = serde_json::to_value(&command)
                     .map_err(|e| format!("Send failed: {e}"))?;
@@ -6485,7 +6471,7 @@ impl Composer {
     ) -> gpui::AnyElement {
         let theme = Theme::of(cx);
         // Zeron composer-actions.tsx: a size-7 filled circle — up-arrow to
-        // send/steer, a dark rounded square on the same light circle to stop.
+        // send/queue, a dark rounded square on the same light circle to stop.
         match mode {
             SendButtonMode::Stop => div()
                 .id("composer-stop")
@@ -6501,7 +6487,7 @@ impl Composer {
                 .on_click(cx.listener(|this, _, _, cx| this.interrupt_selected(cx)))
                 .child(div().size(px(11.0)).rounded(px(3.0)).bg(theme.bg))
                 .into_any_element(),
-            SendButtonMode::Send | SendButtonMode::Steer => {
+            SendButtonMode::Send | SendButtonMode::Queue => {
                 // Dimmed and inert while no project is picked or no agent is
                 // runnable (`send_blocked` also gates `on_submit`, so Enter
                 // is a no-op too).
@@ -6806,26 +6792,6 @@ impl Render for Composer {
                         .child(div().min_w_0().truncate().child(notice)),
                 ))
             });
-
-        // Turn-boundary steering notice: for agents without mid-turn
-        // injection (Grok over ACP today), a "steer" is queued and applies
-        // when the current turn finishes. Without this hint the queue read
-        // as a dropped steer (user report: "my steer didn't apply until
-        // grok already finished").
-        let steer_queues = mode == SendButtonMode::Steer
-            && self.pickers.read(cx).resolved_steering_mode(cx)
-                == Some(zeron_proto::SteeringMode::TurnBoundary);
-        let container = container.when(steer_queues, |el| {
-            el.child(
-                div()
-                    .mt(px(6.0))
-                    .px(px(12.0))
-                    .text_size(crate::typography::ui_rems(11.0))
-                    .line_height(px(15.0))
-                    .text_color(theme.text_muted.opacity(0.8))
-                    .child("This agent can't be steered mid-turn — your message will be queued and sent when the current turn finishes."),
-            )
-        });
 
         if wizard_active {
             let wizard = self.render_wizard(cx);
@@ -8164,13 +8130,13 @@ mod tests {
     }
 
     #[test]
-    fn a_comment_only_stage_steers_a_live_run_instead_of_stopping_it() {
+    fn a_comment_only_stage_queues_during_a_live_run() {
         let live = true;
         let comment_only = composer_has_content("", 0, 2);
         assert_eq!(
             send_button_mode(live, comment_only),
-            SendButtonMode::Steer,
-            "comment-only submit must steer, not interrupt the run"
+            SendButtonMode::Queue,
+            "comment-only submit must queue without interrupting the run"
         );
         // Nothing staged at all is still the stop square.
         assert_eq!(
@@ -8183,7 +8149,7 @@ mod tests {
     fn send_button_morph() {
         assert_eq!(send_button_mode(false, false), SendButtonMode::Send);
         assert_eq!(send_button_mode(false, true), SendButtonMode::Send);
-        assert_eq!(send_button_mode(true, true), SendButtonMode::Steer);
+        assert_eq!(send_button_mode(true, true), SendButtonMode::Queue);
         assert_eq!(send_button_mode(true, false), SendButtonMode::Stop);
     }
 

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -772,32 +772,6 @@ impl Pickers {
         }
     }
 
-    /// The fully-resolved config the composer threads into the Run request and
-    /// `Mutate createChat`: concrete model + reasoning whenever the catalog is
-    /// loaded (no "engine picks a default" passthrough).
-    /// The resolved harness's steering mode, from the loaded descriptor list.
-    /// `None` while the catalog is loading (callers should assume the common
-    /// StepBoundary case and show nothing).
-    pub fn resolved_steering_mode(&self, cx: &App) -> Option<zeron_proto::SteeringMode> {
-        let harness = self.effective_harness(cx)?;
-        self.harnesses
-            .ready()
-            .and_then(|list| list.iter().find(|d| d.id == harness))
-            .map(|d| d.steering_mode)
-    }
-
-    /// Whether the selected harness can accept a prompt inside the current
-    /// turn. This is deliberately stricter than `supports_steering`: a
-    /// turn-boundary harness cannot fulfil the queue row's non-interrupting
-    /// `Steer` action.
-    pub fn resolved_mid_turn_steering(&self, cx: &App) -> Option<bool> {
-        let harness = self.effective_harness(cx)?;
-        self.harnesses
-            .ready()
-            .and_then(|list| list.iter().find(|d| d.id == harness))
-            .map(HarnessDescriptor::steers_mid_turn)
-    }
-
     /// The catalog is loaded and offers nothing runnable — the no-agents
     /// state (every enabled harness is missing its CLI, or nothing is
     /// enabled). False while the catalog is still loading or failed
@@ -808,6 +782,9 @@ impl Pickers {
             .is_some_and(|list| offered_harnesses(list).is_empty())
     }
 
+    /// The fully-resolved config the composer threads into the Run request and
+    /// `Mutate createChat`: concrete model + reasoning whenever the catalog is
+    /// loaded (no "engine picks a default" passthrough).
     pub fn resolved(&self, cx: &App) -> ResolvedRunConfig {
         ResolvedRunConfig {
             harness: self.effective_harness(cx),

--- a/crates/ui/src/queue.rs
+++ b/crates/ui/src/queue.rs
@@ -4,9 +4,9 @@
 //! The rows live on the session doc ([`zeron_doc::QueuedMessage`]), so the phone
 //! shows the same queue and either device can reorder it.
 //!
-//! Each row exposes a uniform `Steer` control, with delivery semantics
-//! explained in its tooltip. Editing moves
-//! the message into the composer while its leased row reserves its position.
+//! Each row exposes a `Send now` control that interrupts the active response.
+//! Editing moves the message into the composer while its leased row reserves
+//! its position.
 
 use gpui::{
     AnyElement, Context, InteractiveElement as _, IntoElement, ParentElement as _, Render,
@@ -88,47 +88,24 @@ const QUEUE_ICON_SIZE: f32 = 13.0;
 /// The single trailing action a queue row advertises and executes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum QueuePrimaryAction {
-    Steer,
     SendNow,
 }
 
 impl QueuePrimaryAction {
     fn tooltip(self) -> &'static str {
         match self {
-            Self::Steer => "Steer without interrupting",
             Self::SendNow => "Send now (interrupt)",
         }
     }
 }
 
-/// Attachments cannot travel through the text-only steering channel. Unknown
-/// catalogs are conservative too: never promise a non-interrupting steer until
-/// the selected provider has advertised it.
-fn queue_primary_action(
-    resolved_mid_turn_steering: Option<bool>,
-    has_attachments: bool,
-) -> Option<QueuePrimaryAction> {
-    match resolved_mid_turn_steering {
-        Some(true) if !has_attachments => Some(QueuePrimaryAction::Steer),
-        Some(_) => Some(QueuePrimaryAction::SendNow),
-        None => None,
-    }
-}
-
-/// The primary action is executable only when both the selected provider and
-/// the chat host can honor it, and nobody currently owns the row for editing
-/// or review. The row button, keyboard accelerator and its hint all use this
-/// decision so they cannot disagree about availability.
+/// All providers use Send now. Only host support and edit/review gates
+/// determine whether the action is available.
 fn available_queue_primary_action(
-    resolved_mid_turn_steering: Option<bool>,
-    has_attachments: bool,
     delivery_blocked: bool,
     host_supports_actions: bool,
 ) -> Option<QueuePrimaryAction> {
-    if delivery_blocked || !host_supports_actions {
-        return None;
-    }
-    queue_primary_action(resolved_mid_turn_steering, has_attachments)
+    (!delivery_blocked && host_supports_actions).then_some(QueuePrimaryAction::SendNow)
 }
 
 fn queue_head_shortcut_visible(
@@ -292,7 +269,6 @@ impl Composer {
             .as_ref()
             .map(|d| (d.from, d.over, d.prev_over, d.epoch));
         let editing = self.editing_queued.clone();
-        let mid_turn_steering = self.pickers().read(cx).resolved_mid_turn_steering(cx);
 
         let list_chat = chat_id.clone();
         let drop_chat = chat_id.clone();
@@ -306,7 +282,6 @@ impl Composer {
                     item,
                     drag,
                     &editing,
-                    mid_turn_steering,
                     host_supports_actions,
                     show_head_shortcut,
                     &theme,
@@ -366,7 +341,6 @@ impl Composer {
         item: &QueuedMessage,
         drag: Option<(usize, usize, usize, usize)>,
         editing: &Option<String>,
-        mid_turn_steering: Option<bool>,
         host_supports_actions: bool,
         show_head_shortcut: bool,
         theme: &Theme,
@@ -415,12 +389,8 @@ impl Composer {
                 this.remove_queued(drop_id.clone(), cx);
             }),
         );
-        let resolved_primary = available_queue_primary_action(
-            mid_turn_steering,
-            !item.attachments.is_empty(),
-            interaction_blocked,
-            host_supports_actions,
-        );
+        let resolved_primary =
+            available_queue_primary_action(interaction_blocked, host_supports_actions);
         let primary_action = resolved_primary.unwrap_or(QueuePrimaryAction::SendNow);
         let primary_id = item.id.clone();
         let primary = self.queue_primary_action_button(
@@ -535,7 +505,7 @@ impl Composer {
                         }),
                 )
             })
-            // Files are why a row can sit through a steerable turn, so say so.
+            // Keep queued attachments visible alongside the message.
             .when(!item.attachments.is_empty(), |el| {
                 el.child(
                     crate::icons::icon(crate::icons::QUEUE_PAPERCLIP)
@@ -650,7 +620,7 @@ impl Composer {
             .into_any_element()
     }
 
-    /// Uniform Steer control; the tooltip explains the resolved delivery behavior.
+    /// Send now interrupts the current response before delivering the row.
     fn queue_primary_action_button(
         &self,
         key: &SharedString,
@@ -692,7 +662,7 @@ impl Composer {
                 .into()
             })
             .tooltip_show_delay(std::time::Duration::from_millis(350))
-            .child("Steer")
+            .child("Send now")
             .into_any_element()
     }
 
@@ -863,20 +833,6 @@ impl Composer {
         );
     }
 
-    /// Steer one row into the current turn without stopping it. If the turn
-    /// ends during the click, the engine sends it as the next turn instead.
-    pub(crate) fn steer_queued_now(&mut self, id: String, cx: &mut Context<Self>) {
-        if self.editing_queued.as_deref() == Some(id.as_str()) {
-            self.clear_queue_edit(cx);
-        }
-        self.queue_rpc(
-            methods::STEER_QUEUED_MESSAGE_NOW,
-            serde_json::json!({ "id": id }),
-            "Couldn't steer that message",
-            cx,
-        );
-    }
-
     /// Execute the same resolved action advertised on the row. Both pointer
     /// clicks and the empty-composer Enter gesture come through here.
     fn activate_queued_primary(
@@ -886,19 +842,17 @@ impl Composer {
         cx: &mut Context<Self>,
     ) {
         match action {
-            QueuePrimaryAction::Steer => self.steer_queued_now(id, cx),
             QueuePrimaryAction::SendNow => self.send_queued_now(id, cx),
         }
     }
 
     /// Cmd/Ctrl+Enter on an empty composer activates the same action shown on
-    /// the first queued row: non-interrupting Steer when possible, Send now
-    /// otherwise. An edit/review gate or an old chat host makes it a no-op.
+    /// the first queued row: Send now, interrupting the current response. An edit/review gate or an old chat host makes it a no-op.
     pub(crate) fn queue_pop_head(&mut self, cx: &mut Context<Self>) {
         if self.editing_queued.is_some() {
             return;
         }
-        let (id, has_attachments, delivery_blocked, host_supports_actions) = {
+        let (id, delivery_blocked, host_supports_actions) = {
             let state = self.state.read(cx);
             let Some(chat_id) = state.selected_chat.as_deref() else {
                 return;
@@ -908,7 +862,6 @@ impl Composer {
             };
             (
                 item.id.clone(),
-                !item.attachments.is_empty(),
                 item.delivery_gate.is_some(),
                 state.chat_host_supports(
                     chat_id,
@@ -916,12 +869,8 @@ impl Composer {
                 ),
             )
         };
-        let Some(action) = available_queue_primary_action(
-            self.pickers().read(cx).resolved_mid_turn_steering(cx),
-            has_attachments,
-            delivery_blocked,
-            host_supports_actions,
-        ) else {
+        let Some(action) = available_queue_primary_action(delivery_blocked, host_supports_actions)
+        else {
             return;
         };
         self.activate_queued_primary(id, action, cx);
@@ -1406,44 +1355,17 @@ mod tests {
     use super::{
         PANEL_PAD_TOP, QueuePrimaryAction, ROW_SLOT, available_queue_primary_action, one_line,
         queue_action_needs_host, queue_drag_offsets, queue_drop_index, queue_head_shortcut_visible,
-        queue_mutation_acknowledged, queue_primary_action, queue_visible_text,
+        queue_mutation_acknowledged, queue_visible_text,
     };
-
-    #[test]
-    fn primary_action_only_promises_steer_when_the_row_can_use_it() {
-        assert_eq!(
-            queue_primary_action(Some(true), false),
-            Some(QueuePrimaryAction::Steer)
-        );
-        assert_eq!(
-            queue_primary_action(Some(false), false),
-            Some(QueuePrimaryAction::SendNow)
-        );
-        assert_eq!(queue_primary_action(None, false), None);
-        assert_eq!(
-            queue_primary_action(Some(true), true),
-            Some(QueuePrimaryAction::SendNow)
-        );
-    }
 
     #[test]
     fn available_primary_action_obeys_row_and_host_gates() {
         assert_eq!(
-            available_queue_primary_action(Some(true), false, false, true),
-            Some(QueuePrimaryAction::Steer)
-        );
-        assert_eq!(
-            available_queue_primary_action(Some(false), false, false, true),
+            available_queue_primary_action(false, true),
             Some(QueuePrimaryAction::SendNow)
         );
-        assert_eq!(
-            available_queue_primary_action(Some(true), false, true, true),
-            None
-        );
-        assert_eq!(
-            available_queue_primary_action(Some(true), false, false, false),
-            None
-        );
+        assert_eq!(available_queue_primary_action(true, true), None);
+        assert_eq!(available_queue_primary_action(false, false), None);
     }
 
     #[test]

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -292,19 +292,6 @@ pub enum ComposerSendBehavior {
     ModEnter,
 }
 
-/// What Enter does with a message while the selected agent has a live turn.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum ActiveTurnSendBehavior {
-    /// Preserve the historical behavior: steer immediately when the harness
-    /// supports it, otherwise leave the message queued for the next turn.
-    #[default]
-    Steer,
-    /// Keep the message visible and editable in the queue until the turn ends
-    /// or the user explicitly chooses the row's Steer / Send now action.
-    Queue,
-}
-
 /// Persist the latest revision. Safe to call at shutdown.
 pub fn flush(cx: &mut App) {
     if !cx.has_global::<SettingsStore>() {
@@ -357,8 +344,6 @@ pub enum SidebarSort {
 pub struct UiSettings {
     /// Submit using Enter or the platform modifier plus Enter.
     pub composer_send_behavior: ComposerSendBehavior,
-    /// Steer immediately when supported or hold until the active turn ends.
-    pub active_turn_send_behavior: ActiveTurnSendBehavior,
     pub sidebar_width: f32,
     pub sidebar_collapsed: bool,
     /// Legacy: the grouped-by-project toggle predates spaces (which group by
@@ -483,7 +468,6 @@ impl Default for UiSettings {
             terminal_open: false,
             keymap: KeymapConfig::default(),
             composer_send_behavior: ComposerSendBehavior::default(),
-            active_turn_send_behavior: ActiveTurnSendBehavior::default(),
             appearance: crate::appearance::AppearanceMode::default(),
             git_history_columns: GitHistoryColumns::default(),
             git_history_column_widths: GitHistoryColumnWidths::default(),
@@ -1086,18 +1070,18 @@ mod tests {
     }
 
     #[test]
-    fn active_turn_send_behavior_preserves_automatic_steering_for_old_settings() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            UiSettings::path(dir.path()),
-            r#"{"sidebarWidth": 300, "soundEnabled": false}"#,
+    fn obsolete_steering_preference_does_not_reset_other_settings() {
+        let loaded: UiSettings = serde_json::from_str(
+            r#"{"activeTurnSendBehavior":"steer","sidebarWidth":300,"soundEnabled":false}"#,
         )
         .unwrap();
-
-        let loaded = UiSettings::load(dir.path());
-        assert_eq!(
-            loaded.active_turn_send_behavior,
-            ActiveTurnSendBehavior::Steer
+        assert_eq!(loaded.sidebar_width, 300.0);
+        assert!(!loaded.sound_enabled);
+        assert!(
+            serde_json::to_value(&loaded)
+                .unwrap()
+                .get("activeTurnSendBehavior")
+                .is_none()
         );
     }
 
@@ -1133,7 +1117,6 @@ mod tests {
                 ..KeymapConfig::default()
             },
             composer_send_behavior: ComposerSendBehavior::ModEnter,
-            active_turn_send_behavior: ActiveTurnSendBehavior::Queue,
             appearance: crate::appearance::AppearanceMode::Light,
             git_history_columns: GitHistoryColumns {
                 author: false,

--- a/crates/ui/src/settings/shortcuts.rs
+++ b/crates/ui/src/settings/shortcuts.rs
@@ -9,8 +9,7 @@ use gpui::{
 };
 
 use crate::settings::{
-    ActiveTurnSendBehavior, ComposerSendBehavior, KeymapConfig, ShortcutId, combo_from_keystroke,
-    display_combo,
+    ComposerSendBehavior, KeymapConfig, ShortcutId, combo_from_keystroke, display_combo,
 };
 use crate::state::AppState;
 use crate::theme::Theme;
@@ -42,15 +41,12 @@ pub enum ShortcutsEvent {
     KeymapChanged(KeymapConfig),
     /// The composer send behavior changed — persist + re-apply.
     ComposerSendBehaviorChanged(ComposerSendBehavior),
-    /// Mid-turn submissions should steer immediately or remain queued.
-    ActiveTurnSendBehaviorChanged(ActiveTurnSendBehavior),
 }
 
 pub struct ShortcutsPage {
     /// Working copy (kept in sync with the shell via change events).
     keymap: KeymapConfig,
     composer_send_behavior: ComposerSendBehavior,
-    active_turn_send_behavior: ActiveTurnSendBehavior,
     recording: Option<ShortcutId>,
     /// A rejected record attempt ("{Combo} is already assigned to {label}.") —
     /// conflicts never persist; they're refused at record time, as in zeron.
@@ -68,29 +64,15 @@ impl ShortcutsPage {
         state: Entity<AppState>,
         keymap: KeymapConfig,
         composer_send_behavior: ComposerSendBehavior,
-        active_turn_send_behavior: ActiveTurnSendBehavior,
         cx: &mut Context<Self>,
     ) -> Self {
         Self {
             keymap,
             composer_send_behavior,
-            active_turn_send_behavior,
             recording: None,
             conflict_notice: None,
             focus: cx.focus_handle(),
             _state: state,
-        }
-    }
-
-    fn set_active_turn_send_behavior(
-        &mut self,
-        behavior: ActiveTurnSendBehavior,
-        cx: &mut Context<Self>,
-    ) {
-        if self.active_turn_send_behavior != behavior {
-            self.active_turn_send_behavior = behavior;
-            cx.emit(ShortcutsEvent::ActiveTurnSendBehaviorChanged(behavior));
-            cx.notify();
         }
     }
 
@@ -337,10 +319,8 @@ impl Render for ShortcutsPage {
         let theme = Theme::of(cx).clone();
         let recording = self.recording;
         let send_behavior = self.composer_send_behavior;
-        let active_turn_behavior = self.active_turn_send_behavior;
         let customized = self.keymap != KeymapConfig::default()
-            || send_behavior != ComposerSendBehavior::default()
-            || active_turn_behavior != ActiveTurnSendBehavior::default();
+            || send_behavior != ComposerSendBehavior::default();
         let modifier_label = modifier_send_label(cfg!(target_os = "macos"));
 
         let send_behavior_control = div()
@@ -446,76 +426,6 @@ impl Render for ShortcutsPage {
                     )
                     .child(send_behavior_control),
             );
-        let active_turn_control = div()
-            .flex_none()
-            .flex()
-            .flex_row()
-            .rounded(px(9.0))
-            .p(px(2.0))
-            .bg(crate::theme::ink(0.04))
-            .children(
-                [
-                    (ActiveTurnSendBehavior::Steer, "Steer"),
-                    (ActiveTurnSendBehavior::Queue, "Queue"),
-                ]
-                .into_iter()
-                .enumerate()
-                .map(|(ix, (behavior, label))| {
-                    let selected = active_turn_behavior == behavior;
-                    div()
-                        .id(("active-turn-send-option", ix))
-                        .min_w(px(72.0))
-                        .px(px(12.0))
-                        .py(px(6.0))
-                        .rounded(px(7.0))
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .text_size(px(12.0))
-                        .text_color(if selected {
-                            theme.text
-                        } else {
-                            theme.text_muted
-                        })
-                        .when(selected, |el| {
-                            el.bg(theme.bg)
-                                .border_1()
-                                .border_color(theme.border.opacity(0.8))
-                        })
-                        .when(!selected, |el| {
-                            el.cursor_pointer()
-                                .hover(|s| s.text_color(theme.text))
-                                .on_click(cx.listener(move |this, _, _, cx| {
-                                    this.set_active_turn_send_behavior(behavior, cx)
-                                }))
-                        })
-                        .child(SharedString::from(label))
-                }),
-            );
-        let active_turn_row = widgets::section_card(&theme).child(
-            widgets::card_row(&theme, true)
-                .min_h(px(84.0))
-                .child(
-                    div()
-                        .flex_1()
-                        .min_w_0()
-                        .flex()
-                        .flex_col()
-                        .child(widgets::row_title(&theme, "Messages during an active turn"))
-                        .child(
-                            div()
-                                .mt(px(4.0))
-                                .max_w(px(430.0))
-                                .text_size(px(11.5))
-                                .line_height(px(17.0))
-                                .text_color(theme.text_muted.opacity(0.65))
-                                .child(SharedString::from(
-                                    "Steer sends immediately when supported. Queue keeps messages visible and editable until the turn ends or you choose an action.",
-                                )),
-                        ),
-                )
-                .child(active_turn_control),
-        );
         // One card per group, each under its small section label — the flat
         // 16-row table read as one undifferentiated wall. `ix` (the id's
         // position in ALL) keys the interactive elements, so ids stay unique
@@ -604,10 +514,6 @@ impl Render for ShortcutsPage {
                                                     ComposerSendBehavior::Enter,
                                                     cx,
                                                 );
-                                                this.set_active_turn_send_behavior(
-                                                    ActiveTurnSendBehavior::Steer,
-                                                    cx,
-                                                );
                                             }),
                                         )
                                     })
@@ -620,7 +526,6 @@ impl Render for ShortcutsPage {
                             }),
                     )
                     .child(send_behavior_row.mt(px(32.0)))
-                    .child(active_turn_row.mt(px(16.0)))
                     .child(
                         div()
                             .mt(px(28.0))

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3253,16 +3253,8 @@ impl Shell {
                     let state = self.state.clone();
                     let keymap = self.settings.keymap.clone();
                     let composer_send_behavior = self.settings.composer_send_behavior;
-                    let active_turn_send_behavior = self.settings.active_turn_send_behavior;
-                    let page = cx.new(|cx| {
-                        ShortcutsPage::new(
-                            state,
-                            keymap,
-                            composer_send_behavior,
-                            active_turn_send_behavior,
-                            cx,
-                        )
-                    });
+                    let page =
+                        cx.new(|cx| ShortcutsPage::new(state, keymap, composer_send_behavior, cx));
                     // Persist + re-apply shortcut preferences whenever the page changes them.
                     self.shortcuts_sub = Some(cx.subscribe(
                         &page,
@@ -3273,9 +3265,6 @@ impl Shell {
                                 }
                                 ShortcutsEvent::ComposerSendBehaviorChanged(behavior) => {
                                     this.settings.composer_send_behavior = *behavior;
-                                }
-                                ShortcutsEvent::ActiveTurnSendBehaviorChanged(behavior) => {
-                                    this.settings.active_turn_send_behavior = *behavior;
                                 }
                             }
                             apply_keymap(


### PR DESCRIPTION
Messages submitted during an active response now wait in the shared queue on desktop and iOS. Previously the desktop default steered them into the running response, so test prompts such as “queue 1” became part of the current answer.

- Remove the Steer/Queue preference, the composer steering warning, and the queue-row Steer action. Existing saved steering preferences are ignored without resetting other settings.
- Keep active-turn messages queued for every harness, including synchronized rows from older clients with `holdForTurnEnd: false`. The queue's **Send now** action explicitly interrupts the active response; editing, ordering, removal, and protected delivery remain available.
- Remove the silent fallback to steering when an engine lacks queue support. Preserve the draft and ask for an engine update instead.

Legacy explicit steering RPCs and harness transport remain compatible with older clients; the updated desktop and iOS composers do not offer or invoke them.

Validation on the reviewed PR head (`c71b8280`), completed before merge:

- 775 Linux UI tests, 495 engine/harness tests, and 103 iOS simulator tests passed (9 engine/harness tests ignored).
- All 18 real-account scenarios passed across Claude Code, Codex, Cursor, Devin, Grok, and OpenCode: queue/edit/reorder/removal and protected editing; cancellation and Send now during active/idle turns; queued image delivery. These exercise 126 assertions, including holding text with the legacy `holdForTurnEnd: false` policy.
- Hermes and Pi are not installed in this environment; their shared protocol behavior is covered by the automated harness suite.
- Added iOS simulator unit tests to PR CI. macOS app compilation, native browser regressions, and frame-recovery CI passed.

Screenshot from the running desktop fixture:

![Queue-only composer with Send now actions and no steering warning](https://github.com/user-attachments/assets/05cefaf5-097c-42d7-8767-b8006ab2994c)


Settings page, with the active-turn steering preference removed:

![Keyboard shortcuts without the steering setting](https://github.com/user-attachments/assets/2d6241e8-540d-4b24-a396-f798a5f04302)


Post-release CI finding: the same Swift source on the version-only `v0.2.53` commit failed transcript animation checks in [run 34335403850](https://github.com/zeronsh/comet/actions/runs/34335403850). The first run failed keyboard-motion range and intermediate tool-height assertions. A fresh-job retry passed the keyboard test but failed `TranscriptLayoutTests.testToolGroupsRevealAndCollapseThroughIntermediateHeights` on the sample count (5 distinct heights, expected >5) and tail gap (24px, expected <4px). Queue tests passed in both runs. This remains unresolved; the earlier 103-test pass should not be read as consistently green iOS CI. Linux/macOS regression checks and all 18 live-harness scenarios passed. The release workflow distributes desktop packages only.
