### PR TITLE
Add Linux sidebar browser with GPUI compositing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
             libx11-dev libxcb1-dev libx11-xcb-dev \
             libfontconfig1-dev libfreetype-dev libasound2-dev \
-            libvulkan-dev pkg-config cmake
+            libvulkan-dev pkg-config cmake libwebkit2gtk-4.1-dev libjson-glib-dev
       - name: rust toolchain (rust-toolchain.toml)
         run: rustup show active-toolchain || rustup toolchain install
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -147,7 +147,11 @@ jobs:
         run: cargo build --release --locked -p zeron-ui --example browser-fixture --features browser-fixture
       - name: X11 and Wayland browser regressions
         timeout-minutes: 5
-        run: scripts/test-linux-browser.sh "$RUNNER_TEMP/linux-browser"
+        env:
+          RUST_LOG: gpui_wgpu=info
+        run: |
+          scripts/test-linux-browser.sh "$RUNNER_TEMP/linux-browser/default"
+          VK_DRIVER_FILES=/dev/null scripts/test-linux-browser.sh "$RUNNER_TEMP/linux-browser/opengl"
       - name: Upload native browser evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -37,7 +37,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: GPUI system dependencies
         run: |
-          sudo apt-get update -qq
+          # Only Ubuntu packages are needed; unrelated runner repositories can be out of sync.
+          sudo apt-get update -qq -o Dir::Etc::sourcelist="sources.list.d/ubuntu.sources" -o Dir::Etc::sourceparts="-"
           sudo apt-get install -y -qq \
             libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
             libx11-dev libxcb1-dev libx11-xcb-dev \
@@ -131,7 +132,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Native browser and GPUI dependencies
         run: |
-          sudo apt-get update -qq
+          # Only Ubuntu packages are needed; unrelated runner repositories can be out of sync.
+          sudo apt-get update -qq -o Dir::Etc::sourcelist="sources.list.d/ubuntu.sources" -o Dir::Etc::sourceparts="-"
           sudo apt-get install -y -qq \
             libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
             libx11-dev libxcb1-dev libx11-xcb-dev libfontconfig1-dev \

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -7,6 +7,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - 'crates/**'
+      - 'scripts/test-linux-browser.sh'
       - 'apps/ios/**'
       - '.github/workflows/ui-tests.yml'
   push:
@@ -16,6 +17,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - 'crates/**'
+      - 'scripts/test-linux-browser.sh'
       - 'apps/ios/**'
       - '.github/workflows/ui-tests.yml'
   workflow_dispatch:
@@ -40,7 +42,7 @@ jobs:
             libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
             libx11-dev libxcb1-dev libx11-xcb-dev \
             libfontconfig1-dev libfreetype-dev libasound2-dev \
-            libvulkan-dev pkg-config cmake
+            libvulkan-dev pkg-config cmake libwebkit2gtk-4.1-dev libjson-glib-dev
       - name: Rust toolchain
         run: rustup show active-toolchain || rustup toolchain install
       - uses: Swatinem/rust-cache@v2
@@ -121,3 +123,33 @@ jobs:
           name: ios-test-results
           path: ${{ runner.temp }}/ios-tests.xcresult
           if-no-files-found: ignore
+
+  linux-browser:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Native browser and GPUI dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
+            libx11-dev libxcb1-dev libx11-xcb-dev libfontconfig1-dev \
+            libfreetype-dev libasound2-dev libvulkan-dev pkg-config cmake \
+            libwebkit2gtk-4.1-dev libjson-glib-dev xvfb xdotool openbox \
+            weston ffmpeg imagemagick fonts-noto-cjk
+      - name: Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+      - uses: Swatinem/rust-cache@v2
+      - name: Build browser fixture
+        run: cargo build --release --locked -p zeron-ui --example browser-fixture --features browser-fixture
+      - name: X11 and Wayland browser regressions
+        timeout-minutes: 5
+        run: scripts/test-linux-browser.sh "$RUNNER_TEMP/linux-browser"
+      - name: Upload native browser evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-browser
+          path: ${{ runner.temp }}/linux-browser
+          if-no-files-found: warn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "gpui-base"
 version = "0.5.2"
-source = "git+https://github.com/zeronsh/gpui-component?rev=ed273275069e2dc0272887afa496bd92a3628909#ed273275069e2dc0272887afa496bd92a3628909"
+source = "git+https://github.com/zeronsh/gpui-component?rev=e1f680ac10fc4c348bb2ab0565d15df1af7de136#e1f680ac10fc4c348bb2ab0565d15df1af7de136"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2980,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "schemars",
  "serde",
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "anyhow",
  "gpui",
@@ -3126,7 +3126,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "anyhow",
  "log",
@@ -3136,7 +3136,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3160,7 +3160,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3189,7 +3189,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4619,7 +4619,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5645,7 +5645,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "collections",
  "serde",
@@ -6618,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "derive_refineable",
 ]
@@ -6930,7 +6930,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7627,7 +7627,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -8869,7 +8869,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=bf3b6a3442f863952aa3f068902ee804ececa596#bf3b6a3442f863952aa3f068902ee804ececa596"
+source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
 dependencies = [
  "perf",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "gpui-base"
 version = "0.5.2"
-source = "git+https://github.com/zeronsh/gpui-component?rev=e1f680ac10fc4c348bb2ab0565d15df1af7de136#e1f680ac10fc4c348bb2ab0565d15df1af7de136"
+source = "git+https://github.com/zeronsh/gpui-component?rev=8c3af053189209db83b92b64aaa5cbcbedd9b72f#8c3af053189209db83b92b64aaa5cbcbedd9b72f"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2980,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "schemars",
  "serde",
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "anyhow",
  "gpui",
@@ -3126,7 +3126,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "anyhow",
  "log",
@@ -3136,7 +3136,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3160,7 +3160,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3189,7 +3189,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4619,7 +4619,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5645,7 +5645,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "collections",
  "serde",
@@ -6618,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "derive_refineable",
 ]
@@ -6930,7 +6930,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7627,7 +7627,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "heapless 0.9.3",
  "log",
@@ -8869,7 +8869,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zeronsh/zui?rev=6c530f15422e58e9f3da112797963f9000a8f76e#6c530f15422e58e9f3da112797963f9000a8f76e"
+source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
 dependencies = [
  "perf",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,15 +62,15 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/zeronsh/zui", rev = "bf3b6a3442f863952aa3f068902ee804ececa596" }
-gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "bf3b6a3442f863952aa3f068902ee804ececa596", features = [
+gpui = { git = "https://github.com/zeronsh/zui", rev = "6c530f15422e58e9f3da112797963f9000a8f76e" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "6c530f15422e58e9f3da112797963f9000a8f76e", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "bf3b6a3442f863952aa3f068902ee804ececa596" }
-gpui-base = { git = "https://github.com/zeronsh/gpui-component", rev = "ed273275069e2dc0272887afa496bd92a3628909" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "6c530f15422e58e9f3da112797963f9000a8f76e" }
+gpui-base = { git = "https://github.com/zeronsh/gpui-component", rev = "e1f680ac10fc4c348bb2ab0565d15df1af7de136" }
 
 # diffs
 similar = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,15 +62,15 @@ loro-protocol = "0.3"
 # stopped vending CABackdropLayer for Selection — window blur went dead);
 # b68970e rasterizes BackdropBlur in the wgpu renderer (frosted floats on
 # Linux — the Metal path's snapshot/blur/composite, ported).
-gpui = { git = "https://github.com/zeronsh/zui", rev = "6c530f15422e58e9f3da112797963f9000a8f76e" }
-gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "6c530f15422e58e9f3da112797963f9000a8f76e", features = [
+gpui = { git = "https://github.com/zeronsh/zui", rev = "07fd941ad72e7edc812fed317aab66adb69fa8cc" }
+gpui_platform = { git = "https://github.com/zeronsh/zui", rev = "07fd941ad72e7edc812fed317aab66adb69fa8cc", features = [
     "wayland",
     "x11",
     "font-kit",
     "runtime_shaders",
 ] }
-gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "6c530f15422e58e9f3da112797963f9000a8f76e" }
-gpui-base = { git = "https://github.com/zeronsh/gpui-component", rev = "e1f680ac10fc4c348bb2ab0565d15df1af7de136" }
+gpui_tokio = { git = "https://github.com/zeronsh/zui", rev = "07fd941ad72e7edc812fed317aab66adb69fa8cc" }
+gpui-base = { git = "https://github.com/zeronsh/gpui-component", rev = "8c3af053189209db83b92b64aaa5cbcbedd9b72f" }
 
 # diffs
 similar = "2"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ zeron status
 
 The installer starts the daemon immediately and keeps it running across reboots. No sign-in or sync configuration is required.
 
+The desktop sidebar browser also needs the [Linux browser runtime](docs/reference/linux-browser.md).
+
 Day-to-day:
 
 ```bash

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -63,6 +63,9 @@ objc2-web-kit = { version = "0.3.2", features = ["WKWebView", "WKNavigationDeleg
 reqwest.workspace = true
 image = { version = "0.25", default-features = false, features = ["png", "ico", "jpeg", "webp"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+image = { version = "0.25", default-features = false, features = ["png"] }
+
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true

--- a/crates/ui/build.rs
+++ b/crates/ui/build.rs
@@ -1,0 +1,32 @@
+use std::{env, path::PathBuf, process::Command};
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/browser/linux/helper.c");
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("linux") {
+        return;
+    }
+    let output = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("zeron-webkit");
+    let flags = Command::new("pkg-config")
+        .args(["--cflags", "--libs", "webkit2gtk-4.1", "json-glib-1.0"])
+        .output()
+        .expect("pkg-config is required to build the Linux browser helper");
+    assert!(
+        flags.status.success(),
+        "Install libwebkit2gtk-4.1-dev and libjson-glib-dev to build the Linux browser"
+    );
+    let status = Command::new(env::var("CC").unwrap_or_else(|_| "cc".into()))
+        .args([
+            "-std=c11",
+            "-O2",
+            "-Wall",
+            "-Wextra",
+            "-Wno-unused-parameter",
+            "src/browser/linux/helper.c",
+            "-o",
+        ])
+        .arg(&output)
+        .args(String::from_utf8(flags.stdout).unwrap().split_whitespace())
+        .status()
+        .expect("C compiler is required to build the Linux browser helper");
+    assert!(status.success(), "Linux browser helper compilation failed");
+}

--- a/crates/ui/build.rs
+++ b/crates/ui/build.rs
@@ -12,7 +12,10 @@ fn main() {
         .expect("pkg-config is required to build the Linux browser helper");
     assert!(
         flags.status.success(),
-        "Install libwebkit2gtk-4.1-dev and libjson-glib-dev to build the Linux browser"
+        "The Linux browser requires WebKitGTK 4.1 and JSON-GLib development files \
+         discoverable by pkg-config (webkit2gtk-4.1 and json-glib-1.0). \
+         See docs/reference/linux-browser.md for distribution-specific installation commands.\n{}",
+        String::from_utf8_lossy(&flags.stderr)
     );
     let status = Command::new(env::var("CC").unwrap_or_else(|_| "cc".into()))
         .args([

--- a/crates/ui/examples/browser-fixture.rs
+++ b/crates/ui/examples/browser-fixture.rs
@@ -118,7 +118,9 @@ fn validate_blur(
 }
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt().with_env_filter("warn").init();
+    tracing_subscriber::fmt()
+        .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| "warn".into()))
+        .init();
     let output = PathBuf::from(
         std::env::args()
             .nth(1)

--- a/crates/ui/examples/browser-fixture.rs
+++ b/crates/ui/examples/browser-fixture.rs
@@ -1,5 +1,8 @@
-//! Real shell + native WebKit smoke test and screenshot fixture. Synthetic
-//! chat data, isolated temp storage, loopback-only website, no engine services.
+#[cfg(target_os = "linux")]
+#[path = "browser-fixture/linux.rs"]
+mod linux;
+// Real shell + native WebKit smoke test and screenshot fixture. Synthetic
+// chat data, isolated temp storage, loopback-only website, no engine services.
 use gpui::{AppContext, AsyncApp, Bounds, WindowBounds, WindowOptions, px, size};
 use std::{
     io::{Read, Write},
@@ -32,6 +35,7 @@ fn capture(directory: &std::path::Path, name: &str) -> anyhow::Result<()> {
     };
     #[cfg(not(target_os = "macos"))]
     let status = {
+        let capture_window = std::env::var("ZERON_BROWSER_CAPTURE_WINDOW").ok();
         let windows = std::process::Command::new("xdotool")
             .args([
                 "search",
@@ -40,11 +44,15 @@ fn capture(directory: &std::path::Path, name: &str) -> anyhow::Result<()> {
                 &std::process::id().to_string(),
             ])
             .output()?;
-        let id = String::from_utf8(windows.stdout)?
-            .lines()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("fixture window not visible"))?
-            .to_owned();
+        let id = capture_window
+            .or_else(|| {
+                String::from_utf8(windows.stdout)
+                    .ok()?
+                    .lines()
+                    .next()
+                    .map(str::to_owned)
+            })
+            .ok_or_else(|| anyhow::anyhow!("fixture window not visible"))?;
         std::process::Command::new("import")
             .args(["-window", &id])
             .arg(&path)
@@ -54,7 +62,7 @@ fn capture(directory: &std::path::Path, name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn validate_blur(
     directory: &std::path::Path,
     region: (f64, f64, f64, f64),
@@ -196,7 +204,7 @@ fn main() -> anyhow::Result<()> {
                 let (first_id, first) = window.update(cx, |shell, w, cx| shell.fixture_open_browser(None, w, cx))?;
                 pause(cx, 500).await;
                 capture(&output, "browser-empty-dark")?;
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "linux"))]
                 {
                     window.update(cx, |_, w, cx| first.update(cx, |b, cx| b.navigate(&_origin, w, cx)))?;
                     let deadline = std::time::Instant::now() + Duration::from_secs(25);
@@ -226,7 +234,7 @@ fn main() -> anyhow::Result<()> {
                 let (second_id, second) = window.update(cx, |shell, w, cx| shell.fixture_open_browser(None, w, cx))?;
                 pause(cx, 250).await;
                 anyhow::ensure!(!first.read_with(cx, |b, _| b.fixture_native_visible()), "background page stayed visible");
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "linux"))]
                 {
                     first.read_with(cx, |b, _| b.fixture_eval("document.cookie = 'browserfixture=shared; path=/'"));
                     window.update(cx, |_, w, cx| second.update(cx, |b, cx| b.navigate(&_origin, w, cx)))?;
@@ -245,6 +253,8 @@ fn main() -> anyhow::Result<()> {
                 pause(cx, 250).await;
                 window.update(cx, |shell, w, cx| shell.fixture_close_browser(second_id, w, cx))?;
                 drop(second);
+                #[cfg(target_os = "linux")]
+                linux::exercise(window, first.clone(), &output, cx).await?;
                 #[cfg(target_os = "macos")]
                 let mut recording;
                 #[cfg(target_os = "macos")]
@@ -441,7 +451,7 @@ fn main() -> anyhow::Result<()> {
                 cx.update(|cx| appearance::set_mode(appearance::AppearanceMode::Light, cx));
                 pause(cx, 600).await;
                 capture(&output, "browser-light")?;
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "linux"))]
                 {
                     anyhow::ensure!(first.read_with(cx, |b, _| b.fixture_native_visible()), "page not restored after overlays/takeover");
                     // Use an ordinary closed localhost port. Port 1 is on
@@ -464,7 +474,7 @@ fn main() -> anyhow::Result<()> {
                 window.update(cx, |shell, w, cx| shell.fixture_close_browser(first_id, w, cx))?;
                 pause(cx, 200).await;
                 anyhow::ensure!(!first.read_with(cx, |b, _| b.fixture_native_visible()), "closed tab retained its native view");
-                std::fs::write(output.join("result.txt"), "PASS: real shell browser fixture; address rejection, tab switching/close, overlays, resizing, takeover and appearance. On macOS: live DOM navigation, history, same-document state, native visibility, rapid hover/tooltip focus and hit testing, overlay outside-click isolation/restoration, live resize/CSS reflow/native drag hit testing, interrupted sidebar clipping, frosted/light/opaque backdrop cleanup, and load failure.\n")?;
+                std::fs::write(output.join("result.txt"), "PASS: real shell browser fixture; address rejection, tab switching/close, overlays, resizing, takeover and appearance. On macOS and Linux: live DOM navigation, history, same-document state, native visibility, rapid hover/tooltip focus and hit testing, overlay outside-click isolation/restoration, live resize/CSS reflow/native drag hit testing, interrupted sidebar clipping, frosted/light/opaque backdrop cleanup, and load failure.\n")?;
                 Ok(())
             }.await;
             if let Err(error) = run { eprintln!("Browser fixture failed: {error:#}"); *result.lock().unwrap() = Some(error.to_string()); }

--- a/crates/ui/examples/browser-fixture/linux.rs
+++ b/crates/ui/examples/browser-fixture/linux.rs
@@ -1,0 +1,534 @@
+use super::*;
+use gpui::{
+    AnyWindowHandle, Entity, MouseButton, Pixels, PlatformInput, Point, WindowHandle, point,
+};
+use zeron_ui::browser::BrowserSurface;
+
+async fn eval(
+    page: &Entity<BrowserSurface>,
+    script: &str,
+    cx: &mut AsyncApp,
+) -> anyhow::Result<serde_json::Value> {
+    page.read_with(cx, |b, _| b.fixture_eval(script));
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(value) = page.read_with(cx, |b, _| b.fixture_linux_evaluation()) {
+            return Ok(value);
+        }
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "JavaScript evaluation timed out: {script}"
+        );
+        pause(cx, 20).await;
+    }
+}
+fn dispatch(
+    window: WindowHandle<shell::Shell>,
+    event: PlatformInput,
+    cx: &mut AsyncApp,
+) -> anyhow::Result<()> {
+    if std::env::var_os("ZERON_BROWSER_NATIVE_POINTER").is_some() {
+        let pointer = match &event {
+            PlatformInput::MouseDown(e) => Some((e.position, Some(("mousedown", e.button)))),
+            PlatformInput::MouseUp(e) => Some((e.position, Some(("mouseup", e.button)))),
+            PlatformInput::MouseMove(e) => Some((e.position, None)),
+            _ => None,
+        };
+        if let Some((position, action)) = pointer {
+            let id = if let Ok(id) = std::env::var("ZERON_BROWSER_CAPTURE_WINDOW") {
+                id
+            } else {
+                let ids = std::process::Command::new("xdotool")
+                    .args([
+                        "search",
+                        "--onlyvisible",
+                        "--pid",
+                        &std::process::id().to_string(),
+                    ])
+                    .output()?;
+                String::from_utf8(ids.stdout)?
+                    .lines()
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("fixture window not found"))?
+                    .to_owned()
+            };
+            let scale = AnyWindowHandle::from(window).update(cx, |_, w, _| w.scale_factor())?;
+            let mut cmd = std::process::Command::new("xdotool");
+            cmd.args([
+                "mousemove",
+                "--window",
+                &id,
+                &((f32::from(position.x) * scale) as i32).to_string(),
+                &((f32::from(position.y) * scale) as i32).to_string(),
+            ]);
+            if let Some((kind, button)) = action {
+                let button = match button {
+                    MouseButton::Left => "1",
+                    MouseButton::Middle => "2",
+                    MouseButton::Right => "3",
+                    _ => "1",
+                };
+                cmd.args([kind, button]);
+            }
+            anyhow::ensure!(cmd.status()?.success(), "native pointer injection failed");
+            return Ok(());
+        }
+    }
+    AnyWindowHandle::from(window).update(cx, |_, w, cx| {
+        w.dispatch_event(event, cx);
+    })?;
+    Ok(())
+}
+fn click(
+    window: WindowHandle<shell::Shell>,
+    position: Point<Pixels>,
+    cx: &mut AsyncApp,
+) -> anyhow::Result<()> {
+    dispatch(
+        window,
+        PlatformInput::MouseDown(gpui::MouseDownEvent {
+            position,
+            button: MouseButton::Left,
+            click_count: 1,
+            ..Default::default()
+        }),
+        cx,
+    )?;
+    dispatch(
+        window,
+        PlatformInput::MouseUp(gpui::MouseUpEvent {
+            position,
+            button: MouseButton::Left,
+            click_count: 1,
+            ..Default::default()
+        }),
+        cx,
+    )
+}
+pub async fn exercise(
+    window: WindowHandle<shell::Shell>,
+    page: Entity<BrowserSurface>,
+    output: &std::path::Path,
+    cx: &mut AsyncApp,
+) -> anyhow::Result<()> {
+    eval(&page,"document.body.insertAdjacentHTML('afterbegin', `<div id='browser-blur-grid' style='height:140px;background:repeating-conic-gradient(#172f25 0% 25%,#f5f0df 0% 50%) 0 0/16px 16px'></div><input id='browser-input' style='height:32px;width:200px' placeholder='Browser input'><button id='browser-button' onclick='window.browserClicks=(window.browserClicks||0)+1'>Click</button>`); window.browserClicks=0; document.body.addEventListener('pointerdown',()=>window.pagePresses=(window.pagePresses||0)+1); let live=document.createElement('div');live.style='position:fixed;bottom:12px;right:12px;background:#29483b;color:white;padding:8px;border-radius:6px;font:12px monospace';document.body.append(live);window.browserFrames=0;function frame(){live.textContent='LIVE '+(++window.browserFrames);requestAnimationFrame(frame)}frame();true",cx).await?;
+    pause(cx, 400).await;
+    let bounds = page.read_with(cx, |b, _| b.fixture_linux_bounds());
+    let input=eval(&page,"(()=>{let r=document.getElementById('browser-input').getBoundingClientRect();return [r.x+20,r.y+15]})()",cx).await?;
+    click(
+        window,
+        bounds.origin
+            + point(
+                px(input[0].as_f64().unwrap() as f32),
+                px(input[1].as_f64().unwrap() as f32),
+            ),
+        cx,
+    )?;
+    pause(cx, 100).await;
+    for c in "hello linux".chars() {
+        let key = if c == ' ' {
+            "space".into()
+        } else {
+            c.to_string()
+        };
+        let stroke = gpui::Keystroke {
+            key,
+            key_char: Some(c.to_string()),
+            modifiers: Default::default(),
+        };
+        dispatch(
+            window,
+            PlatformInput::KeyDown(gpui::KeyDownEvent {
+                keystroke: stroke.clone(),
+                is_held: false,
+                prefer_character_input: false,
+            }),
+            cx,
+        )?;
+        dispatch(
+            window,
+            PlatformInput::KeyUp(gpui::KeyUpEvent { keystroke: stroke }),
+            cx,
+        )?;
+        pause(cx, 35).await;
+    }
+    anyhow::ensure!(
+        eval(&page, "document.getElementById('browser-input').value", cx).await? == "hello linux",
+        "GPUI keyboard input did not reach WebKit"
+    );
+    if let Ok(id) = std::env::var("ZERON_BROWSER_CAPTURE_WINDOW") {
+        let scale = AnyWindowHandle::from(window).update(cx, |_, w, _| w.scale_factor())?;
+        let x = ((f32::from(bounds.origin.x) + input[0].as_f64().unwrap() as f32) * scale) as i32;
+        let y = ((f32::from(bounds.origin.y) + input[1].as_f64().unwrap() as f32) * scale) as i32;
+        std::process::Command::new("xdotool")
+            .args([
+                "mousemove",
+                "--window",
+                &id,
+                &x.to_string(),
+                &y.to_string(),
+                "click",
+                "1",
+            ])
+            .status()?;
+        pause(cx, 200).await;
+        // Restore caret to end after the real seat-focus click.
+        eval(&page,"(()=>{let e=document.getElementById('browser-input');e.setSelectionRange(e.value.length,e.value.length);return true})()",cx).await?;
+    }
+    cx.update(|cx| cx.write_to_clipboard(gpui::ClipboardItem::new_string(" — café 日本語".into())));
+    pause(cx, 200).await;
+    let paste = gpui::Keystroke::parse("ctrl-v")?;
+    dispatch(
+        window,
+        PlatformInput::KeyDown(gpui::KeyDownEvent {
+            keystroke: paste,
+            is_held: false,
+            prefer_character_input: false,
+        }),
+        cx,
+    )?;
+    pause(cx, 150).await;
+    anyhow::ensure!(
+        eval(&page, "document.getElementById('browser-input').value", cx).await?
+            == "hello linux — café 日本語",
+        "Unicode clipboard paste failed: {:?}",
+        eval(&page, "document.getElementById('browser-input').value", cx).await?
+    );
+    eval(
+        &page,
+        "document.getElementById('browser-input').select();true",
+        cx,
+    )
+    .await?;
+    dispatch(
+        window,
+        PlatformInput::KeyDown(gpui::KeyDownEvent {
+            keystroke: gpui::Keystroke::parse("ctrl-c")?,
+            is_held: false,
+            prefer_character_input: false,
+        }),
+        cx,
+    )?;
+    pause(cx, 150).await;
+    anyhow::ensure!(
+        cx.update(|cx| cx.read_from_clipboard().and_then(|v| v.text()))
+            .as_deref()
+            == Some("hello linux — café 日本語"),
+        "browser copy did not reach app clipboard"
+    );
+    eval(&page,"(()=>{let e=document.getElementById('browser-input');e.setSelectionRange(e.value.length,e.value.length);return true})()",cx).await?;
+    window.update(cx, |_, w, cx| {
+        page.update(cx, |b, cx| {
+            gpui::EntityInputHandler::replace_and_mark_text_in_range(b, None, "にほ", None, w, cx)
+        })
+    })?;
+    pause(cx, 100).await;
+    window.update(cx, |_, w, cx| {
+        page.update(cx, |b, cx| {
+            gpui::EntityInputHandler::replace_and_mark_text_in_range(b, None, "日本語", None, w, cx)
+        })
+    })?;
+    pause(cx, 100).await;
+    capture(output, "linux-ime-dark")?;
+    window.update(cx, |_, w, cx| {
+        page.update(cx, |b, cx| {
+            gpui::EntityInputHandler::replace_text_in_range(b, None, "日本語", w, cx)
+        })
+    })?;
+    pause(cx, 150).await;
+    anyhow::ensure!(
+        eval(&page, "document.getElementById('browser-input').value", cx).await?
+            == "hello linux — café 日本語日本語",
+        "IME composition did not commit correctly"
+    );
+    eval(&page,"document.getElementById('browser-button').insertAdjacentHTML('afterend','<select id=browser-select><option value=a>Alpha</option><option value=b>Beta</option></select>');true",cx).await?;
+    let select=eval(&page,"(()=>{let r=document.getElementById('browser-select').getBoundingClientRect();return [r.x+10,r.y+10]})()",cx).await?;
+    click(
+        window,
+        bounds.origin
+            + point(
+                px(select[0].as_f64().unwrap() as f32),
+                px(select[1].as_f64().unwrap() as f32),
+            ),
+        cx,
+    )?;
+    pause(cx, 250).await;
+    anyhow::ensure!(
+        page.read_with(cx, |b, _| b.fixture_linux_menu_open()),
+        "HTML select did not open a GPUI menu"
+    );
+    capture(output, "linux-select-dark")?;
+    for key in ["down", "enter"] {
+        dispatch(
+            window,
+            PlatformInput::KeyDown(gpui::KeyDownEvent {
+                keystroke: gpui::Keystroke::parse(key)?,
+                is_held: false,
+                prefer_character_input: false,
+            }),
+            cx,
+        )?;
+        pause(cx, 100).await;
+    }
+    anyhow::ensure!(
+        eval(&page, "document.getElementById('browser-select').value", cx).await? == "b",
+        "select keyboard navigation failed"
+    );
+    let context = bounds.origin + point(px(300.), px(330.));
+    dispatch(
+        window,
+        PlatformInput::MouseDown(gpui::MouseDownEvent {
+            position: context,
+            button: MouseButton::Right,
+            click_count: 1,
+            ..Default::default()
+        }),
+        cx,
+    )?;
+    dispatch(
+        window,
+        PlatformInput::MouseUp(gpui::MouseUpEvent {
+            position: context,
+            button: MouseButton::Right,
+            click_count: 1,
+            ..Default::default()
+        }),
+        cx,
+    )?;
+    pause(cx, 250).await;
+    anyhow::ensure!(
+        page.read_with(cx, |b, _| b.fixture_linux_menu_open()),
+        "context menu did not open in GPUI"
+    );
+    capture(output, "linux-context-dark")?;
+    dispatch(
+        window,
+        PlatformInput::KeyDown(gpui::KeyDownEvent {
+            keystroke: gpui::Keystroke::parse("escape")?,
+            is_held: false,
+            prefer_character_input: false,
+        }),
+        cx,
+    )?;
+    pause(cx, 150).await;
+    anyhow::ensure!(
+        !page.read_with(cx, |b, _| b.fixture_linux_menu_open()),
+        "context menu did not dismiss"
+    );
+    for _ in 0..5 {
+        for pos in [
+            point(bounds.origin.x + px(25.), px(20.)),
+            point(bounds.origin.x + px(75.), px(56.)),
+            point(bounds.origin.x + px(180.), px(20.)),
+        ] {
+            dispatch(
+                window,
+                PlatformInput::MouseMove(gpui::MouseMoveEvent {
+                    position: pos,
+                    ..Default::default()
+                }),
+                cx,
+            )?;
+            pause(cx, 120).await;
+            anyhow::ensure!(
+                page.read_with(cx, |b, _| b.fixture_native_visible()),
+                "hover hid the browser"
+            );
+        }
+    }
+    dispatch(
+        window,
+        PlatformInput::MouseMove(gpui::MouseMoveEvent {
+            position: point(bounds.origin.x + px(75.), px(56.)),
+            ..Default::default()
+        }),
+        cx,
+    )?;
+    pause(cx, 800).await;
+    capture(output, "linux-tooltip-dark")?;
+    let button=eval(&page,"(()=>{let r=document.getElementById('browser-button').getBoundingClientRect();return [r.x+15,r.y+10]})()",cx).await?;
+    click(
+        window,
+        bounds.origin
+            + point(
+                px(button[0].as_f64().unwrap() as f32),
+                px(button[1].as_f64().unwrap() as f32),
+            ),
+        cx,
+    )?;
+    pause(cx, 100).await;
+    anyhow::ensure!(
+        eval(&page, "window.browserClicks", cx).await? == 1,
+        "page button did not activate"
+    );
+    dispatch(
+        window,
+        PlatformInput::ScrollWheel(gpui::ScrollWheelEvent {
+            position: bounds.origin + point(px(300.), px(300.)),
+            delta: gpui::ScrollDelta::Pixels(point(px(0.), px(-250.))),
+            ..Default::default()
+        }),
+        cx,
+    )?;
+    pause(cx, 250).await;
+    anyhow::ensure!(
+        eval(&page, "scrollY", cx).await?.as_f64().unwrap() > 50.,
+        "scroll did not reach page"
+    );
+    eval(&page, "scrollTo(0,0);true", cx).await?;
+    pause(cx, 200).await;
+    let start = point(bounds.origin.x - px(2.), bounds.origin.y + px(100.));
+    dispatch(
+        window,
+        PlatformInput::MouseDown(gpui::MouseDownEvent {
+            position: start,
+            button: MouseButton::Left,
+            click_count: 1,
+            ..Default::default()
+        }),
+        cx,
+    )?;
+    let mut widths = Vec::new();
+    for delta in [
+        20., 60., 100., 140., 100., 60., 20., -20., -60., -100., -140., -100., -60., -20., 0.,
+    ] {
+        dispatch(
+            window,
+            PlatformInput::MouseMove(gpui::MouseMoveEvent {
+                position: start + point(px(delta), px(0.)),
+                pressed_button: Some(MouseButton::Left),
+                ..Default::default()
+            }),
+            cx,
+        )?;
+        pause(cx, 100).await;
+        anyhow::ensure!(
+            cx.update(|cx| cx.has_active_drag()),
+            "resize failed to start"
+        );
+        widths.push(f32::from(
+            page.read_with(cx, |b, _| b.fixture_linux_bounds().size.width),
+        ));
+        anyhow::ensure!(
+            page.read_with(cx, |b, _| b.fixture_native_visible()),
+            "resizing hid browser"
+        );
+    }
+    dispatch(
+        window,
+        PlatformInput::MouseUp(gpui::MouseUpEvent {
+            position: start,
+            button: MouseButton::Left,
+            click_count: 1,
+            ..Default::default()
+        }),
+        cx,
+    )?;
+    pause(cx, 400).await;
+    anyhow::ensure!(
+        widths.iter().copied().fold(f32::MIN, f32::max)
+            - widths.iter().copied().fold(f32::MAX, f32::min)
+            > 150.,
+        "resize did not change viewport"
+    );
+    let width = eval(&page, "innerWidth", cx).await?.as_f64().unwrap();
+    let layout = f32::from(page.read_with(cx, |b, _| b.fixture_linux_bounds().size.width));
+    anyhow::ensure!(
+        (width - layout as f64).abs() < 2.,
+        "CSS viewport {width} differs from GPUI {layout}"
+    );
+    capture(output, "linux-resize-dark")?;
+    for _ in 0..4 {
+        window.update(cx, |s, _, cx| s.fixture_toggle_sidebar(false, cx))?;
+        pause(cx, 400).await;
+        anyhow::ensure!(
+            page.read_with(cx, |b, _| b.fixture_native_visible()),
+            "left sidebar lost browser"
+        );
+    }
+    for _ in 0..3 {
+        window.update(cx, |s, _, cx| s.fixture_toggle_sidebar(true, cx))?;
+        pause(cx, 60).await;
+        window.update(cx, |s, _, cx| s.fixture_toggle_sidebar(true, cx))?;
+        pause(cx, 400).await;
+        anyhow::ensure!(
+            page.read_with(cx, |b, _| b.fixture_native_visible()),
+            "interrupted sidebar lost browser"
+        );
+    }
+    window.update(cx, |s, _, cx| s.fixture_toggle_sidebar(true, cx))?;
+    pause(cx, 400).await;
+    anyhow::ensure!(
+        !page.read_with(cx, |b, _| b.fixture_native_visible()),
+        "closed sidebar kept browser active"
+    );
+    window.update(cx, |s, _, cx| s.fixture_toggle_sidebar(true, cx))?;
+    pause(cx, 400).await;
+    anyhow::ensure!(
+        page.read_with(cx, |b, _| b.fixture_native_visible()),
+        "reopened sidebar lost browser"
+    );
+    cx.update(|cx| appearance::set_surface(zeron_theme::SurfacePreference::Frosted, cx));
+    capture(output, "browser-blur-baseline-dark")?;
+    window.update(cx, |s, _, cx| s.fixture_browser_menu(true, cx))?;
+    pause(cx, 700).await;
+    let presses = eval(&page, "window.pagePresses||0", cx).await?;
+    let outside =
+        page.read_with(cx, |b, _| b.fixture_linux_bounds().origin) + point(px(350.), px(300.));
+    click(window, outside, cx)?;
+    pause(cx, 150).await;
+    anyhow::ensure!(
+        eval(&page, "window.pagePresses||0", cx).await? == presses,
+        "outside menu click leaked into browser"
+    );
+    click(window, outside, cx)?;
+    pause(cx, 150).await;
+    anyhow::ensure!(
+        eval(&page, "window.pagePresses||0", cx).await?.as_u64()
+            == Some(presses.as_u64().unwrap() + 1),
+        "browser input did not return after menu dismissal"
+    );
+    window.update(cx, |s, _, cx| s.fixture_browser_menu(true, cx))?;
+    pause(cx, 500).await;
+    capture(output, "browser-blur-dark")?;
+    cx.update(|cx| appearance::set_mode(appearance::AppearanceMode::Light, cx));
+    pause(cx, 500).await;
+    capture(output, "browser-blur-light")?;
+    eval(
+        &page,
+        "document.getElementById('browser-blur-grid').style.background='#263d35'",
+        cx,
+    )
+    .await?;
+    pause(cx, 300).await;
+    capture(output, "browser-blur-solid-light")?;
+    cx.update(|cx| appearance::set_surface(zeron_theme::SurfacePreference::Opaque, cx));
+    pause(cx, 300).await;
+    capture(output, "browser-menu-opaque")?;
+    let bounds = page.read_with(cx, |b, _| b.fixture_linux_bounds());
+    let viewport =
+        AnyWindowHandle::from(window).update(cx, |_, w, _| f32::from(w.viewport_size().width))?;
+    super::validate_blur(
+        output,
+        (f32::from(bounds.origin.x) as f64 + 124., 42., 168., 112.),
+        viewport,
+    )?;
+    window.update(cx, |s, _, cx| s.fixture_browser_menu(false, cx))?;
+    cx.update(|cx| {
+        appearance::set_mode(appearance::AppearanceMode::Dark, cx);
+        appearance::set_surface(zeron_theme::SurfacePreference::Frosted, cx);
+    });
+    pause(cx, 300).await;
+    let frames = eval(&page, "window.browserFrames", cx)
+        .await?
+        .as_u64()
+        .unwrap();
+    anyhow::ensure!(frames > 60, "page stopped rendering during interaction");
+    std::fs::write(
+        output.join("linux-results.json"),
+        serde_json::to_vec_pretty(
+            &serde_json::json!({"keyboard":true,"unicodeClipboard":true,"imeComposition":true,"buttonAndScroll":true,"menuClickIsolation":true,"hoverVisibility":true,"resizeWidths":widths,"cssViewport":width,"liveFrames":frames,"sidebarTransitions":true}),
+        )?,
+    )?;
+    Ok(())
+}

--- a/crates/ui/src/browser/linux/helper.c
+++ b/crates/ui/src/browser/linux/helper.c
@@ -1,0 +1,628 @@
+// WebKitGTK runs in its own process. Only rendered pixels and explicit browser
+// commands cross the pipe; GPUI owns all visible windows and input routing.
+#include <errno.h>
+#include <glib-unix.h>
+#include <json-glib/json-glib.h>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <webkit2/webkit2.h>
+
+#define MAX_COMMAND (1024 * 1024)
+#define MAX_DIMENSION 8192
+
+typedef struct {
+    guint id;
+    GtkWidget *window;
+    WebKitWebView *web;
+    gboolean visible, dirty;
+    gchar *error;
+    guint width, height;
+    double scale;
+    WebKitOptionMenu *options;
+    gchar *context_link;
+} Page;
+static GHashTable *pages;
+static WebKitWebContext *context;
+static GByteArray *input;
+
+static gboolean write_all(const void *data, size_t length) {
+    const char *p = data;
+    while (length) {
+        ssize_t n = write(STDOUT_FILENO, p, length);
+        if (n < 0 && errno == EINTR)
+            continue;
+        if (n <= 0) {
+            gtk_main_quit();
+            return FALSE;
+        }
+        p += n;
+        length -= n;
+    }
+    return TRUE;
+}
+static void send_packet(char kind, guint id, const void *data, guint length) {
+    guint32 header[2] = {GUINT32_TO_LE(id), GUINT32_TO_LE(length)};
+    if (!write_all(&kind, 1) || !write_all(header, sizeof header))
+        return;
+    write_all(data, length);
+}
+static void send_json(char kind, guint id, JsonBuilder *builder) {
+    JsonGenerator *gen = json_generator_new();
+    JsonNode *root = json_builder_get_root(builder);
+    json_generator_set_root(gen, root);
+    gsize length;
+    gchar *data = json_generator_to_data(gen, &length);
+    send_packet(kind, id, data, length);
+    g_free(data);
+    json_node_free(root);
+    g_object_unref(gen);
+    g_object_unref(builder);
+}
+static void member_string(JsonBuilder *b, const char *name, const char *value) {
+    json_builder_set_member_name(b, name);
+    if (value)
+        json_builder_add_string_value(b, value);
+    else
+        json_builder_add_null_value(b);
+}
+static void member_bool(JsonBuilder *b, const char *name, gboolean value) {
+    json_builder_set_member_name(b, name);
+    json_builder_add_boolean_value(b, value);
+}
+// Relay the platform IME through GPUI while WebKit retains editor semantics.
+typedef struct {
+    WebKitInputMethodContext parent;
+    guint id;
+    gchar *preedit;
+    guint cursor;
+} BrowserIM;
+typedef struct {
+    WebKitInputMethodContextClass parent;
+} BrowserIMClass;
+G_DEFINE_TYPE(BrowserIM, browser_im, WEBKIT_TYPE_INPUT_METHOD_CONTEXT)
+static void im_preedit(WebKitInputMethodContext *ctx, gchar **text, GList **underlines,
+                       guint *cursor) {
+    BrowserIM *im = (BrowserIM *)ctx;
+    *text = g_strdup(im->preedit ?: "");
+    *cursor = im->cursor;
+    *underlines =
+        im->preedit && *im->preedit
+            ? g_list_append(NULL,
+                            webkit_input_method_underline_new(0, g_utf8_strlen(im->preedit, -1)))
+            : NULL;
+}
+static gboolean im_filter(WebKitInputMethodContext *ctx, GdkEventKey *event) { return FALSE; }
+static void im_focus(WebKitInputMethodContext *ctx, gboolean focused) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    member_bool(b, "focused", focused);
+    json_builder_end_object(b);
+    send_json('I', ((BrowserIM *)ctx)->id, b);
+}
+static void im_focus_in(WebKitInputMethodContext *ctx) { im_focus(ctx, TRUE); }
+static void im_focus_out(WebKitInputMethodContext *ctx) { im_focus(ctx, FALSE); }
+static void im_cursor(WebKitInputMethodContext *ctx, int x, int y, int w, int h) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "caret");
+    json_builder_begin_array(b);
+    json_builder_add_int_value(b, x);
+    json_builder_add_int_value(b, y);
+    json_builder_add_int_value(b, w);
+    json_builder_add_int_value(b, h);
+    json_builder_end_array(b);
+    json_builder_end_object(b);
+    send_json('I', ((BrowserIM *)ctx)->id, b);
+}
+static void im_surrounding(WebKitInputMethodContext *ctx, const gchar *text, guint length,
+                           guint cursor, guint selection) {
+    // Password contents must never leave WebKit's editor process boundary.
+    if (webkit_input_method_context_get_input_purpose(ctx) == WEBKIT_INPUT_PURPOSE_PASSWORD)
+        return;
+    gchar *copy = g_strndup(text, length);
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    member_string(b, "text", copy);
+    member_bool(b, "focused", TRUE);
+    g_free(copy);
+    json_builder_set_member_name(b, "cursor");
+    json_builder_add_int_value(b, cursor);
+    json_builder_set_member_name(b, "selection");
+    json_builder_add_int_value(b, selection);
+    json_builder_end_object(b);
+    send_json('I', ((BrowserIM *)ctx)->id, b);
+}
+static void im_finalize(GObject *object) {
+    g_free(((BrowserIM *)object)->preedit);
+    G_OBJECT_CLASS(browser_im_parent_class)->finalize(object);
+}
+static void browser_im_class_init(BrowserIMClass *klass) {
+    G_OBJECT_CLASS(klass)->finalize = im_finalize;
+    WebKitInputMethodContextClass *im = WEBKIT_INPUT_METHOD_CONTEXT_CLASS(klass);
+    im->get_preedit = im_preedit;
+    im->filter_key_event = im_filter;
+    im->notify_focus_in = im_focus_in;
+    im->notify_focus_out = im_focus_out;
+    im->notify_cursor_area = im_cursor;
+    im->notify_surrounding = im_surrounding;
+}
+static void browser_im_init(BrowserIM *im) { im->preedit = g_strdup(""); }
+static void state(Page *p) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    member_string(b, "url", webkit_web_view_get_uri(p->web));
+    member_string(b, "title", webkit_web_view_get_title(p->web) ?: "");
+    member_string(b, "error", p->error);
+    member_bool(b, "loading", webkit_web_view_is_loading(p->web));
+    member_bool(b, "can_back", webkit_web_view_can_go_back(p->web));
+    member_bool(b, "can_forward", webkit_web_view_can_go_forward(p->web));
+    json_builder_end_object(b);
+    send_json('S', p->id, b);
+}
+static void changed(GObject *web, GParamSpec *spec, Page *p) { state(p); }
+static void loaded(WebKitWebView *web, WebKitLoadEvent event, Page *p) {
+    if (event == WEBKIT_LOAD_STARTED)
+        g_clear_pointer(&p->error, g_free);
+    state(p);
+}
+static gboolean failed(WebKitWebView *web, WebKitLoadEvent event, const char *uri, GError *error,
+                       Page *p) {
+    if (g_error_matches(error, WEBKIT_NETWORK_ERROR, WEBKIT_NETWORK_ERROR_CANCELLED))
+        return TRUE;
+    g_free(p->error);
+    p->error = g_strdup(error->message);
+    state(p);
+    return TRUE;
+}
+static void terminated(WebKitWebView *web, WebKitWebProcessTerminationReason reason, Page *p) {
+    g_free(p->error);
+    p->error = g_strdup("The browser process stopped. Reload to try again.");
+    state(p);
+}
+static gboolean allowed(const char *uri) {
+    GUri *u = g_uri_parse(uri, G_URI_FLAGS_NONE, NULL);
+    if (!u)
+        return FALSE;
+    const char *scheme = g_uri_get_scheme(u);
+    gboolean ok = scheme && (!strcmp(scheme, "http") || !strcmp(scheme, "https")) &&
+                  g_uri_get_host(u) && !g_uri_get_userinfo(u);
+    g_uri_unref(u);
+    return ok;
+}
+static gboolean policy(WebKitWebView *web, WebKitPolicyDecision *decision,
+                       WebKitPolicyDecisionType type, Page *p) {
+    if (type == WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION ||
+        type == WEBKIT_POLICY_DECISION_TYPE_NEW_WINDOW_ACTION) {
+        WebKitNavigationAction *action = webkit_navigation_policy_decision_get_navigation_action(
+            WEBKIT_NAVIGATION_POLICY_DECISION(decision));
+        const char *uri = webkit_uri_request_get_uri(webkit_navigation_action_get_request(action));
+        if (!allowed(uri)) {
+            webkit_policy_decision_ignore(decision);
+            return TRUE;
+        }
+        if (type == WEBKIT_POLICY_DECISION_TYPE_NEW_WINDOW_ACTION) {
+            if (webkit_navigation_action_is_user_gesture(action))
+                send_packet('N', p->id, uri, strlen(uri));
+            webkit_policy_decision_ignore(decision);
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+static gboolean permission(WebKitWebView *web, WebKitPermissionRequest *request, Page *p) {
+    webkit_permission_request_deny(request);
+    return TRUE;
+}
+static JsonBuilder *menu_builder(double x, double y) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "x");
+    json_builder_add_double_value(b, x);
+    json_builder_set_member_name(b, "y");
+    json_builder_add_double_value(b, y);
+    json_builder_set_member_name(b, "items");
+    json_builder_begin_array(b);
+    return b;
+}
+static void menu_item(JsonBuilder *b, const char *label, const char *action, gboolean enabled,
+                      gboolean selected) {
+    json_builder_begin_object(b);
+    member_string(b, "label", label);
+    member_string(b, "action", action);
+    member_bool(b, "enabled", enabled);
+    member_bool(b, "selected", selected);
+    json_builder_end_object(b);
+}
+static void send_menu(Page *p, JsonBuilder *b) {
+    json_builder_end_array(b);
+    json_builder_end_object(b);
+    send_json('M', p->id, b);
+}
+static gboolean context_menu(WebKitWebView *web, WebKitContextMenu *menu, GdkEvent *event,
+                             WebKitHitTestResult *hit, Page *p) {
+    double x = 0, y = 0;
+    gdk_event_get_coords(event, &x, &y);
+    g_free(p->context_link);
+    p->context_link = NULL;
+    JsonBuilder *b = menu_builder(x / p->scale, y / p->scale);
+    if (webkit_hit_test_result_context_is_link(hit)) {
+        p->context_link = g_strdup(webkit_hit_test_result_get_link_uri(hit));
+        menu_item(b, "Open link in new tab", "open-link", allowed(p->context_link), FALSE);
+        menu_item(b, "Copy link address", "copy-link", TRUE, FALSE);
+    }
+    menu_item(b, "Copy", "copy",
+              webkit_hit_test_result_context_is_selection(hit) ||
+                  webkit_hit_test_result_context_is_editable(hit),
+              FALSE);
+    if (webkit_hit_test_result_context_is_editable(hit))
+        menu_item(b, "Paste", "text", TRUE, FALSE);
+    menu_item(b, "Select all", "select-all", TRUE, FALSE);
+    menu_item(b, "Back", "back", webkit_web_view_can_go_back(web), FALSE);
+    menu_item(b, "Forward", "forward", webkit_web_view_can_go_forward(web), FALSE);
+    menu_item(b, "Reload", "reload", TRUE, FALSE);
+    send_menu(p, b);
+    return TRUE;
+}
+static gboolean option_menu(WebKitWebView *web, WebKitOptionMenu *menu, GdkEvent *event,
+                            GdkRectangle *rect, Page *p) {
+    g_set_object(&p->options, menu);
+    JsonBuilder *b = menu_builder(rect->x / p->scale, (rect->y + rect->height) / p->scale);
+    for (guint i = 0; i < webkit_option_menu_get_n_items(menu); i++) {
+        WebKitOptionMenuItem *item = webkit_option_menu_get_item(menu, i);
+        gchar *action = g_strdup_printf("option:%u", i);
+        menu_item(b, webkit_option_menu_item_get_label(item), action,
+                  webkit_option_menu_item_is_enabled(item) &&
+                      !webkit_option_menu_item_is_group_label(item),
+                  webkit_option_menu_item_is_selected(item));
+        g_free(action);
+    }
+    send_menu(p, b);
+    return TRUE;
+}
+static void download(WebKitWebContext *ctx, WebKitDownload *item, gpointer data) {
+    webkit_download_cancel(item);
+}
+static gboolean damaged(GtkWidget *widget, GdkEvent *event, Page *p) {
+    p->dirty = TRUE;
+    return FALSE;
+}
+static void free_page(gpointer data) {
+    Page *p = data;
+    if (p->options) {
+        webkit_option_menu_close(p->options);
+        g_clear_object(&p->options);
+    }
+    gtk_widget_destroy(p->window);
+    g_free(p->error);
+    g_free(p->context_link);
+    g_free(p);
+}
+static Page *new_page(guint id) {
+    Page *p = g_new0(Page, 1);
+    p->id = id;
+    p->width = 800;
+    p->height = 600;
+    p->scale = 1;
+    p->visible = TRUE;
+    p->window = gtk_offscreen_window_new();
+    p->web = WEBKIT_WEB_VIEW(webkit_web_view_new_with_context(context));
+    BrowserIM *im = g_object_new(browser_im_get_type(), NULL);
+    im->id = id;
+    webkit_web_view_set_input_method_context(p->web, WEBKIT_INPUT_METHOD_CONTEXT(im));
+    g_object_unref(im);
+    webkit_settings_set_enable_developer_extras(webkit_web_view_get_settings(p->web), FALSE);
+    gtk_container_add(GTK_CONTAINER(p->window), GTK_WIDGET(p->web));
+    gtk_window_set_default_size(GTK_WINDOW(p->window), p->width, p->height);
+    g_signal_connect(p->window, "damage-event", G_CALLBACK(damaged), p);
+    g_signal_connect(p->web, "notify::uri", G_CALLBACK(changed), p);
+    g_signal_connect(p->web, "notify::title", G_CALLBACK(changed), p);
+    g_signal_connect(p->web, "notify::is-loading", G_CALLBACK(changed), p);
+    g_signal_connect(p->web, "load-changed", G_CALLBACK(loaded), p);
+    g_signal_connect(p->web, "load-failed", G_CALLBACK(failed), p);
+    g_signal_connect(p->web, "web-process-terminated", G_CALLBACK(terminated), p);
+    g_signal_connect(p->web, "decide-policy", G_CALLBACK(policy), p);
+    g_signal_connect(p->web, "permission-request", G_CALLBACK(permission), p);
+    g_signal_connect(p->web, "context-menu", G_CALLBACK(context_menu), p);
+    g_signal_connect(p->web, "show-option-menu", G_CALLBACK(option_menu), p);
+    gtk_widget_show_all(p->window);
+    g_hash_table_insert(pages, GUINT_TO_POINTER(id), p);
+    return p;
+}
+static gboolean render_frames(gpointer unused) {
+    GHashTableIter it;
+    gpointer value;
+    g_hash_table_iter_init(&it, pages);
+    while (g_hash_table_iter_next(&it, NULL, &value)) {
+        Page *p = value;
+        if (!p->visible || !p->dirty)
+            continue;
+        p->dirty = FALSE;
+        GdkPixbuf *pix = gtk_offscreen_window_get_pixbuf(GTK_OFFSCREEN_WINDOW(p->window));
+        if (!pix)
+            continue;
+        guint w = gdk_pixbuf_get_width(pix), h = gdk_pixbuf_get_height(pix),
+              channels = gdk_pixbuf_get_n_channels(pix);
+        guint stride = gdk_pixbuf_get_rowstride(pix);
+        const guchar *src = gdk_pixbuf_read_pixels(pix);
+        if (w > MAX_DIMENSION || h > MAX_DIMENSION) {
+            g_object_unref(pix);
+            continue;
+        }
+        if (w != p->width || h != p->height) {
+            p->dirty = TRUE;
+            g_object_unref(pix);
+            continue;
+        }
+        guint length = 12 + w * h * 4;
+        guchar *out = g_malloc(length);
+        ((guint32 *)out)[0] = GUINT32_TO_LE(w);
+        ((guint32 *)out)[1] = GUINT32_TO_LE(h);
+        float scale = p->scale;
+        guint32 scale_bits;
+        memcpy(&scale_bits, &scale, 4);
+        ((guint32 *)out)[2] = GUINT32_TO_LE(scale_bits);
+        for (guint y = 0; y < h; y++)
+            for (guint x = 0; x < w; x++) {
+                const guchar *s = src + y * stride + x * channels;
+                guchar *d = out + 12 + (y * w + x) * 4;
+                // GPUI's image atlas uses BGRA byte order.
+                d[0] = s[2];
+                d[1] = s[1];
+                d[2] = s[0];
+                d[3] = channels == 4 ? s[3] : 255;
+            }
+        send_packet('F', p->id, out, length);
+        g_free(out);
+        g_object_unref(pix);
+    }
+    return G_SOURCE_CONTINUE;
+}
+static double number(JsonObject *o, const char *key) {
+    return json_object_has_member(o, key) ? json_object_get_double_member(o, key) : 0;
+}
+static const char *string(JsonObject *o, const char *key) {
+    return json_object_has_member(o, key) ? json_object_get_string_member(o, key) : "";
+}
+static void input_event(Page *p, JsonObject *o, const char *command) {
+    GdkEventType type = !strcmp(command, "move")       ? GDK_MOTION_NOTIFY
+                        : !strcmp(command, "down")     ? GDK_BUTTON_PRESS
+                        : !strcmp(command, "up")       ? GDK_BUTTON_RELEASE
+                        : !strcmp(command, "scroll")   ? GDK_SCROLL
+                        : !strcmp(command, "key_down") ? GDK_KEY_PRESS
+                                                       : GDK_KEY_RELEASE;
+    GdkEvent *e = gdk_event_new(type);
+    GdkWindow *window = gtk_widget_get_window(GTK_WIDGET(p->web));
+    e->any.window = g_object_ref(window);
+    e->any.send_event = TRUE;
+    GdkSeat *seat = gdk_display_get_default_seat(gdk_window_get_display(window));
+    gboolean key = type == GDK_KEY_PRESS || type == GDK_KEY_RELEASE;
+    if (seat)
+        gdk_event_set_device(e, key ? gdk_seat_get_keyboard(seat) : gdk_seat_get_pointer(seat));
+    guint32 time = (guint32)(g_get_monotonic_time() / 1000);
+    guint mods = number(o, "mods");
+    double x = number(o, "x") * p->scale, y = number(o, "y") * p->scale;
+    if (type == GDK_MOTION_NOTIFY) {
+        e->motion.time = time;
+        e->motion.x = x;
+        e->motion.y = y;
+        e->motion.state = mods;
+    } else if (type == GDK_SCROLL) {
+        e->scroll.time = time;
+        e->scroll.x = x;
+        e->scroll.y = y;
+        e->scroll.state = mods;
+        e->scroll.direction = GDK_SCROLL_SMOOTH;
+        e->scroll.delta_x = number(o, "dx");
+        e->scroll.delta_y = number(o, "dy");
+    } else if (key) {
+        e->key.time = time;
+        e->key.state = mods;
+        e->key.keyval = gdk_keyval_from_name(string(o, "key"));
+        if (e->key.keyval == GDK_KEY_VoidSymbol) {
+            gunichar u = g_utf8_get_char_validated(string(o, "key"), -1);
+            if (u != (gunichar)-1 && u != (gunichar)-2)
+                e->key.keyval = gdk_unicode_to_keyval(u);
+        }
+        e->key.string = g_strdup(string(o, "text"));
+        e->key.length = strlen(e->key.string);
+        GdkKeymapKey *keys = NULL;
+        gint count = 0;
+        if (gdk_keymap_get_entries_for_keyval(
+                gdk_keymap_get_for_display(gdk_window_get_display(window)), e->key.keyval, &keys,
+                &count) &&
+            count) {
+            e->key.hardware_keycode = keys[0].keycode;
+            e->key.group = keys[0].group;
+            g_free(keys);
+        }
+    } else {
+        e->button.time = time;
+        e->button.x = x;
+        e->button.y = y;
+        e->button.state = mods;
+        e->button.button = number(o, "button");
+        if (type == GDK_BUTTON_PRESS)
+            gtk_widget_grab_focus(GTK_WIDGET(p->web));
+    }
+    gtk_widget_event(GTK_WIDGET(p->web), e);
+    gdk_event_free(e);
+}
+static void copied(GObject *web, GAsyncResult *result, gpointer data) {
+    GError *error = NULL;
+    JSCValue *v = webkit_web_view_evaluate_javascript_finish(WEBKIT_WEB_VIEW(web), result, &error);
+    if (v) {
+        gchar *text = jsc_value_to_string(v);
+        send_packet('C', GPOINTER_TO_UINT(data), text, strlen(text));
+        g_free(text);
+        g_object_unref(v);
+    }
+    g_clear_error(&error);
+}
+static void evaluated(GObject *web, GAsyncResult *result, gpointer data) {
+    guint id = GPOINTER_TO_UINT(data);
+    GError *error = NULL;
+    JSCValue *v = webkit_web_view_evaluate_javascript_finish(WEBKIT_WEB_VIEW(web), result, &error);
+    gchar *s = v ? jsc_value_to_json(v, 0) : g_strdup("null");
+    send_packet('J', id, s ?: "null", strlen(s ?: "null"));
+    g_free(s);
+    g_clear_object(&v);
+    g_clear_error(&error);
+}
+static void command(JsonObject *o) {
+    guint id = number(o, "id");
+    const char *cmd = string(o, "cmd");
+    Page *p = g_hash_table_lookup(pages, GUINT_TO_POINTER(id));
+    if (!strcmp(cmd, "create")) {
+        if (!p)
+            new_page(id);
+        return;
+    }
+    if (!p)
+        return;
+    if (!strcmp(cmd, "close")) {
+        g_hash_table_remove(pages, GUINT_TO_POINTER(id));
+        return;
+    }
+    if (!strcmp(cmd, "load")) {
+        const char *url = string(o, "url");
+        if (allowed(url))
+            webkit_web_view_load_uri(p->web, url);
+    } else if (!strcmp(cmd, "dismiss-menu")) {
+        if (p->options) {
+            webkit_option_menu_close(p->options);
+            g_clear_object(&p->options);
+        }
+    } else if (g_str_has_prefix(cmd, "option:")) {
+        if (p->options) {
+            guint index = g_ascii_strtoull(cmd + 7, NULL, 10);
+            if (index < webkit_option_menu_get_n_items(p->options))
+                webkit_option_menu_activate_item(p->options, index);
+            webkit_option_menu_close(p->options);
+            g_clear_object(&p->options);
+        }
+    } else if (!strcmp(cmd, "open-link")) {
+        if (p->context_link && allowed(p->context_link))
+            send_packet('N', p->id, p->context_link, strlen(p->context_link));
+    } else if (!strcmp(cmd, "copy-link")) {
+        if (p->context_link)
+            send_packet('C', p->id, p->context_link, strlen(p->context_link));
+    } else if (!strcmp(cmd, "select-all"))
+        webkit_web_view_execute_editing_command(p->web, "SelectAll");
+    else if (!strcmp(cmd, "reload"))
+        webkit_web_view_reload(p->web);
+    else if (!strcmp(cmd, "commit") || !strcmp(cmd, "preedit") || !strcmp(cmd, "unmark")) {
+        BrowserIM *im = (BrowserIM *)webkit_web_view_get_input_method_context(p->web);
+        if (!strcmp(cmd, "preedit")) {
+            if (!*im->preedit)
+                g_signal_emit_by_name(im, "preedit-started");
+            g_free(im->preedit);
+            im->preedit = g_strdup(string(o, "text"));
+            im->cursor = g_utf8_strlen(im->preedit, -1);
+            g_signal_emit_by_name(im, "preedit-changed");
+        } else {
+            if (!strcmp(cmd, "commit"))
+                g_signal_emit_by_name(im, "committed", string(o, "text"));
+            g_free(im->preedit);
+            im->preedit = g_strdup("");
+            im->cursor = 0;
+            g_signal_emit_by_name(im, "preedit-changed");
+            g_signal_emit_by_name(im, "preedit-finished");
+        }
+    } else if (!strcmp(cmd, "text"))
+        webkit_web_view_execute_editing_command_with_argument(p->web, "InsertText",
+                                                              string(o, "text"));
+    else if (!strcmp(cmd, "copy") || !strcmp(cmd, "cut")) {
+        const char *script =
+            !strcmp(cmd, "cut")
+                ? "(()=>{let e=document.activeElement;let s=e&&e.type==='password'?'':e&&typeof "
+                  "e.selectionStart==='number'?e.value.slice(e.selectionStart,e.selectionEnd):"
+                  "String(getSelection());if(s)document.execCommand('delete');return s})()"
+                : "(()=>{let e=document.activeElement;return e&&e.type==='password'?'':e&&typeof "
+                  "e.selectionStart==='number'?e.value.slice(e.selectionStart,e.selectionEnd):"
+                  "String(getSelection())})()";
+        webkit_web_view_evaluate_javascript(p->web, script, -1, NULL, NULL, NULL, copied,
+                                            GUINT_TO_POINTER(id));
+    } else if (!strcmp(cmd, "back"))
+        webkit_web_view_go_back(p->web);
+    else if (!strcmp(cmd, "forward"))
+        webkit_web_view_go_forward(p->web);
+    else if (!strcmp(cmd, "resize")) {
+        guint w = CLAMP(number(o, "width"), 1, MAX_DIMENSION),
+              h = CLAMP(number(o, "height"), 1, MAX_DIMENSION);
+        double scale = CLAMP(number(o, "scale"), 0.5, 4);
+        if (w != p->width || h != p->height || scale != p->scale) {
+            p->width = w;
+            p->height = h;
+            p->scale = scale;
+            webkit_web_view_set_zoom_level(p->web, scale);
+            gtk_window_set_default_size(GTK_WINDOW(p->window), w, h);
+            gtk_widget_set_size_request(GTK_WIDGET(p->web), w, h);
+            gtk_widget_queue_resize(p->window);
+            p->dirty = TRUE;
+        }
+    } else if (!strcmp(cmd, "visible")) {
+        p->visible = number(o, "value") != 0;
+        if (p->visible) {
+            gtk_widget_show(p->window);
+            p->dirty = TRUE;
+        } else
+            gtk_widget_hide(p->window);
+    } else if (!strcmp(cmd, "eval"))
+        webkit_web_view_evaluate_javascript(p->web, string(o, "script"), -1, NULL, NULL, NULL,
+                                            evaluated, GUINT_TO_POINTER(id));
+    else
+        input_event(p, o, cmd);
+}
+static gboolean read_commands(gint fd, GIOCondition condition, gpointer unused) {
+    guint8 bytes[65536];
+    ssize_t n = read(fd, bytes, sizeof bytes);
+    if (n <= 0) {
+        gtk_main_quit();
+        return G_SOURCE_REMOVE;
+    }
+    g_byte_array_append(input, bytes, n);
+    while (input->len >= 4) {
+        guint32 length;
+        memcpy(&length, input->data, 4);
+        length = GUINT32_FROM_LE(length);
+        if (length > MAX_COMMAND) {
+            gtk_main_quit();
+            return G_SOURCE_REMOVE;
+        }
+        if (input->len < 4 + length)
+            break;
+        JsonParser *parser = json_parser_new();
+        if (json_parser_load_from_data(parser, (char *)input->data + 4, length, NULL)) {
+            JsonNode *root = json_parser_get_root(parser);
+            if (JSON_NODE_HOLDS_OBJECT(root))
+                command(json_node_get_object(root));
+        }
+        g_object_unref(parser);
+        g_byte_array_remove_range(input, 0, length + 4);
+    }
+    return G_SOURCE_CONTINUE;
+}
+int main(int argc, char **argv) {
+    signal(SIGPIPE, SIG_IGN);
+    // Offscreen GTK surfaces need CPU-addressable frames, never native GL child windows.
+    g_setenv("WEBKIT_DISABLE_DMABUF_RENDERER", "1", TRUE);
+    g_setenv("GDK_SCALE", "1", TRUE);
+    g_setenv("GDK_DPI_SCALE", "1", TRUE);
+    if (!gtk_init_check(&argc, &argv)) {
+        g_printerr("Could not connect WebKitGTK to the display.\n");
+        return 1;
+    }
+    pages = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, free_page);
+    input = g_byte_array_new();
+    context = webkit_web_context_new_ephemeral();
+    g_signal_connect(context, "download-started", G_CALLBACK(download), NULL);
+    g_unix_fd_add(STDIN_FILENO, G_IO_IN | G_IO_HUP | G_IO_ERR, read_commands, NULL);
+    g_timeout_add(16, render_frames, NULL);
+    gtk_main();
+    g_hash_table_destroy(pages);
+    g_byte_array_unref(input);
+    g_object_unref(context);
+    return 0;
+}

--- a/crates/ui/src/browser/linux/mod.rs
+++ b/crates/ui/src/browser/linux/mod.rs
@@ -1,0 +1,675 @@
+//! WebKitGTK renders offscreen in an isolated helper process. GPUI composites
+//! its frames, so browser content uses the same clipping and blur as other UI.
+use super::model::{PageState, Presentation};
+use gpui::{Bounds, Pixels, RenderImage};
+use serde_json::{Value, json};
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+    os::unix::fs::{OpenOptionsExt, PermissionsExt},
+    process::{Child, ChildStdin, Command, Stdio},
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicU32, Ordering},
+    },
+};
+use tokio::sync::mpsc::Sender;
+
+#[derive(Clone, Debug)]
+pub enum NativeEvent {
+    Changed,
+    Frame,
+    NewTab(String),
+    Clipboard(String),
+    Menu(Value),
+}
+
+#[derive(Clone, Default)]
+pub struct BrowserData(Arc<Mutex<Weak<Worker>>>);
+
+struct Worker {
+    child: Mutex<Child>,
+    stdin: Mutex<ChildStdin>,
+    routes: Arc<Mutex<HashMap<u32, Weak<Route>>>>,
+    next_id: AtomicU32,
+}
+impl Drop for Worker {
+    fn drop(&mut self) {
+        if let Ok(child) = self.child.get_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+struct Route {
+    tx: Sender<NativeEvent>,
+    state: Mutex<PageState>,
+    frame: Mutex<Option<(Arc<RenderImage>, f32)>>,
+    input: Mutex<Value>,
+    #[cfg(feature = "browser-fixture")]
+    evaluation: Mutex<Option<Value>>,
+}
+
+fn helper_path() -> Result<std::path::PathBuf, String> {
+    use sha2::{Digest, Sha256};
+    const HELPER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/zeron-webkit"));
+    let hash = format!("{:x}", Sha256::digest(HELPER));
+    let root = std::env::var_os("XDG_CACHE_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|p| std::path::PathBuf::from(p).join(".cache")))
+        .ok_or("Could not locate the browser cache directory")?
+        .join("zeron/browser");
+    std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
+    let path = root.join(format!("webkit-{hash}"));
+    if std::fs::read(&path).ok().as_deref() != Some(HELPER) {
+        let temp = root.join(format!(".webkit-{}", std::process::id()));
+        let result = (|| -> std::io::Result<()> {
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o700)
+                .open(&temp)?;
+            f.write_all(HELPER)?;
+            f.sync_all()?;
+            std::fs::rename(&temp, &path)
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&temp);
+        }
+        result.map_err(|e| e.to_string())?;
+    }
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))
+        .map_err(|e| e.to_string())?;
+    Ok(path)
+}
+impl BrowserData {
+    fn worker(&self) -> Result<Arc<Worker>, String> {
+        let mut current = self.0.lock().unwrap();
+        if let Some(worker) = current.upgrade() {
+            if worker
+                .child
+                .lock()
+                .unwrap()
+                .try_wait()
+                .map_err(|e| e.to_string())?
+                .is_none()
+            {
+                return Ok(worker);
+            }
+        }
+        let mut child = Command::new(helper_path()?).stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::inherit()).spawn()
+            .map_err(|e| format!("Could not start WebKitGTK: {e}. Install the WebKitGTK 4.1 runtime for your distribution."))?;
+        let stdin = child.stdin.take().unwrap();
+        let mut stdout = child.stdout.take().unwrap();
+        let routes: Arc<Mutex<HashMap<u32, Weak<Route>>>> = Arc::default();
+        let reader_routes = routes.clone();
+        std::thread::Builder::new().name("browser-frames".into()).spawn(move || {
+            let result = (|| -> std::io::Result<()> {
+                loop {
+                    let mut header = [0u8; 9]; stdout.read_exact(&mut header)?;
+                    let id = u32::from_le_bytes(header[1..5].try_into().unwrap());
+                    let length = u32::from_le_bytes(header[5..9].try_into().unwrap()) as usize;
+                    if length > 8192 * 8192 * 4 + 12 { return Err(std::io::Error::other("Browser packet is too large")); }
+                    let mut data = vec![0; length]; stdout.read_exact(&mut data)?;
+                    let route = reader_routes.lock().unwrap().get(&id).and_then(Weak::upgrade);
+                    let Some(route) = route else { continue; };
+                    let event = match header[0] {
+                        b'F' => {
+                            if data.len() < 12 { continue; }
+                            let width = u32::from_le_bytes(data[..4].try_into().unwrap());
+                            let height = u32::from_le_bytes(data[4..8].try_into().unwrap());
+                            let scale=f32::from_bits(u32::from_le_bytes(data[8..12].try_into().unwrap()));
+                            if !scale.is_finite() || !(0.5..=4.).contains(&scale) {continue;}
+                            data.drain(..12);
+                            let Some(pixels) = image::RgbaImage::from_raw(width, height, data) else { continue; };
+                            *route.frame.lock().unwrap() = Some((Arc::new(RenderImage::new([image::Frame::new(pixels)])),scale));
+                            NativeEvent::Frame
+                        }
+                        b'I' => {
+                            if let Ok(Value::Object(update))=serde_json::from_slice::<Value>(&data) {
+                                let mut input=route.input.lock().unwrap();
+                                if !input.is_object() {*input=json!({});}
+                                for (key,value) in update {input[&key]=value;}
+                            }
+                            NativeEvent::Frame
+                        }
+                        b'S' => {
+                            let Ok(state) = serde_json::from_slice(&data) else { continue; };
+                            *route.state.lock().unwrap() = state; NativeEvent::Changed
+                        }
+                        b'M' => {let Ok(menu)=serde_json::from_slice(&data) else {continue;};NativeEvent::Menu(menu)}
+                        b'C' => NativeEvent::Clipboard(String::from_utf8_lossy(&data).into_owned()),
+                        b'N' => NativeEvent::NewTab(String::from_utf8_lossy(&data).into_owned()),
+                        #[cfg(feature = "browser-fixture")]
+                        b'J' => { *route.evaluation.lock().unwrap() = serde_json::from_slice(&data).ok(); continue; }
+                        _ => continue,
+                    };
+                    // At most one latest frame is retained per page. A busy UI
+                    // never accumulates video frames or blocks the engine.
+                    match event {
+                        NativeEvent::NewTab(_) | NativeEvent::Clipboard(_) | NativeEvent::Menu(_) => { let _ = route.tx.blocking_send(event); }
+                        _ => { let _ = route.tx.try_send(event); }
+                    }
+                }
+            })();
+            if result.is_err() {
+                for route in reader_routes.lock().unwrap().values().filter_map(Weak::upgrade) {
+                    let mut state = route.state.lock().unwrap();
+                    state.loading = false;
+                    state.error = Some("The browser helper stopped. Check that WebKitGTK 4.1 is installed, then reopen the tab.".into());
+                    drop(state); let _ = route.tx.try_send(NativeEvent::Changed);
+                }
+            }
+        }).map_err(|e| e.to_string())?;
+        let worker = Arc::new(Worker {
+            child: Mutex::new(child),
+            stdin: Mutex::new(stdin),
+            routes,
+            next_id: AtomicU32::new(1),
+        });
+        *current = Arc::downgrade(&worker);
+        Ok(worker)
+    }
+}
+impl Worker {
+    fn send(&self, id: u32, mut command: Value) -> Result<(), String> {
+        command["id"] = id.into();
+        let data = serde_json::to_vec(&command).map_err(|e| e.to_string())?;
+        let mut pipe = self.stdin.lock().unwrap();
+        pipe.write_all(&(data.len() as u32).to_le_bytes())
+            .and_then(|_| pipe.write_all(&data))
+            .map_err(|e| e.to_string())
+    }
+}
+
+pub struct NativePage {
+    worker: Arc<Worker>,
+    route: Arc<Route>,
+    id: u32,
+    pub bounds: Bounds<Pixels>,
+    pub scale: f32,
+    geometry: Option<(u32, u32, u32)>,
+    presentation: Presentation,
+    pub image: Option<Arc<RenderImage>>,
+    pub image_scale: f32,
+    pub menu: Option<Value>,
+    pub menu_active: usize,
+    preedit: String,
+    pub pressed: std::cell::Cell<Option<gpui::MouseButton>>,
+}
+impl NativePage {
+    pub fn new(
+        _: &gpui::Window,
+        data: &BrowserData,
+        tx: Sender<NativeEvent>,
+    ) -> Result<Self, String> {
+        let worker = data.worker()?;
+        let id = worker.next_id.fetch_add(1, Ordering::Relaxed);
+        let route = Arc::new(Route {
+            tx,
+            state: Mutex::default(),
+            frame: Mutex::default(),
+            input: Mutex::new(json!({})),
+            #[cfg(feature = "browser-fixture")]
+            evaluation: Mutex::default(),
+        });
+        worker
+            .routes
+            .lock()
+            .unwrap()
+            .insert(id, Arc::downgrade(&route));
+        worker.send(id, json!({"cmd":"create"}))?;
+        Ok(Self {
+            worker,
+            route,
+            id,
+            bounds: Bounds::default(),
+            scale: 1.,
+            geometry: None,
+            presentation: Presentation::Live,
+            image: None,
+            image_scale: 1.,
+            menu: None,
+            menu_active: 0,
+            preedit: String::new(),
+            pressed: std::cell::Cell::new(None),
+        })
+    }
+    pub fn load(&self, url: &str) -> Result<(), String> {
+        self.worker.send(self.id, json!({"cmd":"load","url":url}))
+    }
+    pub fn reload(&self) {
+        self.command(json!({"cmd":"reload"}));
+    }
+    pub fn history(&self, forward: bool) {
+        self.command(json!({"cmd":if forward {"forward"} else {"back"}}));
+    }
+    pub fn state(&self) -> PageState {
+        self.route.state.lock().unwrap().clone()
+    }
+    pub fn present(&mut self, presentation: Presentation) {
+        if (self.presentation == Presentation::Hidden) != (presentation == Presentation::Hidden) {
+            self.command(
+                json!({"cmd":"visible","value":u8::from(presentation != Presentation::Hidden)}),
+            );
+        }
+        if presentation == Presentation::Hidden && self.menu.take().is_some() {
+            self.command(json!({"cmd":"dismiss-menu"}));
+        }
+        self.presentation = presentation;
+    }
+    pub fn update_frame(&mut self, window: &mut gpui::Window) {
+        if let Some((frame, scale)) = self.route.frame.lock().unwrap().take() {
+            self.image_scale = scale;
+            if let Some(old) = self.image.replace(frame) {
+                let _ = window.drop_image(old);
+            }
+        }
+    }
+    pub fn sync(&mut self, bounds: Bounds<Pixels>, scale: f32) {
+        self.bounds = bounds;
+        self.scale = scale;
+        let geometry = (
+            (f32::from(bounds.size.width) * scale)
+                .round()
+                .clamp(1., 8192.) as u32,
+            (f32::from(bounds.size.height) * scale)
+                .round()
+                .clamp(1., 8192.) as u32,
+            scale.to_bits(),
+        );
+        if self.geometry != Some(geometry) {
+            self.command(
+                json!({"cmd":"resize","width":geometry.0,"height":geometry.1,"scale":scale}),
+            );
+            self.geometry = Some(geometry);
+        }
+    }
+    pub fn command(&self, value: Value) {
+        let _ = self.worker.send(self.id, value);
+    }
+    #[cfg(feature = "browser-fixture")]
+    pub fn evaluate(&self, script: &str) {
+        *self.route.evaluation.lock().unwrap() = None;
+        self.command(json!({"cmd":"eval","script":script}));
+    }
+    #[cfg(feature = "browser-fixture")]
+    pub fn evaluation(&self) -> Option<Value> {
+        self.route.evaluation.lock().unwrap().take()
+    }
+}
+impl Drop for NativePage {
+    fn drop(&mut self) {
+        self.command(json!({"cmd":"close"}));
+        self.worker.routes.lock().unwrap().remove(&self.id);
+    }
+}
+
+impl super::BrowserSurface {
+    pub(super) fn on_native_event(
+        &mut self,
+        event: NativeEvent,
+        window: &mut gpui::Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        use gpui::Focusable;
+        let Some(native) = &mut self.native else {
+            return;
+        };
+        native.update_frame(window);
+        match event {
+            NativeEvent::NewTab(url) => {
+                if self.presentation == Presentation::Live {
+                    cx.emit(super::BrowserEvent::NewTab(Some(url)));
+                }
+            }
+            NativeEvent::Menu(menu) => {
+                if self.presentation == Presentation::Live {
+                    native.menu_active = menu["items"]
+                        .as_array()
+                        .and_then(|items| {
+                            items
+                                .iter()
+                                .position(|item| item["selected"].as_bool().unwrap_or(false))
+                        })
+                        .unwrap_or(0);
+                    native.menu = Some(menu);
+                } else {
+                    native.command(json!({"cmd":"dismiss-menu"}));
+                }
+            }
+            NativeEvent::Clipboard(text) => {
+                cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+            }
+            NativeEvent::Frame | NativeEvent::Changed => {
+                let mut page = native.state();
+                if page.url.is_none() {
+                    page.url = self.page.url.clone();
+                }
+                if page.error.is_some() {
+                    page.loading = false;
+                }
+                if !self.address.focus_handle(cx).is_focused(window) {
+                    if let Some(url) = &page.url {
+                        if self.address.read(cx).text() != url {
+                            self.address
+                                .update(cx, |input, cx| input.set_text(url.clone(), cx));
+                        }
+                    }
+                    self.address_edited = false;
+                }
+                if page != self.page {
+                    self.page = page;
+                    cx.emit(super::BrowserEvent::Changed);
+                }
+            }
+        }
+        cx.notify();
+    }
+    pub(super) fn linux_pointer(
+        &self,
+        kind: &str,
+        position: gpui::Point<Pixels>,
+        button: Option<gpui::MouseButton>,
+        modifiers: gpui::Modifiers,
+    ) {
+        let Some(native) = &self.native else {
+            return;
+        };
+        if self.presentation != Presentation::Live {
+            return;
+        }
+        if kind == "down" {
+            native.pressed.set(button);
+        }
+        if kind == "up" && native.pressed.replace(None) != button {
+            return;
+        }
+        let position = position - native.bounds.origin;
+        native.command(json!({"cmd":kind,"x":f32::from(position.x),"y":f32::from(position.y),"button":button.map(mouse_button).unwrap_or(0),"mods":modifiers_mask(modifiers) | if kind == "move" { button.map(|b| 1 << (mouse_button(b)+7)).unwrap_or(0) } else { 0 }}));
+    }
+    pub(super) fn linux_key(&self, stroke: &gpui::Keystroke, down: bool) {
+        let Some(native) = &self.native else {
+            return;
+        };
+        let printable = stroke.key_char.as_deref().filter(|s| {
+            s.chars().count() == 1
+                && !s.chars().any(char::is_control)
+                && !stroke.modifiers.control
+                && !stroke.modifiers.platform
+        });
+        let key = match printable.unwrap_or(stroke.key.as_str()) {
+            "enter" => "Return",
+            "backspace" => "BackSpace",
+            "delete" => "Delete",
+            "escape" => "Escape",
+            "tab" => "Tab",
+            "left" => "Left",
+            "right" => "Right",
+            "up" => "Up",
+            "down" => "Down",
+            "home" => "Home",
+            "end" => "End",
+            "pageup" => "Page_Up",
+            "pagedown" => "Page_Down",
+            "space" => "space",
+            key => key,
+        };
+        native.command(json!({"cmd":if down {"key_down"} else {"key_up"},"key":key,"text":stroke.key_char.as_deref().unwrap_or(""),"mods":modifiers_mask(stroke.modifiers)}));
+    }
+}
+pub(super) fn modifiers_mask(m: gpui::Modifiers) -> u32 {
+    u32::from(m.shift)
+        | (u32::from(m.control) << 2)
+        | (u32::from(m.alt) << 3)
+        | (u32::from(m.platform) << 26)
+}
+fn mouse_button(button: gpui::MouseButton) -> u32 {
+    match button {
+        gpui::MouseButton::Left => 1,
+        gpui::MouseButton::Middle => 2,
+        gpui::MouseButton::Right => 3,
+        gpui::MouseButton::Navigate(gpui::NavigationDirection::Back) => 8,
+        gpui::MouseButton::Navigate(gpui::NavigationDirection::Forward) => 9,
+    }
+}
+
+#[cfg(feature = "browser-fixture")]
+impl super::BrowserSurface {
+    pub fn fixture_linux_menu_open(&self) -> bool {
+        self.native.as_ref().is_some_and(|n| n.menu.is_some())
+    }
+    pub fn fixture_linux_bounds(&self) -> Bounds<Pixels> {
+        self.native.as_ref().unwrap().bounds
+    }
+    pub fn fixture_linux_evaluation(&self) -> Option<Value> {
+        self.native.as_ref().unwrap().evaluation()
+    }
+}
+
+impl gpui::EntityInputHandler for super::BrowserSurface {
+    fn text_for_range(
+        &mut self,
+        range: std::ops::Range<usize>,
+        actual: &mut Option<std::ops::Range<usize>>,
+        _: &mut gpui::Window,
+        _: &mut gpui::Context<Self>,
+    ) -> Option<String> {
+        let native = self.native.as_ref()?;
+        let input = native.route.input.lock().unwrap();
+        let text = input["text"].as_str().unwrap_or("");
+        let units: Vec<u16> = text.encode_utf16().collect();
+        let range = range.start.min(units.len())..range.end.min(units.len());
+        *actual = Some(range.clone());
+        Some(String::from_utf16_lossy(units.get(range)?))
+    }
+    fn selected_text_range(
+        &mut self,
+        _: bool,
+        _: &mut gpui::Window,
+        _: &mut gpui::Context<Self>,
+    ) -> Option<gpui::UTF16Selection> {
+        let native = self.native.as_ref()?;
+        let input = native.route.input.lock().unwrap();
+        let text = input["text"].as_str().unwrap_or("");
+        let offset = |key: &str| {
+            let n = input[key].as_u64().unwrap_or(0) as usize;
+            text.get(..n).unwrap_or(text).encode_utf16().count()
+        };
+        let cursor = offset("cursor");
+        let selection = offset("selection");
+        Some(gpui::UTF16Selection {
+            range: cursor.min(selection)..cursor.max(selection),
+            reversed: cursor < selection,
+        })
+    }
+    fn marked_text_range(
+        &self,
+        _: &mut gpui::Window,
+        _: &mut gpui::Context<Self>,
+    ) -> Option<std::ops::Range<usize>> {
+        let native = self.native.as_ref()?;
+        (!native.preedit.is_empty()).then(|| 0..native.preedit.encode_utf16().count())
+    }
+    fn unmark_text(&mut self, _: &mut gpui::Window, _: &mut gpui::Context<Self>) {
+        if let Some(native) = &mut self.native {
+            native.command(json!({"cmd":"unmark"}));
+            native.preedit.clear();
+        }
+    }
+    fn replace_text_in_range(
+        &mut self,
+        _: Option<std::ops::Range<usize>>,
+        text: &str,
+        _: &mut gpui::Window,
+        _: &mut gpui::Context<Self>,
+    ) {
+        if let Some(native) = &mut self.native {
+            native.command(json!({"cmd":"commit","text":text}));
+            native.preedit.clear();
+        }
+    }
+    fn replace_and_mark_text_in_range(
+        &mut self,
+        _: Option<std::ops::Range<usize>>,
+        text: &str,
+        _: Option<std::ops::Range<usize>>,
+        _: &mut gpui::Window,
+        _: &mut gpui::Context<Self>,
+    ) {
+        if let Some(native) = &mut self.native {
+            native.command(json!({"cmd":"preedit","text":text}));
+            native.preedit = text.to_owned();
+        }
+    }
+    fn bounds_for_range(
+        &mut self,
+        _: std::ops::Range<usize>,
+        _: Bounds<Pixels>,
+        _: &mut gpui::Window,
+        _: &mut gpui::Context<Self>,
+    ) -> Option<Bounds<Pixels>> {
+        let native = self.native.as_ref()?;
+        let input = native.route.input.lock().unwrap();
+        let c = &input["caret"];
+        Some(Bounds::new(
+            native.bounds.origin
+                + gpui::point(
+                    gpui::px(c[0].as_f64().unwrap_or(0.) as f32 / native.scale),
+                    gpui::px(c[1].as_f64().unwrap_or(0.) as f32 / native.scale),
+                ),
+            gpui::size(
+                gpui::px(c[2].as_f64().unwrap_or(1.) as f32 / native.scale),
+                gpui::px(c[3].as_f64().unwrap_or(18.) as f32 / native.scale),
+            ),
+        ))
+    }
+    fn character_index_for_point(
+        &mut self,
+        _: gpui::Point<Pixels>,
+        _: &mut gpui::Window,
+        _: &mut gpui::Context<Self>,
+    ) -> Option<usize> {
+        None
+    }
+    fn accepts_text_input(&self, _: &mut gpui::Window, _: &mut gpui::Context<Self>) -> bool {
+        self.native.as_ref().is_some_and(|n| {
+            n.route.input.lock().unwrap()["focused"]
+                .as_bool()
+                .unwrap_or(false)
+        })
+    }
+}
+
+impl super::BrowserSurface {
+    pub(super) fn linux_dismiss_menu(&mut self, cx: &mut gpui::Context<Self>) {
+        if let Some(native) = &mut self.native {
+            native.menu = None;
+            native.command(json!({"cmd":"dismiss-menu"}));
+        }
+        cx.notify();
+    }
+    pub(super) fn linux_choose_menu(&mut self, index: usize, cx: &mut gpui::Context<Self>) {
+        if let Some(native) = &mut self.native {
+            if let Some(item) = native
+                .menu
+                .as_ref()
+                .and_then(|m| m["items"].get(index))
+                .filter(|i| i["enabled"].as_bool().unwrap_or(false))
+            {
+                let action = item["action"].as_str().unwrap_or("");
+                if action == "text" {
+                    if let Some(text) = cx.read_from_clipboard().and_then(|i| i.text()) {
+                        native.command(json!({"cmd":"text","text":text}));
+                    }
+                } else {
+                    native.command(json!({"cmd":action}));
+                }
+            }
+        }
+        self.linux_dismiss_menu(cx);
+    }
+    pub(super) fn linux_menu_key(&mut self, key: &str, cx: &mut gpui::Context<Self>) -> bool {
+        let Some(native) = self.native.as_mut().filter(|n| n.menu.is_some()) else {
+            return false;
+        };
+        match key {
+            "escape" => self.linux_dismiss_menu(cx),
+            "enter" => {
+                let index = native.menu_active;
+                self.linux_choose_menu(index, cx);
+            }
+            "up" | "down" => {
+                if let Some(items) = native.menu.as_ref().unwrap()["items"]
+                    .as_array()
+                    .filter(|items| !items.is_empty())
+                {
+                    for _ in 0..items.len() {
+                        native.menu_active = if key == "down" {
+                            (native.menu_active + 1) % items.len()
+                        } else {
+                            (native.menu_active + items.len() - 1) % items.len()
+                        };
+                        if items[native.menu_active]["enabled"]
+                            .as_bool()
+                            .unwrap_or(false)
+                        {
+                            break;
+                        }
+                    }
+                    cx.notify();
+                }
+            }
+            _ => {}
+        }
+        true
+    }
+    pub(super) fn linux_menu(
+        &self,
+        theme: &crate::theme::Theme,
+        cx: &mut gpui::Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        use gpui::{IntoElement, div, prelude::*, px};
+        let native = self.native.as_ref()?;
+        let menu = native.menu.as_ref()?;
+        let items = menu["items"].as_array()?;
+        let pos = native.bounds.origin
+            + gpui::point(
+                px(menu["x"].as_f64().unwrap_or(0.) as f32),
+                px(menu["y"].as_f64().unwrap_or(0.) as f32),
+            );
+        let mut content = crate::popover::popover_card(theme)
+            .w(px(240.))
+            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.linux_dismiss_menu(cx)));
+        let mut rows = div()
+            .id("browser-menu-options")
+            .flex()
+            .flex_col()
+            .max_h(px(320.))
+            .overflow_y_scroll();
+        for (index, item) in items.iter().enumerate() {
+            let enabled = item["enabled"].as_bool().unwrap_or(false);
+            let row = crate::popover::menu_row(
+                theme,
+                index == native.menu_active,
+                format!("browser-option-{index}"),
+            )
+            .id(("browser-option", index))
+            .child(gpui::SharedString::from(
+                item["label"].as_str().unwrap_or("").to_owned(),
+            ))
+            .when(!enabled, |el| el.opacity(0.4))
+            .when(enabled, |el| {
+                el.on_click(cx.listener(move |this, _, _, cx| this.linux_choose_menu(index, cx)))
+            });
+            rows = rows.child(row);
+        }
+        content = content.child(rows);
+        Some(crate::popover::menu_at(
+            "browser-page-menu",
+            pos,
+            content.into_any_element(),
+            None,
+        ))
+    }
+}

--- a/crates/ui/src/browser/mod.rs
+++ b/crates/ui/src/browser/mod.rs
@@ -1,6 +1,12 @@
 //! Device-local browser tabs. GPUI owns chrome; the native host owns pages.
+#[cfg(target_os = "linux")]
+mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
+#[cfg(target_os = "linux")]
+use linux as native;
+#[cfg(target_os = "macos")]
+use macos as native;
 pub mod model;
 mod view;
 
@@ -64,12 +70,12 @@ pub enum BrowserEvent {
 /// A window/profile's ephemeral website data, allocated on first navigation.
 #[derive(Clone, Default)]
 pub struct BrowserContext {
-    #[cfg(target_os = "macos")]
-    data: macos::BrowserData,
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    data: native::BrowserData,
 }
 
 pub struct BrowserSurface {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     context: BrowserContext,
     address: Entity<ComposerInput>,
     focus: FocusHandle,
@@ -80,11 +86,11 @@ pub struct BrowserSurface {
     remote: bool,
     presentation: Presentation,
     _input_sub: Subscription,
-    #[cfg(target_os = "macos")]
-    native: Option<macos::NativePage>,
-    #[cfg(target_os = "macos")]
-    native_tx: tokio::sync::mpsc::Sender<macos::NativeEvent>,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    native: Option<native::NativePage>,
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    native_tx: tokio::sync::mpsc::Sender<native::NativeEvent>,
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     _native_task: gpui::Task<()>,
     #[cfg(target_os = "macos")]
     favicon_task: Option<gpui::Task<()>>,
@@ -119,9 +125,9 @@ impl BrowserSurface {
                 cx.notify();
             }
         });
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         let (native_tx, mut events) = tokio::sync::mpsc::channel(64);
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         let native_task = cx.spawn_in(window, async move |this, cx| {
             while let Some(event) = events.recv().await {
                 if this
@@ -134,10 +140,10 @@ impl BrowserSurface {
                 }
             }
         });
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         let _ = (window, context);
         Self {
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             context,
             address,
             focus: cx.focus_handle(),
@@ -148,11 +154,11 @@ impl BrowserSurface {
             remote,
             presentation: Presentation::Hidden,
             _input_sub: input_sub,
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             native: None,
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             native_tx,
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             _native_task: native_task,
             #[cfg(target_os = "macos")]
             favicon_task: None,
@@ -196,7 +202,7 @@ impl BrowserSurface {
             return;
         }
         self.presentation = presentation;
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         if let Some(native) = &mut self.native {
             native.present(presentation);
         }
@@ -220,14 +226,17 @@ impl BrowserSurface {
         self.page.title.clear();
         self.page.error = None;
         self.clear_favicon(cx);
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
-            self.favicon_generation += 1;
-            self.favicon_task = None;
+            #[cfg(target_os = "macos")]
+            {
+                self.favicon_generation += 1;
+                self.favicon_task = None;
+            }
             let result = if let Some(native) = &self.native {
                 native.load(&url)
             } else {
-                macos::NativePage::new(window, &self.context.data, self.native_tx.clone())
+                native::NativePage::new(window, &self.context.data, self.native_tx.clone())
                     .map(|mut native| {
                         native.present(self.presentation);
                         self.native = Some(native);
@@ -240,7 +249,7 @@ impl BrowserSurface {
             }
             window.focus(&self.focus, cx);
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             let _ = window;
             cx.open_url(&url);
@@ -255,7 +264,7 @@ impl BrowserSurface {
     }
 
     fn reload(&mut self, cx: &mut Context<Self>) {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         if let Some(native) = &self.native {
             if self.page.error.is_some() {
                 if let Some(url) = &self.page.url {
@@ -266,7 +275,7 @@ impl BrowserSurface {
             }
             self.page.error = None;
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         self.open_external(cx);
         cx.notify();
     }
@@ -283,11 +292,11 @@ impl BrowserSurface {
     }
 
     fn history(&mut self, forward: bool) {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         if let Some(native) = &self.native {
             native.history(forward);
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         let _ = forward;
     }
 
@@ -301,14 +310,21 @@ impl BrowserSurface {
     pub fn close(&mut self, cx: &mut Context<Self>) {
         self.set_presentation(Presentation::Hidden, cx);
         self.clear_favicon(cx);
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
             if let Some(native) = &mut self.native {
                 native.present(Presentation::Hidden);
             }
+            #[cfg(target_os = "linux")]
+            if let Some(image) = self.native.as_mut().and_then(|native| native.image.take()) {
+                cx.defer(move |cx| gpui::ImageSource::Render(image).evict(None, cx));
+            }
             self.native = None;
-            self.favicon_task = None;
-            self.favicon_generation += 1;
+            #[cfg(target_os = "macos")]
+            {
+                self.favicon_task = None;
+                self.favicon_generation += 1;
+            }
         }
     }
 }
@@ -317,7 +333,7 @@ impl BrowserSurface {
 impl BrowserSurface {
     fn on_native_event(
         &mut self,
-        event: macos::NativeEvent,
+        event: native::NativeEvent,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -325,8 +341,8 @@ impl BrowserSurface {
             return;
         };
         match event {
-            macos::NativeEvent::Changed | macos::NativeEvent::Finished => {
-                let finished = matches!(event, macos::NativeEvent::Finished);
+            native::NativeEvent::Changed | native::NativeEvent::Finished => {
+                let finished = matches!(event, native::NativeEvent::Finished);
                 let mut page = native.state();
                 // A failed provisional request has no committed WebKit URL.
                 if page.url.is_none() {
@@ -361,12 +377,12 @@ impl BrowserSurface {
                 }
                 cx.notify();
             }
-            macos::NativeEvent::NewTab(url) => {
+            native::NativeEvent::NewTab(url) => {
                 if self.presentation == Presentation::Live {
                     cx.emit(BrowserEvent::NewTab(Some(url)));
                 }
             }
-            macos::NativeEvent::Key(key) => {
+            native::NativeEvent::Key(key) => {
                 if self.presentation == Presentation::Live {
                     window.focus(&self.focus, cx);
                     window.defer(cx, move |window, cx| {
@@ -374,7 +390,7 @@ impl BrowserSurface {
                     });
                 }
             }
-            macos::NativeEvent::Favicon { page, url } => {
+            native::NativeEvent::Favicon { page, url } => {
                 if self.page.url.as_deref() != Some(&page) || !model::allowed_navigation(&url) {
                     return;
                 }
@@ -476,7 +492,12 @@ impl BrowserSurface {
                 .as_ref()
                 .is_some_and(|native| native.fixture_visible())
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        {
+            self.presentation != Presentation::Hidden
+                && self.native.as_ref().is_some_and(|n| n.image.is_some())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             false
         }
@@ -502,7 +523,11 @@ impl BrowserSurface {
         if let Some(native) = &self.native {
             native.fixture_eval(script);
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        if let Some(native) = &self.native {
+            native.evaluate(script);
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         let _ = script;
     }
 }

--- a/crates/ui/src/browser/model.rs
+++ b/crates/ui/src/browser/model.rs
@@ -1,7 +1,7 @@
 //! Browser state shared by the chrome and platform host. No native handles.
 use std::net::IpAddr;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize)]
 pub struct PageState {
     pub url: Option<String>,
     pub title: String,

--- a/crates/ui/src/browser/view.rs
+++ b/crates/ui/src/browser/view.rs
@@ -31,7 +31,51 @@ impl BrowserSurface {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        #[cfg(target_os = "linux")]
+        if self.linux_menu_key(&event.keystroke.key, cx) {
+            cx.stop_propagation();
+            return;
+        }
         let address_focused = self.address.focus_handle(cx).is_focused(window);
+        #[cfg(target_os = "linux")]
+        if !address_focused
+            && self.focus.is_focused(window)
+            && self.presentation == super::model::Presentation::Live
+        {
+            if event.prefer_character_input
+                && let Some(text) = &event.keystroke.key_char
+            {
+                if let Some(native) = &self.native {
+                    native.command(serde_json::json!({"cmd":"commit","text":text}));
+                }
+                cx.stop_propagation();
+                return;
+            }
+            if event.keystroke.modifiers.control && !event.keystroke.modifiers.alt {
+                if let Some(native) = &self.native {
+                    match event.keystroke.key.as_str() {
+                        "c" | "x" => {
+                            native.command(serde_json::json!({"cmd":if event.keystroke.key=="c" {"copy"} else {"cut"}}));
+                            cx.stop_propagation();
+                            return;
+                        }
+                        "v" => {
+                            if let Some(text) =
+                                cx.read_from_clipboard().and_then(|item| item.text())
+                            {
+                                native.command(serde_json::json!({"cmd":"text","text":text}));
+                            }
+                            cx.stop_propagation();
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            self.linux_key(&event.keystroke, true);
+            cx.stop_propagation();
+            return;
+        }
         let key = event.keystroke.key.as_str();
         let mods = event.keystroke.modifiers;
         let primary = if cfg!(target_os = "macos") {
@@ -58,7 +102,7 @@ impl BrowserSurface {
     }
 
     fn empty_body(&self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
-        let external = !cfg!(target_os = "macos");
+        let external = !cfg!(any(target_os = "macos", target_os = "linux"));
         let has_error = self.page.error.is_some();
         let title = if has_error {
             "Couldn’t load this page"
@@ -70,7 +114,7 @@ impl BrowserSurface {
         let description = if let Some(error) = &self.page.error {
             error.clone()
         } else if external {
-            "Open a website or local app in your default browser. Embedded browsing is available on macOS.".into()
+            "Open a website or local app in your default browser. Embedded browsing is available on macOS and Linux.".into()
         } else {
             "Preview your local app or keep a website beside your conversation.".into()
         };
@@ -177,7 +221,7 @@ impl Render for BrowserSurface {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = Theme::of(cx).clone();
         let focused = self.address.focus_handle(cx).is_focused(window);
-        let external = !cfg!(target_os = "macos");
+        let external = !cfg!(any(target_os = "macos", target_os = "linux"));
         let has_page = self.page.url.is_some();
         let back = button(
             "browser-back",
@@ -329,8 +373,73 @@ impl Render for BrowserSurface {
         } else {
             body.child(self.empty_body(&theme, cx))
         };
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        let body = if let Some(native) = &self.native {
+            if self.page.error.is_some() {
+                body.child(self.empty_body(&theme, cx))
+            } else {
+                let image = native.image.clone();
+                let image_scale = native.image_scale;
+                let entity = cx.entity().downgrade();
+                body.child(gpui::canvas(|_,_,_| (), move |bounds,_,window,cx| {
+                    let scale = window.scale_factor();
+                    if let Some(view)=entity.upgrade() {
+                        let focus=view.read(cx).focus.clone();
+                        window.handle_input(&focus,gpui::ElementInputHandler::new(bounds,view),cx);
+                    }
+                    let _ = entity.update(cx, |this,_| {
+                        if let Some(native)=&mut this.native { native.sync(bounds,scale); }
+                    });
+                    let capture=entity.clone();
+                    window.on_mouse_event(move |event: &gpui::MouseMoveEvent,phase,_,cx| {
+                        if phase==gpui::DispatchPhase::Bubble && !bounds.contains(&event.position) && !cx.has_active_drag() {
+                            let _=capture.update(cx,|this,_| {
+                                if this.native.as_ref().is_some_and(|n|n.pressed.get().is_some()) {
+                                    this.linux_pointer("move",event.position,event.pressed_button,event.modifiers);
+                                }
+                            });
+                        }
+                    });
+                    if let Some(image)=&image {
+                        if let Some(bytes)=image.as_bytes(0).filter(|b| b.len() >= 4) {
+                            let color=gpui::rgb(((bytes[2] as u32)<<16)|((bytes[1] as u32)<<8)|bytes[0] as u32);
+                            window.paint_quad(gpui::fill(bounds,color));
+                        }
+                        let dimensions=image.size(0);
+                        // Keep the previous frame at its original scale while
+                        // WebKit reflows; clipping never stretches the page.
+                        let viewport=gpui::Bounds::new(bounds.origin,gpui::size(px(dimensions.width.0 as f32/image_scale),px(dimensions.height.0 as f32/image_scale)));
+                        let _=window.paint_image(viewport,gpui::Corners::default(),image.clone(),0,false);
+                    }
+                }).absolute().inset_0())
+                .on_mouse_down(MouseButton::Left,cx.listener(|this,event: &gpui::MouseDownEvent,w,cx| {
+                    if !cx.has_active_drag() { w.focus(&this.focus,cx); this.linux_pointer("down",event.position,Some(event.button),event.modifiers); cx.stop_propagation(); }
+                }))
+                .on_mouse_down(MouseButton::Right,cx.listener(|this,event: &gpui::MouseDownEvent,w,cx| {
+                    w.focus(&this.focus,cx);this.linux_pointer("down",event.position,Some(event.button),event.modifiers);cx.stop_propagation();
+                }))
+                .on_mouse_up(MouseButton::Left,cx.listener(|this,event: &gpui::MouseUpEvent,_,cx| {this.linux_pointer("up",event.position,Some(event.button),event.modifiers);cx.stop_propagation();}))
+                .on_mouse_up_out(MouseButton::Left,cx.listener(|this,event: &gpui::MouseUpEvent,_,_| {this.linux_pointer("up",event.position,Some(event.button),event.modifiers);}))
+                .on_mouse_up(MouseButton::Right,cx.listener(|this,event: &gpui::MouseUpEvent,_,cx| {this.linux_pointer("up",event.position,Some(event.button),event.modifiers);cx.stop_propagation();}))
+                .on_mouse_down(MouseButton::Middle,cx.listener(|this,event: &gpui::MouseDownEvent,w,cx| {w.focus(&this.focus,cx);this.linux_pointer("down",event.position,Some(event.button),event.modifiers);cx.stop_propagation();}))
+                .on_mouse_up(MouseButton::Middle,cx.listener(|this,event: &gpui::MouseUpEvent,_,cx| {this.linux_pointer("up",event.position,Some(event.button),event.modifiers);cx.stop_propagation();}))
+                .on_mouse_move(cx.listener(|this,event: &gpui::MouseMoveEvent,_,cx| {if !cx.has_active_drag(){this.linux_pointer("move",event.position,event.pressed_button,event.modifiers);}}))
+                .on_scroll_wheel(cx.listener(|this,event: &gpui::ScrollWheelEvent,_,cx| {
+                    if let Some(native)=&this.native {
+                        let delta=event.delta.pixel_delta(px(16.));let p=event.position-native.bounds.origin;
+                        native.command(serde_json::json!({"cmd":"scroll","x":f32::from(p.x),"y":f32::from(p.y),"dx":-f32::from(delta.x)/40.,"dy":-f32::from(delta.y)/40.,"mods":super::linux::modifiers_mask(event.modifiers)}));
+                        cx.stop_propagation();
+                    }
+                }))
+            }
+        } else {
+            body.child(self.empty_body(&theme, cx))
+        };
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         let body = body.child(self.empty_body(&theme, cx));
+
+        #[cfg(target_os = "linux")]
+        let body = body.when_some(self.linux_menu(&theme, cx), |el, menu| el.child(menu));
 
         let remote_loopback = self.remote
             && self
@@ -341,6 +450,12 @@ impl Render for BrowserSurface {
                 .is_some_and(|u| super::model::loopback(&u));
         div().id("browser-surface").size_full().flex().flex_col().track_focus(&self.focus)
             .key_context("Browser").on_key_down(cx.listener(Self::key_down))
+            .on_key_up(cx.listener(|this,event: &gpui::KeyUpEvent,w,cx| {
+                #[cfg(target_os = "linux")]
+                if this.focus.is_focused(w) {this.linux_key(&event.keystroke,false);cx.stop_propagation();}
+                #[cfg(not(target_os = "linux"))]
+                let _=(this,event,w,cx);
+            }))
             .on_action(cx.listener(|this, _: &super::Reload, _, cx| this.reload(cx)))
             .on_action(cx.listener(|this, _: &super::FocusAddress, w, cx| this.focus_address(w, cx)))
             .on_action(cx.listener(|_, _: &super::NewTab, _, cx| cx.emit(BrowserEvent::NewTab(None))))

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -367,7 +367,31 @@ fn exit_progress(since: std::time::Instant) -> f32 {
 /// hold full strength through the fade and pop off at unmount.
 fn frosted_menu(exit: Option<f32>, content: AnyElement) -> AnyElement {
     let blur = crate::frost::MENU_BLUR * (1.0 - exit.unwrap_or(0.0));
-    crate::frost::frosted(CARD_RADIUS, blur, content).into_any_element()
+    // Outside-dismiss listeners run during capture. Consume that same press
+    // during bubble, after dismissal, so content behind the menu cannot act
+    // on it too. The following click can reach that content normally.
+    let guard = gpui::canvas(
+        |_, _, _| (),
+        |bounds, _, window, _| {
+            window.on_mouse_event(move |event: &gpui::MouseDownEvent, phase, _, cx| {
+                if phase == gpui::DispatchPhase::Bubble && !bounds.contains(&event.position) {
+                    cx.stop_propagation();
+                }
+            });
+        },
+    )
+    .absolute()
+    .inset_0();
+    crate::frost::frosted(
+        CARD_RADIUS,
+        blur,
+        div()
+            .relative()
+            .child(guard)
+            .child(content)
+            .into_any_element(),
+    )
+    .into_any_element()
 }
 
 /// Entrance or exit motion for a popover layer. While exiting (the [`Popup`]

--- a/docs/reference/linux-browser.md
+++ b/docs/reference/linux-browser.md
@@ -1,13 +1,35 @@
 # Browser on Linux
 
-The sidebar browser uses the distribution's WebKitGTK 4.1 runtime. On Ubuntu or Debian, install it with:
+The sidebar browser requires the distribution's WebKitGTK 4.1 and JSON-GLib runtime packages, including when using a prebuilt Zeron release. The Linux installer does not currently install or validate these dependencies; install them separately before opening a browser tab.
+
+On Ubuntu or Debian:
 
 ```sh
 sudo apt install libwebkit2gtk-4.1-0 libjson-glib-1.0-0
+```
+
+On Fedora:
+
+```sh
+sudo dnf install webkit2gtk4.1 json-glib
 ```
 
 Zeron starts its browser helper when a page is first opened. The main application does not link to GTK or WebKit, so other app features remain available if the browser runtime is missing. WebKit runs in a separate process and uses an ephemeral website-data context shared by the open tabs.
 
 The helper sends live offscreen frames to GPUI, which draws the page alongside the rest of the app. Both X11 and Wayland use this path, including clipping, sidebar transitions, tooltips, and frosted overlays. It uses CPU-addressable frames rather than embedding a separate native browser window. Animated pages therefore incur frame-copy and texture-upload work.
 
-For development, install `libwebkit2gtk-4.1-dev` and `libjson-glib-dev` in addition to the normal GPUI build dependencies. The build embeds the small helper executable, which is extracted to the user's cache directory when needed. WebKit itself stays system-managed and receives security updates through the distribution.
+For development, install the development packages in addition to the normal GPUI build dependencies. These provide the `webkit2gtk-4.1` and `json-glib-1.0` pkg-config modules used to compile the helper.
+
+On Ubuntu or Debian:
+
+```sh
+sudo apt install libwebkit2gtk-4.1-dev libjson-glib-dev
+```
+
+On Fedora:
+
+```sh
+sudo dnf install webkit2gtk4.1-devel json-glib-devel
+```
+
+The build embeds the small helper executable, which is extracted to the user's cache directory when needed. WebKit itself stays system-managed and receives security updates through the distribution.

--- a/docs/reference/linux-browser.md
+++ b/docs/reference/linux-browser.md
@@ -1,0 +1,13 @@
+# Browser on Linux
+
+The sidebar browser uses the distribution's WebKitGTK 4.1 runtime. On Ubuntu or Debian, install it with:
+
+```sh
+sudo apt install libwebkit2gtk-4.1-0 libjson-glib-1.0-0
+```
+
+Zeron starts its browser helper when a page is first opened. The main application does not link to GTK or WebKit, so other app features remain available if the browser runtime is missing. WebKit runs in a separate process and uses an ephemeral website-data context shared by the open tabs.
+
+The helper sends live offscreen frames to GPUI, which draws the page alongside the rest of the app. Both X11 and Wayland use this path, including clipping, sidebar transitions, tooltips, and frosted overlays. It uses CPU-addressable frames rather than embedding a separate native browser window. Animated pages therefore incur frame-copy and texture-upload work.
+
+For development, install `libwebkit2gtk-4.1-dev` and `libjson-glib-dev` in addition to the normal GPUI build dependencies. The build embeds the small helper executable, which is extracted to the user's cache directory when needed. WebKit itself stays system-managed and receives security updates through the distribution.

--- a/scripts/test-linux-browser.sh
+++ b/scripts/test-linux-browser.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run the real shell browser fixture with native mouse input on X11 and Wayland.
+# Captures stay outside the repository and can be uploaded as PR attachments.
+set -euo pipefail
+output="${1:?usage: test-linux-browser.sh OUTPUT_DIRECTORY}"
+binary="${BROWSER_FIXTURE_BINARY:-target/release/examples/browser-fixture}"
+mkdir -p "$output"
+output="$(realpath "$output")"
+runtime="$(mktemp -d)"
+chmod 700 "$runtime"
+processes=()
+cleanup() {
+  for pid in "${processes[@]}"; do kill "$pid" 2>/dev/null || true; done
+  rm -rf "$runtime"
+}
+trap cleanup EXIT
+Xvfb -displayfd 3 -screen 0 1280x800x24 -ac -nolisten tcp 3>"$runtime/display" >"$output/xvfb.log" 2>&1 &
+processes+=("$!")
+for _ in $(seq 1 100); do
+  [ -s "$runtime/display" ] && break
+  sleep .1
+done
+export DISPLAY=":$(cat "$runtime/display")"
+export XDG_RUNTIME_DIR="$runtime"
+export ZERON_BROWSER_NATIVE_POINTER=1
+openbox >"$output/openbox.log" 2>&1 &
+processes+=("$!")
+record_fixture() {
+  local mode="$1" capture_window="${2:-}" fixture_pid video_pid
+  mkdir -p "$output/$mode"
+  "$binary" "$output/$mode" >"$output/$mode/fixture.log" 2>&1 &
+  fixture_pid=$!
+  processes+=("$fixture_pid")
+  if [ -z "$capture_window" ]; then
+    for _ in $(seq 1 100); do
+      capture_window="$(xdotool search --onlyvisible --pid "$fixture_pid" 2>/dev/null | head -1 || true)"
+      [ -n "$capture_window" ] && break
+      kill -0 "$fixture_pid" 2>/dev/null || { cat "$output/$mode/fixture.log"; return 1; }
+      sleep .1
+    done
+  fi
+  [ -n "$capture_window" ]
+  ffmpeg -nostdin -loglevel error -y -f x11grab -framerate 30 -window_id "$capture_window" -i "$DISPLAY" \
+    -c:v libx264 -preset veryfast -crf 20 -pix_fmt yuv420p -movflags +faststart \
+    "$output/$mode/browser.mp4" >"$output/$mode/video.log" 2>&1 &
+  video_pid=$!
+  processes+=("$video_pid")
+  local result=0
+  wait "$fixture_pid" || result=$?
+  kill -INT "$video_pid" 2>/dev/null || true
+  wait "$video_pid" || true # X11 grab may end when the fixture closes its window.
+  cat "$output/$mode/fixture.log"
+  [ "$result" -eq 0 ]
+  test -f "$output/$mode/result.txt"
+  test -f "$output/$mode/linux-results.json"
+  ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of json "$output/$mode/browser.mp4"
+}
+export WAYLAND_DISPLAY= GDK_BACKEND=x11
+record_fixture x11
+export WAYLAND_DISPLAY=zeron-browser-test GDK_BACKEND=wayland
+weston --backend=x11 --renderer=pixman --shell=kiosk-shell.so --socket="$WAYLAND_DISPLAY" \
+  --idle-time=0 --width=1000 --height=680 >"$output/weston.log" 2>&1 &
+processes+=("$!")
+for _ in $(seq 1 100); do
+  [ -S "$runtime/$WAYLAND_DISPLAY" ] && break
+  sleep .1
+done
+export ZERON_BROWSER_CAPTURE_WINDOW="$(xdotool search --class weston | head -1)"
+record_fixture wayland "$ZERON_BROWSER_CAPTURE_WINDOW"


### PR DESCRIPTION
Linux browser tabs now display inside the sidebar on X11 and Wayland. A lazily started WebKitGTK helper renders offscreen frames into the GPUI scene, so resizing, sidebar transitions, tooltips, and frosted overlays compose with the rest of the app.

Includes navigation/history, shared ephemeral tab cookies, keyboard and mouse input, Unicode clipboard and IME composition, GPUI select/context menus, high-DPI sizing, and load-error handling. WebKit remains a distribution-managed runtime; only the small helper executable is embedded. Installation and rendering costs are documented in `docs/reference/linux-browser.md`.

The real-shell fixture passes locally on **X11 and Wayland with both Vulkan and OpenGL**, including OpenGL at **2× scale**. It checks resize/CSS reflow, interrupted sidebar toggles, rapid tooltip hover, dark/light/opaque overlays, outside-click isolation, clipboard and composition, select/context menus, tab lifecycle, navigation, and load failures. Evidence uses Xvfb/Openbox and nested Weston with real GPUI/WebKit processes and software rendering. The videos are continuous native-mouse recordings; media is uploaded as user attachments and is not committed.

[Final CI passed](https://github.com/zeronsh/comet/actions/runs/34386293995): 777 UI tests, four Linux native runs (X11/Wayland with automatic adapter selection and forced OpenGL), macOS browser and frame-recovery regressions, and iOS tests. Ubuntu 24.04 selected OpenGL in both modes; Vulkan was additionally validated locally. The full Linux application check also passed.

Depends on https://github.com/zeronsh/zui/pull/6 and https://github.com/zeronsh/gpui-component/pull/3. These fix a Linux portal startup borrow panic and a real OpenGL blur failure found by Ubuntu 24.04 CI. Surfaces without framebuffer-copy support now use a copyable target for backdrop effects instead of skipping blur. The unchanged pixel assertion passes with the fix: dark checkerboard edge contrast dropped from 10.16 to 0.055.

Frame analysis found no black page frames during the hover/resize interval in either attached recording.

Recordings below: **X11/Vulkan**, then **Wayland/OpenGL**. Each exercises input/popups, hover and resizing, sidebar toggles, then blur/appearance checks.

https://github.com/user-attachments/assets/9c7c9172-6981-43b7-ae7e-f47510764712

https://github.com/user-attachments/assets/ff6aae6f-a7f5-4c83-8b37-bc774ae2179e

![Linux sidebar browser](https://github.com/user-attachments/assets/35d7f3a9-ec75-4c91-b9dc-9aec9a06fffd)

![OpenGL: dark frosted overlay over the live browser](https://github.com/user-attachments/assets/5e56e003-f5af-4f8e-8cb0-341589ba31c0)

![OpenGL: light frosted overlay over the live browser](https://github.com/user-attachments/assets/173966be-54b6-4ab6-8351-3230cc102c4e)

![Wayland OpenGL at 2× scale after resizing](https://github.com/user-attachments/assets/5763fb70-3e46-43bd-8ec6-3a526629b990)