### PR TITLE
Fix unreliable session shortcuts and release v0.2.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10538,7 +10538,7 @@ dependencies = [
 
 [[package]]
 name = "zeron"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "anyhow",
  "clap",
@@ -10557,7 +10557,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-doc"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "chrono",
  "loro",
@@ -10571,7 +10571,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-engine"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10607,7 +10607,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-harness"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10628,7 +10628,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-proto"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "chrono",
  "serde",
@@ -10638,7 +10638,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-rpc"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10657,7 +10657,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-sync"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -10680,7 +10680,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-syntax"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "thiserror 2.0.20",
  "tree-sitter",
@@ -10714,7 +10714,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-theme"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "anyhow",
  "clap",
@@ -10729,7 +10729,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-ui"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -10780,7 +10780,7 @@ dependencies = [
 
 [[package]]
 name = "zeron-update"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.53"
+version = "0.2.54"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -94,6 +94,21 @@ pub(crate) fn restore_focus_if_empty_on_next_frame<T: 'static>(
     cx.notify();
 }
 
+/// Check the completed dispatch tree, not just the lifetime of the focused
+/// handle: a hidden editor can stay alive after its element has unmounted.
+fn restore_mounted_focus(
+    root: &FocusHandle,
+    preferred: &FocusHandle,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let preferred_mounted = root.contains(preferred, window);
+    if !root.contains_focused(window, cx) || (root.is_focused(window) && preferred_mounted) {
+        let target = if preferred_mounted { preferred } else { root };
+        window.focus(target, cx);
+    }
+}
+
 #[derive(Clone, Copy)]
 enum ChatMenuPage {
     Root,
@@ -1306,9 +1321,10 @@ pub struct Shell {
     splash_task: Option<Task<()>>,
     /// Focus fallback (registered on first paint — [`Shell::new`] has no
     /// window): keyboard shortcuts dispatch through the window focus chain, so
-    /// with nothing focused they go dead. Initial focus lands on the composer
-    /// and focus lost with no successor routes back there.
+    /// with missing or unmounted focus they go dead. Recover after handoffs
+    /// settle, preserving focus on mounted controls.
     focus_sub: Option<Subscription>,
+    shortcut_focus: FocusHandle,
     /// Clears the jump hints when the window deactivates: a Cmd+Tab away
     /// swallows the key-up, so without this the chips stay on screen for good.
     activation_sub: Option<Subscription>,
@@ -1573,6 +1589,7 @@ impl Shell {
             splash: SplashPhase::Visible,
             splash_task: None,
             focus_sub: None,
+            shortcut_focus: cx.focus_handle(),
             activation_sub: None,
             _ticker: ticker,
             _state_observation: observation,
@@ -3420,7 +3437,10 @@ impl Shell {
     /// Track held modifiers for sidebar jump hints and the queue's submit hint.
     /// Only a visibility change repaints; modifier traffic is otherwise constant.
     fn on_modifiers_changed(&mut self, event: &ModifiersChangedEvent, cx: &mut Context<Self>) {
-        let mods = &event.modifiers;
+        self.update_jump_hints(&event.modifiers, cx);
+    }
+
+    fn update_jump_hints(&mut self, mods: &gpui::Modifiers, cx: &mut Context<Self>) {
         let primary = if cfg!(target_os = "macos") {
             mods.platform
         } else {
@@ -8454,37 +8474,37 @@ impl Render for Shell {
             ));
         }
 
-        // Keyboard shortcuts (mod-s/b/r/j) dispatch through the window focus
-        // chain — with nothing focused they go dead. Land initial focus on the
-        // composer, and whenever focus is lost with no successor (e.g. the
-        // focused element unmounted), route it back there after allowing any
-        // in-flight focus handoff to settle.
+        // A live handle can refer to an unmounted element. Recover against
+        // the completed frame so newly mounted dialogs can claim focus first.
         if self.focus_sub.is_none() {
             self.focus_sub = Some(cx.on_focus_lost(window, |this: &mut Shell, window, cx| {
-                match this.route {
-                    Route::Chat => restore_focus_if_empty_on_next_frame(
-                        this.composer.focus_handle(cx),
-                        window,
-                        cx,
-                    ),
-                    // No composer here — clear the stale handle so `focused()`
-                    // reads None (the render hook below re-lands focus when the
-                    // route returns to Chat; a lingering unmounted handle would
-                    // otherwise dead-end keyboard dispatch for good).
-                    Route::Settings(_) => window.blur(),
-                }
+                let root = this.shortcut_focus.clone();
+                let preferred = this.composer.focus_handle(cx);
+                window.on_next_frame(move |window, cx| {
+                    restore_mounted_focus(&root, &preferred, window, cx);
+                });
+                cx.notify();
             }));
         }
-        if !restart_required
-            && matches!(gate, GatePhase::Ready)
-            && matches!(self.route, Route::Chat)
-            && window.focused(cx).is_none()
-        {
-            window.focus(&self.composer.focus_handle(cx), cx);
+        let shortcut_focus = self.shortcut_focus.clone();
+        let preferred_focus = self.composer.focus_handle(cx);
+        window.defer(cx, move |window, cx| {
+            restore_mounted_focus(&shortcut_focus, &preferred_focus, window, cx);
+        });
+
+        // Modifier events follow focus too. Reconcile from the window's input
+        // snapshot so a missed release (or pointer event after it) heals hints.
+        if !window.is_window_active() {
+            self.set_jump_hints(false, cx);
+        } else if self.jump_hints {
+            // Only a fresh modifier event may turn hints on: activation can
+            // retain the snapshot from before Cmd+Tab.
+            self.update_jump_hints(&window.modifiers(), cx);
         }
 
         let root = div()
             .id("shell-root")
+            .track_focus(&self.shortcut_focus)
             .relative()
             .flex()
             .flex_row()
@@ -9907,5 +9927,72 @@ impl Shell {
     pub fn fixture_resize_browser(&mut self, width: f32, cx: &mut Context<Self>) {
         self.settings.right_pane_width = width;
         cx.notify();
+    }
+}
+
+#[cfg(test)]
+mod shortcut_focus_regressions {
+    use super::*;
+    use gpui::{AppContext, TestAppContext};
+
+    struct ShortcutHost {
+        root: FocusHandle,
+        editor: FocusHandle,
+        show_editor: bool,
+        jumps: usize,
+    }
+
+    impl Render for ShortcutHost {
+        fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .track_focus(&self.root)
+                .on_action(cx.listener(|this, _: &JumpSession, _, _| this.jumps += 1))
+                .when(self.show_editor, |el| {
+                    el.child(div().track_focus(&self.editor))
+                })
+        }
+    }
+
+    #[gpui::test]
+    fn shortcuts_recover_from_retained_editor_focus(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.bind_keys([KeyBinding::new(
+                &platform_combo("mod-2"),
+                JumpSession(1),
+                None,
+            )]);
+        });
+        let host = cx.add_window(|_, cx| ShortcutHost {
+            root: cx.focus_handle(),
+            editor: cx.focus_handle(),
+            show_editor: true,
+            jumps: 0,
+        });
+        for show_editor in [true, false, true, false] {
+            host.update(cx, |host, window, cx| {
+                host.show_editor = show_editor;
+                // Keep the editor handle alive and focused even when hidden.
+                window.focus(&host.editor, cx);
+                cx.notify();
+            })
+            .unwrap();
+            cx.run_until_parked();
+            cx.update_window(host.into(), |_, window, cx| window.draw(cx).clear())
+                .unwrap();
+            host.update(cx, |host, window, cx| {
+                restore_mounted_focus(&host.root, &host.editor, window, cx);
+                assert!(host.root.contains_focused(window, cx));
+                assert_eq!(host.editor.is_focused(window), show_editor);
+            })
+            .unwrap();
+            cx.simulate_keystrokes(host.into(), &platform_combo("mod-2"));
+        }
+        host.update(cx, |host, window, cx| {
+            assert_eq!(host.jumps, 4);
+            window.blur();
+            restore_mounted_focus(&host.root, &host.editor, window, cx);
+            assert!(host.root.is_focused(window));
+        })
+        .unwrap();
     }
 }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -9943,9 +9943,29 @@ mod shortcut_focus_regressions {
     }
 
     impl Render for ShortcutHost {
-        fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            let root = self.root.clone();
+            let preferred = self.editor.clone();
+            window.defer(cx, move |window, cx| {
+                restore_mounted_focus(&root, &preferred, window, cx);
+            });
             div()
+                .size_full()
                 .track_focus(&self.root)
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, event: &MouseDownEvent, window, cx| {
+                        // Exercise mouse focus handoffs, hiding a focused pane,
+                        // and clicking a control that explicitly clears focus.
+                        this.show_editor = event.position.x < px(100.0);
+                        if event.position.x < px(200.0) {
+                            window.focus(&this.editor, cx);
+                        } else {
+                            window.blur();
+                        }
+                        cx.notify();
+                    }),
+                )
                 .on_action(cx.listener(|this, _: &JumpSession, _, _| this.jumps += 1))
                 .when(self.show_editor, |el| {
                     el.child(div().track_focus(&self.editor))
@@ -9994,5 +10014,53 @@ mod shortcut_focus_regressions {
             assert!(host.root.is_focused(window));
         })
         .unwrap();
+    }
+
+    #[gpui::test]
+    fn shortcuts_work_after_mouse_focus_changes(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.bind_keys([KeyBinding::new(
+                &platform_combo("mod-2"),
+                JumpSession(1),
+                None,
+            )]);
+        });
+        let host = cx.add_window(|_, cx| ShortcutHost {
+            root: cx.focus_handle(),
+            editor: cx.focus_handle(),
+            show_editor: true,
+            jumps: 0,
+        });
+        for (index, x) in [50.0, 150.0, 250.0, 50.0, 150.0, 250.0]
+            .into_iter()
+            .enumerate()
+        {
+            cx.update_window(host.into(), |_, window, cx| {
+                window.draw(cx).clear();
+                window.dispatch_event(
+                    gpui::PlatformInput::MouseDown(MouseDownEvent {
+                        position: gpui::point(px(x), px(20.0)),
+                        button: MouseButton::Left,
+                        modifiers: gpui::Modifiers::default(),
+                        click_count: 1,
+                        first_mouse: false,
+                    }),
+                    cx,
+                );
+            })
+            .unwrap();
+            // Dispatch immediately after the mouse event; no manual recovery.
+            cx.simulate_keystrokes(host.into(), &platform_combo("mod-2"));
+            host.update(cx, |host, window, cx| {
+                assert_eq!(
+                    host.jumps,
+                    index + 1,
+                    "shortcut failed after mouse click at {x}"
+                );
+                assert!(host.root.contains_focused(window, cx));
+                assert_eq!(host.editor.is_focused(window), x < 100.0);
+            })
+            .unwrap();
+        }
     }
 }


### PR DESCRIPTION
Mouse clicks and right-pane changes can leave keyboard focus attached to an unmounted control, causing session shortcuts to stop dispatching and Command-key previews to remain visible. Add a persistent shell focus target, restore focus against the rendered control tree after handoffs, and reconcile preview state with the window modifier snapshot. Preserve focus on mounted editors and dialogs.

Prepare v0.2.54.

Validation: all 57 shell tests pass, including repeated session jumps after mouse focus changes, pane unmounting, and explicit blur. Native browser clicks on macOS have not been manually verified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791566181&installation_model_id=425430&pr_number=285&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F285&signature=05ff5bc89a233263ae60c081b06b7874eef5b4086653cbd93aabe71224c16098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->