### PR TITLE
Fix file tree flicker and preserve browsing state during refreshes

### DIFF
--- a/crates/engine/src/workspace_files.rs
+++ b/crates/engine/src/workspace_files.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
@@ -65,7 +65,8 @@ struct WorkspaceFileKey {
 struct CheckoutWatch {
     checkout_id: String,
     root: PathBuf,
-    sequence: AtomicU64,
+    // Serializes publication with subscription baselines, including lag recovery.
+    sequence: Mutex<u64>,
     subscribers: AtomicUsize,
     changes_tx: broadcast::Sender<WorkspaceFileChanges>,
     cancel: CancellationToken,
@@ -548,7 +549,7 @@ impl CheckoutWatch {
         let watch = Arc::new(Self {
             checkout_id,
             root,
-            sequence: AtomicU64::new(0),
+            sequence: Mutex::new(0),
             subscribers: AtomicUsize::new(0),
             changes_tx,
             cancel,
@@ -568,25 +569,35 @@ impl CheckoutWatch {
 
     fn subscribe(self: &Arc<Self>, owner: Weak<WorkspaceFilesInner>) -> WorkspaceFileSubscription {
         self.subscribers.fetch_add(1, Ordering::AcqRel);
-        let initial = self.resync();
+        let (receiver, initial) = self.subscribe_with_baseline();
         WorkspaceFileSubscription {
-            receiver: self.changes_tx.subscribe(),
+            receiver,
             watch: self.clone(),
             owner,
             initial: Some(initial),
         }
     }
 
-    fn resync(&self) -> WorkspaceFileChanges {
-        WorkspaceFileChanges {
-            sequence: self.sequence.fetch_add(1, Ordering::AcqRel) + 1,
+    fn subscribe_with_baseline(
+        &self,
+    ) -> (
+        broadcast::Receiver<WorkspaceFileChanges>,
+        WorkspaceFileChanges,
+    ) {
+        let sequence = lock(&self.sequence);
+        let receiver = self.changes_tx.subscribe();
+        let baseline = WorkspaceFileChanges {
+            sequence: *sequence,
             resync_required: true,
             changes: Vec::new(),
-        }
+        };
+        (receiver, baseline)
     }
 
     fn publish(&self, resync_required: bool, changes: Vec<WorkspaceFileChange>) {
-        let sequence = self.sequence.fetch_add(1, Ordering::AcqRel) + 1;
+        let mut counter = lock(&self.sequence);
+        *counter += 1;
+        let sequence = *counter;
         tracing::trace!(
             checkout_id = %self.checkout_id,
             sequence,
@@ -616,7 +627,11 @@ impl WorkspaceFileSubscription {
         };
         match received {
             Ok(changes) => Some(changes),
-            Err(broadcast::error::RecvError::Lagged(_)) => Some(self.watch.resync()),
+            Err(broadcast::error::RecvError::Lagged(_)) => {
+                let (receiver, baseline) = self.watch.subscribe_with_baseline();
+                self.receiver = receiver;
+                Some(baseline)
+            }
             Err(broadcast::error::RecvError::Closed) => None,
         }
     }
@@ -2398,6 +2413,59 @@ mod tests {
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].path, "removed.rs");
         assert_eq!(changes[0].kind, WorkspaceFileChangeKind::Removed);
+    }
+
+    #[tokio::test]
+    async fn new_subscribers_do_not_create_sequence_gaps_for_existing_subscribers() {
+        let root = tempfile::tempdir().unwrap();
+        let watch = CheckoutWatch::start(
+            "checkout".into(),
+            root.path().into(),
+            true,
+            CancellationToken::new(),
+        );
+        let mut first = watch.subscribe(Weak::new());
+        let baseline = first.recv().await.unwrap();
+        watch.publish(false, Vec::new());
+        let first_event = first.recv().await.unwrap();
+        assert_eq!(first_event.sequence, baseline.sequence + 1);
+        let mut second = watch.subscribe(Weak::new());
+        assert_eq!(second.recv().await.unwrap().sequence, first_event.sequence);
+        watch.publish(false, Vec::new());
+        assert_eq!(
+            first.recv().await.unwrap().sequence,
+            first_event.sequence + 1
+        );
+        assert_eq!(
+            second.recv().await.unwrap().sequence,
+            first_event.sequence + 1
+        );
+    }
+
+    #[tokio::test]
+    async fn lag_recovery_drops_old_frames_without_advancing_shared_sequence() {
+        let root = tempfile::tempdir().unwrap();
+        let watch = CheckoutWatch::start(
+            "checkout".into(),
+            root.path().into(),
+            true,
+            CancellationToken::new(),
+        );
+        let mut slow = watch.subscribe(Weak::new());
+        let mut fast = watch.subscribe(Weak::new());
+        slow.recv().await.unwrap();
+        fast.recv().await.unwrap();
+        let mut last = 0;
+        for _ in 0..WATCH_BROADCAST_BUFFER + 2 {
+            watch.publish(false, Vec::new());
+            last = fast.recv().await.unwrap().sequence;
+        }
+        let recovery = slow.recv().await.unwrap();
+        assert!(recovery.resync_required);
+        assert_eq!(recovery.sequence, last);
+        watch.publish(false, Vec::new());
+        assert_eq!(slow.recv().await.unwrap().sequence, last + 1);
+        assert_eq!(fast.recv().await.unwrap().sequence, last + 1);
     }
 
     #[tokio::test]

--- a/crates/ui/src/files/client.rs
+++ b/crates/ui/src/files/client.rs
@@ -124,6 +124,44 @@ impl WorkspaceFilesClient {
         self.call(methods::LIST_WORKSPACE_DIRECTORY, &request).await
     }
 
+    /// Refresh through the cached children before publishing the new listing.
+    /// Usually this reads only the pages already visited. If a cached child is
+    /// missing, reach the end before treating it as deleted.
+    pub(super) async fn list_directory_snapshot(
+        &self,
+        mut request: ListWorkspaceDirectoryRequest,
+        cached_paths: &[String],
+    ) -> Result<WorkspaceDirectoryPage, FilesClientError> {
+        let mut page = self.list_directory(request.clone()).await?;
+        if !cached_paths.is_empty() {
+            let mut remaining = cached_paths
+                .iter()
+                .map(String::as_str)
+                .collect::<std::collections::HashSet<_>>();
+            for entry in &page.entries {
+                remaining.remove(entry.path.as_str());
+            }
+            let mut cursors = std::collections::HashSet::new();
+            while !remaining.is_empty() {
+                let Some(cursor) = page.next_cursor.take() else {
+                    break;
+                };
+                if !cursors.insert(cursor.clone()) {
+                    return Err(FilesClientError::Decode("Repeated directory cursor".into()));
+                }
+                request.cursor = Some(cursor);
+                let next = self.list_directory(request.clone()).await?;
+                for entry in &next.entries {
+                    remaining.remove(entry.path.as_str());
+                }
+                page.entries.extend(next.entries);
+                page.next_cursor = next.next_cursor;
+                page.truncated = next.truncated;
+            }
+        }
+        Ok(page)
+    }
+
     pub async fn search(
         &self,
         request: SearchWorkspaceFilesRequest,
@@ -201,12 +239,16 @@ mod tests {
         responses: HashMap<String, Value>,
         calls: Mutex<Vec<(String, Value)>>,
         watch_values: Vec<Value>,
+        scripted_responses: Mutex<std::collections::VecDeque<Result<Value, RpcError>>>,
     }
 
     #[async_trait]
     impl WorkspaceFilesTransport for DeterministicTransport {
         async fn call(&self, method: &str, params: Value) -> Result<Value, RpcError> {
             self.calls.lock().unwrap().push((method.into(), params));
+            if let Some(response) = self.scripted_responses.lock().unwrap().pop_front() {
+                return response;
+            }
             Ok(self.responses.get(method).cloned().unwrap())
         }
 
@@ -229,6 +271,149 @@ mod tests {
             chat_id: Some("chat-1".into()),
             space_id: None,
             checkout_path: None,
+        }
+    }
+
+    fn directory_page(name: &str, next: Option<&str>) -> Value {
+        serde_json::json!({
+            "directory": "", "entries": [{
+                "path": name, "name": name, "kind": "file", "size": 1,
+                "modifiedAt": null, "ignored": false, "readOnly": false
+            }], "nextCursor": next, "truncated": next.is_some()
+        })
+    }
+
+    #[tokio::test]
+    async fn cached_directory_refresh_collects_pages_but_initial_load_stays_lazy() {
+        for refresh in [false, true] {
+            let transport = Arc::new(DeterministicTransport {
+                scripted_responses: Mutex::new(
+                    [
+                        Ok(directory_page("a", Some("next"))),
+                        Ok(directory_page("z", None)),
+                    ]
+                    .into(),
+                ),
+                ..Default::default()
+            });
+            let client = WorkspaceFilesClient::with_transport(
+                transport.clone(),
+                FilesRequestContext {
+                    target: target(),
+                    target_device_id: Some("remote".into()),
+                    cwd: "/workspace".into(),
+                    checkout_id: None,
+                },
+            );
+            let page = client
+                .list_directory_snapshot(
+                    ListWorkspaceDirectoryRequest {
+                        target: target(),
+                        directory: "".into(),
+                        include_ignored: true,
+                        cursor: None,
+                    },
+                    &if refresh {
+                        vec!["a".into(), "z".into()]
+                    } else {
+                        vec![]
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(page.entries.len(), if refresh { 2 } else { 1 });
+            assert_eq!(page.next_cursor.is_none(), refresh);
+            let calls = transport.calls.lock().unwrap();
+            assert_eq!(calls.len(), if refresh { 2 } else { 1 });
+            if refresh {
+                assert_eq!(calls[1].1["cursor"], "next");
+                assert_eq!(calls[1].1["targetDeviceId"], "remote");
+                assert_eq!(calls[1].1["includeIgnored"], true);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_does_not_expand_unvisited_pages_unless_a_cached_child_is_missing() {
+        for missing in [false, true] {
+            let transport = Arc::new(DeterministicTransport {
+                scripted_responses: Mutex::new(
+                    [
+                        Ok(directory_page("a", Some("next"))),
+                        Ok(directory_page("z", None)),
+                    ]
+                    .into(),
+                ),
+                ..Default::default()
+            });
+            let client = WorkspaceFilesClient::with_transport(
+                transport.clone(),
+                FilesRequestContext {
+                    target: target(),
+                    target_device_id: None,
+                    cwd: "/workspace".into(),
+                    checkout_id: None,
+                },
+            );
+            let page = client
+                .list_directory_snapshot(
+                    ListWorkspaceDirectoryRequest {
+                        target: target(),
+                        directory: "".into(),
+                        include_ignored: false,
+                        cursor: None,
+                    },
+                    &[if missing {
+                        "deleted".into()
+                    } else {
+                        "a".into()
+                    }],
+                )
+                .await
+                .unwrap();
+            assert_eq!(page.next_cursor.is_none(), missing);
+            assert_eq!(
+                transport.calls.lock().unwrap().len(),
+                if missing { 2 } else { 1 }
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_or_repeated_later_page_does_not_publish_a_partial_refresh() {
+        for second in [
+            Err(RpcError::Transport("offline".into())),
+            Ok(directory_page("z", Some("next"))),
+        ] {
+            let transport = Arc::new(DeterministicTransport {
+                scripted_responses: Mutex::new(
+                    [Ok(directory_page("a", Some("next"))), second].into(),
+                ),
+                ..Default::default()
+            });
+            let client = WorkspaceFilesClient::with_transport(
+                transport,
+                FilesRequestContext {
+                    target: target(),
+                    target_device_id: None,
+                    cwd: "/workspace".into(),
+                    checkout_id: None,
+                },
+            );
+            assert!(
+                client
+                    .list_directory_snapshot(
+                        ListWorkspaceDirectoryRequest {
+                            target: target(),
+                            directory: "".into(),
+                            include_ignored: false,
+                            cursor: None,
+                        },
+                        &["missing".into()]
+                    )
+                    .await
+                    .is_err()
+            );
         }
     }
 

--- a/crates/ui/src/files/mod.rs
+++ b/crates/ui/src/files/mod.rs
@@ -182,6 +182,8 @@ pub struct FilesSurface {
     pending_request_context: Option<FilesRequestContext>,
     tree: FileTreeModel,
     tree_list: ListState,
+    tree_list_rows: Vec<model::VisibleTreeRow>,
+    tree_list_generation: u64,
     tree_focus: FocusHandle,
     search: Entity<ComposerInput>,
     search_state: FileSearchState,
@@ -204,7 +206,7 @@ impl Render for FilesSurface {
         let phase = self.tree.node("").map(|root| root.load.clone());
         let content = if !self.search_state.query.is_empty() {
             self.render_search_results(cx)
-        } else if let Some(error) = self.error.clone() {
+        } else if let Some(error) = self.error.clone().filter(|_| !self.tree_has_content()) {
             div()
                 .flex_1()
                 .flex()
@@ -239,10 +241,12 @@ impl Render for FilesSurface {
                         .on_click(cx.listener(|this, _, _, cx| this.retry_root(cx))),
                 )
                 .into_any_element()
-        } else if matches!(
-            phase.as_ref(),
-            Some(DirectoryLoadState::Unloaded | DirectoryLoadState::Loading { .. })
-        ) {
+        } else if !self.tree_has_content()
+            && matches!(
+                phase.as_ref(),
+                Some(DirectoryLoadState::Unloaded | DirectoryLoadState::Loading { .. })
+            )
+        {
             div().flex_1().into_any_element()
         } else {
             self.render_tree(cx)
@@ -529,6 +533,8 @@ impl FilesSurface {
             pending_request_context: None,
             tree: FileTreeModel::with_include_ignored(show_all_files),
             tree_list: ListState::new(0, ListAlignment::Top, px(560.0)),
+            tree_list_rows: Vec::new(),
+            tree_list_generation: 0,
             tree_focus: cx.focus_handle(),
             search,
             search_state: FileSearchState::default(),
@@ -730,12 +736,15 @@ impl FilesSurface {
     }
 
     fn refresh(&mut self, cx: &mut Context<Self>) {
-        self.loads.clear();
         self.error = None;
-        self.tree.reset();
-        self.sync_tree_list();
         self.started = true;
-        self.load_directory(String::new(), None, cx);
+        self.tree.invalidate_all_directories();
+        let directories = std::iter::once(String::new())
+            .chain(self.tree.expanded_directories())
+            .collect::<Vec<_>>();
+        for directory in directories {
+            self.load_directory(directory, None, cx);
+        }
     }
 
     pub fn tab_title(&self) -> SharedString {
@@ -796,6 +805,14 @@ impl FilesSurface {
             return;
         };
         let generation = self.tree.generation();
+        let cached_paths = if cursor.is_none() {
+            self.tree
+                .node(&directory)
+                .map(|node| node.children.clone())
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
         if !self.tree.begin_load(&directory, cursor.clone(), generation) {
             return;
         }
@@ -820,17 +837,20 @@ impl FilesSurface {
         };
         let client = WorkspaceFilesClient::new(engine, request_context);
         let task = cx.spawn(async move |this, cx| {
-            let mut result = client.list_directory(request.clone()).await;
+            let mut result = client
+                .list_directory_snapshot(request.clone(), &cached_paths)
+                .await;
             if result.as_ref().is_err_and(|error| error.retryable()) {
                 cx.background_executor()
                     .timer(Duration::from_millis(250))
                     .await;
-                result = client.list_directory(request).await;
+                result = client.list_directory_snapshot(request, &cached_paths).await;
             }
             let _ = this.update(cx, |surface, cx| {
                 if surface.tree.generation() != generation {
                     return;
                 }
+                let reload = surface.tree.node(&directory).is_some_and(|node| node.stale);
                 match result {
                     Ok(page) => {
                         surface.error = None;
@@ -847,6 +867,9 @@ impl FilesSurface {
                     }
                 }
                 surface.sync_tree_list();
+                if reload {
+                    surface.load_directory(directory, None, cx);
+                }
                 cx.notify();
             });
         });
@@ -914,9 +937,25 @@ impl FilesSurface {
         self.started = false;
     }
 
-    fn sync_tree_list(&self) {
-        self.tree_list
-            .reset_with_uniform_height(self.tree.visible_rows().len(), px(tree::TREE_ROW_HEIGHT));
+    fn tree_has_content(&self) -> bool {
+        self.tree.node("").is_some_and(|node| node.has_loaded)
+    }
+
+    fn sync_tree_list(&mut self) {
+        if self.tree_list_generation != self.tree.generation() {
+            self.tree_list.reset_with_uniform_height(
+                self.tree.visible_rows().len(),
+                px(tree::TREE_ROW_HEIGHT),
+            );
+            self.tree_list_generation = self.tree.generation();
+        } else {
+            tree::sync_list_rows(
+                &self.tree_list,
+                &self.tree_list_rows,
+                self.tree.visible_rows(),
+            );
+        }
+        self.tree_list_rows = self.tree.visible_rows().to_vec();
     }
 
     fn render_header(&mut self, theme: &crate::theme::Theme, cx: &mut Context<Self>) -> gpui::Div {

--- a/crates/ui/src/files/model.rs
+++ b/crates/ui/src/files/model.rs
@@ -25,6 +25,7 @@ pub struct TreeNode {
     pub children: Vec<String>,
     pub load: DirectoryLoadState,
     pub stale: bool,
+    pub has_loaded: bool,
 }
 
 impl TreeNode {
@@ -39,6 +40,7 @@ impl TreeNode {
             children: Vec::new(),
             load,
             stale: false,
+            has_loaded: false,
         }
     }
 }
@@ -76,6 +78,7 @@ pub struct FileTreeModel {
     selected: Option<String>,
     include_ignored: bool,
     generation: u64,
+    listing_children: HashMap<String, HashSet<String>>,
 }
 
 impl Default for FileTreeModel {
@@ -99,6 +102,7 @@ impl FileTreeModel {
             selected: None,
             include_ignored,
             generation: 0,
+            listing_children: HashMap::new(),
         }
     }
 
@@ -147,6 +151,7 @@ impl FileTreeModel {
     pub fn reset(&mut self) -> u64 {
         self.generation = self.generation.wrapping_add(1);
         self.nodes.clear();
+        self.listing_children.clear();
         self.nodes
             .insert(String::new(), TreeNode::new(root_entry()));
         self.expanded.clear();
@@ -217,13 +222,30 @@ impl FileTreeModel {
 
         let append = matches!(parent.load, DirectoryLoadState::Loading { cursor: Some(_) });
         if !append {
+            self.listing_children
+                .insert(directory.clone(), HashSet::new());
+        }
+        let seen = self.listing_children.entry(directory.clone()).or_default();
+        seen.extend(
+            page.entries
+                .iter()
+                .filter(|entry| is_direct_child(&entry.path, &directory))
+                .map(|entry| entry.path.clone()),
+        );
+        if page.next_cursor.is_none() {
+            let incoming = self.listing_children.remove(&directory).unwrap_or_default();
             let previous = parent.children.clone();
             for child in previous {
-                self.remove_subtree(&child);
+                // A partial listing cannot establish that an unseen child was deleted.
+                if !incoming.contains(&child) {
+                    self.remove_subtree(&child);
+                }
             }
-            if let Some(parent) = self.nodes.get_mut(&directory) {
-                parent.children.clear();
-            }
+            self.nodes
+                .get_mut(&directory)
+                .unwrap()
+                .children
+                .retain(|path| incoming.contains(path));
         }
 
         let mut known_children = self
@@ -237,6 +259,13 @@ impl FileTreeModel {
             }
             entry.ignored |= parent_ignored;
             let path = entry.path.clone();
+            if self
+                .nodes
+                .get(&path)
+                .is_some_and(|node| node.entry.kind != entry.kind)
+            {
+                self.remove_subtree(&path);
+            }
             self.nodes
                 .entry(path.clone())
                 .and_modify(|node| node.entry = entry.clone())
@@ -260,6 +289,7 @@ impl FileTreeModel {
                 next_cursor: page.next_cursor,
             };
             parent.stale = false;
+            parent.has_loaded = true;
         }
         self.rebuild_visible_rows();
         true
@@ -345,6 +375,14 @@ impl FileTreeModel {
         true
     }
 
+    pub fn invalidate_all_directories(&mut self) {
+        for node in self.nodes.values_mut() {
+            if node.entry.kind == WorkspaceEntryKind::Directory {
+                node.stale = true;
+            }
+        }
+    }
+
     pub fn remove(&mut self, path: &str) -> bool {
         if path.is_empty() || !self.nodes.contains_key(path) {
             return false;
@@ -413,6 +451,7 @@ impl FileTreeModel {
             self.remove_subtree(&child);
         }
         self.nodes.remove(path);
+        self.listing_children.remove(path);
         self.expanded.remove(path);
     }
 
@@ -464,6 +503,17 @@ impl FileTreeModel {
         }
         match &node.load {
             DirectoryLoadState::Unloaded => {}
+            DirectoryLoadState::Loading { cursor: None } if node.has_loaded => {
+                if node.children.is_empty() {
+                    rows.push(VisibleTreeRow {
+                        path: synthetic_path(directory, "empty"),
+                        depth,
+                        kind: VisibleRowKind::Empty {
+                            directory: directory.to_string(),
+                        },
+                    });
+                }
+            }
             DirectoryLoadState::Loading { .. } => rows.push(VisibleTreeRow {
                 path: synthetic_path(directory, "loading"),
                 depth,
@@ -585,6 +635,158 @@ mod tests {
             next_cursor: next_cursor.map(str::to_string),
             truncated: next_cursor.is_some(),
         }
+    }
+
+    #[test]
+    fn background_refresh_keeps_loaded_rows_even_when_empty_or_failed() {
+        let mut tree = FileTreeModel::new();
+        tree.apply_page(page("", vec![], None), 0);
+        let empty = tree.visible_rows().to_vec();
+        tree.begin_load("", None, 0);
+        assert_eq!(tree.visible_rows(), empty);
+        assert!(tree.node("").unwrap().has_loaded);
+        tree.apply_page(
+            page("", vec![entry("src", WorkspaceEntryKind::Directory)], None),
+            0,
+        );
+        let loaded = tree.visible_rows().to_vec();
+        tree.begin_load("", None, 0);
+        assert_eq!(tree.visible_rows(), loaded);
+        tree.fail_load("", None, "offline", 0);
+        assert_eq!(tree.visible_rows()[0].path, "src");
+        assert!(tree.node("").unwrap().has_loaded);
+    }
+
+    #[test]
+    fn changes_during_load_are_remembered_and_collapsed_caches_become_stale() {
+        let mut tree = FileTreeModel::new();
+        tree.apply_page(
+            page("", vec![entry("src", WorkspaceEntryKind::Directory)], None),
+            0,
+        );
+        tree.begin_load("", None, 0);
+        tree.invalidate_all_directories();
+        assert!(tree.node("").unwrap().stale);
+        assert!(tree.node("src").unwrap().stale);
+        assert!(!tree.begin_load("", None, 0));
+        assert!(tree.node("").unwrap().stale);
+        tree.apply_page(
+            page("", vec![entry("src", WorkspaceEntryKind::Directory)], None),
+            0,
+        );
+        assert!(tree.node("src").unwrap().stale);
+        tree.expand("src");
+        assert!(tree.begin_load("src", None, 0));
+        assert!(!tree.node("src").unwrap().stale);
+    }
+
+    #[test]
+    fn refreshing_a_directory_preserves_descendants_expansion_and_selection() {
+        let mut tree = FileTreeModel::new();
+        tree.apply_page(
+            page("", vec![entry("src", WorkspaceEntryKind::Directory)], None),
+            0,
+        );
+        tree.expand("src");
+        tree.apply_page(
+            page(
+                "src",
+                vec![entry("src/lib.rs", WorkspaceEntryKind::File)],
+                None,
+            ),
+            0,
+        );
+        tree.select("src/lib.rs");
+        tree.begin_load("", None, 0);
+        assert!(
+            tree.visible_rows()
+                .iter()
+                .any(|row| row.path == "src/lib.rs")
+        );
+        tree.apply_page(
+            page("", vec![entry("src", WorkspaceEntryKind::Directory)], None),
+            0,
+        );
+        assert!(tree.is_expanded("src"));
+        assert!(tree.is_directory_loaded("src"));
+        assert_eq!(tree.selected(), Some("src/lib.rs"));
+    }
+
+    #[test]
+    fn paginated_refresh_prunes_missing_children_only_after_the_last_page() {
+        let mut tree = FileTreeModel::new();
+        tree.apply_page(
+            page(
+                "",
+                vec![
+                    entry("a", WorkspaceEntryKind::Directory),
+                    entry("z", WorkspaceEntryKind::Directory),
+                    entry("removed", WorkspaceEntryKind::File),
+                ],
+                None,
+            ),
+            0,
+        );
+        tree.expand("z");
+        tree.apply_page(
+            page("z", vec![entry("z/child", WorkspaceEntryKind::File)], None),
+            0,
+        );
+        tree.select("z/child");
+        tree.begin_load("", None, 0);
+        tree.apply_page(
+            page(
+                "",
+                vec![entry("a", WorkspaceEntryKind::Directory)],
+                Some("next"),
+            ),
+            0,
+        );
+        assert!(tree.node("z/child").is_some());
+        assert!(tree.node("removed").is_some());
+        tree.begin_load("", Some("next".into()), 0);
+        tree.apply_page(
+            page("", vec![entry("z", WorkspaceEntryKind::Directory)], None),
+            0,
+        );
+        assert!(tree.node("a").is_some());
+        assert!(tree.node("removed").is_none());
+        assert!(tree.is_expanded("z"));
+        assert_eq!(tree.selected(), Some("z/child"));
+    }
+
+    #[test]
+    fn refresh_removes_deleted_subtrees_and_handles_directory_becoming_file() {
+        let mut tree = FileTreeModel::new();
+        tree.apply_page(
+            page("", vec![entry("src", WorkspaceEntryKind::Directory)], None),
+            0,
+        );
+        tree.expand("src");
+        tree.apply_page(
+            page(
+                "src",
+                vec![entry("src/lib.rs", WorkspaceEntryKind::File)],
+                None,
+            ),
+            0,
+        );
+        tree.select("src/lib.rs");
+        tree.begin_load("", None, 0);
+        tree.apply_page(
+            page("", vec![entry("src", WorkspaceEntryKind::File)], None),
+            0,
+        );
+        assert!(tree.node("src/lib.rs").is_none());
+        assert!(!tree.is_expanded("src"));
+        assert_eq!(tree.selected(), None);
+        assert_eq!(
+            tree.node("src").unwrap().entry.kind,
+            WorkspaceEntryKind::File
+        );
+        tree.begin_load("", None, 0);
+        tree.apply_page(page("", vec![], None), 0);
+        assert!(tree.node("src").is_none());
     }
 
     #[test]

--- a/crates/ui/src/files/tree.rs
+++ b/crates/ui/src/files/tree.rs
@@ -16,6 +16,53 @@ use crate::{
 pub const TREE_ROW_HEIGHT: f32 = 27.0;
 const TREE_INDENT: f32 = 14.0;
 
+/// Keep the viewport attached to a path rather than an index when rows move.
+pub(super) fn sync_list_rows(
+    list: &gpui::ListState,
+    old: &[super::model::VisibleTreeRow],
+    new: &[super::model::VisibleTreeRow],
+) {
+    if old == new {
+        return;
+    }
+    let mut anchor = list.logical_scroll_top();
+    let prefix = old.iter().zip(new).take_while(|(a, b)| a == b).count();
+    let suffix = old[prefix..]
+        .iter()
+        .rev()
+        .zip(new[prefix..].iter().rev())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let positions = new
+        .iter()
+        .enumerate()
+        .map(|(index, row)| (row.path.as_str(), index))
+        .collect::<std::collections::HashMap<_, _>>();
+    let old_index = anchor.item_ix.min(old.len().saturating_sub(1));
+    let mut path = old.get(old_index).map(|row| row.path.clone());
+    let mut target = None;
+    while let Some(candidate) = path {
+        if let Some(index) = positions.get(candidate.as_str()) {
+            target = Some(*index);
+            break;
+        }
+        path = super::model::parent_path(&candidate);
+    }
+    let target = target.or_else(|| {
+        old.iter()
+            .skip(old_index)
+            .chain(old[..old_index].iter().rev())
+            .find_map(|row| positions.get(row.path.as_str()).copied())
+    });
+    list.splice(prefix..old.len() - suffix, new.len() - prefix - suffix);
+    list.clone().with_uniform_item_height(px(TREE_ROW_HEIGHT));
+    anchor.item_ix = target.unwrap_or(0);
+    if target.is_none() {
+        anchor.offset_in_item = px(0.0);
+    }
+    list.scroll_to(anchor);
+}
+
 impl FilesSurface {
     pub(super) fn render_tree(&mut self, cx: &mut Context<Self>) -> AnyElement {
         div()
@@ -76,7 +123,10 @@ impl FilesSurface {
                     WorkspaceEntryKind::File | WorkspaceEntryKind::Symlink => icons::DOCUMENT,
                 };
                 div()
-                    .id(("files-tree-entry", index))
+                    .id(gpui::SharedString::from(format!(
+                        "files-tree-entry:{}",
+                        row.path
+                    )))
                     .role(gpui::Role::TreeItem)
                     .aria_label(node.entry.name.clone())
                     .aria_selected(selected)
@@ -341,4 +391,62 @@ fn status_row(
         .text_color(color)
         .child(label)
         .into_any_element()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::model::VisibleTreeRow;
+    use super::*;
+    use gpui::{ListAlignment, ListOffset, ListState};
+
+    fn rows(paths: &[&str]) -> Vec<VisibleTreeRow> {
+        paths
+            .iter()
+            .map(|path| VisibleTreeRow {
+                path: (*path).into(),
+                depth: 0,
+                kind: VisibleRowKind::Entry,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn directory_load_keeps_the_viewport_on_the_same_path() {
+        let old = rows(&["a", "src", "z"]);
+        let loading = rows(&["a", "src", "src/loading", "z"]);
+        let loaded = rows(&["a", "src", "src/a", "src/b", "z"]);
+        let list = ListState::new(old.len(), ListAlignment::Top, px(100.0))
+            .with_uniform_item_height(px(TREE_ROW_HEIGHT));
+        list.scroll_to(ListOffset {
+            item_ix: 2,
+            offset_in_item: px(7.0),
+        });
+        sync_list_rows(&list, &old, &loading);
+        assert_eq!(list.logical_scroll_top().item_ix, 3);
+        sync_list_rows(&list, &loading, &loaded);
+        assert_eq!(list.logical_scroll_top().item_ix, 4);
+        assert_eq!(list.logical_scroll_top().offset_in_item, px(7.0));
+        sync_list_rows(&list, &loaded, &loaded);
+        assert_eq!(list.logical_scroll_top().item_ix, 4);
+        assert_eq!(list.logical_scroll_top().offset_in_item, px(7.0));
+    }
+
+    #[test]
+    fn removed_anchor_falls_back_to_parent_then_neighbor() {
+        let old = rows(&["a", "src", "src/child", "z"]);
+        let collapsed = rows(&["a", "src", "z"]);
+        let removed = rows(&["a", "z"]);
+        let list = ListState::new(old.len(), ListAlignment::Top, px(100.0));
+        list.scroll_to(ListOffset {
+            item_ix: 2,
+            offset_in_item: px(3.0),
+        });
+        sync_list_rows(&list, &old, &collapsed);
+        assert_eq!(list.logical_scroll_top().item_ix, 1);
+        sync_list_rows(&list, &collapsed, &removed);
+        assert_eq!(list.logical_scroll_top().item_ix, 1);
+        sync_list_rows(&list, &removed, &[]);
+        assert_eq!(list.item_count(), 0);
+        assert_eq!(list.logical_scroll_top().item_ix, 0);
+    }
 }

--- a/crates/ui/src/files/watch.rs
+++ b/crates/ui/src/files/watch.rs
@@ -129,13 +129,13 @@ impl FilesSurface {
             }
         }
 
-        let reload = parents
-            .into_iter()
-            .filter(|parent| self.tree.is_expanded(parent) && self.tree.is_directory_loaded(parent))
-            .collect::<Vec<_>>();
-        for parent in &reload {
+        for parent in &parents {
             self.tree.invalidate_directory(parent);
         }
+        let reload = parents
+            .into_iter()
+            .filter(|parent| self.tree.is_expanded(parent))
+            .collect::<Vec<_>>();
         self.sync_tree_list();
         for parent in reload {
             self.load_directory(parent, None, cx);


### PR DESCRIPTION
Files could flash blank, jump to the top, and collapse expanded folders when directories loaded or filesystem events arrived. The periodic watcher repair also reset the entire browser, and opening another file tab could make existing subscribers incorrectly report missing events. This change preserves the visible tree during refreshes and fixes watcher sequencing.

## Improvements

- **Preserve the viewport during tree updates.** Replace unconditional list resets with a splice of the changed row range. Anchor scrolling to the first visible path and its pixel offset; fall back to a visible ancestor or neighboring row if that path disappears. Unchanged rows do not trigger list mutations, and file rows use stable path-based element IDs. Generation changes still reset the list when the underlying tree is explicitly reset.
- **Keep cached content visible while loading or recovering from errors.** Distinguish an initial load from a refresh, including previously loaded empty directories. Root reloads no longer replace the tree with a blank panel, and background loads do not insert loading rows into cached directories.
- **Reconcile directory contents instead of rebuilding every subtree.** Retain loaded descendants, expansion, and selection for surviving entries. Remove genuinely missing subtrees and handle entries changing between files and directories. Partial pages cannot establish that an unseen child was deleted; track children across pages before pruning.
- **Refresh cached pages together.** Collect enough pages to cover previously cached children before publishing the updated listing. Initial loads remain lazy, and normal refreshes stop once cached paths are accounted for. If a cached child is missing, read to the end to confirm its removal. Later-page failures and repeated cursors return an error without publishing a partial refresh. Confirming missing children can therefore require additional page requests in large directories.
- **Make watcher resyncs preserve browsing state.** The existing 120-second repair, startup resync, and sequence-gap recovery now invalidate and reload directories without clearing the tree. Changes arriving during a load mark it for a follow-up reload. Closed directories retain their cache but become stale so reopening them fetches current contents.
- **Fix subscription and lag-recovery sequencing.** Only broadcast events advance the shared sequence. Serialize publication with receiver creation and baseline capture so new subscriptions cannot create artificial gaps in other tabs. Lagging subscribers get a fresh receiver and current baseline, discarding obsolete queued frames without consuming a shared sequence number.

## Validation

- `cargo test -p zeron-ui -p zeron-engine --lib files::` — **102 passed**: 75 UI Files tests and 27 workspace-files engine tests.
- Added regressions for scroll anchors and fallback, unchanged rows, retained expansion/selection, empty and failed refreshes, paginated reconciliation, deleted/type-changed nodes, invalidation during loads, lazy pagination, later-page failures, new subscriptions, and lag recovery.
- Targeted `rustfmt --check` on all six changed files and `git diff --check` passed.
- Interactive visual verification in the running app remains pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791569705&installation_model_id=425430&pr_number=287&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F287&signature=5119509083c7e37cee7661a9628e13de9de6779160217eb6ae18edc7a6cec54e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->