### PR TITLE
Add automatic project previews with stable URLs and P2P networking

### DIFF
--- a/.github/workflows/preview-tests.yml
+++ b/.github/workflows/preview-tests.yml
@@ -1,0 +1,40 @@
+name: Preview networking
+on:
+  pull_request:
+    paths: ['crates/preview/**', 'crates/proto/**', 'Cargo.toml', 'Cargo.lock', 'edge/**', '.github/workflows/preview-tests.yml']
+  push:
+    branches: [main]
+    paths: ['crates/preview/**', 'crates/proto/**', 'Cargo.toml', 'Cargo.lock', 'edge/**', '.github/workflows/preview-tests.yml']
+permissions:
+  contents: read
+concurrency:
+  group: preview-tests-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  networking:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --locked -p zeron-preview
+  coordinator:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: edge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: edge/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Check macOS application
         run: cargo check --release --locked -p zeron
       - name: Build native browser fixture
-        run: cargo build --release --locked -p zeron-ui --example browser-fixture --features browser-fixture
+        run: cargo build --release --locked -p zeron-ui --example browser-fixture --example preview-fixture --features browser-fixture
       - name: Native browser regression and screenshots
         timeout-minutes: 3
         env:
@@ -88,6 +88,25 @@ jobs:
         with:
           name: browser-macos-captures
           path: ${{ runner.temp }}/browser-captures
+          if-no-files-found: ignore
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install preview fixture server
+        run: npm ci --prefix edge
+      - name: Project discovery, stable URLs and HMR in native WebKit
+        timeout-minutes: 3
+        env:
+          ZERON_PREVIEW_AUTO_OPEN: 1
+        run: |
+          VITE_BINARY="$GITHUB_WORKSPACE/edge/node_modules/vite/bin/vite.js" target/release/examples/preview-fixture "$RUNNER_TEMP/preview-captures"
+          test -f "$RUNNER_TEMP/preview-captures/result.txt"
+      - name: Upload preview screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-macos-captures
+          path: ${{ runner.temp }}/preview-captures
           if-no-files-found: ignore
       - name: Native frame-source recovery regression
         working-directory: frame-source-tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +137,20 @@ dependencies = [
  "cipher",
  "cpufeatures 0.2.17",
  "zeroize",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -158,7 +182,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda177466b9524d59f1b12f0dd30b68696788e9992a7e959021c4a0ed96fcf59"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "home",
  "libc",
@@ -365,6 +389,73 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "zbus",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -678,10 +769,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
@@ -732,6 +841,9 @@ name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit_field"
@@ -858,6 +970,29 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26333eeac754f0ad8a6bcd0eb0ac012156302e4e16b852b72ee399aea4f12c29"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "bytemuck"
@@ -1002,6 +1137,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1196,17 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
@@ -1056,6 +1214,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1311,6 +1482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1713,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,12 +1837,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1679,10 +1893,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "darling"
@@ -1730,6 +1979,45 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.2",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "deranged"
@@ -1794,6 +2082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1933,10 +2222,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embed-resource"
@@ -2191,6 +2515,22 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -2594,6 +2934,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2668,6 +3009,16 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -3221,6 +3572,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,7 +3727,7 @@ version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -3534,6 +3896,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,6 +3914,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3575,7 +3944,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -4736,6 +5105,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "naga"
 version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4803,6 +5192,19 @@ dependencies = [
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -5454,6 +5856,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,6 +5927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5539,6 +5965,30 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -5634,6 +6084,25 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -5797,6 +6266,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5808,7 +6287,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap",
  "quick-xml",
  "serde",
@@ -5896,12 +6375,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polycool"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -5932,7 +6434,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.25.1",
  "serial",
  "shared_library",
  "shell-words",
@@ -6024,6 +6526,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -6169,6 +6680,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6268,7 +6799,7 @@ dependencies = [
  "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp",
+ "quinn-udp 0.5.15",
  "rustc-hash 2.1.3",
  "rustls",
  "socket2",
@@ -6315,6 +6846,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn-udp"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca72c3f2792761ab5fa848490694cbc728c7f659669ed4320c4c79c12150966"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "log",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6334,6 +6878,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b534442d0fcdb55d66f373d9cac6d33b6293a2335bc2136dbd06ce0e87d2572"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -6362,7 +6915,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -6548,6 +7101,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser 0.18.1",
+ "yasna",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6653,6 +7220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rend"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6664,7 +7240,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6717,6 +7293,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6737,6 +7323,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6761,6 +7377,282 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "rtc"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66355ae7cad547376873a2ee7968eee1e3727492a241c05bf511b01db4cef077"
+dependencies = [
+ "bytes",
+ "hex",
+ "log",
+ "rand 0.10.2",
+ "rcgen",
+ "ring",
+ "rtc-datachannel",
+ "rtc-dtls",
+ "rtc-ice",
+ "rtc-interceptor",
+ "rtc-mdns",
+ "rtc-media",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-sctp",
+ "rtc-sdp",
+ "rtc-shared",
+ "rtc-srtp",
+ "rtc-stun",
+ "rtc-turn",
+ "rustls",
+ "sansio",
+ "serde",
+ "serde_json",
+ "sha2",
+ "unicase",
+ "url",
+]
+
+[[package]]
+name = "rtc-datachannel"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1767cfa2571e226e16d1594518c5160d7bef10c6e0fe7a60a8f979051233ea1"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-sctp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-dtls"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb84feb0331735ab54ba58bfeb15300b517c283c5ee45e9f94d8727e6573ec5"
+dependencies = [
+ "aes",
+ "bytecheck",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ccm",
+ "chacha20poly1305",
+ "der-parser 9.0.0",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "rand 0.10.2",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rkyv",
+ "rtc-shared",
+ "rustls",
+ "sec1",
+ "sha1",
+ "sha2",
+ "subtle",
+ "x25519-dalek",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "rtc-ice"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee1c117265c3460ef2d88b54bdd5048c7ee05d5de948310e9ca053ff5154f74"
+dependencies = [
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.10.2",
+ "rtc-mdns",
+ "rtc-shared",
+ "rtc-stun",
+ "sansio",
+ "serde",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "rtc-interceptor"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a76412e39ae1a8a024be246009ffb5e6300f9703bc7b1ba41a3e0e1c5e63c1"
+dependencies = [
+ "log",
+ "rand 0.10.2",
+ "rtc-interceptor-derive",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-interceptor-derive"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57385751766059daa81c7badbef27b894c358057be0413bf329875c6950ae125"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "rtc-mdns"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e1e0868d134ff0f10cd6ee71ad0d53c4a81a733f9950947eb8806b0a090159"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-shared",
+ "sansio",
+ "socket2",
+]
+
+[[package]]
+name = "rtc-media"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd79fb066099a90edd43dfe5ef296021218def9070ce39dcd0756e309e8945f"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand 0.10.2",
+ "rtc-rtp",
+ "rtc-shared",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "rtc-rtcp"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b515f133b14a119a3862c34b36c807bb985e90dc64515b2283b8e9a177d6ae3f"
+dependencies = [
+ "bytes",
+ "rtc-shared",
+]
+
+[[package]]
+name = "rtc-rtp"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a5509cd26a487309ac0d933b100af8976c399c1082009d4d4364a205968127"
+dependencies = [
+ "bytes",
+ "memchr",
+ "rand 0.10.2",
+ "rtc-shared",
+ "serde",
+]
+
+[[package]]
+name = "rtc-sctp"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f786b8224032e25084a52401fcc28a8b6a4a5b1b1971152ad01113279628861"
+dependencies = [
+ "bytes",
+ "crc32c",
+ "log",
+ "rand 0.10.2",
+ "rtc-shared",
+ "rustc-hash 2.1.3",
+ "slab",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "rtc-sdp"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb942d52e95a0b6b6178374e88e90b069d8aa7078e6e581e1490db2521978e8"
+dependencies = [
+ "rand 0.10.2",
+ "rtc-shared",
+ "url",
+]
+
+[[package]]
+name = "rtc-shared"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "393280ae9959b5245df9eb38a5cd02b373a98021599d36111c339a4696bf8488"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "bitflags 1.3.2",
+ "bytes",
+ "nix 0.31.3",
+ "p256",
+ "rand 0.10.2",
+ "rcgen",
+ "sec1",
+ "serde",
+ "substring",
+ "thiserror 2.0.20",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "rtc-srtp"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77ba0abc312a93840746c27d4d1f16efc71baa9d3838ca9dda65e478e41461d"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac",
+ "ring",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-shared",
+ "sha1",
+ "subtle",
+]
+
+[[package]]
+name = "rtc-stun"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc22012b96070d048d16bd6d2b0ca451bc8e920a28fb850b8f9644f21e32a826"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.10.2",
+ "ring",
+ "rtc-shared",
+ "sansio",
+ "subtle",
+ "url",
+]
+
+[[package]]
+name = "rtc-turn"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55fd9c23215c3e22ae698b423ae86992a89cb0c24440e3e7e2932dcad75aa3f0"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-shared",
+ "rtc-stun",
+ "sansio",
 ]
 
 [[package]]
@@ -6802,6 +7694,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -6928,6 +7829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sansio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62751faa8bc286982334a082fe125184a29fc89d17775766e4f891b7d726980"
+
+[[package]]
 name = "scheduler"
 version = "0.1.0"
 source = "git+https://github.com/zeronsh/zui?rev=07fd941ad72e7edc812fed317aab66adb69fa8cc#07fd941ad72e7edc812fed317aab66adb69fa8cc"
@@ -7008,6 +7915,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "selectors"
@@ -7321,6 +8242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7334,6 +8265,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -7501,6 +8438,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7616,6 +8563,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -8804,6 +9760,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8827,7 +9793,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "data-url",
  "flate2",
  "fontdb",
@@ -9313,6 +10279,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ce8fa1c8b8aa8753b7313a26e46e27d973e11945e35f525ac6700062c3b295"
+dependencies = [
+ "async-broadcast",
+ "async-channel",
+ "async-trait",
+ "bytes",
+ "event-listener",
+ "futures",
+ "log",
+ "quinn-udp 0.6.2",
+ "rtc",
+ "tokio",
 ]
 
 [[package]]
@@ -10095,7 +11079,7 @@ version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375becb4aded9913f736443cf88000c6311478db69814cc06070465e4cc44c98"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
@@ -10170,6 +11154,53 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry 0.7.1",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs 0.7.2",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry 0.8.1",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
 
 [[package]]
 name = "xcb"
@@ -10252,6 +11283,16 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yazi"
@@ -10575,7 +11616,7 @@ version = "0.2.54"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "gethostname",
@@ -10599,6 +11640,7 @@ dependencies = [
  "uuid",
  "zeron-doc",
  "zeron-harness",
+ "zeron-preview",
  "zeron-proto",
  "zeron-rpc",
  "zeron-sync",
@@ -10611,7 +11653,7 @@ version = "0.2.54"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "futures",
  "libc",
  "reqwest",
@@ -10623,6 +11665,33 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+ "zeron-proto",
+]
+
+[[package]]
+name = "zeron-preview"
+version = "0.2.54"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "libc",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "webrtc",
  "zeron-proto",
 ]
 
@@ -10734,7 +11803,7 @@ dependencies = [
  "alacritty_terminal",
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "block2 0.6.2",
  "chrono",
  "fontdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11813,6 +11813,7 @@ dependencies = [
  "gpui_platform",
  "gpui_tokio",
  "image",
+ "libc",
  "mimalloc",
  "objc",
  "objc2 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/theme",
     "crates/proto",
+    "crates/preview",
     "crates/doc",
     "crates/sync",
     "crates/harness",
@@ -22,6 +23,7 @@ publish = false
 
 [workspace.dependencies]
 zeron-proto = { path = "crates/proto" }
+zeron-preview = { path = "crates/preview" }
 zeron-doc = { path = "crates/doc" }
 zeron-sync = { path = "crates/sync" }
 zeron-harness = { path = "crates/harness" }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+zeron-preview.workspace = true
 zeron-proto.workspace = true
 zeron-doc.workspace = true
 zeron-sync.workspace = true

--- a/crates/engine/src/auth.rs
+++ b/crates/engine/src/auth.rs
@@ -1181,3 +1181,10 @@ mod tests {
         );
     }
 }
+
+#[async_trait::async_trait]
+impl zeron_preview::signaling::TokenSource for Auth {
+    async fn token(&self) -> Option<String> {
+        self.access_token().await
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -124,6 +124,7 @@ pub struct EngineCore {
     pub repos: Repos,
     pub workspace_files: WorkspaceFiles,
     pub terminals: Terminals,
+    pub previews: zeron_preview::PreviewService,
     pub change_requests: CheckoutChangeRequests,
     pub diff_sync: CheckoutDiffSync,
     pub spaces_sync: SpacesSync,
@@ -246,6 +247,12 @@ impl EngineCore {
         let workspace_files =
             WorkspaceFiles::new(repos.clone(), workspace.clone(), device_id.clone());
         let terminals = Terminals::new();
+        let previews = zeron_preview::PreviewService::new(
+            profile.store_root().join("previews.json"),
+            device_id.clone(),
+            local_device_name(&device_id),
+        )
+        .map_err(|e| EngineError::Other(e.to_string()))?;
         let uploads = Uploads::from_root_with_fallback(
             profile.uploads_root(),
             legacy_uploads_root.as_deref(),
@@ -295,6 +302,7 @@ impl EngineCore {
             repos,
             workspace_files,
             terminals,
+            previews,
             change_requests,
             diff_sync,
             spaces_sync,
@@ -432,7 +440,8 @@ impl EngineCore {
             self.agent_accounts.clone(),
             self.workspace_scope,
         )
-        .with_auth(self.auth());
+        .with_auth(self.auth())
+        .with_previews(self.previews.clone());
         if let Some(links) = self.links() {
             rpc = rpc.with_links(links);
         }
@@ -449,6 +458,7 @@ impl EngineCore {
     /// draining. Connected sockets remain authorized by their handshake, so
     /// clearing credentials alone is not a security boundary.
     pub fn disconnect_edge(&self) {
+        self.previews.stop();
         if let Some(links) = self.links() {
             links.disconnect_all();
         }
@@ -460,6 +470,7 @@ impl EngineCore {
     /// kill live PTYs, stamp our workspace `lastSeenAt`, and flush every open doc
     /// snapshot.
     pub async fn shutdown(&self) {
+        self.previews.shutdown().await;
         // A run interruption transitions its chat to Idle, and Idle normally
         // releases the next queued row. Freeze first so quitting never starts
         // recovered work while the engine is being torn down.
@@ -738,6 +749,7 @@ impl Engine {
             EdgeConfig::new(config.edge_url.clone(), Arc::new(auth.clone())).with_device(device_id)
         });
 
+        let preview_org = profile.org_id().to_string();
         let core = match lock {
             Some(lock) => EngineCore::assemble_with_profile_locked(
                 profile,
@@ -754,6 +766,23 @@ impl Engine {
             )?,
         };
         core.set_auth(auth.clone());
+        let preview_workspace = core.workspace.clone();
+        let preview_device = core.device_id.clone();
+        let projects = Arc::new(move || {
+            preview_workspace
+                .read_chats()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|chat| chat.device_id == preview_device)
+                .filter_map(|chat| chat.cwd.map(std::path::PathBuf::from))
+                .collect()
+        });
+        let preview_signaling = edge_enabled.then(|| zeron_preview::signaling::Config {
+            edge_url: config.edge_url.clone(),
+            org_id: preview_org,
+            tokens: Arc::new(auth.clone()),
+        });
+        core.previews.start(projects, preview_signaling).await;
         if edge_enabled {
             // Release checker: polls {edge}/releases on a 6h cadence; headless
             // installs with ZERON_AUTO_UPDATE=1 apply + restart themselves — gated

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -470,6 +470,7 @@ pub struct EngineRpc {
     repos: Repos,
     workspace_files: crate::WorkspaceFiles,
     terminals: Terminals,
+    previews: Option<zeron_preview::PreviewService>,
     change_requests: CheckoutChangeRequests,
     diff_sync: CheckoutDiffSync,
     uploads: Uploads,
@@ -510,6 +511,7 @@ impl EngineRpc {
             repos,
             workspace_files,
             terminals,
+            previews: None,
             change_requests,
             diff_sync,
             uploads,
@@ -520,6 +522,11 @@ impl EngineRpc {
             local_import: None,
             engine_info,
         }
+    }
+
+    pub fn with_previews(mut self, previews: zeron_preview::PreviewService) -> Self {
+        self.previews = Some(previews);
+        self
     }
 
     /// Attach the auth service (AuthStatus + AuthRpc mutations).
@@ -1447,6 +1454,69 @@ impl RpcService for EngineRpc {
             methods::WATCH_TRANSFERS => Ok(RpcReply::Stream(watch_stream(
                 self.doc_host.watch_transfers(),
             ))),
+            methods::WATCH_PREVIEWS => {
+                let p: zeron_proto::WatchPreviewsParams = parse_params(params)?;
+                if self
+                    .workspace
+                    .chat(&p.chat_id)
+                    .map_err(|e| RpcError::Failed(e.to_string()))?
+                    .is_none()
+                {
+                    return Err(RpcError::Failed("Project session not found".into()));
+                }
+                let previews = self
+                    .previews
+                    .as_ref()
+                    .ok_or_else(|| RpcError::Failed("Preview discovery unavailable".into()))?;
+                let catalog = previews.catalog().clone();
+                let changes = catalog.subscribe();
+                let chats = self.workspace.watch_chats();
+                let workspace = self.workspace.clone();
+                // This subscription stays on the viewing device. A remote chat
+                // selects advertised services, but its URL uses our local proxy.
+                let stream = futures::stream::unfold(
+                    (changes, chats, true, workspace, catalog, p.chat_id),
+                    |(mut changes, mut chats, first, workspace, catalog, chat_id)| async move {
+                        if !first {
+                            tokio::select! {
+                                result = changes.changed() => { if result.is_err() { return None; } }
+                                result = chats.changed() => { if result.is_err() { return None; } }
+                            }
+                        }
+                        let mut snapshot = changes.borrow_and_update().clone();
+                        chats.borrow_and_update();
+                        let chat = workspace.chat(&chat_id).ok().flatten();
+                        let device = chat
+                            .as_ref()
+                            .map(|c| c.device_id.clone())
+                            .unwrap_or_default();
+                        snapshot.remote = device != catalog.device_id();
+                        let cwd = chat.and_then(|c| c.cwd);
+                        let cwd = cwd.map(|cwd| {
+                            if snapshot.remote {
+                                std::path::PathBuf::from(cwd)
+                            } else {
+                                std::path::PathBuf::from(&cwd)
+                                    .canonicalize()
+                                    .unwrap_or_else(|_| cwd.into())
+                            }
+                        });
+                        snapshot.project_name = cwd
+                            .as_ref()
+                            .and_then(|p| p.file_name())
+                            .map(|s| s.to_string_lossy().into_owned());
+                        snapshot.services.retain(|service| {
+                            service.device_id == device
+                                && cwd.as_ref().is_some_and(|cwd| {
+                                    cwd == std::path::Path::new(&service.project_cwd)
+                                })
+                        });
+                        let value = serde_json::to_value(snapshot).ok()?;
+                        Some((value, (changes, chats, false, workspace, catalog, chat_id)))
+                    },
+                );
+                Ok(RpcReply::Stream(Box::pin(stream)))
+            }
             methods::WATCH_CHATS => {
                 Ok(RpcReply::Stream(watch_stream(self.workspace.watch_chats())))
             }

--- a/crates/engine/tests/previews.rs
+++ b/crates/engine/tests/previews.rs
@@ -1,0 +1,88 @@
+use futures::StreamExt;
+use std::{sync::Arc, time::Duration};
+use zeron_engine::{EngineCore, HarnessRegistry};
+use zeron_proto::{HarnessId, PreviewService};
+use zeron_rpc::{RpcReply, RpcService, methods};
+
+fn service(device: &str, cwd: &std::path::Path, id: &str) -> PreviewService {
+    PreviewService {
+        id: id.into(),
+        project_id: "project".into(),
+        project_name: "project".into(),
+        project_cwd: cwd.to_string_lossy().into_owned(),
+        device_id: device.into(),
+        device_name: device.into(),
+        hostname: format!("{device}.{id}.localhost"),
+        name: "Vite".into(),
+        port: 5173,
+        pid: 123,
+        cwd: cwd.to_string_lossy().into_owned(),
+        started_at: 1,
+        zeron_owned: true,
+    }
+}
+#[tokio::test]
+async fn preview_watch_follows_the_session_checkout_and_owning_device() {
+    let temp = tempfile::tempdir().unwrap();
+    let a = temp.path().join("a");
+    let b = temp.path().join("b");
+    std::fs::create_dir(&a).unwrap();
+    std::fs::create_dir(&b).unwrap();
+    let core = EngineCore::assemble(
+        &temp.path().join("engine"),
+        Arc::new(HarnessRegistry::new()),
+        HarnessId::Mock,
+        None,
+    )
+    .unwrap();
+    core.workspace
+        .create_chat(
+            "chat",
+            None,
+            Some("peer"),
+            None,
+            Some(a.to_string_lossy().into_owned()),
+        )
+        .unwrap();
+    let catalog = core.previews.catalog();
+    catalog
+        .set_remote(
+            "peer",
+            vec![service("peer", &a, "a"), service("peer", &b, "b")],
+        )
+        .unwrap();
+    catalog
+        .set_remote("other", vec![service("other", &a, "other")])
+        .unwrap();
+    let rpc = core.rpc_service();
+    let RpcReply::Stream(mut stream) = rpc
+        .handle(
+            methods::WATCH_PREVIEWS,
+            serde_json::json!({"chatId":"chat", "targetDeviceId":"peer"}),
+        )
+        .await
+        .unwrap()
+    else {
+        panic!("expected preview watch")
+    };
+    let first = stream.next().await.unwrap();
+    assert_eq!(first["services"].as_array().unwrap().len(), 1);
+    assert_eq!(first["services"][0]["id"], "a");
+    assert_eq!(first["remote"], true);
+    core.workspace
+        .set_chat_cwd("chat", &b.to_string_lossy())
+        .unwrap();
+    let next = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(next["services"][0]["id"], "b");
+    catalog.remove_remote("peer");
+    let next = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(next["services"], serde_json::json!([]));
+    drop(stream);
+    core.shutdown().await;
+}

--- a/crates/preview/Cargo.toml
+++ b/crates/preview/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "zeron-preview"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+zeron-proto.workspace = true
+tokio.workspace = true
+tokio-util = { workspace = true, features = ["rt"] }
+futures.workspace = true
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+uuid.workspace = true
+sha2.workspace = true
+libc.workspace = true
+chrono.workspace = true
+reqwest.workspace = true
+tokio-tungstenite.workspace = true
+bytes = "1"
+hyper = { version = "1", features = ["client", "server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+webrtc = "0.20.2"
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/preview/src/catalog.rs
+++ b/crates/preview/src/catalog.rs
@@ -1,0 +1,563 @@
+//! Persisted names are independent of ephemeral process/listener observations.
+use crate::discovery::{Listener, command_identity, framework};
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+use tokio::sync::watch;
+use zeron_proto::{PREVIEW_PROXY_PORT, PreviewService, PreviewSnapshot};
+
+#[derive(Clone)]
+pub struct Catalog(Arc<Inner>);
+struct Inner {
+    file: PathBuf,
+    device_id: String,
+    device_name: String,
+    state: Mutex<State>,
+    changes: watch::Sender<PreviewSnapshot>,
+}
+struct State {
+    names: Names,
+    routes: HashMap<String, LocalRoute>,
+    remote: HashMap<String, Vec<PreviewService>>,
+    proxy_port: u16,
+    error: Option<String>,
+}
+#[derive(Clone)]
+pub struct LocalRoute {
+    pub service: PreviewService,
+    pub listener: Listener,
+}
+#[derive(Default, Serialize, Deserialize)]
+struct Names {
+    device_label: String,
+    #[serde(default)]
+    peer_labels: BTreeMap<String, String>,
+    projects: BTreeMap<String, ProjectName>,
+}
+#[derive(Serialize, Deserialize)]
+struct ProjectName {
+    id: String,
+    label: String,
+    services: Vec<ServiceName>,
+}
+#[derive(Serialize, Deserialize)]
+struct ServiceName {
+    id: String,
+    fingerprint: String,
+    label: String,
+}
+
+pub fn slug(value: &str) -> String {
+    let mut result = String::new();
+    for character in value.chars() {
+        if character.is_ascii_alphanumeric() {
+            result.push(character.to_ascii_lowercase());
+        } else if !result.ends_with('-') && !result.is_empty() {
+            result.push('-');
+        }
+        if result.len() >= 48 {
+            break;
+        }
+    }
+    let result = result.trim_matches('-');
+    if result.is_empty() {
+        "project".into()
+    } else {
+        result.into()
+    }
+}
+
+pub fn valid_hostname(host: &str) -> bool {
+    let labels: Vec<_> = host.split('.').collect();
+    labels.len() == 3
+        && labels[2] == "localhost"
+        && labels[..2].iter().all(|s| {
+            !s.is_empty()
+                && s.len() <= 63
+                && !s.starts_with('-')
+                && !s.ends_with('-')
+                && s.bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        })
+}
+
+fn allocate(base: &str, used: &HashSet<String>) -> String {
+    let base = &base[..base.len().min(58)];
+    let base = base.trim_end_matches('-');
+    if !used.contains(base) {
+        return base.to_owned();
+    }
+    for index in 2.. {
+        let label = format!("{}-{index}", &base[..base.len().min(48)]);
+        if !used.contains(&label) {
+            return label;
+        }
+    }
+    unreachable!()
+}
+
+impl Catalog {
+    pub fn open(
+        file: impl Into<PathBuf>,
+        device_id: String,
+        device_name: String,
+    ) -> anyhow::Result<Self> {
+        let file = file.into();
+        let mut names = match std::fs::read(&file) {
+            Ok(bytes) => serde_json::from_slice::<Names>(&bytes)
+                .context("invalid preview identity registry")?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Names::default(),
+            Err(e) => return Err(e.into()),
+        };
+        if names.device_label.is_empty() {
+            names.device_label = slug(&device_name);
+        }
+        let (changes, _) = watch::channel(PreviewSnapshot::default());
+        Ok(Self(Arc::new(Inner {
+            file,
+            device_id,
+            device_name,
+            state: Mutex::new(State {
+                names,
+                routes: HashMap::new(),
+                remote: HashMap::new(),
+                proxy_port: PREVIEW_PROXY_PORT,
+                error: None,
+            }),
+            changes,
+        })))
+    }
+    pub fn device_id(&self) -> &str {
+        &self.0.device_id
+    }
+    pub fn subscribe(&self) -> watch::Receiver<PreviewSnapshot> {
+        self.0.changes.subscribe()
+    }
+    pub fn snapshot(&self) -> PreviewSnapshot {
+        self.0.changes.borrow().clone()
+    }
+    pub fn local_services(&self) -> Vec<PreviewService> {
+        {
+            let mut services: Vec<_> = self
+                .0
+                .state
+                .lock()
+                .unwrap()
+                .routes
+                .values()
+                .map(|r| r.service.clone())
+                .collect();
+            services.sort_by(|a, b| a.id.cmp(&b.id));
+            services
+        }
+    }
+    pub fn local_route(&self, id: &str) -> Option<LocalRoute> {
+        self.0.state.lock().unwrap().routes.get(id).cloned()
+    }
+    pub fn by_hostname(&self, hostname: &str) -> Option<PreviewService> {
+        // Ambiguous remote aliases never pick an arbitrary machine. Local
+        // aliases retain their established meaning when a peer has the same name.
+        let state = self.0.state.lock().unwrap();
+        if let Some(route) = state
+            .routes
+            .values()
+            .find(|r| r.service.hostname == hostname)
+        {
+            return Some(route.service.clone());
+        }
+        let mut matches = state
+            .remote
+            .values()
+            .flatten()
+            .filter(|s| s.hostname == hostname);
+        let result = matches.next()?.clone();
+        matches.next().is_none().then_some(result)
+    }
+    pub fn set_proxy_status(&self, port: u16, error: Option<String>) {
+        let mut state = self.0.state.lock().unwrap();
+        state.proxy_port = port;
+        state.error = error;
+        self.publish(&state);
+    }
+    pub fn set_remote(
+        &self,
+        device: &str,
+        mut services: Vec<PreviewService>,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            device != self.device_id(),
+            "cannot replace the local device catalog"
+        );
+        anyhow::ensure!(
+            services.len() <= 256,
+            "too many advertised preview services"
+        );
+        let mut ids = HashSet::new();
+        anyhow::ensure!(
+            services.iter().all(|s| s.device_id == device
+                && valid_hostname(&s.hostname)
+                && s.id.len() <= 128
+                && !s.id.is_empty()
+                && ids.insert(s.id.clone())
+                && s.project_cwd.len() <= 4096
+                && s.name.len() <= 128),
+            "invalid peer service advertisement"
+        );
+        let mut state = self.0.state.lock().unwrap();
+        if let Some(first) = services.first() {
+            if !state.names.peer_labels.contains_key(device) {
+                let base = first.hostname.split('.').next().unwrap();
+                let used = state
+                    .names
+                    .peer_labels
+                    .values()
+                    .cloned()
+                    .chain(std::iter::once(state.names.device_label.clone()))
+                    .collect();
+                let label = allocate(base, &used);
+                state.names.peer_labels.insert(device.to_owned(), label);
+                self.persist(&state.names)?;
+            }
+            let label = &state.names.peer_labels[device];
+            for service in &mut services {
+                service.hostname =
+                    format!("{label}.{}", service.hostname.split_once('.').unwrap().1);
+            }
+        }
+        state.remote.insert(device.to_owned(), services);
+        self.publish(&state);
+        Ok(())
+    }
+    pub fn remove_remote(&self, device: &str) {
+        let mut state = self.0.state.lock().unwrap();
+        state.remote.remove(device);
+        self.publish(&state);
+    }
+    pub fn clear_remote(&self) {
+        let mut state = self.0.state.lock().unwrap();
+        state.remote.clear();
+        self.publish(&state);
+    }
+    fn persist(&self, names: &Names) -> anyhow::Result<()> {
+        let parent = self
+            .0
+            .file
+            .parent()
+            .context("preview registry has no parent directory")?;
+        std::fs::create_dir_all(parent)?;
+        let temporary = self
+            .0
+            .file
+            .with_extension(format!("{}.tmp", std::process::id()));
+        std::fs::write(&temporary, serde_json::to_vec_pretty(names)?)?;
+        std::fs::rename(temporary, &self.0.file)?;
+        Ok(())
+    }
+    fn publish(&self, state: &State) {
+        let mut services: Vec<_> = state
+            .routes
+            .values()
+            .map(|r| r.service.clone())
+            .chain(state.remote.values().flatten().cloned())
+            .collect();
+        services.sort_by(|a, b| {
+            (&a.device_id, &a.project_cwd, a.hostname.len(), &a.hostname).cmp(&(
+                &b.device_id,
+                &b.project_cwd,
+                b.hostname.len(),
+                &b.hostname,
+            ))
+        });
+        let next = PreviewSnapshot {
+            services,
+            proxy_port: state.proxy_port,
+            error: state.error.clone(),
+            project_name: None,
+            remote: false,
+        };
+        self.0.changes.send_if_modified(|previous| {
+            if *previous == next {
+                false
+            } else {
+                *previous = next;
+                true
+            }
+        });
+    }
+    /// Input has already passed cwd association and an HTTP handshake probe.
+    pub fn replace_local(&self, mut observations: Vec<(PathBuf, Listener)>) -> anyhow::Result<()> {
+        observations.sort_by_key(|(root, l)| {
+            (
+                root.clone(),
+                std::cmp::Reverse(framework(&l.args).1),
+                std::cmp::Reverse(l.zeron_owned),
+                l.started_at,
+                l.pid,
+                l.address,
+            )
+        });
+        let mut state = self.0.state.lock().unwrap();
+        let mut used_labels: HashSet<String> = state
+            .names
+            .projects
+            .values()
+            .flat_map(|p| {
+                std::iter::once(p.label.clone()).chain(p.services.iter().map(|s| s.label.clone()))
+            })
+            .collect();
+        let mut next = HashMap::new();
+        let mut seen_listeners = HashSet::new();
+        let mut changed_names = false;
+        for (root, listener) in observations.into_iter().take(256) {
+            if !seen_listeners.insert((root.clone(), listener.address.port())) {
+                continue;
+            }
+            let cwd = root.to_string_lossy().into_owned();
+            if !state.names.projects.contains_key(&cwd) {
+                let label = allocate(
+                    &slug(
+                        root.file_name()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("project"),
+                    ),
+                    &used_labels,
+                );
+                used_labels.insert(label.clone());
+                state.names.projects.insert(
+                    cwd.clone(),
+                    ProjectName {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        label,
+                        services: Vec::new(),
+                    },
+                );
+                changed_names = true;
+            }
+            let fingerprint = format!(
+                "{:x}",
+                Sha256::digest(format!(
+                    "{}\0{}",
+                    listener.cwd.display(),
+                    command_identity(
+                        &listener
+                            .args
+                            .iter()
+                            .filter(|arg| arg.parse::<u16>().ok() != Some(listener.address.port()))
+                            .cloned()
+                            .collect::<Vec<_>>()
+                    )
+                ))
+            );
+            let previous_id = state
+                .routes
+                .values()
+                .find(|r| {
+                    r.listener.pid == listener.pid
+                        && r.listener.started_at == listener.started_at
+                        && r.listener.address.port() == listener.address.port()
+                })
+                .map(|r| r.service.id.clone());
+            let device_label = state.names.device_label.clone();
+            let project = state.names.projects.get_mut(&cwd).unwrap();
+            let existing = project
+                .services
+                .iter()
+                .find(|s| {
+                    s.fingerprint == fingerprint
+                        && previous_id.as_ref() == Some(&s.id)
+                        && !next.contains_key(&s.id)
+                })
+                .or_else(|| {
+                    project
+                        .services
+                        .iter()
+                        .find(|s| s.fingerprint == fingerprint && !next.contains_key(&s.id))
+                })
+                .map(|s| s.id.clone());
+            let (framework_name, _) = framework(&listener.args);
+            let role = service_role(&listener, framework_name);
+            let id = if let Some(id) = existing {
+                id
+            } else {
+                let label = if project.services.is_empty() {
+                    project.label.clone()
+                } else {
+                    allocate(&format!("{}-{}", project.label, slug(&role)), &used_labels)
+                };
+                used_labels.insert(label.clone());
+                let id = uuid::Uuid::new_v4().to_string();
+                project.services.push(ServiceName {
+                    id: id.clone(),
+                    fingerprint,
+                    label,
+                });
+                changed_names = true;
+                id
+            };
+            let service_name = project.services.iter().find(|s| s.id == id).unwrap();
+            let service = PreviewService {
+                id: id.clone(),
+                project_id: project.id.clone(),
+                project_name: root
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .into_owned(),
+                project_cwd: cwd,
+                device_id: self.0.device_id.clone(),
+                device_name: self.0.device_name.clone(),
+                hostname: format!("{}.{}.localhost", device_label, service_name.label),
+                name: role,
+                port: listener.address.port(),
+                pid: listener.pid,
+                cwd: listener.cwd.to_string_lossy().into_owned(),
+                started_at: listener.started_at,
+                zeron_owned: listener.zeron_owned,
+            };
+            next.insert(id, LocalRoute { service, listener });
+        }
+        if changed_names {
+            self.persist(&state.names)?;
+        }
+        state.routes = next;
+        self.publish(&state);
+        Ok(())
+    }
+}
+
+fn service_role(listener: &Listener, framework_name: &str) -> String {
+    if !matches!(framework_name, "HTTP server" | "Node HTTP server") {
+        return framework_name.into();
+    }
+    for value in listener.args.iter().chain(std::iter::once(
+        &listener.cwd.to_string_lossy().into_owned(),
+    )) {
+        let stem = Path::new(value)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        if matches!(stem.as_str(), "api" | "api-server") {
+            return "API".into();
+        }
+        if matches!(stem.as_str(), "docs" | "documentation") {
+            return "Docs".into();
+        }
+    }
+    framework_name.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn server(port: u16, pid: u32, command: &str) -> Listener {
+        Listener {
+            pid,
+            parent: 1,
+            cwd: "/work/my-app".into(),
+            args: vec![
+                "node".into(),
+                command.into(),
+                "--port".into(),
+                port.to_string(),
+            ],
+            started_at: pid as u64,
+            address: ([127, 0, 0, 1], port).into(),
+            zeron_owned: true,
+        }
+    }
+    #[test]
+    fn urls_survive_port_changes_daemon_restarts_and_multiple_services() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("previews.json");
+        let catalog = Catalog::open(&file, "device-id".into(), "MacBook".into()).unwrap();
+        let root = PathBuf::from("/work/my-app");
+        catalog
+            .replace_local(vec![
+                (root.clone(), server(5173, 1, "vite")),
+                (root.clone(), server(3000, 2, "api.js")),
+            ])
+            .unwrap();
+        let before = catalog.snapshot();
+        assert!(
+            before
+                .services
+                .iter()
+                .any(|s| s.hostname == "macbook.my-app.localhost" && s.port == 5173)
+        );
+        assert!(
+            before
+                .services
+                .iter()
+                .any(|s| s.hostname == "macbook.my-app-api.localhost" && s.port == 3000)
+        );
+        catalog.replace_local(Vec::new()).unwrap();
+        assert!(catalog.snapshot().services.is_empty());
+        drop(catalog);
+        let catalog = Catalog::open(&file, "device-id".into(), "Renamed computer".into()).unwrap();
+        catalog
+            .replace_local(vec![
+                (root.clone(), server(5174, 3, "vite")),
+                (root, server(3001, 4, "api.js")),
+            ])
+            .unwrap();
+        let after = catalog.snapshot();
+        for old in before.services {
+            let new = after.services.iter().find(|s| s.id == old.id).unwrap();
+            assert_eq!(old.hostname, new.hostname);
+            assert_ne!(old.port, new.port);
+        }
+    }
+    #[test]
+    fn duplicate_device_names_get_persistent_distinct_aliases() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("names.json");
+        let catalog = Catalog::open(&file, "local".into(), "MacBook".into()).unwrap();
+        catalog
+            .replace_local(vec![("/work/my-app".into(), server(5173, 1, "vite"))])
+            .unwrap();
+        let mut remote = catalog.local_services()[0].clone();
+        remote.device_id = "peer".into();
+        catalog.set_remote("peer", vec![remote.clone()]).unwrap();
+        assert_eq!(
+            catalog
+                .by_hostname("macbook.my-app.localhost")
+                .unwrap()
+                .device_id,
+            "local"
+        );
+        assert_eq!(
+            catalog
+                .by_hostname("macbook-2.my-app.localhost")
+                .unwrap()
+                .device_id,
+            "peer"
+        );
+        drop(catalog);
+        let catalog = Catalog::open(&file, "local".into(), "MacBook".into()).unwrap();
+        catalog.set_remote("peer", vec![remote]).unwrap();
+        assert_eq!(
+            catalog.snapshot().services[0].hostname,
+            "macbook-2.my-app.localhost"
+        );
+    }
+    #[test]
+    fn hostnames_cannot_address_arbitrary_hosts() {
+        for host in [
+            "localhost",
+            "foo.localhost.evil.test",
+            "a..localhost",
+            "a.b.localhost:80",
+            "a.b.localhost/path",
+            "a.b.c.localhost",
+        ] {
+            assert!(!valid_hostname(host));
+        }
+        assert!(valid_hostname("macbook.my-app-api.localhost"));
+    }
+}

--- a/crates/preview/src/catalog.rs
+++ b/crates/preview/src/catalog.rs
@@ -266,12 +266,20 @@ impl Catalog {
             .chain(state.remote.values().flatten().cloned())
             .collect();
         services.sort_by(|a, b| {
-            (&a.device_id, &a.project_cwd, a.hostname.len(), &a.hostname).cmp(&(
-                &b.device_id,
-                &b.project_cwd,
-                b.hostname.len(),
-                &b.hostname,
-            ))
+            (
+                &a.device_id,
+                &a.project_cwd,
+                !matches!(a.name.as_str(), "Vite" | "Next.js" | "Astro"),
+                a.hostname.len(),
+                &a.hostname,
+            )
+                .cmp(&(
+                    &b.device_id,
+                    &b.project_cwd,
+                    !matches!(b.name.as_str(), "Vite" | "Next.js" | "Astro"),
+                    b.hostname.len(),
+                    &b.hostname,
+                ))
         });
         let next = PreviewSnapshot {
             services,

--- a/crates/preview/src/discovery.rs
+++ b/crates/preview/src/discovery.rs
@@ -1,0 +1,425 @@
+//! Observe only this user's listeners. HTTP probes run only after project
+//! ownership has been established from the process's actual working directory.
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[derive(Debug, Clone)]
+pub struct Listener {
+    pub pid: u32,
+    pub parent: u32,
+    pub cwd: PathBuf,
+    pub args: Vec<String>,
+    pub started_at: u64,
+    pub address: SocketAddr,
+    pub zeron_owned: bool,
+}
+
+impl Listener {
+    pub fn belongs_to(&self, root: &Path) -> bool {
+        self.cwd.starts_with(root)
+    }
+}
+
+/// Preserve a useful framework label without advertising process arguments,
+/// which may contain credentials. Rank frontends above generic HTTP services.
+pub fn framework(args: &[String]) -> (&'static str, u8) {
+    for (needle, name) in [
+        ("vite", "Vite"),
+        ("next", "Next.js"),
+        ("astro", "Astro"),
+        ("miniflare", "Miniflare"),
+    ] {
+        if args.iter().any(|arg| {
+            let arg = arg.to_lowercase();
+            Path::new(&arg).file_stem().and_then(|s| s.to_str()) == Some(needle)
+                || arg.contains(&format!("/{needle}/"))
+                || arg.starts_with(&format!("{needle}-server"))
+        }) {
+            return (name, if needle == "miniflare" { 80 } else { 100 });
+        }
+    }
+    if args.first().is_some_and(|s| {
+        Path::new(s)
+            .file_name()
+            .is_some_and(|n| n == "node" || n == "bun" || n == "deno")
+    }) {
+        ("Node HTTP server", 50)
+    } else {
+        ("HTTP server", 40)
+    }
+}
+
+/// Port flags are operational settings, never part of a service identity.
+pub fn command_identity(args: &[String]) -> String {
+    let mut skip = false;
+    let python_http = args.iter().any(|arg| arg == "http.server");
+    args.iter()
+        .filter_map(|arg| {
+            if skip {
+                skip = false;
+                return None;
+            }
+            if matches!(arg.as_str(), "--port" | "-p" | "--inspect-port") {
+                skip = true;
+                return None;
+            }
+            if arg.starts_with("--port=")
+                || arg.starts_with("PORT=")
+                || arg.starts_with("--inspect-port=")
+            {
+                return None;
+            }
+            if python_http && arg.parse::<u16>().is_ok() {
+                return None;
+            }
+            Some(arg.as_str())
+        })
+        .collect::<Vec<_>>()
+        .join("\0")
+}
+
+pub async fn is_http(address: SocketAddr) -> bool {
+    tokio::time::timeout(Duration::from_millis(800), async move {
+        let mut socket = tokio::net::TcpStream::connect(address).await.ok()?;
+        socket
+            .write_all(
+                format!(
+                    "HEAD / HTTP/1.1\r\nHost: localhost:{}\r\nConnection: close\r\n\r\n",
+                    address.port()
+                )
+                .as_bytes(),
+            )
+            .await
+            .ok()?;
+        let mut prefix = [0; 12];
+        socket.read_exact(&mut prefix).await.ok()?;
+        let version = &prefix[..9];
+        let status = std::str::from_utf8(&prefix[9..])
+            .ok()?
+            .parse::<u16>()
+            .ok()?;
+        ((version == b"HTTP/1.1 " || version == b"HTTP/1.0 ") && (100..600).contains(&status))
+            .then_some(())
+    })
+    .await
+    .ok()
+    .flatten()
+    .is_some()
+}
+
+fn mark_descendants(listeners: &mut [Listener], parents: &HashMap<u32, u32>, owner: u32) {
+    for listener in listeners {
+        let mut pid = listener.pid;
+        for _ in 0..128 {
+            if pid == owner {
+                listener.zeron_owned = true;
+                break;
+            }
+            let Some(&parent) = parents.get(&pid) else {
+                break;
+            };
+            if parent == pid || parent == 0 {
+                break;
+            }
+            pid = parent;
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn listeners() -> Vec<Listener> {
+    use std::{fs, os::unix::fs::MetadataExt};
+    let mut sockets = HashMap::new();
+    for (file, ipv6) in [("/proc/net/tcp", false), ("/proc/net/tcp6", true)] {
+        if let Ok(text) = fs::read_to_string(file) {
+            for line in text.lines().skip(1) {
+                let parts: Vec<_> = line.split_whitespace().collect();
+                if parts.len() <= 9 || parts[3] != "0A" {
+                    continue;
+                }
+                if let Some(address) = proc_address(parts[1], ipv6) {
+                    sockets.insert(parts[9].to_string(), address);
+                }
+            }
+        }
+    }
+    let boot = fs::read_to_string("/proc/stat")
+        .ok()
+        .and_then(|s| {
+            s.lines().find_map(|line| {
+                line.strip_prefix("btime ")
+                    .and_then(|v| v.parse::<u64>().ok())
+            })
+        })
+        .unwrap_or(0);
+    let ticks = unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.max(1) as u64;
+    let uid = unsafe { libc::geteuid() };
+    let mut result = Vec::new();
+    let mut parents = HashMap::new();
+    let Ok(processes) = fs::read_dir("/proc") else {
+        return result;
+    };
+    for process in processes.flatten() {
+        let Ok(pid) = process.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        let path = process.path();
+        if !fs::metadata(&path).is_ok_and(|m| m.uid() == uid) {
+            continue;
+        }
+        let Ok(stat) = fs::read_to_string(path.join("stat")) else {
+            continue;
+        };
+        let Some((_, tail)) = stat.rsplit_once(") ") else {
+            continue;
+        };
+        let fields: Vec<_> = tail.split_whitespace().collect();
+        let Some(parent) = fields.get(1).and_then(|v| v.parse().ok()) else {
+            continue;
+        };
+        parents.insert(pid, parent);
+        let Ok(cwd) = fs::read_link(path.join("cwd")) else {
+            continue;
+        };
+        let started_at = boot * 1000
+            + fields
+                .get(19)
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0)
+                * 1000
+                / ticks;
+        let args = fs::read(path.join("cmdline"))
+            .unwrap_or_default()
+            .split(|b| *b == 0)
+            .filter(|b| !b.is_empty())
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .collect::<Vec<_>>();
+        let Ok(fds) = fs::read_dir(path.join("fd")) else {
+            continue;
+        };
+        for fd in fds.flatten() {
+            let Ok(link) = fs::read_link(fd.path()) else {
+                continue;
+            };
+            let link = link.to_string_lossy();
+            let Some(inode) = link
+                .strip_prefix("socket:[")
+                .and_then(|s| s.strip_suffix(']'))
+            else {
+                continue;
+            };
+            if let Some(&address) = sockets.get(inode) {
+                result.push(Listener {
+                    pid,
+                    parent,
+                    cwd: cwd.clone(),
+                    args: args.clone(),
+                    started_at,
+                    address,
+                    zeron_owned: false,
+                });
+            }
+        }
+    }
+    mark_descendants(&mut result, &parents, std::process::id());
+    result.sort_by_key(|l| (l.address, l.pid));
+    result.dedup_by_key(|l| (l.address, l.pid));
+    result
+}
+
+#[cfg(target_os = "linux")]
+fn proc_address(value: &str, ipv6: bool) -> Option<SocketAddr> {
+    let (host, port) = value.split_once(':')?;
+    let port = u16::from_str_radix(port, 16).ok()?;
+    let ip = if ipv6 {
+        if host.len() != 32 {
+            return None;
+        }
+        let mut bytes = [0; 16];
+        for (i, chunk) in host.as_bytes().chunks_exact(8).enumerate() {
+            bytes[i * 4..i * 4 + 4].copy_from_slice(
+                &u32::from_str_radix(std::str::from_utf8(chunk).ok()?, 16)
+                    .ok()?
+                    .to_le_bytes(),
+            );
+        }
+        IpAddr::V6(Ipv6Addr::from(bytes))
+    } else {
+        IpAddr::V4(Ipv4Addr::from(
+            u32::from_str_radix(host, 16).ok()?.to_le_bytes(),
+        ))
+    };
+    if !ip.is_loopback() && !ip.is_unspecified() {
+        return None;
+    }
+    Some(SocketAddr::new(
+        if ip.is_unspecified() {
+            if ipv6 {
+                Ipv6Addr::LOCALHOST.into()
+            } else {
+                Ipv4Addr::LOCALHOST.into()
+            }
+        } else {
+            ip
+        },
+        port,
+    ))
+}
+
+#[cfg(target_os = "macos")]
+pub fn listeners() -> Vec<Listener> {
+    use chrono::TimeZone;
+    use std::process::Command;
+    let uid = unsafe { libc::geteuid() }.to_string();
+    let fields = |arguments: &[&str]| -> Vec<(u32, String)> {
+        let Ok(output) = Command::new("/usr/sbin/lsof").args(arguments).output() else {
+            return Vec::new();
+        };
+        let mut pid = 0;
+        let mut values = Vec::new();
+        for field in output.stdout.split(|b| *b == 0) {
+            let field = String::from_utf8_lossy(field);
+            let field = field.trim_start_matches('\n');
+            if let Some(value) = field.strip_prefix('p') {
+                pid = value.parse().unwrap_or(0);
+            }
+            if let Some(value) = field.strip_prefix('n') {
+                values.push((pid, value.to_owned()));
+            }
+        }
+        values
+    };
+    let cwds: HashMap<_, _> = fields(&["-nP", "-a", "-u", &uid, "-d", "cwd", "-F0pn"])
+        .into_iter()
+        .collect();
+    let mut parents = HashMap::new();
+    let mut processes = HashMap::new();
+    if let Ok(output) = Command::new("/bin/ps")
+        .args(["-axo", "pid=,ppid=,lstart=,command="])
+        .env("LC_ALL", "C")
+        .output()
+    {
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let parts: Vec<_> = line.split_whitespace().collect();
+            if parts.len() < 8 {
+                continue;
+            }
+            let (Ok(pid), Ok(parent)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) else {
+                continue;
+            };
+            parents.insert(pid, parent);
+            let started_at =
+                chrono::NaiveDateTime::parse_from_str(&parts[2..7].join(" "), "%a %b %e %T %Y")
+                    .ok()
+                    .and_then(|d| chrono::Local.from_local_datetime(&d).earliest())
+                    .map(|d| d.timestamp_millis().max(0) as u64)
+                    .unwrap_or(0);
+            processes.insert(
+                pid,
+                (
+                    parent,
+                    started_at,
+                    parts[7..].iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                ),
+            );
+        }
+    }
+    let mut result = Vec::new();
+    for (pid, socket) in fields(&["-nP", "-a", "-u", &uid, "-iTCP", "-sTCP:LISTEN", "-F0pn"]) {
+        let Some(cwd) = cwds.get(&pid).and_then(|s| std::fs::canonicalize(s).ok()) else {
+            continue;
+        };
+        let Some((parent, started_at, args)) = processes.get(&pid) else {
+            continue;
+        };
+        let addresses = if let Some(port) = socket
+            .strip_prefix("*:")
+            .and_then(|p| p.parse::<u16>().ok())
+        {
+            vec![
+                SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port),
+                SocketAddr::new(Ipv6Addr::LOCALHOST.into(), port),
+            ]
+        } else {
+            socket
+                .parse::<SocketAddr>()
+                .ok()
+                .filter(|a| a.ip().is_loopback())
+                .into_iter()
+                .collect()
+        };
+        for address in addresses {
+            result.push(Listener {
+                pid,
+                parent: *parent,
+                cwd: cwd.clone(),
+                args: args.clone(),
+                started_at: *started_at,
+                address,
+                zeron_owned: false,
+            });
+        }
+    }
+    mark_descendants(&mut result, &parents, std::process::id());
+    result
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn listeners() -> Vec<Listener> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn service_identity_ignores_port_configuration() {
+        let args = |port: &str| vec!["node".into(), "api.js".into(), "--port".into(), port.into()];
+        assert_eq!(
+            command_identity(&args("3000")),
+            command_identity(&args("3001"))
+        );
+        assert_ne!(
+            command_identity(&args("3000")),
+            command_identity(&["node".into(), "docs.js".into()])
+        );
+    }
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn accepts_only_loopback_reachable_listeners() {
+        assert_eq!(
+            proc_address("0100007F:1435", false).unwrap(),
+            "127.0.0.1:5173".parse::<SocketAddr>().unwrap()
+        );
+        assert_eq!(
+            proc_address("00000000000000000000000001000000:1435", true).unwrap(),
+            "[::1]:5173".parse::<SocketAddr>().unwrap()
+        );
+        assert!(proc_address("0101A8C0:1435", false).is_none());
+        assert!(proc_address("malformed:00", true).is_none());
+    }
+    #[tokio::test]
+    async fn requires_an_http_response() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            for response in [
+                b"SSH-2.0-test\r\n".as_slice(),
+                b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n",
+            ] {
+                let (mut client, _) = listener.accept().await.unwrap();
+                let mut input = [0; 512];
+                let _ = client.read(&mut input).await;
+                client.write_all(response).await.unwrap();
+            }
+        });
+        assert!(!is_http(address).await);
+        assert!(is_http(address).await);
+        task.await.unwrap();
+    }
+}

--- a/crates/preview/src/lib.rs
+++ b/crates/preview/src/lib.rs
@@ -1,0 +1,12 @@
+//! Project-scoped HTTP discovery, stable local routing, and authenticated peers.
+//! Application bytes use bounded multiplexed streams; edge signaling never
+//! transports preview requests or response bodies.
+pub mod catalog;
+pub mod discovery;
+pub mod mux;
+pub mod peer;
+pub mod proxy;
+pub mod signaling;
+
+pub mod service;
+pub use service::PreviewService;

--- a/crates/preview/src/mux.rs
+++ b/crates/preview/src/mux.rs
@@ -163,6 +163,9 @@ impl Mux {
             slot.cancel.cancel();
         }
     }
+    pub async fn closed(&self) {
+        self.0.stop.cancelled().await;
+    }
     pub fn is_closed(&self) -> bool {
         self.0.stop.is_cancelled()
     }

--- a/crates/preview/src/mux.rs
+++ b/crates/preview/src/mux.rs
@@ -1,0 +1,423 @@
+//! Bounded, bidirectional streams over either a socket or an ordered DataChannel.
+//! Each stream has an independent receive window, so a stalled response does
+//! not stall other requests. END is a half-close; CANCEL aborts both directions.
+use std::{
+    collections::HashMap,
+    io,
+    pin::Pin,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU32, AtomicUsize, Ordering},
+    },
+    task::{Context, Poll},
+};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream, ReadBuf},
+    sync::{Semaphore, mpsc, oneshot},
+};
+use tokio_util::sync::CancellationToken;
+
+const CHUNK: usize = 8192;
+const WINDOW: usize = 65536;
+const MAX_STREAMS: usize = 64;
+const OPEN: u8 = 1;
+const DATA: u8 = 2;
+const END: u8 = 3;
+const CANCEL: u8 = 4;
+const WS_OPEN: u8 = 5;
+const WS_DATA: u8 = 6;
+const WS_CLOSE: u8 = 7;
+const CREDIT: u8 = 8;
+const READY: u8 = 9;
+
+pub trait Io: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> Io for T {}
+pub type BoxIo = Box<dyn Io>;
+#[async_trait::async_trait]
+pub trait Connector: Send + Sync + 'static {
+    async fn connect(&self, service: &str) -> anyhow::Result<BoxIo>;
+}
+#[async_trait::async_trait]
+pub trait Transport: Send + Sync + 'static {
+    async fn send(&self, bytes: &[u8]) -> anyhow::Result<()>;
+    async fn receive(&self) -> anyhow::Result<Vec<u8>>;
+}
+
+pub struct SocketTransport<R, W> {
+    read: tokio::sync::Mutex<R>,
+    write: tokio::sync::Mutex<W>,
+}
+impl<R, W> SocketTransport<R, W> {
+    pub fn new(read: R, write: W) -> Self {
+        Self {
+            read: tokio::sync::Mutex::new(read),
+            write: tokio::sync::Mutex::new(write),
+        }
+    }
+}
+#[async_trait::async_trait]
+impl<R: AsyncRead + Unpin + Send + 'static, W: AsyncWrite + Unpin + Send + 'static> Transport
+    for SocketTransport<R, W>
+{
+    async fn send(&self, bytes: &[u8]) -> anyhow::Result<()> {
+        let mut writer = self.write.lock().await;
+        writer.write_u32(bytes.len() as u32).await?;
+        writer.write_all(bytes).await?;
+        Ok(())
+    }
+    async fn receive(&self) -> anyhow::Result<Vec<u8>> {
+        let mut reader = self.read.lock().await;
+        let size = reader.read_u32().await? as usize;
+        anyhow::ensure!(
+            (5..=CHUNK + 5).contains(&size),
+            "invalid preview frame size"
+        );
+        let mut bytes = vec![0; size];
+        reader.read_exact(&mut bytes).await?;
+        Ok(bytes)
+    }
+}
+struct Frame {
+    kind: u8,
+    id: u32,
+    data: Vec<u8>,
+}
+impl Frame {
+    fn new(kind: u8, id: u32, data: Vec<u8>) -> Self {
+        Self { kind, id, data }
+    }
+    fn encode(self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(5 + self.data.len());
+        bytes.push(self.kind);
+        bytes.extend(self.id.to_be_bytes());
+        bytes.extend(self.data);
+        bytes
+    }
+    fn decode(bytes: Vec<u8>) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            (5..=CHUNK + 5).contains(&bytes.len()),
+            "invalid preview frame size"
+        );
+        Ok(Self {
+            kind: bytes[0],
+            id: u32::from_be_bytes(bytes[1..5].try_into()?),
+            data: bytes[5..].to_vec(),
+        })
+    }
+}
+struct Slot {
+    incoming: mpsc::Sender<Frame>,
+    credit: Arc<Semaphore>,
+    cancel: CancellationToken,
+    ready: Mutex<Option<oneshot::Sender<bool>>>,
+    receive_credit: AtomicUsize,
+}
+struct Inner {
+    slots: Mutex<HashMap<u32, Arc<Slot>>>,
+    outgoing: mpsc::Sender<Frame>,
+    ids: AtomicU32,
+    parity: u32,
+    stop: CancellationToken,
+}
+#[derive(Clone)]
+pub struct Mux(Arc<Inner>);
+impl Mux {
+    pub fn start(
+        transport: Arc<dyn Transport>,
+        connector: Arc<dyn Connector>,
+        initiator: bool,
+        stop: CancellationToken,
+    ) -> Self {
+        let (outgoing, mut output) = mpsc::channel::<Frame>(64);
+        let parity = if initiator { 1 } else { 0 };
+        let mux = Self(Arc::new(Inner {
+            slots: Mutex::new(HashMap::new()),
+            outgoing,
+            ids: AtomicU32::new(if initiator { 1 } else { 2 }),
+            parity,
+            stop,
+        }));
+        let writer = transport.clone();
+        let cancel = mux.0.stop.clone();
+        tokio::spawn(async move {
+            tokio::select! { _ = cancel.cancelled() => {}, _ = async {
+                while let Some(frame) = output.recv().await { if writer.send(&frame.encode()).await.is_err() { break; } }
+            } => {} }
+            cancel.cancel();
+        });
+        let reader = mux.clone();
+        tokio::spawn(async move {
+            tokio::select! { _ = reader.0.stop.cancelled() => {}, _ = async {
+                loop {
+                    let frame = match transport.receive().await.and_then(Frame::decode) { Ok(f) => f, Err(_) => break };
+                    if reader.dispatch(frame, &connector).await.is_err() { break; }
+                }
+            } => {} }
+            reader.close();
+        });
+        mux
+    }
+    pub fn close(&self) {
+        self.0.stop.cancel();
+        for (_, slot) in self.0.slots.lock().unwrap().drain() {
+            slot.cancel.cancel();
+        }
+    }
+    pub fn is_closed(&self) -> bool {
+        self.0.stop.is_cancelled()
+    }
+    async fn send(&self, frame: Frame) -> anyhow::Result<()> {
+        tokio::select! { _ = self.0.stop.cancelled() => anyhow::bail!("preview connection closed"), result = self.0.outgoing.send(frame) => { result?; Ok(()) } }
+    }
+    fn stream(
+        &self,
+        id: u32,
+        websocket: bool,
+    ) -> anyhow::Result<(Stream, oneshot::Receiver<bool>)> {
+        let mut slots = self.0.slots.lock().unwrap();
+        anyhow::ensure!(
+            slots.len() < MAX_STREAMS && !slots.contains_key(&id),
+            "preview stream limit reached"
+        );
+        let (app, bridge) = tokio::io::duplex(WINDOW);
+        let (incoming, mut input) = mpsc::channel::<Frame>(WINDOW + 2);
+        let (ready, result) = oneshot::channel();
+        let slot = Arc::new(Slot {
+            incoming,
+            credit: Arc::new(Semaphore::new(WINDOW)),
+            cancel: self.0.stop.child_token(),
+            ready: Mutex::new(Some(ready)),
+            receive_credit: AtomicUsize::new(WINDOW),
+        });
+        slots.insert(id, slot.clone());
+        let mux = self.clone();
+        let cancel = slot.cancel.clone();
+        let app_cancel = cancel.clone();
+        tokio::spawn(async move {
+            let (mut read, mut write) = tokio::io::split(bridge);
+            let sending = async {
+                let mut bytes = vec![0; CHUNK];
+                loop {
+                    let length = read.read(&mut bytes).await?;
+                    if length == 0 {
+                        mux.send(Frame::new(
+                            if websocket { WS_CLOSE } else { END },
+                            id,
+                            Vec::new(),
+                        ))
+                        .await?;
+                        break;
+                    }
+                    let permit = slot.credit.acquire_many(length as u32).await?;
+                    permit.forget();
+                    mux.send(Frame::new(
+                        if websocket { WS_DATA } else { DATA },
+                        id,
+                        bytes[..length].to_vec(),
+                    ))
+                    .await?;
+                }
+                anyhow::Ok(())
+            };
+            let receiving = async {
+                while let Some(frame) = input.recv().await {
+                    if matches!(frame.kind, END | WS_CLOSE) {
+                        write.shutdown().await?;
+                        return anyhow::Ok(());
+                    }
+                    write.write_all(&frame.data).await?;
+                    slot.receive_credit
+                        .fetch_add(frame.data.len(), Ordering::Relaxed);
+                    mux.send(Frame::new(
+                        CREDIT,
+                        id,
+                        (frame.data.len() as u32).to_be_bytes().to_vec(),
+                    ))
+                    .await?;
+                }
+                anyhow::bail!("preview stream closed")
+            };
+            let graceful = tokio::select! { _ = cancel.cancelled() => false, result = async { tokio::try_join!(sending, receiving) } => result.is_ok() };
+            mux.0.slots.lock().unwrap().remove(&id);
+            // Queue cancellation with backpressure; closing the connection also
+            // interrupts this send. No unbounded task/frame queue on stream drop.
+            if !graceful {
+                let _ = mux.send(Frame::new(CANCEL, id, Vec::new())).await;
+            }
+        });
+        Ok((
+            Stream {
+                io: app,
+                cancel: app_cancel,
+                read_eof: false,
+                write_closed: false,
+            },
+            result,
+        ))
+    }
+    pub async fn open(&self, service: &str, websocket: bool) -> anyhow::Result<Stream> {
+        anyhow::ensure!(
+            !service.is_empty() && service.len() <= 128,
+            "invalid preview service id"
+        );
+        let id = self.0.ids.fetch_add(2, Ordering::Relaxed);
+        anyhow::ensure!(id < u32::MAX - 2, "preview stream ids exhausted");
+        let (stream, ready) = self.stream(id, websocket)?;
+        self.send(Frame::new(
+            if websocket { WS_OPEN } else { OPEN },
+            id,
+            service.as_bytes().to_vec(),
+        ))
+        .await?;
+        anyhow::ensure!(
+            tokio::time::timeout(std::time::Duration::from_secs(10), ready).await??,
+            "preview service unavailable"
+        );
+        Ok(stream)
+    }
+    async fn dispatch(&self, frame: Frame, connector: &Arc<dyn Connector>) -> anyhow::Result<()> {
+        if matches!(frame.kind, OPEN | WS_OPEN) {
+            anyhow::ensure!(
+                frame.id != 0
+                    && frame.id % 2 != self.0.parity
+                    && (1..=128).contains(&frame.data.len()),
+                "invalid preview OPEN"
+            );
+            let service = String::from_utf8(frame.data)?;
+            let Ok((mut stream, _)) = self.stream(frame.id, frame.kind == WS_OPEN) else {
+                return self.send(Frame::new(CANCEL, frame.id, Vec::new())).await;
+            };
+            let mux = self.clone();
+            let connector = connector.clone();
+            let id = frame.id;
+            tokio::spawn(async move {
+                let cancel = stream.cancel.clone();
+                tokio::select! { _ = cancel.cancelled() => {}, _ = async {
+                    if let Ok(Ok(mut socket)) = tokio::time::timeout(std::time::Duration::from_secs(5), connector.connect(&service)).await {
+                        if mux.send(Frame::new(READY, id, Vec::new())).await.is_ok() { let _ = tokio::io::copy_bidirectional(&mut stream, &mut socket).await; }
+                    }
+                } => {} }
+            });
+            return Ok(());
+        }
+        let slot = self.0.slots.lock().unwrap().get(&frame.id).cloned();
+        let Some(slot) = slot else {
+            return Ok(());
+        }; // late frames after cancellation
+        match frame.kind {
+            READY => {
+                if let Some(ready) = slot.ready.lock().unwrap().take() {
+                    let _ = ready.send(true);
+                }
+            }
+            CANCEL => {
+                slot.cancel.cancel();
+                if let Some(ready) = slot.ready.lock().unwrap().take() {
+                    let _ = ready.send(false);
+                }
+            }
+            CREDIT => {
+                anyhow::ensure!(frame.data.len() == 4, "invalid preview credit");
+                let count = u32::from_be_bytes(frame.data.try_into().unwrap()) as usize;
+                anyhow::ensure!(
+                    count > 0
+                        && count <= WINDOW
+                        && slot.credit.available_permits() + count <= WINDOW,
+                    "invalid preview receive window"
+                );
+                slot.credit.add_permits(count);
+            }
+            DATA | WS_DATA | END | WS_CLOSE => {
+                // The peer cannot queue more than its advertised window. Tiny
+                // frames are bounded too: abusive streams are cancelled.
+                if matches!(frame.kind, DATA | WS_DATA) {
+                    anyhow::ensure!(
+                        !frame.data.is_empty()
+                            && slot
+                                .receive_credit
+                                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n
+                                    .checked_sub(frame.data.len()))
+                                .is_ok(),
+                        "preview receive window exceeded"
+                    );
+                }
+                if slot.incoming.try_send(frame).is_err() {
+                    slot.cancel.cancel();
+                }
+            }
+            _ => anyhow::bail!("unknown preview frame"),
+        }
+        Ok(())
+    }
+}
+
+pub struct Stream {
+    io: DuplexStream,
+    cancel: CancellationToken,
+    read_eof: bool,
+    write_closed: bool,
+}
+impl Drop for Stream {
+    fn drop(&mut self) {
+        if !(self.read_eof && self.write_closed) {
+            self.cancel.cancel();
+        }
+    }
+}
+impl AsyncRead for Stream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let before = buf.filled().len();
+        let remaining = buf.remaining();
+        let result = Pin::new(&mut self.io).poll_read(cx, buf);
+        if matches!(result, Poll::Ready(Ok(()))) && remaining > 0 && buf.filled().len() == before {
+            self.read_eof = true;
+        }
+        result
+    }
+}
+impl AsyncWrite for Stream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.io).poll_write(cx, buf)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let result = Pin::new(&mut self.io).poll_shutdown(cx);
+        if matches!(result, Poll::Ready(Ok(()))) {
+            self.write_closed = true;
+        }
+        result
+    }
+}
+
+pub fn local(connector: Arc<dyn Connector>, stop: CancellationToken) -> Mux {
+    // An actual local socket keeps the framing/flow-control path identical to P2P.
+    #[cfg(unix)]
+    let (a, b) = tokio::net::UnixStream::pair().expect("local preview socket pair");
+    #[cfg(not(unix))]
+    let (a, b) = tokio::io::duplex(WINDOW);
+    let (ar, aw) = tokio::io::split(a);
+    let (br, bw) = tokio::io::split(b);
+    let client = Mux::start(
+        Arc::new(SocketTransport::new(ar, aw)),
+        connector.clone(),
+        true,
+        stop.child_token(),
+    );
+    Mux::start(
+        Arc::new(SocketTransport::new(br, bw)),
+        connector,
+        false,
+        stop.child_token(),
+    );
+    client
+}

--- a/crates/preview/src/peer.rs
+++ b/crates/preview/src/peer.rs
@@ -1,0 +1,485 @@
+//! Authenticated signaling supplies SDP/DTLS fingerprints. Preview bytes only
+//! use the resulting reliable, ordered DataChannel; there is no edge byte relay.
+use crate::mux::{Connector, Mux, Stream, Transport};
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+use tokio::sync::{Mutex, Notify, mpsc, watch};
+use tokio_util::sync::CancellationToken;
+use webrtc::{
+    data_channel::{DataChannel, DataChannelEvent},
+    peer_connection::{
+        PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler, RTCConfigurationBuilder,
+        RTCIceGatheringState, RTCIceServer, RTCPeerConnectionState, RTCSessionDescription,
+    },
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Signal {
+    pub kind: String,
+    pub session: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sdp: Option<RTCSessionDescription>,
+}
+#[derive(Clone)]
+pub struct OutgoingSignal {
+    pub to: String,
+    pub signal: Signal,
+}
+struct Peer {
+    session: String,
+    pc: Arc<dyn PeerConnection>,
+    ready: watch::Receiver<Option<Mux>>,
+    gathered: watch::Receiver<bool>,
+    stop: CancellationToken,
+}
+impl Peer {
+    async fn close(&self) {
+        self.stop.cancel();
+        let _ = self.pc.close().await;
+    }
+}
+struct Inner {
+    device: String,
+    connector: Arc<dyn Connector>,
+    peers: Mutex<HashMap<String, Arc<Peer>>>,
+    requested: Mutex<HashMap<String, tokio::time::Instant>>,
+    output: mpsc::Sender<OutgoingSignal>,
+    changed: Arc<Notify>,
+    stop: CancellationToken,
+    ice_servers: Vec<RTCIceServer>,
+}
+#[derive(Clone)]
+pub struct Peers(Arc<Inner>);
+impl Peers {
+    pub fn new(
+        device: String,
+        connector: Arc<dyn Connector>,
+        stop: CancellationToken,
+    ) -> (Self, mpsc::Receiver<OutgoingSignal>) {
+        let (output, receiver) = mpsc::channel(64);
+        (
+            Self(Arc::new(Inner {
+                device,
+                connector,
+                peers: Mutex::new(HashMap::new()),
+                requested: Mutex::new(HashMap::new()),
+                output,
+                changed: Arc::new(Notify::new()),
+                stop,
+                ice_servers: vec![RTCIceServer {
+                    urls: vec![
+                        "stun:stun.l.google.com:19302".into(),
+                        "stun:stun1.l.google.com:19302".into(),
+                    ],
+                    ..Default::default()
+                }],
+            })),
+            receiver,
+        )
+    }
+    async fn send(&self, to: &str, signal: Signal) -> anyhow::Result<()> {
+        tokio::select! { _ = self.0.stop.cancelled() => anyhow::bail!("preview networking stopped"), result = self.0.output.send(OutgoingSignal { to: to.into(), signal }) => { result?; Ok(()) } }
+    }
+    async fn create(&self, session: String, initiator: bool) -> anyhow::Result<Arc<Peer>> {
+        let (ready, receiver) = watch::channel(None);
+        let (gathered, gathering) = watch::channel(false);
+        let stop = self.0.stop.child_token();
+        let handler = Arc::new(Handler {
+            ready,
+            gathered,
+            channel_claimed: AtomicBool::new(false),
+            connector: self.0.connector.clone(),
+            initiator,
+            stop: stop.clone(),
+            changed: self.0.changed.clone(),
+        });
+        let pc: Arc<dyn PeerConnection> = Arc::new(
+            PeerConnectionBuilder::new()
+                .with_configuration(
+                    RTCConfigurationBuilder::new()
+                        .with_ice_servers(self.0.ice_servers.clone())
+                        .build(),
+                )
+                .with_handler(handler.clone())
+                .with_udp_addrs(vec!["0.0.0.0:0"])
+                .with_data_channel_send_buffer_limit(256 * 1024)
+                .with_sctp_receive_buffer_size(512 * 1024)
+                .build()
+                .await?,
+        );
+        if initiator {
+            let channel = pc.create_data_channel("zeron-preview-v1", None).await?;
+            handler.attach(channel);
+        }
+        Ok(Arc::new(Peer {
+            session,
+            pc,
+            ready: receiver,
+            gathered: gathering,
+            stop,
+        }))
+    }
+    async fn description(&self, peer: &Peer, offer: bool) -> anyhow::Result<RTCSessionDescription> {
+        let description = if offer {
+            peer.pc.create_offer(None).await?
+        } else {
+            peer.pc.create_answer(None).await?
+        };
+        peer.pc.set_local_description(description).await?;
+        // Include the gathered ICE candidates in SDP. This avoids candidate /
+        // remote-description races and keeps reconnect messages self-contained.
+        let mut gathered = peer.gathered.clone();
+        tokio::time::timeout(Duration::from_secs(12), gathered.wait_for(|done| *done)).await??;
+        peer.pc
+            .local_description()
+            .await
+            .context("missing local preview SDP")
+    }
+    async fn offer(&self, device: &str, session: String) -> anyhow::Result<()> {
+        let mut peers = self.0.peers.lock().await;
+        if peers.get(device).is_some_and(|p| !p.stop.is_cancelled()) {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            peers.len() < 16 || peers.contains_key(device),
+            "too many preview peers"
+        );
+        let peer = self.create(session, true).await?;
+        if let Some(old) = peers.insert(device.into(), peer.clone()) {
+            old.close().await;
+        }
+        drop(peers);
+        let result = async {
+            let sdp = self.description(&peer, true).await?;
+            self.send(
+                device,
+                Signal {
+                    kind: "offer".into(),
+                    session: peer.session.clone(),
+                    sdp: Some(sdp),
+                },
+            )
+            .await
+        }
+        .await;
+        if result.is_err() {
+            peer.close().await;
+        }
+        result
+    }
+    /// Called only for messages stamped by the authenticated coordinator.
+    pub async fn signal(&self, device: &str, signal: Signal) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            device != self.0.device && !signal.session.is_empty() && signal.session.len() <= 128,
+            "invalid preview pairing"
+        );
+        match signal.kind.as_str() {
+            "connect" => {
+                anyhow::ensure!(
+                    self.0.device.as_str() < device && signal.sdp.is_none(),
+                    "invalid preview initiator"
+                );
+                self.offer(device, signal.session).await?;
+            }
+            "offer" => {
+                anyhow::ensure!(
+                    device < self.0.device.as_str(),
+                    "invalid preview offer sender"
+                );
+                let mut peers = self.0.peers.lock().await;
+                anyhow::ensure!(
+                    peers.len() < 16 || peers.contains_key(device),
+                    "too many preview peers"
+                );
+                let peer = self.create(signal.session, false).await?;
+                if let Some(old) = peers.insert(device.into(), peer.clone()) {
+                    old.close().await;
+                }
+                drop(peers);
+                let result = async {
+                    peer.pc
+                        .set_remote_description(signal.sdp.context("missing offer")?)
+                        .await?;
+                    let sdp = self.description(&peer, false).await?;
+                    self.send(
+                        device,
+                        Signal {
+                            kind: "answer".into(),
+                            session: peer.session.clone(),
+                            sdp: Some(sdp),
+                        },
+                    )
+                    .await
+                }
+                .await;
+                if result.is_err() {
+                    peer.close().await;
+                }
+                result?;
+            }
+            "answer" => {
+                anyhow::ensure!(
+                    self.0.device.as_str() < device,
+                    "invalid preview answer sender"
+                );
+                let peer = self
+                    .0
+                    .peers
+                    .lock()
+                    .await
+                    .get(device)
+                    .cloned()
+                    .context("unexpected preview answer")?;
+                anyhow::ensure!(peer.session == signal.session, "stale preview answer");
+                peer.pc
+                    .set_remote_description(signal.sdp.context("missing answer")?)
+                    .await?;
+            }
+            _ => anyhow::bail!("unknown preview signaling message"),
+        }
+        self.0.changed.notify_waiters();
+        Ok(())
+    }
+    pub async fn open(
+        &self,
+        device: &str,
+        service: &str,
+        websocket: bool,
+    ) -> anyhow::Result<Stream> {
+        let device = device.to_owned();
+        let result = tokio::time::timeout(Duration::from_secs(30), async {
+            let existing = self.0.peers.lock().await.get(&device).cloned();
+            if existing.as_ref().is_none_or(|p| p.stop.is_cancelled() || p.ready.borrow().as_ref().is_some_and(Mux::is_closed)) {
+                if let Some(peer) = existing { peer.close().await; }
+                let session = uuid::Uuid::new_v4().to_string();
+                if self.0.device < device { self.offer(&device, session).await?; }
+                else {
+                    let should_request = {
+                        let mut requested = self.0.requested.lock().await;
+                        let now = tokio::time::Instant::now();
+                        if requested.get(&device).is_some_and(|at| now.duration_since(*at) < Duration::from_secs(10)) { false }
+                        else { requested.insert(device.clone(), now); true }
+                    };
+                    if should_request { self.send(&device, Signal { kind: "connect".into(), session, sdp: None }).await?; }
+                }
+            }
+            loop {
+                let changed = self.0.changed.notified();
+                let mux = self.0.peers.lock().await.get(&device).and_then(|peer| peer.ready.borrow().clone());
+                if let Some(mux) = mux.filter(|m| !m.is_closed()) { return mux.open(service, websocket).await; }
+                tokio::select! { _ = self.0.stop.cancelled() => anyhow::bail!("preview networking stopped"), _ = changed => {}, _ = tokio::time::sleep(Duration::from_millis(100)) => {} }
+            }
+        }).await;
+        if result.is_err() {
+            self.remove(&device).await;
+        }
+        result.context("Could not connect directly to this device. Check that both devices are online and their networks allow WebRTC.")?
+    }
+    pub async fn remove(&self, device: &str) {
+        self.0.requested.lock().await.remove(device);
+        if let Some(peer) = self.0.peers.lock().await.remove(device) {
+            peer.close().await;
+        }
+        self.0.changed.notify_waiters();
+    }
+    pub async fn clear(&self) {
+        self.0.requested.lock().await.clear();
+        let peers = std::mem::take(&mut *self.0.peers.lock().await);
+        for (_, peer) in peers {
+            peer.close().await;
+        }
+        self.0.changed.notify_waiters();
+    }
+}
+struct Handler {
+    channel_claimed: AtomicBool,
+    ready: watch::Sender<Option<Mux>>,
+    gathered: watch::Sender<bool>,
+    connector: Arc<dyn Connector>,
+    initiator: bool,
+    stop: CancellationToken,
+    changed: Arc<Notify>,
+}
+impl Handler {
+    fn attach(&self, channel: Arc<dyn DataChannel>) {
+        if self.channel_claimed.swap(true, Ordering::SeqCst) {
+            tokio::spawn(async move {
+                let _ = channel.close().await;
+            });
+            return;
+        }
+        let ready = self.ready.clone();
+        let connector = self.connector.clone();
+        let stop = self.stop.clone();
+        let initiator = self.initiator;
+        let changed = self.changed.clone();
+        tokio::spawn(async move {
+            let valid = channel.label().await.is_ok_and(|s| s == "zeron-preview-v1")
+                && channel.ordered().await.unwrap_or(false)
+                && channel.max_retransmits().await.is_ok_and(|v| v.is_none())
+                && channel
+                    .max_packet_life_time()
+                    .await
+                    .is_ok_and(|v| v.is_none());
+            if !valid {
+                let _ = channel.close().await;
+                return;
+            }
+            loop {
+                let event = tokio::select! { _ = stop.cancelled() => return, event = channel.poll() => event };
+                match event {
+                    Some(DataChannelEvent::OnOpen) => {
+                        if ready.borrow().is_some() {
+                            let _ = channel.close().await;
+                            return;
+                        }
+                        let mux = Mux::start(
+                            Arc::new(ChannelTransport(channel)),
+                            connector,
+                            initiator,
+                            stop.child_token(),
+                        );
+                        ready.send_replace(Some(mux));
+                        changed.notify_waiters();
+                        return;
+                    }
+                    None | Some(DataChannelEvent::OnClose) => return,
+                    _ => {}
+                }
+            }
+        });
+    }
+}
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for Handler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            self.gathered.send_replace(true);
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if matches!(
+            state,
+            RTCPeerConnectionState::Failed
+                | RTCPeerConnectionState::Closed
+                | RTCPeerConnectionState::Disconnected
+        ) {
+            self.stop.cancel();
+            self.ready.send_replace(None);
+            self.changed.notify_waiters();
+        }
+    }
+    async fn on_data_channel(&self, channel: Arc<dyn DataChannel>) {
+        self.attach(channel);
+    }
+}
+struct ChannelTransport(Arc<dyn DataChannel>);
+#[async_trait::async_trait]
+impl Transport for ChannelTransport {
+    async fn send(&self, bytes: &[u8]) -> anyhow::Result<()> {
+        self.0.send(bytes::BytesMut::from(bytes)).await?;
+        Ok(())
+    }
+    async fn receive(&self) -> anyhow::Result<Vec<u8>> {
+        loop {
+            match self.0.poll().await {
+                Some(DataChannelEvent::OnMessage(message)) => {
+                    anyhow::ensure!(
+                        message.data.len() <= 8197,
+                        "oversized preview DataChannel frame"
+                    );
+                    return Ok(message.data.to_vec());
+                }
+                None | Some(DataChannelEvent::OnClose) => {
+                    anyhow::bail!("preview DataChannel closed")
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    struct Echo;
+    #[async_trait::async_trait]
+    impl Connector for Echo {
+        async fn connect(&self, id: &str) -> anyhow::Result<crate::mux::BoxIo> {
+            anyhow::ensure!(id == "service", "unknown service");
+            let (client, server) = tokio::io::duplex(65536);
+            tokio::spawn(async move {
+                let (mut r, mut w) = tokio::io::split(server);
+                let _ = tokio::io::copy(&mut r, &mut w).await;
+            });
+            Ok(Box::new(client))
+        }
+    }
+    #[tokio::test]
+    async fn actual_webrtc_pair_streams_in_both_directions() {
+        let stop = CancellationToken::new();
+        let (mut a, mut a_out) = Peers::new("a".into(), Arc::new(Echo), stop.clone());
+        let (mut b, mut b_out) = Peers::new("b".into(), Arc::new(Echo), stop.clone());
+        Arc::get_mut(&mut a.0).unwrap().ice_servers.clear();
+        Arc::get_mut(&mut b.0).unwrap().ice_servers.clear();
+        let peer_b = b.clone();
+        let forward_a = tokio::spawn(async move {
+            while let Some(message) = a_out.recv().await {
+                peer_b.signal("a", message.signal).await.unwrap();
+            }
+        });
+        let peer_a = a.clone();
+        let forward_b = tokio::spawn(async move {
+            while let Some(message) = b_out.recv().await {
+                peer_a.signal("b", message.signal).await.unwrap();
+            }
+        });
+        // A page's initial burst must pair once, rather than flood signaling
+        // with one connection request per asset.
+        futures::future::join_all((0..8).map(|_| async {
+            let mut stream = b.open("a", "service", false).await.unwrap();
+            stream.write_all(b"asset").await.unwrap();
+            stream.shutdown().await.unwrap();
+            let mut bytes = Vec::new();
+            stream.read_to_end(&mut bytes).await.unwrap();
+            assert_eq!(bytes, b"asset");
+        }))
+        .await;
+        for (from, to) in [(&b, "a"), (&a, "b")] {
+            let stream = from.open(to, "service", true).await.unwrap();
+            let (mut read, mut write) = tokio::io::split(stream);
+            let expected = vec![42; 1024 * 1024 + 3];
+            let bytes = expected.clone();
+            tokio::time::timeout(Duration::from_secs(15), async {
+                let sender = async {
+                    write.write_all(&bytes).await.unwrap();
+                    write.shutdown().await.unwrap();
+                };
+                let receiver = async {
+                    let mut received = Vec::new();
+                    read.read_to_end(&mut received).await.unwrap();
+                    assert_eq!(received.len(), expected.len());
+                    assert!(received == expected);
+                };
+                tokio::join!(sender, receiver);
+            })
+            .await
+            .expect("P2P stream stalled");
+        }
+        stop.cancel();
+        a.clear().await;
+        b.clear().await;
+        forward_a.abort();
+        forward_b.abort();
+    }
+}

--- a/crates/preview/src/proxy.rs
+++ b/crates/preview/src/proxy.rs
@@ -1,0 +1,272 @@
+//! HTTP/1 reverse proxy. Hyper owns HTTP framing; upgrades carry their original
+//! bytes through the same multiplexed stream, including WebSocket close frames.
+use crate::{
+    catalog::Catalog,
+    mux::{Mux, Stream},
+    peer::Peers,
+};
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full, combinators::UnsyncBoxBody};
+use hyper::{
+    Request, Response, StatusCode,
+    body::Incoming,
+    header::{self, HeaderMap, HeaderValue},
+};
+use hyper_util::rt::TokioIo;
+use std::{convert::Infallible, sync::Arc};
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+type Body = UnsyncBoxBody<Bytes, hyper::Error>;
+#[derive(Clone)]
+pub struct Router {
+    pub catalog: Catalog,
+    pub local: Mux,
+    pub peers: Peers,
+}
+impl Router {
+    async fn open(&self, device: &str, service: &str, websocket: bool) -> anyhow::Result<Stream> {
+        if device == self.catalog.device_id() {
+            self.local.open(service, websocket).await
+        } else {
+            self.peers.open(device, service, websocket).await
+        }
+    }
+    async fn request(&self, mut request: Request<Incoming>) -> anyhow::Result<Response<Body>> {
+        anyhow::ensure!(
+            request.method() != hyper::Method::CONNECT && request.uri().scheme().is_none(),
+            "only origin-form HTTP requests are supported"
+        );
+        let host = request
+            .headers()
+            .get(header::HOST)
+            .and_then(|h| h.to_str().ok())
+            .ok_or_else(|| anyhow::anyhow!("missing preview hostname"))?
+            .to_ascii_lowercase();
+        let authority: hyper::http::uri::Authority = host.parse()?;
+        anyhow::ensure!(
+            authority.port_u16().unwrap_or(80) == self.catalog.snapshot().proxy_port,
+            "incorrect preview proxy port"
+        );
+        let service = self.catalog.by_hostname(authority.host()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "This preview is not running. Start the project's dev server and try again."
+            )
+        })?;
+        let upgrade = request
+            .headers()
+            .get(header::UPGRADE)
+            .is_some_and(|v| v.as_bytes().eq_ignore_ascii_case(b"websocket"))
+            && connection_has(request.headers(), "upgrade");
+        let browser_upgrade = upgrade.then(|| hyper::upgrade::on(&mut request));
+        let upstream_host = format!("localhost:{}", service.port);
+        let preview_origin = format!("http://{host}");
+        if request
+            .headers()
+            .get(header::ORIGIN)
+            .is_some_and(|v| v.as_bytes() == preview_origin.as_bytes())
+        {
+            request.headers_mut().insert(
+                header::ORIGIN,
+                HeaderValue::from_str(&format!("http://{upstream_host}"))?,
+            );
+        }
+        strip_hop_headers(request.headers_mut(), upgrade);
+        request
+            .headers_mut()
+            .insert(header::HOST, HeaderValue::from_str(&upstream_host)?);
+        request
+            .headers_mut()
+            .insert("x-forwarded-host", HeaderValue::from_str(&host)?);
+        request
+            .headers_mut()
+            .insert("x-forwarded-proto", HeaderValue::from_static("http"));
+        // Never pass client-supplied proxy credentials to a project server.
+        request.headers_mut().remove(header::PROXY_AUTHORIZATION);
+        let stream = self.open(&service.device_id, &service.id, upgrade).await?;
+        let (mut sender, connection) =
+            hyper::client::conn::http1::handshake(TokioIo::new(stream)).await?;
+        let connection = tokio::spawn(async move {
+            let _ = connection.with_upgrades().await;
+        });
+        // Aborting a disconnected browser's pending request tears down its
+        // upstream mux stream too, even when no response headers arrive.
+        let guard = AbortOnDrop(Some(connection.abort_handle()));
+        let mut response = sender.send_request(request).await?;
+        if response.status() == StatusCode::SWITCHING_PROTOCOLS {
+            anyhow::ensure!(upgrade, "unsolicited server upgrade");
+            let server_upgrade = hyper::upgrade::on(&mut response);
+            let browser_upgrade = browser_upgrade.unwrap();
+            tokio::spawn(async move {
+                let _guard = guard;
+                if let Ok((browser, server)) = tokio::try_join!(browser_upgrade, server_upgrade) {
+                    let _ = tokio::io::copy_bidirectional(
+                        &mut TokioIo::new(browser),
+                        &mut TokioIo::new(server),
+                    )
+                    .await;
+                }
+            });
+        } else {
+            // The response body's guard aborts the connection on cancellation;
+            // it is retained until the last streamed byte is consumed.
+            let (mut parts, body) = response.into_parts();
+            strip_hop_headers(&mut parts.headers, false);
+            rewrite_location(&mut parts.headers, &upstream_host, &preview_origin);
+            return Ok(Response::from_parts(
+                parts,
+                GuardedBody {
+                    body,
+                    _guard: guard,
+                }
+                .boxed_unsync(),
+            ));
+        }
+        strip_hop_headers(response.headers_mut(), true);
+        Ok(response.map(BodyExt::boxed_unsync))
+    }
+}
+struct AbortOnDrop(Option<tokio::task::AbortHandle>);
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        if let Some(task) = self.0.take() {
+            task.abort();
+        }
+    }
+}
+struct GuardedBody {
+    body: Incoming,
+    _guard: AbortOnDrop,
+}
+impl hyper::body::Body for GuardedBody {
+    type Data = Bytes;
+    type Error = hyper::Error;
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<hyper::body::Frame<Bytes>, Self::Error>>> {
+        std::pin::Pin::new(&mut self.body).poll_frame(cx)
+    }
+    fn is_end_stream(&self) -> bool {
+        self.body.is_end_stream()
+    }
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.body.size_hint()
+    }
+}
+fn connection_has(headers: &HeaderMap, token: &str) -> bool {
+    headers
+        .get_all(header::CONNECTION)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|v| v.split(','))
+        .any(|v| v.trim().eq_ignore_ascii_case(token))
+}
+fn strip_hop_headers(headers: &mut HeaderMap, upgrade: bool) {
+    let nominated: Vec<String> = headers
+        .get_all(header::CONNECTION)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|v| v.split(','))
+        .map(|v| v.trim().to_ascii_lowercase())
+        .collect();
+    for name in nominated {
+        if !(upgrade && name == "upgrade") {
+            headers.remove(name);
+        }
+    }
+    for name in [
+        "connection",
+        "keep-alive",
+        "proxy-connection",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+    ] {
+        headers.remove(name);
+    }
+    if upgrade {
+        headers.insert(header::CONNECTION, HeaderValue::from_static("upgrade"));
+    } else {
+        headers.remove(header::UPGRADE);
+    }
+}
+fn rewrite_location(headers: &mut HeaderMap, upstream: &str, preview: &str) {
+    if let Some(value) = headers.get(header::LOCATION).and_then(|v| v.to_str().ok()) {
+        let prefix = format!("http://{upstream}");
+        if let Some(path) = value.strip_prefix(&prefix).filter(|path| {
+            path.is_empty()
+                || path.starts_with('/')
+                || path.starts_with('?')
+                || path.starts_with('#')
+        }) {
+            if let Ok(value) = HeaderValue::from_str(&format!("{preview}{path}")) {
+                headers.insert(header::LOCATION, value);
+            }
+        }
+    }
+}
+fn error(message: String) -> Response<Body> {
+    let mut response = Response::new(
+        Full::new(Bytes::from(message))
+            .map_err(|never: Infallible| match never {})
+            .boxed_unsync(),
+    );
+    *response.status_mut() = StatusCode::BAD_GATEWAY;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    response
+}
+/// Bind both loopback families: `.localhost` commonly resolves to ::1 first.
+/// Fail explicitly if another application owns the stable port.
+pub async fn serve(
+    router: Router,
+    port: u16,
+    stop: CancellationToken,
+) -> anyhow::Result<(u16, Vec<tokio::task::JoinHandle<()>>)> {
+    let v4 = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, port)).await?;
+    let port = v4.local_addr()?.port();
+    let mut sockets = vec![v4];
+    match TcpListener::bind((std::net::Ipv6Addr::LOCALHOST, port)).await {
+        Ok(v6) => sockets.push(v6),
+        Err(error)
+            if matches!(
+                error.raw_os_error(),
+                Some(libc::EAFNOSUPPORT | libc::EPROTONOSUPPORT | libc::EADDRNOTAVAIL)
+            ) => {}
+        Err(error) => return Err(error.into()),
+    }
+    let slots = Arc::new(tokio::sync::Semaphore::new(128));
+    let mut listeners = Vec::new();
+    for listener in sockets {
+        let router = router.clone();
+        let stop = stop.clone();
+        let slots = slots.clone();
+        listeners.push(tokio::spawn(async move {
+            loop {
+                let accepted = tokio::select! { _ = stop.cancelled() => break, result = listener.accept() => result };
+                let Ok((socket, _)) = accepted else { break; };
+                let Ok(permit) = slots.clone().try_acquire_owned() else { drop(socket); continue; };
+                let router = router.clone(); let stop = stop.clone();
+                tokio::spawn(async move {
+                    let _permit = permit;
+                    let service = hyper::service::service_fn(move |request| {
+                        let router = router.clone();
+                        async move { Ok::<_, Infallible>(router.request(request).await.unwrap_or_else(|e| error(e.to_string()))) }
+                    });
+                    let mut builder = hyper::server::conn::http1::Builder::new();
+                    builder.timer(hyper_util::rt::TokioTimer::new()).header_read_timeout(std::time::Duration::from_secs(15));
+                    tokio::select! { _ = stop.cancelled() => {}, _ = builder.serve_connection(TokioIo::new(socket), service).with_upgrades() => {} }
+                });
+            }
+        }));
+    }
+    Ok((port, listeners))
+}

--- a/crates/preview/src/proxy.rs
+++ b/crates/preview/src/proxy.rs
@@ -18,6 +18,10 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
 type Body = UnsyncBoxBody<Bytes, hyper::Error>;
+fn tunnel_slot() -> anyhow::Result<tokio::sync::SemaphorePermit<'static>> {
+    static TUNNELS: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(128);
+    Ok(TUNNELS.try_acquire()?)
+}
 #[derive(Clone)]
 pub struct Router {
     pub catalog: Catalog,
@@ -32,9 +36,51 @@ impl Router {
             self.peers.open(device, service, websocket).await
         }
     }
-    async fn request(&self, mut request: Request<Incoming>) -> anyhow::Result<Response<Body>> {
+    /// WebKit on older macOS releases delegates `.localhost` DNS to the OS.
+    /// Its per-domain CONNECT proxy reaches this same loopback HTTP listener
+    /// without a hosts-file entry. Targets are catalog names at our port only.
+    async fn connect_loopback(
+        &self,
+        mut request: Request<Incoming>,
+    ) -> anyhow::Result<Response<Body>> {
+        let authority = request
+            .uri()
+            .authority()
+            .ok_or_else(|| anyhow::anyhow!("invalid preview CONNECT"))?;
+        let port = self.catalog.snapshot().proxy_port;
         anyhow::ensure!(
-            request.method() != hyper::Method::CONNECT && request.uri().scheme().is_none(),
+            authority.port_u16() == Some(port)
+                && self
+                    .catalog
+                    .by_hostname(&authority.host().to_ascii_lowercase())
+                    .is_some(),
+            "unknown preview CONNECT target"
+        );
+        let permit = tunnel_slot()?;
+        let lifecycle = self.local.clone();
+        let mut socket =
+            tokio::net::TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port)).await?;
+        let upgrade = hyper::upgrade::on(&mut request);
+        tokio::spawn(async move {
+            let _permit = permit;
+            tokio::select! { _ = lifecycle.closed() => {}, _ = async {
+                if let Ok(browser) = upgrade.await {
+                    let _ = tokio::io::copy_bidirectional(&mut TokioIo::new(browser), &mut socket).await;
+                }
+            } => {} }
+        });
+        Ok(Response::new(
+            Full::new(Bytes::new())
+                .map_err(|never: Infallible| match never {})
+                .boxed_unsync(),
+        ))
+    }
+    async fn request(&self, mut request: Request<Incoming>) -> anyhow::Result<Response<Body>> {
+        if request.method() == hyper::Method::CONNECT {
+            return self.connect_loopback(request).await;
+        }
+        anyhow::ensure!(
+            request.uri().scheme().is_none(),
             "only origin-form HTTP requests are supported"
         );
         let host = request
@@ -58,23 +104,17 @@ impl Router {
             .get(header::UPGRADE)
             .is_some_and(|v| v.as_bytes().eq_ignore_ascii_case(b"websocket"))
             && connection_has(request.headers(), "upgrade");
+        let tunnel_permit = upgrade.then(tunnel_slot).transpose()?;
         let browser_upgrade = upgrade.then(|| hyper::upgrade::on(&mut request));
         let upstream_host = format!("localhost:{}", service.port);
         let preview_origin = format!("http://{host}");
-        if request
-            .headers()
-            .get(header::ORIGIN)
-            .is_some_and(|v| v.as_bytes() == preview_origin.as_bytes())
-        {
-            request.headers_mut().insert(
-                header::ORIGIN,
-                HeaderValue::from_str(&format!("http://{upstream_host}"))?,
-            );
-        }
+        // Preserve the browser's origin and authority together. In particular,
+        // Next.js Server Actions compare Origin with X-Forwarded-Host; rewriting
+        // only Origin to the ephemeral backend would reject valid submissions.
         strip_hop_headers(request.headers_mut(), upgrade);
         request
             .headers_mut()
-            .insert(header::HOST, HeaderValue::from_str(&upstream_host)?);
+            .insert(header::HOST, HeaderValue::from_str(&host)?);
         request
             .headers_mut()
             .insert("x-forwarded-host", HeaderValue::from_str(&host)?);
@@ -97,15 +137,15 @@ impl Router {
             anyhow::ensure!(upgrade, "unsolicited server upgrade");
             let server_upgrade = hyper::upgrade::on(&mut response);
             let browser_upgrade = browser_upgrade.unwrap();
+            let lifecycle = self.local.clone();
             tokio::spawn(async move {
                 let _guard = guard;
-                if let Ok((browser, server)) = tokio::try_join!(browser_upgrade, server_upgrade) {
-                    let _ = tokio::io::copy_bidirectional(
-                        &mut TokioIo::new(browser),
-                        &mut TokioIo::new(server),
-                    )
-                    .await;
-                }
+                let _permit = tunnel_permit;
+                tokio::select! { _ = lifecycle.closed() => {}, _ = async {
+                    if let Ok((browser, server)) = tokio::try_join!(browser_upgrade, server_upgrade) {
+                        let _ = tokio::io::copy_bidirectional(&mut TokioIo::new(browser), &mut TokioIo::new(server)).await;
+                    }
+                } => {} }
             });
         } else {
             // The response body's guard aborts the connection on cancellation;

--- a/crates/preview/src/service.rs
+++ b/crates/preview/src/service.rs
@@ -1,0 +1,186 @@
+//! Engine-owned discovery/proxy lifecycle, independent of headed UI lifetimes.
+use crate::{
+    catalog::Catalog,
+    discovery,
+    mux::{self, BoxIo, Connector},
+    peer::Peers,
+    proxy, signaling,
+};
+use futures::{StreamExt, stream};
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+use tokio_util::sync::CancellationToken;
+#[derive(Clone)]
+pub struct PreviewService(Arc<Inner>);
+struct Inner {
+    catalog: Catalog,
+    stop: CancellationToken,
+    started: AtomicBool,
+    tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
+}
+pub type Projects = Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>;
+impl PreviewService {
+    pub fn new(file: PathBuf, device_id: String, device_name: String) -> anyhow::Result<Self> {
+        Ok(Self(Arc::new(Inner {
+            catalog: Catalog::open(file, device_id, device_name)?,
+            stop: CancellationToken::new(),
+            started: AtomicBool::new(false),
+            tasks: Mutex::new(Vec::new()),
+        })))
+    }
+    pub fn catalog(&self) -> &Catalog {
+        &self.0.catalog
+    }
+    pub async fn start(&self, projects: Projects, signaling: Option<signaling::Config>) {
+        if self.0.started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let connector = Arc::new(LocalConnector(self.0.catalog.clone()));
+        let local = mux::local(connector.clone(), self.0.stop.child_token());
+        let (peers, output) = Peers::new(
+            self.0.catalog.device_id().into(),
+            connector,
+            self.0.stop.child_token(),
+        );
+        let router = proxy::Router {
+            catalog: self.0.catalog.clone(),
+            local,
+            peers: peers.clone(),
+        };
+        let proxy_catalog = self.0.catalog.clone();
+        let proxy_stop = self.0.stop.clone();
+        let listener_task = tokio::spawn(async move {
+            loop {
+                let binding = tokio::select! {
+                    _ = proxy_stop.cancelled() => break,
+                    binding = proxy::serve(router.clone(), zeron_proto::PREVIEW_PROXY_PORT, proxy_stop.child_token()) => binding,
+                };
+                match binding {
+                    Ok((port, tasks)) => {
+                        proxy_catalog.set_proxy_status(port, None);
+                        for task in tasks {
+                            let _ = task.await;
+                        }
+                        break;
+                    }
+                    Err(error) => proxy_catalog.set_proxy_status(
+                        zeron_proto::PREVIEW_PROXY_PORT,
+                        Some(format!(
+                            "Local previews could not listen on port 7331: {error}"
+                        )),
+                    ),
+                }
+                tokio::select! { _ = proxy_stop.cancelled() => break, _ = tokio::time::sleep(Duration::from_secs(2)) => {} }
+            }
+        });
+        self.0.tasks.lock().unwrap().push(listener_task);
+        let catalog = self.0.catalog.clone();
+        let stop = self.0.stop.clone();
+        let scanner = tokio::spawn(async move {
+            loop {
+                let scan = async {
+                    let projects = projects.clone();
+                    let candidates = tokio::task::spawn_blocking(move || {
+                        let mut roots: Vec<_> = projects()
+                            .into_iter()
+                            .collect::<std::collections::BTreeSet<_>>()
+                            .into_iter()
+                            .filter_map(|p| p.canonicalize().ok())
+                            .collect::<std::collections::BTreeSet<_>>()
+                            .into_iter()
+                            .collect();
+                        if roots.is_empty() {
+                            return Vec::new();
+                        }
+                        roots.sort_by_key(|p| std::cmp::Reverse(p.components().count()));
+                        discovery::listeners()
+                            .into_iter()
+                            .filter(|l| {
+                                l.address.port() != zeron_proto::PREVIEW_PROXY_PORT
+                                    && l.pid != std::process::id()
+                            })
+                            .filter_map(|listener| {
+                                roots
+                                    .iter()
+                                    .find(|root| listener.belongs_to(root))
+                                    .cloned()
+                                    .map(|root| (root, listener))
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .await
+                    .unwrap_or_default();
+                    let servers = stream::iter(candidates)
+                        .map(|(root, listener)| async move {
+                            discovery::is_http(listener.address)
+                                .await
+                                .then_some((root, listener))
+                        })
+                        .buffer_unordered(12)
+                        .filter_map(|item| async { item })
+                        .collect()
+                        .await;
+                    if let Err(error) = catalog.replace_local(servers) {
+                        tracing::warn!(%error, "could not update preview services");
+                    }
+                };
+                tokio::select! { _ = stop.cancelled() => break, _ = scan => {} }
+                tokio::select! { _ = stop.cancelled() => break, _ = tokio::time::sleep(Duration::from_secs(2)) => {} }
+            }
+        });
+        let mut tasks = self.0.tasks.lock().unwrap();
+        tasks.push(scanner);
+        if let Some(config) = signaling {
+            tasks.push(tokio::spawn(signaling::run(
+                config,
+                self.0.catalog.clone(),
+                peers,
+                output,
+                self.0.stop.child_token(),
+            )));
+        }
+    }
+    pub fn stop(&self) {
+        self.0.stop.cancel();
+        self.0.catalog.clear_remote();
+    }
+    pub async fn shutdown(&self) {
+        self.stop();
+        let tasks = std::mem::take(&mut *self.0.tasks.lock().unwrap());
+        for task in tasks {
+            let _ = task.await;
+        }
+    }
+}
+struct LocalConnector(Catalog);
+#[async_trait::async_trait]
+impl Connector for LocalConnector {
+    async fn connect(&self, id: &str) -> anyhow::Result<BoxIo> {
+        let route = self
+            .0
+            .local_route(id)
+            .ok_or_else(|| anyhow::anyhow!("preview service stopped"))?;
+        // Recheck process ownership before dialing: a stopped dev server's port
+        // may have been reused by an unrelated process since the last scan.
+        let expected = route.listener.clone();
+        let valid = tokio::task::spawn_blocking(move || {
+            discovery::listeners().iter().any(|actual| {
+                actual.pid == expected.pid
+                    && actual.started_at == expected.started_at
+                    && actual.cwd == expected.cwd
+                    && actual.address == expected.address
+            })
+        })
+        .await?;
+        anyhow::ensure!(valid, "preview process changed; waiting for rediscovery");
+        Ok(Box::new(
+            tokio::net::TcpStream::connect(route.listener.address).await?,
+        ))
+    }
+}

--- a/crates/preview/src/signaling.rs
+++ b/crates/preview/src/signaling.rs
@@ -1,0 +1,140 @@
+//! The coordinator receives presence, catalogs and SDP only. Reconnects obtain
+//! fresh credentials and clear the previous connection's remote routes/peers.
+use crate::{
+    catalog::Catalog,
+    peer::{OutgoingSignal, Peers, Signal},
+};
+use futures::{SinkExt, StreamExt};
+use serde::Deserialize;
+use std::{sync::Arc, time::Duration};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::{Message, client::IntoClientRequest};
+use tokio_util::sync::CancellationToken;
+use zeron_proto::PreviewService;
+#[async_trait::async_trait]
+pub trait TokenSource: Send + Sync {
+    async fn token(&self) -> Option<String>;
+}
+pub struct Config {
+    pub edge_url: String,
+    pub org_id: String,
+    pub tokens: Arc<dyn TokenSource>,
+}
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+enum Incoming {
+    Catalog {
+        device: String,
+        services: Vec<PreviewService>,
+    },
+    Gone {
+        device: String,
+    },
+    Signal {
+        from: String,
+        signal: Signal,
+    },
+}
+pub async fn run(
+    config: Config,
+    catalog: Catalog,
+    peers: Peers,
+    mut outgoing: mpsc::Receiver<OutgoingSignal>,
+    stop: CancellationToken,
+) {
+    loop {
+        let connected = connect(&config, &catalog, &peers, &mut outgoing);
+        tokio::select! { _ = stop.cancelled() => break, result = connected => {
+            if let Err(error) = result { tracing::debug!(%error, "preview coordinator disconnected"); }
+        } }
+        catalog.clear_remote();
+        peers.clear().await;
+        while outgoing.try_recv().is_ok() {} // signaling from the old lease is stale
+        tokio::select! { _ = stop.cancelled() => break, _ = tokio::time::sleep(Duration::from_secs(3)) => {} }
+    }
+    catalog.clear_remote();
+    peers.clear().await;
+}
+async fn connect(
+    config: &Config,
+    catalog: &Catalog,
+    peers: &Peers,
+    outgoing: &mut mpsc::Receiver<OutgoingSignal>,
+) -> anyhow::Result<()> {
+    let token = config
+        .tokens
+        .token()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("preview authentication unavailable"))?;
+    let mut url = reqwest::Url::parse(&config.edge_url)?;
+    let scheme = if url.scheme() == "https" { "wss" } else { "ws" };
+    url.set_scheme(scheme)
+        .map_err(|_| anyhow::anyhow!("invalid preview coordinator URL"))?;
+    url.set_path(&format!("/preview/{}/ws", config.org_id));
+    url.query_pairs_mut()
+        .clear()
+        .append_pair("device", catalog.device_id());
+    let mut request = url.as_str().into_client_request()?;
+    request
+        .headers_mut()
+        .insert("authorization", format!("Bearer {token}").parse()?);
+    let mut websocket_config = tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default();
+    websocket_config.max_message_size = Some(1024 * 1024);
+    websocket_config.max_frame_size = Some(1024 * 1024);
+    let (socket, _) = tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio_tungstenite::connect_async_with_config(request, Some(websocket_config), false),
+    )
+    .await??;
+    let (mut write, mut read) = socket.split();
+    let mut changes = catalog.subscribe();
+    let mut advertised = catalog.local_services();
+    write
+        .send(Message::Text(
+            serde_json::json!({"type":"catalog", "services":advertised}).to_string(),
+        ))
+        .await?;
+    let mut ping = tokio::time::interval(Duration::from_secs(10));
+    let mut last_message = tokio::time::Instant::now();
+    // SDP gathering must not block the socket heartbeat or other devices.
+    let mut negotiations = tokio::task::JoinSet::new();
+    loop {
+        tokio::select! {
+            _ = ping.tick() => {
+                anyhow::ensure!(last_message.elapsed() < Duration::from_secs(40), "preview coordinator lease expired");
+                write.send(Message::Text("ping".into())).await?;
+            }
+            _ = changes.changed() => {
+                let next = catalog.local_services();
+                if next != advertised { write.send(Message::Text(serde_json::json!({"type":"catalog", "services":next}).to_string())).await?; advertised = next; }
+            }
+            Some(message) = outgoing.recv() => {
+                write.send(Message::Text(serde_json::json!({"type":"signal", "to":message.to, "signal":message.signal}).to_string())).await?;
+            }
+            Some(_) = negotiations.join_next(), if !negotiations.is_empty() => {}
+            message = read.next() => {
+                let message = message.ok_or_else(|| anyhow::anyhow!("preview coordinator closed"))??;
+                last_message = tokio::time::Instant::now();
+                match message {
+                    Message::Text(text) if text == "pong" => {},
+                    Message::Text(text) => {
+                        anyhow::ensure!(text.len() <= 1024*1024, "oversized preview coordinator message");
+                        match serde_json::from_str::<Incoming>(&text)? {
+                            Incoming::Catalog { device, services } => catalog.set_remote(&device, services)?,
+                            Incoming::Gone { device } => { catalog.remove_remote(&device); peers.remove(&device).await; }
+                            Incoming::Signal { from, signal } => {
+                                anyhow::ensure!(negotiations.len() < 16, "too many concurrent preview negotiations");
+                                let peers = peers.clone();
+                                negotiations.spawn(async move { if let Err(error) = peers.signal(&from, signal).await { tracing::debug!(%error, "preview negotiation failed"); } });
+                            }
+                        }
+                    }
+                    Message::Ping(bytes) => write.send(Message::Pong(bytes)).await?,
+                    Message::Close(_) => anyhow::bail!("preview coordinator closed"),
+                    Message::Binary(_) => anyhow::bail!("application traffic is not allowed on preview signaling"),
+                    _ => {}
+                }
+            }
+        }
+    }
+}

--- a/crates/preview/tests/coordinator.rs
+++ b/crates/preview/tests/coordinator.rs
@@ -1,0 +1,71 @@
+//! Full authenticated Worker → catalog → SDP/ICE → P2P → HTTP integration.
+//! Run against `wrangler dev --local --var AUTH_MODE:dev --port 27641`:
+//! ZERON_PREVIEW_TEST_EDGE=http://127.0.0.1:27641 cargo test -p zeron-preview --test coordinator -- --ignored
+use std::{sync::Arc, time::Duration};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
+use tokio_util::sync::CancellationToken;
+use zeron_preview::{
+    catalog::Catalog,
+    discovery::Listener,
+    mux::{self, BoxIo, Connector},
+    peer::Peers,
+    proxy::{self, Router},
+    signaling::{self, Config, TokenSource},
+};
+struct Token(String);
+#[async_trait::async_trait]
+impl TokenSource for Token {
+    async fn token(&self) -> Option<String> {
+        Some(self.0.clone())
+    }
+}
+struct Backend(Catalog);
+#[async_trait::async_trait]
+impl Connector for Backend {
+    async fn connect(&self, id: &str) -> anyhow::Result<BoxIo> {
+        let route = self
+            .0
+            .local_route(id)
+            .ok_or_else(|| anyhow::anyhow!("unknown service"))?;
+        Ok(Box::new(TcpStream::connect(route.listener.address).await?))
+    }
+}
+#[tokio::test]
+#[ignore = "requires a local Worker in AUTH_MODE=dev"]
+async fn authenticated_coordinator_pairs_devices_for_large_http_preview() {
+    let edge = std::env::var("ZERON_PREVIEW_TEST_EDGE")
+        .expect("set ZERON_PREVIEW_TEST_EDGE to the local dev Worker");
+    tokio::time::timeout(Duration::from_secs(60), async {
+        let temp = tempfile::tempdir().unwrap(); let stop = CancellationToken::new();
+        let host = Catalog::open(temp.path().join("host.json"),"host".into(),"MacBook".into()).unwrap();
+        let viewer = Catalog::open(temp.path().join("viewer.json"),"viewer".into(),"Desktop".into()).unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap(); let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket,_) = listener.accept().await.unwrap(); let mut headers = Vec::new();
+            while !headers.ends_with(b"\r\n\r\n") { headers.push(socket.read_u8().await.unwrap()); }
+            let request = String::from_utf8(headers).unwrap(); assert!(request.to_lowercase().contains("host: macbook.project.localhost:"));
+            socket.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4194304\r\nContent-Type: application/octet-stream\r\n\r\n").await.unwrap();
+            for _ in 0..512 { socket.write_all(&[42;8192]).await.unwrap(); }
+            socket.shutdown().await.unwrap();
+        });
+        host.replace_local(vec![("/work/project".into(),Listener { pid:std::process::id(),parent:1,cwd:"/work/project".into(),args:vec!["node".into(),"vite".into()],started_at:1,address,zeron_owned:true })]).unwrap();
+        let host_backend = Arc::new(Backend(host.clone())); let viewer_backend = Arc::new(Backend(viewer.clone()));
+        let (host_peers, host_output) = Peers::new("host".into(),host_backend,stop.child_token());
+        let (viewer_peers, viewer_output) = Peers::new("viewer".into(),viewer_backend.clone(),stop.child_token());
+        let tokens: Arc<dyn TokenSource> = Arc::new(Token(format!("{}@preview-test",uuid::Uuid::new_v4())));
+        let config = || Config { edge_url:edge.clone(),org_id:"preview-test".into(),tokens:tokens.clone() };
+        let host_signal = tokio::spawn(signaling::run(config(),host.clone(),host_peers,host_output,stop.child_token()));
+        let viewer_signal = tokio::spawn(signaling::run(config(),viewer.clone(),viewer_peers.clone(),viewer_output,stop.child_token()));
+        let (port, listeners) = proxy::serve(Router { catalog:viewer.clone(),local:mux::local(viewer_backend,stop.child_token()),peers:viewer_peers },0,stop.child_token()).await.unwrap(); viewer.set_proxy_status(port,None);
+        let mut changes = viewer.subscribe();
+        changes.wait_for(|snapshot|snapshot.services.len()==1).await.unwrap();
+        let service = viewer.snapshot().services[0].clone(); assert_eq!(service.device_id,"host"); assert_eq!(service.hostname,"macbook.project.localhost");
+        let client = reqwest::Client::builder().no_proxy().resolve(&service.hostname,([127,0,0,1],port).into()).build().unwrap();
+        let response = client.get(service.url(port)).send().await.unwrap(); assert_eq!(response.status(),200);
+        let bytes = response.bytes().await.unwrap(); assert_eq!(bytes.len(),4194304); assert!(bytes.iter().all(|b|*b==42));
+        server.await.unwrap(); stop.cancel(); host_signal.await.unwrap(); viewer_signal.await.unwrap(); for listener in listeners { listener.await.unwrap(); }
+    }).await.expect("coordinated P2P preview did not complete");
+}

--- a/crates/preview/tests/discovery.rs
+++ b/crates/preview/tests/discovery.rs
@@ -79,7 +79,7 @@ async fn only_current_project_http_processes_are_exposed_and_removals_are_live()
     }
     let found = &service.catalog().snapshot().services[0];
     assert!(found.zeron_owned);
-    assert_eq!(std::path::Path::new(&found.cwd), a);
+    assert_eq!(std::path::Path::new(&found.cwd), a.canonicalize().unwrap());
     assert!(found.started_at > 0);
     *roots.lock().unwrap() = vec![b];
     wait(&service, Some(other.0.id())).await;

--- a/crates/preview/tests/discovery.rs
+++ b/crates/preview/tests/discovery.rs
@@ -14,7 +14,10 @@ impl Drop for Child {
 fn launch(cwd: &std::path::Path, http: bool) -> Child {
     let mut command = std::process::Command::new("python3");
     if http {
-        command.args(["-m", "http.server", "0", "--bind", "127.0.0.1"]);
+        // HTTPServer.server_bind does a reverse DNS lookup before listen(),
+        // which can stall on isolated macOS runners. TCPServer exercises the
+        // same real HTTP handler without depending on external DNS readiness.
+        command.args(["-c", "import http.server,socketserver; socketserver.TCPServer(('127.0.0.1',0),http.server.SimpleHTTPRequestHandler).serve_forever()"]);
     } else {
         command.args(["-c", "import socket,time; s=socket.socket(); s.bind(('127.0.0.1',0)); s.listen(); time.sleep(30)"]);
     }
@@ -22,7 +25,7 @@ fn launch(cwd: &std::path::Path, http: bool) -> Child {
         command
             .current_dir(cwd)
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::inherit())
             .spawn()
             .unwrap(),
     )

--- a/crates/preview/tests/discovery.rs
+++ b/crates/preview/tests/discovery.rs
@@ -1,0 +1,97 @@
+//! Real OS process/listener association, including unrelated project isolation.
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use zeron_preview::PreviewService;
+struct Child(std::process::Child);
+impl Drop for Child {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+fn launch(cwd: &std::path::Path, http: bool) -> Child {
+    let mut command = std::process::Command::new("python3");
+    if http {
+        command.args(["-m", "http.server", "0", "--bind", "127.0.0.1"]);
+    } else {
+        command.args(["-c", "import socket,time; s=socket.socket(); s.bind(('127.0.0.1',0)); s.listen(); time.sleep(30)"]);
+    }
+    Child(
+        command
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap(),
+    )
+}
+async fn wait(service: &PreviewService, expected_pid: Option<u32>) {
+    tokio::time::timeout(Duration::from_secs(12), async {
+        loop {
+            let services = service.catalog().snapshot().services;
+            if match expected_pid {
+                Some(pid) => services.len() == 1 && services[0].pid == pid,
+                None => services.is_empty(),
+            } {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("discovery did not converge");
+}
+#[tokio::test]
+async fn only_current_project_http_processes_are_exposed_and_removals_are_live() {
+    let temp = tempfile::tempdir().unwrap();
+    let a = temp.path().join("app");
+    let b = temp.path().join("unrelated");
+    std::fs::create_dir(&a).unwrap();
+    std::fs::create_dir(&b).unwrap();
+    let local = launch(&a, true);
+    let other = launch(&b, true);
+    let _non_http = launch(&a, false);
+    let roots = Arc::new(Mutex::new(vec![a.clone()]));
+    let projects = roots.clone();
+    let service = PreviewService::new(
+        temp.path().join("names.json"),
+        "local".into(),
+        "Laptop".into(),
+    )
+    .unwrap();
+    let occupied = tokio::net::TcpListener::bind("127.0.0.1:7331").await.ok();
+    service
+        .start(Arc::new(move || projects.lock().unwrap().clone()), None)
+        .await;
+    wait(&service, Some(local.0.id())).await;
+    if let Some(listener) = occupied {
+        assert!(service.catalog().snapshot().error.is_some());
+        drop(listener);
+        tokio::time::timeout(Duration::from_secs(6), async {
+            while service.catalog().snapshot().error.is_some() {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("proxy did not retry the freed port");
+    }
+    let found = &service.catalog().snapshot().services[0];
+    assert!(found.zeron_owned);
+    assert_eq!(std::path::Path::new(&found.cwd), a);
+    assert!(found.started_at > 0);
+    *roots.lock().unwrap() = vec![b];
+    wait(&service, Some(other.0.id())).await;
+    drop(other);
+    wait(&service, None).await;
+    service.shutdown().await;
+    // Shutdown fully releases the fixed proxy port before a profile boots.
+    if service.catalog().snapshot().error.is_none() {
+        assert!(
+            tokio::net::TcpListener::bind("127.0.0.1:7331")
+                .await
+                .is_ok()
+        );
+    }
+}

--- a/crates/preview/tests/proxy.rs
+++ b/crates/preview/tests/proxy.rs
@@ -1,0 +1,305 @@
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use http_body_util::{BodyExt, Full, StreamBody, combinators::UnsyncBoxBody};
+use hyper::{
+    Request, Response,
+    body::{Frame, Incoming},
+};
+use hyper_util::rt::TokioIo;
+use std::{
+    convert::Infallible,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{
+    WebSocketStream,
+    tungstenite::{Message, client::IntoClientRequest, protocol::Role},
+};
+use tokio_util::sync::CancellationToken;
+use zeron_preview::{
+    catalog::Catalog,
+    discovery::Listener,
+    mux::{self, BoxIo, Connector},
+    peer::Peers,
+    proxy::{self, Router},
+};
+type Body = UnsyncBoxBody<Bytes, hyper::Error>;
+fn full(value: impl Into<Bytes>) -> Body {
+    Full::new(value.into())
+        .map_err(|never: Infallible| match never {})
+        .boxed_unsync()
+}
+struct Count(Arc<AtomicUsize>);
+impl Drop for Count {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+async fn server(stop: CancellationToken, active: Arc<AtomicUsize>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            let socket = tokio::select! { _ = stop.cancelled() => break, value = listener.accept() => value.unwrap().0 };
+            active.fetch_add(1, Ordering::SeqCst);
+            let guard = Count(active.clone());
+            let stop = stop.clone();
+            tokio::spawn(async move {
+                let _guard = guard;
+                let service = hyper::service::service_fn(
+                    move |mut request: Request<Incoming>| async move {
+                        let response = match request.uri().path() {
+                            "/echo" => Response::new(request.into_body().boxed_unsync()),
+                            "/stream" | "/infinite" => {
+                                let max = if request.uri().path() == "/infinite" {
+                                    usize::MAX
+                                } else {
+                                    20
+                                };
+                                let body = futures::stream::unfold(0, move |index| async move {
+                                    if index >= max {
+                                        return None;
+                                    }
+                                    tokio::time::sleep(Duration::from_millis(20)).await;
+                                    Some((
+                                        Ok::<_, hyper::Error>(Frame::data(Bytes::from(vec![
+                                            42;
+                                            8192
+                                        ]))),
+                                        index + 1,
+                                    ))
+                                });
+                                Response::new(StreamBody::new(body).boxed_unsync())
+                            }
+                            "/headers" => {
+                                let values = serde_json::json!({"host":request.headers()["host"].to_str().unwrap(), "forwarded":request.headers()["x-forwarded-host"].to_str().unwrap(), "hop":request.headers().contains_key("x-hop"), "origin":request.headers().get("origin").and_then(|v|v.to_str().ok()), "query":request.uri().query()});
+                                let mut response = Response::new(full(values.to_string()));
+                                response
+                                    .headers_mut()
+                                    .append("set-cookie", "a=1; Path=/".parse().unwrap());
+                                response
+                                    .headers_mut()
+                                    .append("set-cookie", "b=2; Path=/".parse().unwrap());
+                                response
+                            }
+                            "/redirect" => Response::builder()
+                                .status(302)
+                                .header(
+                                    "location",
+                                    format!("http://localhost:{port}/headers?q=yes"),
+                                )
+                                .body(full(""))
+                                .unwrap(),
+                            "/ws" => {
+                                let accept =
+                                    tokio_tungstenite::tungstenite::handshake::derive_accept_key(
+                                        request.headers()["sec-websocket-key"].as_bytes(),
+                                    );
+                                let upgrade = hyper::upgrade::on(&mut request);
+                                tokio::spawn(async move {
+                                    let mut socket = WebSocketStream::from_raw_socket(
+                                        TokioIo::new(upgrade.await.unwrap()),
+                                        Role::Server,
+                                        None,
+                                    )
+                                    .await;
+                                    while let Some(Ok(message)) = socket.next().await {
+                                        if message.is_close() {
+                                            let _ = socket.flush().await;
+                                            break;
+                                        }
+                                        if message.is_text() || message.is_binary() {
+                                            if socket.send(message).await.is_err() {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                });
+                                Response::builder()
+                                    .status(101)
+                                    .header("connection", "upgrade")
+                                    .header("upgrade", "websocket")
+                                    .header("sec-websocket-accept", accept)
+                                    .body(full(""))
+                                    .unwrap()
+                            }
+                            _ => Response::new(full(format!("server:{port}"))),
+                        };
+                        Ok::<_, Infallible>(response)
+                    },
+                );
+                tokio::select! { _ = stop.cancelled() => {}, _ = hyper::server::conn::http1::Builder::new().serve_connection(TokioIo::new(socket), service).with_upgrades() => {} }
+            });
+        }
+    });
+    port
+}
+struct Backend(Catalog);
+#[async_trait::async_trait]
+impl Connector for Backend {
+    async fn connect(&self, id: &str) -> anyhow::Result<BoxIo> {
+        Ok(Box::new(
+            TcpStream::connect(self.0.local_route(id).unwrap().listener.address).await?,
+        ))
+    }
+}
+fn observe(catalog: &Catalog, port: u16, pid: u32) {
+    catalog
+        .replace_local(vec![(
+            "/work/app".into(),
+            Listener {
+                pid,
+                parent: 1,
+                cwd: "/work/app".into(),
+                args: vec!["node".into(), "vite".into()],
+                started_at: pid as u64,
+                address: ([127, 0, 0, 1], port).into(),
+                zeron_owned: true,
+            },
+        )])
+        .unwrap();
+}
+#[tokio::test]
+async fn streaming_headers_websocket_cancellation_and_restart() {
+    tokio::time::timeout(Duration::from_secs(20), async {
+        let temp = tempfile::tempdir().unwrap();
+        let catalog = Catalog::open(
+            temp.path().join("names.json"),
+            "local".into(),
+            "Laptop".into(),
+        )
+        .unwrap();
+        let stop = CancellationToken::new();
+        let backend_stop = stop.child_token();
+        let active = Arc::new(AtomicUsize::new(0));
+        let backend_port = server(backend_stop.clone(), active.clone()).await;
+        observe(&catalog, backend_port, 1);
+        let connector = Arc::new(Backend(catalog.clone()));
+        let local = mux::local(connector.clone(), stop.clone());
+        let (peers, _) = Peers::new("local".into(), connector, stop.clone());
+        let (port, _listeners) = proxy::serve(
+            Router {
+                catalog: catalog.clone(),
+                local,
+                peers,
+            },
+            0,
+            stop.clone(),
+        )
+        .await
+        .unwrap();
+        catalog.set_proxy_status(port, None);
+        let service = catalog.snapshot().services[0].clone();
+        let url = service.url(port);
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .resolve(&service.hostname, ([127, 0, 0, 1], port).into())
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap();
+        let response = client
+            .get(format!("{url}/headers?q=yes"))
+            .header("connection", "x-hop")
+            .header("x-hop", "remove")
+            .header("origin", &url)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.headers().get_all("set-cookie").iter().count(), 2);
+        let headers: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(headers["host"], format!("localhost:{backend_port}"));
+        assert_eq!(headers["forwarded"], format!("{}:{port}", service.hostname));
+        assert_eq!(headers["hop"], false);
+        assert_eq!(headers["query"], "q=yes");
+        assert_eq!(
+            headers["origin"],
+            format!("http://localhost:{backend_port}")
+        );
+        let body = vec![5u8; 2 * 1024 * 1024 + 17];
+        let received = client
+            .post(format!("{url}/echo"))
+            .body(body.clone())
+            .send()
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert!(received.as_ref() == body);
+        let started = tokio::time::Instant::now();
+        let mut streaming = client
+            .get(format!("{url}/stream"))
+            .send()
+            .await
+            .unwrap()
+            .bytes_stream();
+        let first = streaming.next().await.unwrap().unwrap();
+        assert!(started.elapsed() < Duration::from_millis(300));
+        let mut length = first.len();
+        while let Some(chunk) = streaming.next().await {
+            length += chunk.unwrap().len();
+        }
+        assert_eq!(length, 20 * 8192);
+        let response = client.get(format!("{url}/redirect")).send().await.unwrap();
+        assert_eq!(
+            response.headers()["location"],
+            format!("{url}/headers?q=yes")
+        );
+        drop(response);
+        let mut request = format!("ws://{}:{port}/ws", service.hostname)
+            .into_client_request()
+            .unwrap();
+        request.headers_mut().insert("origin", url.parse().unwrap());
+        let tcp = TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port))
+            .await
+            .unwrap();
+        let (mut ws, _) = tokio_tungstenite::client_async(request, tcp).await.unwrap();
+        for msg in [
+            Message::Text("hot-update".into()),
+            Message::Binary(vec![7; 256 * 1024]),
+        ] {
+            ws.send(msg.clone()).await.unwrap();
+            assert!(ws.next().await.unwrap().unwrap() == msg);
+        }
+        ws.close(None).await.unwrap();
+        let _ = ws.next().await;
+        drop(ws);
+        let mut infinite = client
+            .get(format!("{url}/infinite"))
+            .send()
+            .await
+            .unwrap()
+            .bytes_stream();
+        infinite.next().await.unwrap().unwrap();
+        drop(infinite);
+        while active.load(Ordering::SeqCst) > 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        backend_stop.cancel();
+        catalog.replace_local(Vec::new()).unwrap();
+        assert_eq!(client.get(&url).send().await.unwrap().status(), 502);
+        let next_port = server(stop.child_token(), active).await;
+        observe(&catalog, next_port, 2);
+        assert_eq!(catalog.snapshot().services[0].url(port), url);
+        assert_eq!(
+            client.get(&url).send().await.unwrap().text().await.unwrap(),
+            format!("server:{next_port}")
+        );
+        assert_eq!(
+            client
+                .get(format!("http://127.0.0.1:{port}"))
+                .send()
+                .await
+                .unwrap()
+                .status(),
+            502
+        );
+        stop.cancel();
+    })
+    .await
+    .expect("proxy test stalled");
+}

--- a/crates/preview/tests/proxy.rs
+++ b/crates/preview/tests/proxy.rs
@@ -14,6 +14,7 @@ use std::{
     },
     time::Duration,
 };
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_tungstenite::{
     WebSocketStream,
@@ -201,6 +202,45 @@ async fn streaming_headers_websocket_cancellation_and_restart() {
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .unwrap();
+        let mut tunnel = TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port))
+            .await
+            .unwrap();
+        tunnel
+            .write_all(
+                format!(
+                    "CONNECT {}:{port} HTTP/1.1\r\nHost: {}:{port}\r\n\r\n",
+                    service.hostname, service.hostname
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let mut reply = Vec::new();
+        while !reply.ends_with(b"\r\n\r\n") {
+            reply.push(tunnel.read_u8().await.unwrap());
+        }
+        assert!(reply.starts_with(b"HTTP/1.1 200"));
+        tunnel
+            .write_all(
+                format!(
+                    "GET / HTTP/1.1\r\nHost: {}:{port}\r\nConnection: close\r\n\r\n",
+                    service.hostname
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let mut page = String::new();
+        tunnel.read_to_string(&mut page).await.unwrap();
+        assert!(page.contains(&format!("server:{backend_port}")));
+        drop(tunnel);
+        let rejected = client
+            .request(reqwest::Method::CONNECT, format!("http://127.0.0.1:{port}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), 502);
+        drop(rejected);
         let response = client
             .get(format!("{url}/headers?q=yes"))
             .header("connection", "x-hop")
@@ -211,14 +251,11 @@ async fn streaming_headers_websocket_cancellation_and_restart() {
             .unwrap();
         assert_eq!(response.headers().get_all("set-cookie").iter().count(), 2);
         let headers: serde_json::Value = response.json().await.unwrap();
-        assert_eq!(headers["host"], format!("localhost:{backend_port}"));
+        assert_eq!(headers["host"], format!("{}:{port}", service.hostname));
         assert_eq!(headers["forwarded"], format!("{}:{port}", service.hostname));
         assert_eq!(headers["hop"], false);
         assert_eq!(headers["query"], "q=yes");
-        assert_eq!(
-            headers["origin"],
-            format!("http://localhost:{backend_port}")
-        );
+        assert_eq!(headers["origin"], url);
         let body = vec![5u8; 2 * 1024 * 1024 + 17];
         let received = client
             .post(format!("{url}/echo"))

--- a/crates/preview/tests/transport.rs
+++ b/crates/preview/tests/transport.rs
@@ -1,0 +1,83 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
+use zeron_preview::mux::{self, BoxIo, Connector};
+struct Echo(Arc<AtomicUsize>);
+#[async_trait::async_trait]
+impl Connector for Echo {
+    async fn connect(&self, service: &str) -> anyhow::Result<BoxIo> {
+        anyhow::ensure!(service == "echo", "unknown service");
+        let (client, mut server) = tokio::io::duplex(16384);
+        let active = self.0.clone();
+        active.fetch_add(1, Ordering::SeqCst);
+        tokio::spawn(async move {
+            let mut bytes = [0; 8192];
+            loop {
+                let Ok(length) = server.read(&mut bytes).await else {
+                    break;
+                };
+                if length == 0 {
+                    break;
+                }
+                if server.write_all(&bytes[..length]).await.is_err() {
+                    break;
+                }
+            }
+            active.fetch_sub(1, Ordering::SeqCst);
+        });
+        Ok(Box::new(client))
+    }
+}
+#[tokio::test]
+async fn independent_streams_large_bodies_half_close_and_cancellation() {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        let active = Arc::new(AtomicUsize::new(0));
+        let stop = CancellationToken::new();
+        let mux = mux::local(Arc::new(Echo(active.clone())), stop.clone());
+        assert!(mux.open("unknown", false).await.is_err());
+        let blocked = mux.open("echo", false).await.unwrap();
+        let (blocked_read, mut blocked_write) = tokio::io::split(blocked);
+        let blocked_sender = tokio::spawn(async move {
+            let _ = blocked_write.write_all(&vec![7; 2 * 1024 * 1024]).await;
+        });
+        let mut tasks = Vec::new();
+        for number in 0..8 {
+            let mux = mux.clone();
+            tasks.push(tokio::spawn(async move {
+                let stream = mux.open("echo", number % 2 == 0).await.unwrap();
+                let (mut read, mut write) = tokio::io::split(stream);
+                let bytes = vec![number; 512 * 1024 + 17];
+                let expected = bytes.clone();
+                let send = async move {
+                    write.write_all(&bytes).await.unwrap();
+                    write.shutdown().await.unwrap();
+                };
+                let receive = async move {
+                    let mut output = Vec::new();
+                    read.read_to_end(&mut output).await.unwrap();
+                    assert_eq!(output.len(), expected.len());
+                    assert!(output == expected);
+                };
+                tokio::join!(send, receive);
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        blocked_sender.abort();
+        let _ = blocked_sender.await;
+        drop(blocked_read);
+        while active.load(Ordering::SeqCst) != 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        stop.cancel();
+    })
+    .await
+    .expect("mux stalled");
+}

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -6,11 +6,13 @@
 pub mod agent;
 pub mod entities;
 pub mod motion;
+pub mod preview;
 pub mod view;
 pub mod workspace;
 
 pub use agent::*;
 pub use entities::*;
+pub use preview::*;
 pub use workspace::*;
 
 /// Parse "0.2.12" (tolerating a `-suffix`/`+build` tail on the last part)

--- a/crates/proto/src/preview.rs
+++ b/crates/proto/src/preview.rs
@@ -1,0 +1,60 @@
+//! Device-local discovery metadata and the browser's live preview list.
+use serde::{Deserialize, Serialize};
+
+pub const PREVIEW_PROXY_PORT: u16 = 7331;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewService {
+    /// Persisted identities; neither includes a listening port or process ID.
+    pub id: String,
+    pub project_id: String,
+    pub project_name: String,
+    pub project_cwd: String,
+    pub device_id: String,
+    pub device_name: String,
+    pub hostname: String,
+    pub name: String,
+    pub port: u16,
+    pub pid: u32,
+    pub cwd: String,
+    /// Process creation time, milliseconds since the Unix epoch.
+    pub started_at: u64,
+    pub zeron_owned: bool,
+}
+
+impl PreviewService {
+    pub fn url(&self, proxy_port: u16) -> String {
+        format!("http://{}:{proxy_port}", self.hostname)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewSnapshot {
+    pub services: Vec<PreviewService>,
+    pub proxy_port: u16,
+    pub error: Option<String>,
+    #[serde(default)]
+    pub project_name: Option<String>,
+    #[serde(default)]
+    pub remote: bool,
+}
+
+impl Default for PreviewSnapshot {
+    fn default() -> Self {
+        Self {
+            services: Vec::new(),
+            proxy_port: PREVIEW_PROXY_PORT,
+            error: None,
+            project_name: None,
+            remote: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatchPreviewsParams {
+    pub chat_id: String,
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -33,6 +33,7 @@ pub use server::{serve_connection, serve_ws_listener};
 /// RPC method names — single source of truth for both ends.
 /// Full surface: docs/research/feature-inventory.md §2.
 pub mod methods {
+    pub const WATCH_PREVIEWS: &str = "WatchPreviews";
     pub const LIST_HARNESSES: &str = "ListHarnesses";
     /// Flip a harness's enablement on the target device (Settings → Agents);
     /// replies with the device's fresh `ListHarnesses` catalog.

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -56,6 +56,7 @@ sha2.workspace = true
 thiserror.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
+libc.workspace = true
 objc = "0.2"
 wry = { version = "0.56", default-features = false, features = ["os-webview"] }
 raw-window-handle = "0.6"

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -14,6 +14,10 @@ name = "macos-resource-profile"
 required-features = ["resource-profile"]
 
 [[example]]
+name = "preview-fixture"
+required-features = ["browser-fixture"]
+
+[[example]]
 name = "browser-fixture"
 required-features = ["browser-fixture"]
 

--- a/crates/ui/examples/preview-fixture.rs
+++ b/crates/ui/examples/preview-fixture.rs
@@ -185,7 +185,7 @@ fn main() -> anyhow::Result<()> {
                 if std::env::var_os("ZERON_PREVIEW_AUTO_OPEN").is_some() {
                     // CI sends a real GPUI pointer sequence through hit testing.
                     let position = browser.read_with(cx,|b,_|b.fixture_preview_open_position()).ok_or_else(||anyhow::anyhow!("Open button was not laid out"))?;
-                    window.update(cx,|_,w,cx| {
+                    gpui::AnyWindowHandle::from(window).update(cx,|_,w,cx| {
                         w.dispatch_event(gpui::PlatformInput::MouseDown(gpui::MouseDownEvent { position,button:gpui::MouseButton::Left,click_count:1,..Default::default() }),cx);
                         w.dispatch_event(gpui::PlatformInput::MouseUp(gpui::MouseUpEvent { position,button:gpui::MouseButton::Left,click_count:1,..Default::default() }),cx);
                     })?;

--- a/crates/ui/examples/preview-fixture.rs
+++ b/crates/ui/examples/preview-fixture.rs
@@ -182,6 +182,14 @@ fn main() -> anyhow::Result<()> {
                 let stable = snapshot.services.iter().find(|s|s.name=="Vite").unwrap().url(snapshot.proxy_port);
                 capture(&output,"preview-servers-dark")?;
                 std::fs::write(output.join("ready.txt"),&stable)?;
+                if std::env::var_os("ZERON_PREVIEW_AUTO_OPEN").is_some() {
+                    // CI sends a real GPUI pointer sequence through hit testing.
+                    window.update(cx,|_,w,cx| {
+                        let position = gpui::point(px(985.),px(207.));
+                        w.dispatch_event(gpui::PlatformInput::MouseDown(gpui::MouseDownEvent { position,button:gpui::MouseButton::Left,click_count:1,..Default::default() }),cx);
+                        w.dispatch_event(gpui::PlatformInput::MouseUp(gpui::MouseUpEvent { position,button:gpui::MouseButton::Left,click_count:1,..Default::default() }),cx);
+                    })?;
+                }
                 // A native mouse click on Open drives navigation; the runner can
                 // inspect the initial screenshot before choosing its coordinates.
                 for _ in 0..1200 { if browser.read_with(cx,|b,_|b.page.title=="Fieldnotes" && !b.page.loading) { break; } pause(cx,100).await; }

--- a/crates/ui/examples/preview-fixture.rs
+++ b/crates/ui/examples/preview-fixture.rs
@@ -184,8 +184,8 @@ fn main() -> anyhow::Result<()> {
                 std::fs::write(output.join("ready.txt"),&stable)?;
                 if std::env::var_os("ZERON_PREVIEW_AUTO_OPEN").is_some() {
                     // CI sends a real GPUI pointer sequence through hit testing.
+                    let position = browser.read_with(cx,|b,_|b.fixture_preview_open_position()).ok_or_else(||anyhow::anyhow!("Open button was not laid out"))?;
                     window.update(cx,|_,w,cx| {
-                        let position = gpui::point(px(985.),px(207.));
                         w.dispatch_event(gpui::PlatformInput::MouseDown(gpui::MouseDownEvent { position,button:gpui::MouseButton::Left,click_count:1,..Default::default() }),cx);
                         w.dispatch_event(gpui::PlatformInput::MouseUp(gpui::MouseUpEvent { position,button:gpui::MouseButton::Left,click_count:1,..Default::default() }),cx);
                     })?;
@@ -193,7 +193,8 @@ fn main() -> anyhow::Result<()> {
                 // A native mouse click on Open drives navigation; the runner can
                 // inspect the initial screenshot before choosing its coordinates.
                 for _ in 0..1200 { if browser.read_with(cx,|b,_|b.page.title=="Fieldnotes" && !b.page.loading) { break; } pause(cx,100).await; }
-                anyhow::ensure!(browser.read_with(cx,|b,_|b.page.title=="Fieldnotes"),"Open did not load the preview");
+                if !browser.read_with(cx,|b,_|b.page.title=="Fieldnotes") { capture(&output,"preview-open-failed")?; }
+                anyhow::ensure!(browser.read_with(cx,|b,_|b.page.title=="Fieldnotes"),"Open did not load the preview: {:?}",browser.read_with(cx,|b,_|b.page.clone()));
                 pause(cx,1000).await; capture(&output,"preview-open-stable-url")?;
                 std::fs::write(project.join("index.html"),html.replace("Fieldnotes</title>","Fieldnotes · Live update</title>").replace("Room for your next idea.","Ideas come to life."))?;
                 for _ in 0..150 { if browser.read_with(cx,|b,_|b.page.title=="Fieldnotes · Live update") {break;} pause(cx,100).await; }

--- a/crates/ui/examples/preview-fixture.rs
+++ b/crates/ui/examples/preview-fixture.rs
@@ -1,0 +1,220 @@
+//! Real project process discovery → RPC → native browser → stable proxy / HMR.
+use gpui::{AppContext, AsyncApp, Bounds, WindowBounds, WindowOptions, px, size};
+use std::{path::PathBuf, sync::Arc, time::Duration};
+use zeron_ui::*;
+async fn pause(cx: &mut AsyncApp, ms: u64) {
+    cx.background_executor()
+        .timer(Duration::from_millis(ms))
+        .await;
+}
+fn capture(directory: &std::path::Path, name: &str) -> anyhow::Result<()> {
+    let path = directory.join(format!("{name}.png"));
+    #[cfg(target_os = "macos")]
+    let status = {
+        let app = objc2_app_kit::NSApplication::sharedApplication(
+            objc2::MainThreadMarker::new().unwrap(),
+        );
+        let window = app
+            .keyWindow()
+            .or_else(|| app.mainWindow())
+            .ok_or_else(|| anyhow::anyhow!("fixture window is not available"))?;
+        std::process::Command::new("/usr/sbin/screencapture")
+            .args(["-x", "-o", "-l", &window.windowNumber().to_string()])
+            .arg(&path)
+            .status()?
+    };
+    #[cfg(not(target_os = "macos"))]
+    let status = {
+        let capture_window = std::env::var("ZERON_BROWSER_CAPTURE_WINDOW").ok();
+        let windows = std::process::Command::new("xdotool")
+            .args([
+                "search",
+                "--onlyvisible",
+                "--pid",
+                &std::process::id().to_string(),
+            ])
+            .output()?;
+        let id = capture_window
+            .or_else(|| {
+                String::from_utf8(windows.stdout)
+                    .ok()?
+                    .lines()
+                    .next()
+                    .map(str::to_owned)
+            })
+            .ok_or_else(|| anyhow::anyhow!("fixture window not visible"))?;
+        std::process::Command::new("import")
+            .args(["-window", &id])
+            .arg(&path)
+            .status()?
+    };
+    anyhow::ensure!(status.success(), "screenshot capture failed");
+    Ok(())
+}
+struct Child(std::process::Child);
+impl Drop for Child {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+fn port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().with_env_filter("warn").init();
+    let output = PathBuf::from(std::env::args().nth(1).expect("capture directory"));
+    std::fs::create_dir_all(&output)?;
+    let temp = tempfile::tempdir()?;
+    let project = temp.path().join("fieldnotes");
+    std::fs::create_dir(&project)?;
+    let html = "<!doctype html><meta charset=\"utf-8\"><title>Fieldnotes</title><style>body{background:#f6f5ed;color:#263d31;font:15px system-ui;padding:32px}h1{font:44px Georgia;letter-spacing:-2px}p{line-height:1.7;color:#5d6d63}small{letter-spacing:2px}article{border:1px solid #d6ded3;border-radius:12px;padding:22px;margin:30px 0}a{color:#345d48}</style><small>FIELDNOTES / YOUR WORKSPACE</small><h1>Room for your next idea.</h1><p>A quiet place to collect thoughts, explore possibilities, and bring your work to life.</p><article><b>Make something thoughtful.</b><p>Your project is live beside your conversation. Changes appear as you work.</p></article><a href='/'>Explore your workspace →</a>";
+    std::fs::write(project.join("index.html"), html)?;
+    std::fs::write(
+        project.join("api.js"),
+        "require('http').createServer((q,s)=>{s.setHeader('Content-Type','application/json');s.end(JSON.stringify({status:'ok'}))}).listen(Number(process.argv[2]),'127.0.0.1')",
+    )?;
+    let vite = std::env::var("VITE_BINARY").expect("VITE_BINARY is the installed vite/bin/vite.js");
+    let start = |port: u16| -> anyhow::Result<Child> {
+        Ok(Child(
+            std::process::Command::new("node")
+                .arg(&vite)
+                .args([
+                    "--host",
+                    "127.0.0.1",
+                    "--strictPort",
+                    "--port",
+                    &port.to_string(),
+                ])
+                .current_dir(&project)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::inherit())
+                .spawn()?,
+        ))
+    };
+    let first_port = port();
+    let vite_child = start(first_port)?;
+    let api = Child(
+        std::process::Command::new("node")
+            .arg("api.js")
+            .arg(port().to_string())
+            .current_dir(&project)
+            .spawn()?,
+    );
+    let runtime = tokio::runtime::Runtime::new()?;
+    let core = runtime.block_on(async {
+        zeron_engine::EngineCore::assemble(
+            &temp.path().join("engine"),
+            Arc::new(zeron_engine::default_registry()),
+            zeron_proto::HarnessId::ClaudeCode,
+            None,
+        )
+    })?;
+    core.workspace.create_space(
+        "project",
+        &core.device_id,
+        &project.to_string_lossy(),
+        Some("Fieldnotes".into()),
+        false,
+    )?;
+    core.workspace.create_chat(
+        "preview-fixture",
+        Some("project"),
+        None,
+        None,
+        Some(project.to_string_lossy().into_owned()),
+    )?;
+    core.workspace
+        .rename_chat("preview-fixture", "Build the Fieldnotes workspace")?;
+    let root = project.clone();
+    runtime.block_on(
+        core.previews
+            .start(Arc::new(move || vec![root.clone()]), None),
+    );
+    let ipc_port = port();
+    let _ipc = runtime.block_on(zeron_engine::serve_ipc(ipc_port, core.rpc_service()))?;
+    let data = temp.path().join("ui");
+    std::fs::create_dir(&data)?;
+    let boot = EngineBootConfig {
+        data_dir: data.clone(),
+        ipc_port,
+        edge_url: String::new(),
+        edge_token: None,
+        org_id: None,
+        workos_client_id: None,
+        default_harness: zeron_proto::HarnessId::ClaudeCode,
+    };
+    let handle = runtime.block_on(state::EngineHandle::bootstrap(boot.clone()))?;
+    let chats = core.workspace.read_chats()?;
+    let spaces = core.workspace.read_spaces()?;
+    let device = core.device_id.clone();
+    let failure = Arc::new(std::sync::Mutex::new(None));
+    let result = failure.clone();
+    let second_port = port();
+    let vite_restart = vite.clone();
+    let restart_root = project.clone();
+    gpui_platform::application().with_assets(icons::Assets).run(move |cx| {
+        gpui_tokio::init(cx); gpui_base::init(cx);
+        let settings = settings::UiSettings::default(); settings::init(settings.clone(), data.clone(), cx);
+        let fonts = typography::register_fonts(cx); typography::init(settings.ui_font_family.clone(), settings.ui_font_size, fonts, cx);
+        theme_library::init(data.clone(), cx); appearance::init(appearance::AppearanceMode::Dark, settings.theme_selection, settings.accent, settings.surface, cx);
+        history::init(settings.git_history_columns, settings.git_history_column_widths, settings.git_history_column_order, settings.git_history_author_display, cx);
+        composer::init(cx, settings.composer_send_behavior); terminal::panel::init(cx); app_menus::init(cx);
+        let state = cx.new(|_| { let mut s = state::AppState::new(); s.connection = zeron_proto::view::ConnectionStatus::Ready; s.workspace_scope = Some(zeron_proto::WorkspaceScope::Development); s.local_device_id = Some(device.clone()); s.devices = vec![serde_json::from_value(serde_json::json!({"id":device,"name":"This device","platform":std::env::consts::OS,"lastSeenAt":null})).unwrap()]; s.chats = chats; s.spaces = spaces; s.selected_chat = Some("preview-fixture".into()); s.selected_space = Some("project".into()); s.auto_selected = true; s.chats_synced = true; s.spaces_synced = true; s });
+        let window = cx.open_window(WindowOptions { window_bounds: Some(WindowBounds::Windowed(Bounds::new(gpui::point(px(12.),px(30.)),size(px(1100.),px(760.))))), ..Default::default() }, |_,cx| cx.new(|cx| shell::Shell::new(state.clone(),boot,cx))).unwrap();
+        state.update(cx, |_,cx| cx.notify()); cx.activate(true);
+        cx.spawn(async move |cx| {
+            let run: anyhow::Result<()> = async {
+                let mut vite_child = Some(vite_child); let mut api = Some(api);
+                pause(cx,1200).await;
+                state.update(cx, |s,cx| { s.receive_transcript_frame(zeron_doc::TranscriptFrame::Reset { reset: serde_json::from_value(serde_json::json!([
+                    {"id":"user","role":"user","parts":[{"id":"text","kind":"text","text":"Let’s preview Fieldnotes while we work on the landing page."}],"createdAt":1788900000000_i64,"deviceId":"local"},
+                    {"id":"assistant","role":"assistant","parts":[{"id":"text","kind":"text","text":"The development server is running. Open **Vite** in the browser tab to see your project.\n\nYour preview keeps the same address when the server restarts, and updates appear live as we edit."}],"createdAt":1788900001000_i64,"deviceId":"local","status":"complete"}
+                ])).unwrap() },cx).unwrap(); });
+                let (_, browser) = window.update(cx,|shell,w,cx|shell.fixture_open_browser(None,w,cx))?;
+                browser.update(cx,|browser,cx|browser.watch_previews(handle.clone(),"preview-fixture".into(),cx));
+                for _ in 0..100 { if browser.read_with(cx,|b,_|b.fixture_previews().services.len()==2) { break; } pause(cx,100).await; }
+                let snapshot = browser.read_with(cx,|b,_|b.fixture_previews()); anyhow::ensure!(snapshot.services.len()==2,"did not discover Vite and API: {snapshot:?}");
+                let stable = snapshot.services.iter().find(|s|s.name=="Vite").unwrap().url(snapshot.proxy_port);
+                capture(&output,"preview-servers-dark")?;
+                std::fs::write(output.join("ready.txt"),&stable)?;
+                // A native mouse click on Open drives navigation; the runner can
+                // inspect the initial screenshot before choosing its coordinates.
+                for _ in 0..1200 { if browser.read_with(cx,|b,_|b.page.title=="Fieldnotes" && !b.page.loading) { break; } pause(cx,100).await; }
+                anyhow::ensure!(browser.read_with(cx,|b,_|b.page.title=="Fieldnotes"),"Open did not load the preview");
+                pause(cx,1000).await; capture(&output,"preview-open-stable-url")?;
+                std::fs::write(project.join("index.html"),html.replace("Fieldnotes</title>","Fieldnotes · Live update</title>").replace("Room for your next idea.","Ideas come to life."))?;
+                for _ in 0..150 { if browser.read_with(cx,|b,_|b.page.title=="Fieldnotes · Live update") {break;} pause(cx,100).await; }
+                anyhow::ensure!(browser.read_with(cx,|b,_|b.page.title=="Fieldnotes · Live update"),"Vite HMR did not reload through the stable proxy: {:?}", browser.read_with(cx,|b,_|b.page.clone()));
+                capture(&output,"preview-live-update")?;
+                drop(vite_child.take()); pause(cx,2600).await;
+                anyhow::ensure!(browser.read_with(cx,|b,_|b.fixture_previews().services.len()==1),"stopped Vite remained in discovery");
+                vite_child = Some(Child(std::process::Command::new("node").arg(vite_restart).args(["--host","127.0.0.1","--strictPort","--port",&second_port.to_string()]).current_dir(restart_root).stdout(std::process::Stdio::null()).spawn()?));
+                for _ in 0..150 { if browser.read_with(cx,|b,_|b.fixture_previews().services.iter().any(|s|s.port==second_port)) {break;} pause(cx,100).await; }
+                let after = browser.read_with(cx,|b,_|b.fixture_previews()); anyhow::ensure!(after.services.iter().any(|s|s.port==second_port && s.url(after.proxy_port)==stable),"port change lost stable identity");
+                window.update(cx,|_,w,cx|browser.update(cx,|b,cx|b.navigate(&stable,w,cx)))?; pause(cx,2000).await; capture(&output,"preview-restarted-stable-url")?;
+                drop(api.take()); pause(cx,2600).await;
+                let (_,empty) = window.update(cx,|shell,w,cx|shell.fixture_open_browser(None,w,cx))?;
+                empty.update(cx,|b,cx|b.watch_previews(handle.clone(),"preview-fixture".into(),cx)); pause(cx,800).await;
+                anyhow::ensure!(empty.read_with(cx,|b,_|b.fixture_previews().services.len()==1),"stopped API remained in new tab");
+                capture(&output,"preview-restarted-server-list")?;
+                cx.update(|cx|appearance::set_mode(appearance::AppearanceMode::Light,cx)); pause(cx,700).await; capture(&output,"preview-servers-light")?;
+                std::fs::write(output.join("result.txt"),format!("PASS: live process discovery, native Open click, stable HTTP URL, Vite HMR, disappearance, restart {first_port} → {second_port}, persistent identity, new-tab scoping\n{stable}\n"))?;
+                pause(cx,1500).await; drop(vite_child); Ok(())
+            }.await;
+            if let Err(error) = run { eprintln!("Preview fixture failed: {error:#}"); *result.lock().unwrap()=Some(format!("{error:#}")); }
+            let _ = window.update(cx,|shell,w,cx|shell.fixture_blur_browser(w,cx)); pause(cx,200).await;
+            drop(state); let _ = window.update(cx,|_,w,_|w.remove_window()); pause(cx,100).await;
+            cx.update(|cx|cx.quit());
+        }).detach();
+    });
+    runtime.block_on(core.shutdown());
+    if let Some(error) = failure.lock().unwrap().take() {
+        anyhow::bail!(error);
+    }
+    Ok(())
+}

--- a/crates/ui/src/browser/macos.rs
+++ b/crates/ui/src/browser/macos.rs
@@ -6,7 +6,7 @@ use gpui::{Bounds, Pixels, Window};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::{
-    AnyThread, DefinedClass, MainThreadMarker, MainThreadOnly, class, define_class, msg_send, sel,
+    DefinedClass, MainThreadMarker, MainThreadOnly, class, define_class, msg_send, sel,
 };
 use objc2_app_kit::{
     NSColor, NSEvent, NSEventMask, NSEventModifierFlags, NSView, NSWindowOrderingMode,

--- a/crates/ui/src/browser/macos.rs
+++ b/crates/ui/src/browser/macos.rs
@@ -6,7 +6,7 @@ use gpui::{Bounds, Pixels, Window};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::{
-    AnyThread, DefinedClass, MainThreadMarker, MainThreadOnly, class, define_class, msg_send,
+    AnyThread, DefinedClass, MainThreadMarker, MainThreadOnly, class, define_class, msg_send, sel,
 };
 use objc2_app_kit::{
     NSColor, NSEvent, NSEventMask, NSEventModifierFlags, NSView, NSWindowOrderingMode,
@@ -25,23 +25,112 @@ use std::{
 };
 use wry::{WebView, WebViewBuilderExtMacos, WebViewExtMacOS};
 
+#[derive(Default)]
+struct BrowserStore {
+    store: Option<Retained<objc2_web_kit::WKWebsiteDataStore>>,
+    preview_hosts: std::collections::BTreeSet<String>,
+}
 #[derive(Clone, Default)]
-pub(super) struct BrowserData(Rc<RefCell<Option<Retained<objc2_web_kit::WKWebsiteDataStore>>>>);
+pub(super) struct BrowserData(Rc<RefCell<BrowserStore>>);
 impl BrowserData {
     fn configuration(
         &self,
         mtm: MainThreadMarker,
     ) -> Retained<objc2_web_kit::WKWebViewConfiguration> {
         let mut data = self.0.borrow_mut();
-        let store = data.get_or_insert_with(|| unsafe {
-            objc2_web_kit::WKWebsiteDataStore::nonPersistentDataStore(mtm)
-        });
+        if data.store.is_none() {
+            data.store =
+                Some(unsafe { objc2_web_kit::WKWebsiteDataStore::nonPersistentDataStore(mtm) });
+            if let Err(error) =
+                configure_preview_proxy(data.store.as_ref().unwrap(), &data.preview_hosts)
+            {
+                tracing::warn!(%error, "preview hostname proxy unavailable");
+            }
+        }
         let configuration = unsafe { objc2_web_kit::WKWebViewConfiguration::new(mtm) };
         unsafe {
-            configuration.setWebsiteDataStore(store);
+            configuration.setWebsiteDataStore(data.store.as_ref().unwrap());
         }
         configuration
     }
+    pub(super) fn register_preview(&self, address: &str) {
+        let Ok(url) = url::Url::parse(address) else {
+            return;
+        };
+        let Some(host) = url.host_str() else {
+            return;
+        };
+        if url.scheme() != "http"
+            || url.port() != Some(zeron_proto::PREVIEW_PROXY_PORT)
+            || !host.ends_with(".localhost")
+        {
+            return;
+        }
+        let mut data = self.0.borrow_mut();
+        if !data.preview_hosts.insert(host.into()) {
+            return;
+        }
+        if let Some(store) = &data.store {
+            if let Err(error) = configure_preview_proxy(store, &data.preview_hosts) {
+                tracing::warn!(%error, "preview hostname proxy unavailable");
+            }
+        }
+    }
+}
+
+/// Network.framework objects are Objective-C OS objects. Resolve the newer API
+/// dynamically so older systems can still open ordinary browser tabs. Match
+/// only discovered/opened preview hostnames; other websites retain normal routing.
+fn configure_preview_proxy(
+    store: &objc2_web_kit::WKWebsiteDataStore,
+    hosts: &std::collections::BTreeSet<String>,
+) -> Result<(), String> {
+    if hosts.is_empty() {
+        return Ok(());
+    }
+    use objc2_foundation::{NSArray, NSObject};
+    use std::ffi::{CStr, CString, c_char};
+    unsafe {
+        let supported: bool = msg_send![store, respondsToSelector: sel!(setProxyConfigurations:)];
+        if !supported {
+            return Err("Automatic preview hostnames require macOS 14 or later".into());
+        }
+        static NETWORK: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+        let handle = *NETWORK.get_or_init(|| {
+            libc::dlopen(
+                c"/System/Library/Frameworks/Network.framework/Network".as_ptr(),
+                libc::RTLD_LAZY,
+            ) as usize
+        });
+        let symbol = |name: &CStr| -> Result<*mut std::ffi::c_void, String> {
+            let value = libc::dlsym(handle as *mut _, name.as_ptr());
+            if handle == 0 || value.is_null() {
+                Err("Preview proxy API unavailable".into())
+            } else {
+                Ok(value)
+            }
+        };
+        let endpoint: unsafe extern "C" fn(*const c_char, *const c_char) -> *mut NSObject =
+            std::mem::transmute(symbol(c"nw_endpoint_create_host")?);
+        let proxy: unsafe extern "C" fn(*mut NSObject, *mut NSObject) -> *mut NSObject =
+            std::mem::transmute(symbol(c"nw_proxy_config_create_http_connect")?);
+        let match_domain: unsafe extern "C" fn(*mut NSObject, *const c_char) =
+            std::mem::transmute(symbol(c"nw_proxy_config_add_match_domain")?);
+        let endpoint = Retained::from_raw(endpoint(c"127.0.0.1".as_ptr(), c"7331".as_ptr()))
+            .ok_or("Could not create preview endpoint")?;
+        let config = Retained::from_raw(proxy(
+            Retained::as_ptr(&endpoint) as *mut _,
+            std::ptr::null_mut(),
+        ))
+        .ok_or("Could not create preview proxy")?;
+        for host in hosts {
+            let host = CString::new(host.as_str()).map_err(|_| "Invalid preview hostname")?;
+            match_domain(Retained::as_ptr(&config) as *mut _, host.as_ptr());
+        }
+        let proxies = NSArray::arrayWithObject(&*config);
+        let _: () = msg_send![store, setProxyConfigurations: &*proxies];
+    }
+    Ok(())
 }
 
 type Sender = tokio::sync::mpsc::Sender<NativeEvent>;
@@ -177,6 +266,7 @@ pub(super) struct NativePage(Rc<RefCell<Host>>);
 
 pub(super) struct Host {
     web: WebView,
+    data: BrowserData,
     view: Retained<WKWebView>,
     observer: Retained<Observer>,
     clip: Retained<BrowserClipView>,
@@ -316,6 +406,7 @@ impl NativePage {
             NSEvent::addLocalMonitorForEventsMatchingMask_handler(NSEventMask::KeyDown, &callback)
         };
         Ok(Self(Rc::new(RefCell::new(Host {
+            data: data.clone(),
             web,
             view,
             observer,
@@ -347,6 +438,7 @@ impl NativePage {
     }
     pub fn load(&self, url: &str) -> Result<(), String> {
         let host = self.0.borrow();
+        host.data.register_preview(url);
         host.observer.ivars().error.borrow_mut().take();
         *host.observer.ivars().requested_url.borrow_mut() = Some(url.into());
         host.web.load_url(url).map_err(|e| e.to_string())

--- a/crates/ui/src/browser/mod.rs
+++ b/crates/ui/src/browser/mod.rs
@@ -84,6 +84,9 @@ pub struct BrowserSurface {
     address_edited: bool,
     validation: Option<String>,
     remote: bool,
+    previews: zeron_proto::PreviewSnapshot,
+    previews_loading: bool,
+    previews_task: Option<gpui::Task<()>>,
     presentation: Presentation,
     _input_sub: Subscription,
     #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -152,6 +155,9 @@ impl BrowserSurface {
             address_edited: false,
             validation: None,
             remote,
+            previews: zeron_proto::PreviewSnapshot::default(),
+            previews_loading: true,
+            previews_task: None,
             presentation: Presentation::Hidden,
             _input_sub: input_sub,
             #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -207,6 +213,64 @@ impl BrowserSurface {
             native.present(presentation);
         }
         cx.notify();
+    }
+
+    #[cfg(feature = "browser-fixture")]
+    pub fn fixture_previews(&self) -> zeron_proto::PreviewSnapshot {
+        self.previews.clone()
+    }
+
+    /// The daemon resolves the session's current cwd for every update, so a
+    /// checkout change cannot leave this tab discovering the previous project.
+    pub fn watch_previews(
+        &mut self,
+        handle: crate::state::EngineHandle,
+        chat_id: String,
+        cx: &mut Context<Self>,
+    ) {
+        self.previews_task = Some(cx.spawn(async move |this, cx| {
+            loop {
+                let subscription = handle
+                    .client()
+                    .subscribe(
+                        zeron_rpc::methods::WATCH_PREVIEWS,
+                        serde_json::json!({"chatId": chat_id}),
+                    )
+                    .await;
+                if let Ok(mut updates) = subscription {
+                    while let Some(value) = updates.recv().await {
+                        if let Ok(snapshot) =
+                            serde_json::from_value::<zeron_proto::PreviewSnapshot>(value)
+                        {
+                            if this
+                                .update(cx, |this, cx| {
+                                    this.previews = snapshot;
+                                    this.previews_loading = false;
+                                    cx.notify();
+                                })
+                                .is_err()
+                            {
+                                return;
+                            }
+                        }
+                    }
+                }
+                if this
+                    .update(cx, |this, cx| {
+                        this.previews.services.clear();
+                        this.previews.error = Some("Connecting to preview discovery…".into());
+                        this.previews_loading = false;
+                        cx.notify();
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+                cx.background_executor()
+                    .timer(std::time::Duration::from_secs(2))
+                    .await;
+            }
+        }));
     }
 
     pub fn navigate(&mut self, input: &str, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/ui/src/browser/mod.rs
+++ b/crates/ui/src/browser/mod.rs
@@ -244,6 +244,12 @@ impl BrowserSurface {
                         {
                             if this
                                 .update(cx, |this, cx| {
+                                    #[cfg(target_os = "macos")]
+                                    for service in &snapshot.services {
+                                        this.context
+                                            .data
+                                            .register_preview(&service.url(snapshot.proxy_port));
+                                    }
                                     this.previews = snapshot;
                                     this.previews_loading = false;
                                     cx.notify();

--- a/crates/ui/src/browser/mod.rs
+++ b/crates/ui/src/browser/mod.rs
@@ -87,6 +87,8 @@ pub struct BrowserSurface {
     previews: zeron_proto::PreviewSnapshot,
     previews_loading: bool,
     previews_task: Option<gpui::Task<()>>,
+    #[cfg(feature = "browser-fixture")]
+    fixture_preview_open: std::rc::Rc<std::cell::Cell<Option<gpui::Point<gpui::Pixels>>>>,
     presentation: Presentation,
     _input_sub: Subscription,
     #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -158,6 +160,8 @@ impl BrowserSurface {
             previews: zeron_proto::PreviewSnapshot::default(),
             previews_loading: true,
             previews_task: None,
+            #[cfg(feature = "browser-fixture")]
+            fixture_preview_open: Default::default(),
             presentation: Presentation::Hidden,
             _input_sub: input_sub,
             #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -218,6 +222,10 @@ impl BrowserSurface {
     #[cfg(feature = "browser-fixture")]
     pub fn fixture_previews(&self) -> zeron_proto::PreviewSnapshot {
         self.previews.clone()
+    }
+    #[cfg(feature = "browser-fixture")]
+    pub fn fixture_preview_open_position(&self) -> Option<gpui::Point<gpui::Pixels>> {
+        self.fixture_preview_open.get()
     }
 
     /// The daemon resolves the session's current cwd for every update, so a

--- a/crates/ui/src/browser/view.rs
+++ b/crates/ui/src/browser/view.rs
@@ -158,12 +158,6 @@ impl BrowserSurface {
                             }))
                     })
                     .child(
-                        icons::icon(icons::GLOBE)
-                            .size(px(15.0))
-                            .flex_none()
-                            .text_color(theme.text_muted),
-                    )
-                    .child(
                         div()
                             .flex_1()
                             .min_w_0()

--- a/crates/ui/src/browser/view.rs
+++ b/crates/ui/src/browser/view.rs
@@ -101,7 +101,188 @@ impl BrowserSurface {
         cx.stop_propagation();
     }
 
+    fn preview_body(&self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+        let snapshot = &self.previews;
+        let available = snapshot.error.is_none();
+        let title = snapshot
+            .project_name
+            .clone()
+            .unwrap_or_else(|| "Local previews".into());
+        let subtitle = if snapshot.remote {
+            "Running on your device"
+        } else {
+            "Running locally"
+        };
+        let mut content = div()
+            .w_full()
+            .max_w(px(380.0))
+            .flex()
+            .flex_col()
+            .gap(px(16.0))
+            .child(
+                div().flex().flex_col().gap(px(6.0)).child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(px(8.0))
+                        .child(
+                            icons::icon(icons::GLOBE)
+                                .size(px(18.0))
+                                .text_color(theme.text_muted),
+                        )
+                        .child(
+                            div()
+                                .text_size(crate::typography::ui_rems(15.0))
+                                .font_weight(gpui::FontWeight::MEDIUM)
+                                .text_color(theme.text)
+                                .truncate()
+                                .child(title),
+                        ),
+                ),
+            )
+            .child(
+                div()
+                    .text_size(crate::typography::ui_rems(11.0))
+                    .text_color(theme.text_muted)
+                    .child(subtitle),
+            );
+        for service in &snapshot.services {
+            let url = service.url(snapshot.proxy_port);
+            let label = if snapshot.remote {
+                format!("{} · localhost:{}", service.device_name, service.port)
+            } else {
+                format!("localhost:{}", service.port)
+            };
+            content = content.child(
+                div()
+                    .w_full()
+                    .p(px(12.0))
+                    .rounded(px(8.0))
+                    .border_1()
+                    .border_color(theme.border)
+                    .bg(theme.surface_raised.opacity(0.5))
+                    .flex()
+                    .items_center()
+                    .gap(px(12.0))
+                    .child(
+                        div()
+                            .size(px(6.0))
+                            .flex_shrink_0()
+                            .rounded_full()
+                            .bg(theme.success),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .flex()
+                            .flex_col()
+                            .gap(px(4.0))
+                            .child(
+                                div()
+                                    .text_size(crate::typography::ui_rems(12.0))
+                                    .font_weight(gpui::FontWeight::MEDIUM)
+                                    .text_color(theme.text)
+                                    .truncate()
+                                    .child(service.name.clone()),
+                            )
+                            .child(
+                                div()
+                                    .text_size(crate::typography::ui_rems(11.0))
+                                    .text_color(theme.text_muted)
+                                    .truncate()
+                                    .child(label),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .id(gpui::SharedString::from(format!(
+                                "open-preview-{}",
+                                service.id
+                            )))
+                            .h(px(28.0))
+                            .px(px(12.0))
+                            .flex_shrink_0()
+                            .rounded(px(6.0))
+                            .border_1()
+                            .border_color(theme.border)
+                            .bg(theme.surface_raised)
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .text_size(crate::typography::ui_rems(12.0))
+                            .text_color(theme.text)
+                            .role(gpui::Role::Button)
+                            .aria_label(format!("Open {} preview", service.name))
+                            .when(available, |el| {
+                                el.cursor_pointer()
+                                    .hover(|style| style.bg(crate::theme::wash(0.10)))
+                                    .on_click(cx.listener(move |this, _, window, cx| {
+                                        this.navigate(&url, window, cx)
+                                    }))
+                            })
+                            .when(!available, |el| el.opacity(0.4))
+                            .child("Open"),
+                    ),
+            );
+        }
+        if snapshot.services.is_empty() {
+            let message = if self.previews_loading {
+                "Looking for dev servers…"
+            } else if snapshot.remote {
+                "Start a dev server in this project on your other device. Its preview will appear here when that device is online."
+            } else {
+                "Start a dev server in this project. It will appear here automatically, ready to open."
+            };
+            content = content.child(
+                div()
+                    .p(px(16.0))
+                    .rounded(px(8.0))
+                    .border_1()
+                    .border_color(theme.border)
+                    .text_size(crate::typography::ui_rems(12.0))
+                    .line_height(px(19.0))
+                    .text_color(theme.text_muted)
+                    .child(message),
+            );
+        }
+        if let Some(error) = &snapshot.error {
+            content = content.child(
+                div()
+                    .text_size(crate::typography::ui_rems(11.0))
+                    .line_height(px(17.0))
+                    .text_color(theme.text_muted)
+                    .child(error.clone()),
+            );
+        }
+        content = content.child(
+            div()
+                .id("preview-enter-address")
+                .mt(px(4.0))
+                .text_size(crate::typography::ui_rems(11.0))
+                .text_color(theme.text_muted)
+                .cursor_pointer()
+                .role(gpui::Role::Button)
+                .aria_label("Enter a website address")
+                .on_click(cx.listener(|this, _, window, cx| this.focus_address(window, cx)))
+                .child("Or enter a website address above"),
+        );
+        div()
+            .id("browser-previews")
+            .size_full()
+            .overflow_y_scroll()
+            .p(px(24.0))
+            .flex()
+            .flex_col()
+            .items_center()
+            .child(content)
+            .into_any_element()
+    }
+
     fn empty_body(&self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+        if self.page.url.is_none() && self.previews_task.is_some() {
+            return self.preview_body(theme, cx);
+        }
         let external = !cfg!(any(target_os = "macos", target_os = "linux"));
         let has_error = self.page.error.is_some();
         let title = if has_error {
@@ -447,7 +628,12 @@ impl Render for BrowserSurface {
                 .url
                 .as_deref()
                 .and_then(|s| url::Url::parse(s).ok())
-                .is_some_and(|u| super::model::loopback(&u));
+                .is_some_and(|u| {
+                    super::model::loopback(&u)
+                        && !(u.port() == Some(zeron_proto::PREVIEW_PROXY_PORT)
+                            && u.host_str()
+                                .is_some_and(|host| host.ends_with(".localhost")))
+                });
         div().id("browser-surface").size_full().flex().flex_col().track_focus(&self.focus)
             .key_context("Browser").on_key_down(cx.listener(Self::key_down))
             .on_key_up(cx.listener(|this,event: &gpui::KeyUpEvent,w,cx| {
@@ -466,7 +652,7 @@ impl Render for BrowserSurface {
             .when_some(self.validation.clone(), |el, message| el.child(div().px(px(12.0)).py(px(8.0)).text_size(crate::typography::ui_rems(11.0)).text_color(theme.danger).child(message)))
             .when(remote_loopback, |el| el.child(div().px(px(12.0)).py(px(8.0)).border_b_1().border_color(theme.border)
                 .text_size(crate::typography::ui_rems(11.0)).text_color(theme.text_muted)
-                .child("Localhost opens on this device. For your remote session, use a reachable server address.")))
+                .child("Localhost opens on this device. Open a detected preview from a new tab to reach your other device.")))
             .child(body)
             .when(external, |el| el.child(div().h(px(26.0)).px(px(10.0)).flex().items_center().gap(px(5.0)).border_t_1().border_color(theme.border)
                 .text_size(crate::typography::ui_rems(10.0)).text_color(theme.text_faint)

--- a/crates/ui/src/browser/view.rs
+++ b/crates/ui/src/browser/view.rs
@@ -196,6 +196,20 @@ impl BrowserSurface {
                     )
                     .child(
                         div()
+                            .map(|el| {
+                                #[cfg(feature = "browser-fixture")]
+                                if snapshot
+                                    .services
+                                    .first()
+                                    .is_some_and(|first| first.id == service.id)
+                                {
+                                    let position = self.fixture_preview_open.clone();
+                                    return el.on_children_prepainted(move |bounds, _, _| {
+                                        position.set(bounds.first().map(|bounds| bounds.center()));
+                                    });
+                                }
+                                el
+                            })
                             .id(gpui::SharedString::from(format!(
                                 "open-preview-{}",
                                 service.id

--- a/crates/ui/src/browser/view.rs
+++ b/crates/ui/src/browser/view.rs
@@ -104,10 +104,6 @@ impl BrowserSurface {
     fn preview_body(&self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
         let snapshot = &self.previews;
         let available = snapshot.error.is_none();
-        let title = snapshot
-            .project_name
-            .clone()
-            .unwrap_or_else(|| "Local previews".into());
         let subtitle = if snapshot.remote {
             "Running on your device"
         } else {
@@ -115,39 +111,23 @@ impl BrowserSurface {
         };
         let mut content = div()
             .w_full()
-            .max_w(px(380.0))
+            .max_w(px(280.0))
+            .flex_shrink_0()
+            .my_auto()
             .flex()
             .flex_col()
-            .gap(px(16.0))
-            .child(
-                div().flex().flex_col().gap(px(6.0)).child(
-                    div()
-                        .flex()
-                        .items_center()
-                        .gap(px(8.0))
-                        .child(
-                            icons::icon(icons::GLOBE)
-                                .size(px(18.0))
-                                .text_color(theme.text_muted),
-                        )
-                        .child(
-                            div()
-                                .text_size(crate::typography::ui_rems(15.0))
-                                .font_weight(gpui::FontWeight::MEDIUM)
-                                .text_color(theme.text)
-                                .truncate()
-                                .child(title),
-                        ),
-                ),
-            )
+            .gap(px(8.0))
             .child(
                 div()
-                    .text_size(crate::typography::ui_rems(11.0))
+                    .mb(px(4.0))
+                    .text_size(crate::typography::ui_rems(12.0))
                     .text_color(theme.text_muted)
                     .child(subtitle),
             );
         for service in &snapshot.services {
             let url = service.url(snapshot.proxy_port);
+            let row_url = url.clone();
+            let border_strong = theme.border_strong;
             let label = if snapshot.remote {
                 format!("{} · localhost:{}", service.device_name, service.port)
             } else {
@@ -155,21 +135,33 @@ impl BrowserSurface {
             };
             content = content.child(
                 div()
+                    .id(gpui::SharedString::from(format!("preview-row-{}", service.id)))
                     .w_full()
-                    .p(px(12.0))
-                    .rounded(px(8.0))
+                    .h(px(56.0))
+                    .px(px(14.0))
+                    .rounded(px(10.0))
                     .border_1()
                     .border_color(theme.border)
-                    .bg(theme.surface_raised.opacity(0.5))
+                    .bg(crate::theme::ink(0.02))
                     .flex()
                     .items_center()
-                    .gap(px(12.0))
+                    .gap(px(10.0))
+                    .when(available, |el| {
+                        el.cursor_pointer()
+                            .hover(move |style| {
+                                style
+                                    .bg(crate::theme::ink(0.05))
+                                    .border_color(border_strong)
+                            })
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                this.navigate(&row_url, window, cx)
+                            }))
+                    })
                     .child(
-                        div()
-                            .size(px(6.0))
-                            .flex_shrink_0()
-                            .rounded_full()
-                            .bg(theme.success),
+                        icons::icon(icons::GLOBE)
+                            .size(px(15.0))
+                            .flex_none()
+                            .text_color(theme.text_muted),
                     )
                     .child(
                         div()
@@ -177,10 +169,10 @@ impl BrowserSurface {
                             .min_w_0()
                             .flex()
                             .flex_col()
-                            .gap(px(4.0))
+                            .gap(px(2.0))
                             .child(
                                 div()
-                                    .text_size(crate::typography::ui_rems(12.0))
+                                    .text_size(crate::typography::ui_rems(13.0))
                                     .font_weight(gpui::FontWeight::MEDIUM)
                                     .text_color(theme.text)
                                     .truncate()
@@ -215,23 +207,21 @@ impl BrowserSurface {
                                 service.id
                             )))
                             .h(px(28.0))
-                            .px(px(12.0))
+                            .px(px(6.0))
                             .flex_shrink_0()
                             .rounded(px(6.0))
-                            .border_1()
-                            .border_color(theme.border)
-                            .bg(theme.surface_raised)
                             .flex()
                             .items_center()
                             .justify_center()
                             .text_size(crate::typography::ui_rems(12.0))
-                            .text_color(theme.text)
+                            .text_color(theme.text_muted)
                             .role(gpui::Role::Button)
                             .aria_label(format!("Open {} preview", service.name))
                             .when(available, |el| {
                                 el.cursor_pointer()
-                                    .hover(|style| style.bg(crate::theme::wash(0.10)))
+                                    .hover(|style| style.bg(crate::theme::ink(0.05)))
                                     .on_click(cx.listener(move |this, _, window, cx| {
+                                        cx.stop_propagation();
                                         this.navigate(&url, window, cx)
                                     }))
                             })
@@ -272,20 +262,20 @@ impl BrowserSurface {
         content = content.child(
             div()
                 .id("preview-enter-address")
-                .mt(px(4.0))
+                .mt(px(8.0))
                 .text_size(crate::typography::ui_rems(11.0))
                 .text_color(theme.text_muted)
                 .cursor_pointer()
                 .role(gpui::Role::Button)
                 .aria_label("Enter a website address")
                 .on_click(cx.listener(|this, _, window, cx| this.focus_address(window, cx)))
-                .child("Or enter a website address above"),
+                .child("Or enter a website address"),
         );
         div()
             .id("browser-previews")
             .size_full()
             .overflow_y_scroll()
-            .p(px(24.0))
+            .p(px(16.0))
             .flex()
             .flex_col()
             .items_center()

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -2299,6 +2299,10 @@ impl Shell {
         let browser = cx.new(|cx| {
             crate::browser::BrowserSurface::new(self.browser_context.clone(), remote, window, cx)
         });
+        if let Some(handle) = self.state.read(cx).engine().cloned() {
+            let chat_id = self.active_chat.clone();
+            browser.update(cx, |browser, cx| browser.watch_previews(handle, chat_id, cx));
+        }
         let owner = key.clone();
         let sub = cx.subscribe_in(&browser, window, move |this, _, event, window, cx| {
             match event {

--- a/docs/preview-networking.md
+++ b/docs/preview-networking.md
@@ -40,6 +40,12 @@ checkout therefore changes the list without copying paths or entering ports.
 
 ## HTTP and stream transport
 
+On macOS 14 and later, WebKit receives a per-domain HTTP CONNECT configuration
+for preview hostnames, avoiding older macOS DNS behavior without system changes.
+The CONNECT endpoint admits only known preview names at the proxy port, and its
+tunnels share bounded limits and account cancellation. Other website traffic
+retains normal routing.
+
 The loopback proxy validates the Host against its catalog, then opens an opaque
 service ID through a transport-independent multiplexer. Locally, framed streams
 travel over a socket pair. Remotely, the identical frames travel over one ordered,
@@ -56,8 +62,8 @@ END half-closes; CANCEL tears down both directions. Graceful shutdown drains the
 last buffered bytes, whereas dropping an unfinished request cancels promptly.
 
 Hyper streams request and response bodies. The proxy removes hop-by-hop headers,
-sets the upstream Host, preserves the original hostname in X-Forwarded-Host,
-and rewrites same-preview Origin and localhost redirects. Set-Cookie and other
+preserves Host and Origin together (including Next.js Server Actions), sets
+X-Forwarded-Host, and rewrites absolute localhost redirects. Set-Cookie and other
 end-to-end headers remain intact. WebSocket upgrades retain their byte stream,
 subprotocol and close handshake, allowing Vite HMR through the same URL.
 
@@ -102,3 +108,8 @@ an isolated project, discovers them through daemon RPC and waits for a native
 click on Vite's Open button. It then verifies HMR, disappearance and a port-change
 restart while capturing the native UI. Screenshots/videos belong in PR user
 attachments, not the repository.
+
+The opt-in `coordinator` integration test connects two authenticated clients to a
+local Worker, advertises a service, pairs over SDP/ICE, then transfers a 4 MiB
+HTTP response through the remote hostname. Run it with
+`ZERON_PREVIEW_TEST_EDGE=http://127.0.0.1:27641 cargo test -p zeron-preview --test coordinator -- --ignored`.

--- a/docs/preview-networking.md
+++ b/docs/preview-networking.md
@@ -1,0 +1,104 @@
+# Project previews
+
+Run an HTTP development server in a project and open a Browser tab in that
+session. The empty tab lists its running services. **Open** navigates to
+`http://<device>.<project>.localhost:7331`; additional services receive persistent
+names such as `<device>.<project>-api.localhost:7331`.
+
+The daemon owns this listener, discovery and peer connections. Closing a browser
+tab does not stop discovery or change an address. Account teardown cancels the
+proxy, discovery, signaling, and existing peer streams before the next profile
+starts. A busy proxy port produces an inline error instead of changing the URL.
+
+## Discovery and identities
+
+On Linux, the scanner joins the current user's `/proc` process cwd, ancestry,
+creation time and socket descriptors to listening TCP sockets. On macOS it uses
+`lsof` and `ps` for equivalent metadata. Only loopback-reachable listeners whose
+cwd belongs to a known local project are probed. The deepest matching project
+wins. Unrelated listeners and non-HTTP services are excluded. HTTP probes are
+bounded and run every two seconds, using HEAD and accepting valid HTTP status
+responses (including authentication and application errors).
+
+Zeron terminal/task/agent descendants are marked as Zeron-owned. Framework
+commands identify Vite, Next.js, Astro, Miniflare and Node servers; otherwise the
+list uses a generic HTTP label. Before a local backend connection, the daemon
+rechecks the listener's process identity and cwd to reject stale port reuse.
+
+The profile's `previews.json` stores project and service IDs and hostname labels
+separately from observed PIDs and ports. Command identities omit common port
+options. Device-name collisions get persisted suffixes. The first service keeps
+the project hostname; additional services get descriptive suffixes. Two
+indistinguishable instances of the same command in the same cwd get separate
+slots; their individual identities cannot be inferred across simultaneous
+restarts without additional application-provided identity.
+
+`WatchPreviews` resolves the session's current cwd on each catalog or workspace
+change. On the viewing device it selects either the local services or the
+advertised services for the session's owning device. Changing the active
+checkout therefore changes the list without copying paths or entering ports.
+
+## HTTP and stream transport
+
+The loopback proxy validates the Host against its catalog, then opens an opaque
+service ID through a transport-independent multiplexer. Locally, framed streams
+travel over a socket pair. Remotely, the identical frames travel over one ordered,
+reliable WebRTC DataChannel. Remote metadata never authorizes an arbitrary TCP
+address: the hosting device resolves only its own live service IDs.
+
+Frames have a one-byte kind, a big-endian 32-bit stream ID, and a bounded payload.
+Kinds are OPEN, DATA, END, CANCEL, WS_OPEN, WS_DATA, WS_CLOSE, READY and CREDIT.
+Socket transport prefixes frames with a big-endian 32-bit length; DataChannel
+messages already provide framing. Peers allocate opposite stream-ID parity.
+DATA payloads are at most 8 KiB. Each stream has a 64 KiB receive window; connection
+queues and the SCTP send buffer are bounded. Up to 64 streams share a connection.
+END half-closes; CANCEL tears down both directions. Graceful shutdown drains the
+last buffered bytes, whereas dropping an unfinished request cancels promptly.
+
+Hyper streams request and response bodies. The proxy removes hop-by-hop headers,
+sets the upstream Host, preserves the original hostname in X-Forwarded-Host,
+and rewrites same-preview Origin and localhost redirects. Set-Cookie and other
+end-to-end headers remain intact. WebSocket upgrades retain their byte stream,
+subprotocol and close handshake, allowing Vite HMR through the same URL.
+
+## Presence and P2P
+
+The Worker authenticates the existing access token, verifies the organization
+claim, and derives a PreviewRoom name from the verified organization and user.
+Clients cannot select another user's room. The coordinator stamps device sender
+identity and accepts only bounded service catalogs and pairing SDP. Gathered ICE
+candidates are included in SDP, along with the DTLS fingerprint. Binary frames
+and arbitrary proxy protocol messages are rejected.
+
+Presence has a heartbeat lease, hibernation-safe catalog storage and periodic
+credential refresh. Disconnects clear advertised routes and peer connections.
+Only the lexicographically lower device creates offers, avoiding simultaneous
+offer collisions. DataChannels are opened lazily when a preview is requested.
+DTLS authenticates the fingerprint exchanged through the authenticated signaling
+connection. Application requests, response bodies and WebSocket messages never
+pass through the Durable Object.
+
+The initial transport uses host candidates and public STUN, without a TURN
+service or a cloud byte-relay fallback. Networks that prohibit direct ICE
+connectivity return a bounded connection error. Deploy the Worker with its v4
+PreviewRoom migration to enable cross-device coordination; local previews work
+independently of edge availability. macOS and Linux currently provide discovery.
+
+## Validation
+
+`cargo test --locked -p zeron-preview` covers real process/cwd isolation, non-HTTP
+exclusion, live disappearance, persistent aliases, port changes, concurrent
+streams, slow readers, cancellation, large bodies, streaming HTTP headers and
+redirects, WebSocket traffic, and a real WebRTC pair in both directions.
+
+`npm --prefix edge test` includes real workerd tests for room isolation,
+organization authorization, stamped signaling, disconnect cleanup and binary
+traffic rejection. CI runs networking tests on Linux and macOS.
+
+Build `cargo build -p zeron-ui --example preview-fixture --features browser-fixture`.
+Run the fixture with an output directory, an available display and `VITE_BINARY`
+pointing to an installed `vite/bin/vite.js`. It starts real Vite/API processes in
+an isolated project, discovers them through daemon RPC and waits for a native
+click on Vite's Open button. It then verifies HMR, disappearance and a port-change
+restart while capturing the native UI. Screenshots/videos belong in PR user
+attachments, not the repository.

--- a/edge/src/env.ts
+++ b/edge/src/env.ts
@@ -1,6 +1,7 @@
 export interface Env {
   SESSION_ROOMS: DurableObjectNamespace;
   DEVICE_ROOMS: DurableObjectNamespace;
+  PREVIEW_ROOMS: DurableObjectNamespace;
   /** Per-user workspace registries (`reg1/{orgId}/{userId}`) — the row-table
    * replacement for the Loro workspace doc (docs/registry-sync.md). */
   REGISTRY_ROOMS: DurableObjectNamespace;

--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -40,12 +40,14 @@ import { authenticate } from "./auth";
 import { handleAuthRoute } from "./auth-routes";
 import { AUTH_USER_HEADER, ROOM_KIND_HEADER, type Env } from "./env";
 import { SessionRoom } from "./session-room";
+import { previewRoute } from "./preview-route";
+import { PreviewRoom } from "./preview-room";
 import { DeviceRoom } from "./device-room";
 import { RegistryRoom } from "./registry-room";
 import { ChatRoom } from "./chat-room";
 import installSh from "./install.sh";
 
-export { SessionRoom, DeviceRoom, RegistryRoom, ChatRoom };
+export { SessionRoom, DeviceRoom, RegistryRoom, ChatRoom, PreviewRoom };
 
 const ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
 
@@ -158,6 +160,9 @@ export default {
 
     const auth = await authenticate(env, request);
     if (!auth) return json({ error: "unauthenticated" }, 401);
+
+    const preview = previewRoute(request, env, auth);
+    if (preview) return preview;
 
     // ── session rooms ───────────────────────────────────────────────────────
     if (parts[0] === "session" && parts[1] && ID_RE.test(parts[1]) && parts[2] === "ws") {

--- a/edge/src/preview-room.test.ts
+++ b/edge/src/preview-room.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { previewCatalog, previewSignal } from "./preview-room";
+const service = { id: "service", projectId: "project", projectName: "app", projectCwd: "/work/app", deviceId: "device", deviceName: "Laptop", hostname: "laptop.app.localhost", name: "Vite", cwd: "/work/app", port: 5173, pid: 123, startedAt: 1000, zeronOwned: true };
+describe("preview coordinator admission", () => {
+  it("accepts bounded service metadata and strips extra fields", () => {
+    expect(previewCatalog([{ ...service, body: "not application traffic" }], "device")).toEqual([service]);
+    for (const change of [{ deviceId: "spoofed" }, { hostname: "example.com" }, { hostname: "x.y.localhost.evil.test" }, { port: 0 }, { pid: -1 }, { cwd: "x".repeat(4097) }]) expect(previewCatalog([{ ...service, ...change }], "device")).toBeUndefined();
+    expect(previewCatalog([service, service], "device")).toBeUndefined();
+    expect(previewCatalog(Array(257).fill(service), "device")).toBeUndefined();
+  });
+  it("only relays pairing and authenticated SDP/ICE, never proxy frames", () => {
+    const sdp = "v=0\r\na=fingerprint:sha-256 AA:BB\r\na=candidate:1 1 udp 1 127.0.0.1 1234 typ host\r\n";
+    expect(previewSignal({ kind: "offer", session: "pair", sdp: { type: "offer", sdp }, body: "ignored" })).toEqual({ kind: "offer", session: "pair", sdp: { type: "offer", sdp } });
+    expect(previewSignal({ kind: "connect", session: "pair" })).toEqual({ kind: "connect", session: "pair" });
+    for (const value of [{ kind: "DATA", session: "pair" }, { kind: "offer", session: "pair", sdp: { type: "answer", sdp } }, { kind: "offer", session: "pair", sdp: { type: "offer", sdp: "HTTP/1.1 200 OK" } }]) expect(previewSignal(value)).toBeUndefined();
+  });
+});

--- a/edge/src/preview-room.ts
+++ b/edge/src/preview-room.ts
@@ -1,0 +1,121 @@
+import { AUTH_USER_HEADER, type Env } from "./env";
+
+const ID = /^[A-Za-z0-9_-]{1,128}$/;
+const HOST = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.localhost$/;
+const MAX_MESSAGE = 1024 * 1024;
+type Attachment = { device: string; connection: string; connected: number; lastSeen: number; budgetAt: number; messages: number };
+type Service = Record<string, string | number | boolean>;
+
+export function previewCatalog(value: unknown, device: string): Service[] | undefined {
+  if (!Array.isArray(value) || value.length > 256) return;
+  const ids = new Set<string>();
+  const output: Service[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return;
+    const s = item as Record<string, unknown>;
+    const strings = ["id", "projectId", "projectName", "projectCwd", "deviceId", "deviceName", "hostname", "name", "cwd"];
+    if (!strings.every(k => typeof s[k] === "string" && (s[k] as string).length <= (k === "cwd" || k === "projectCwd" ? 4096 : 128))) return;
+    if (s.deviceId !== device || !ID.test(s.id as string) || ids.has(s.id as string) || !HOST.test(s.hostname as string)) return;
+    if (!Number.isInteger(s.port) || (s.port as number) < 1 || (s.port as number) > 65535 || !Number.isSafeInteger(s.pid) || (s.pid as number) < 1 || !Number.isSafeInteger(s.startedAt) || (s.startedAt as number) < 0 || typeof s.zeronOwned !== "boolean") return;
+    ids.add(s.id as string);
+    const clean: Service = {};
+    for (const key of [...strings, "port", "pid", "startedAt", "zeronOwned"]) clean[key] = s[key] as string | number | boolean;
+    output.push(clean);
+  }
+  return output;
+}
+export function previewSignal(value: unknown): object | undefined {
+  if (!value || typeof value !== "object") return;
+  const s = value as Record<string, unknown>;
+  if (typeof s.session !== "string" || !ID.test(s.session)) return;
+  if (s.kind === "connect" && s.sdp === undefined) return { kind: "connect", session: s.session };
+  if ((s.kind !== "offer" && s.kind !== "answer") || !s.sdp || typeof s.sdp !== "object") return;
+  const desc = s.sdp as Record<string, unknown>;
+  if (desc.type !== s.kind || typeof desc.sdp !== "string" || desc.sdp.length > 65536 || !desc.sdp.startsWith("v=0\r\n") || !desc.sdp.includes("a=fingerprint:sha-256 ")) return;
+  return { kind: s.kind, session: s.session, sdp: { type: desc.type, sdp: desc.sdp } };
+}
+
+/** One authenticated user's devices in one organization. Only presence, service
+ * metadata and SDP/ICE coordination live here; binary preview frames are rejected. */
+export class PreviewRoom {
+  constructor(private state: DurableObjectState, _env: Env) {
+    state.storage.sql.exec("CREATE TABLE IF NOT EXISTS preview_catalog (device TEXT PRIMARY KEY, services TEXT NOT NULL)");
+    state.setWebSocketAutoResponse(new WebSocketRequestResponsePair("ping", "pong"));
+  }
+  async fetch(request: Request): Promise<Response> {
+    if (!request.headers.get(AUTH_USER_HEADER)) return new Response("Unauthorized", { status: 401 });
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") return new Response("Expected WebSocket", { status: 426 });
+    const device = new URL(request.url).searchParams.get("device") ?? "";
+    if (!ID.test(device)) return new Response("Invalid device", { status: 400 });
+    const existing = this.sockets().find(ws => this.info(ws).device === device);
+    if (!existing && this.sockets().length >= 16) return new Response("Device limit reached", { status: 429 });
+    if (existing) { existing.serializeAttachment({ ...this.info(existing), device: "" }); existing.close(1000, "Device reconnected"); }
+    this.state.storage.sql.exec("DELETE FROM preview_catalog WHERE device = ?", device);
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    this.state.acceptWebSocket(server);
+    const now = Date.now();
+    server.serializeAttachment({ device, connection: crypto.randomUUID(), connected: now, lastSeen: now, budgetAt: now, messages: 0 } satisfies Attachment);
+    this.broadcast({ type: "catalog", device, services: [] }, server);
+    for (const other of this.sockets()) {
+      const peer = this.info(other).device;
+      if (peer && peer !== device) this.send(server, { type: "catalog", device: peer, services: this.catalog(peer) });
+    }
+    await this.state.storage.setAlarm(now + 30000);
+    return new Response(null, { status: 101, webSocket: client });
+  }
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const info = this.info(ws);
+    if (!info.device) return;
+    if (typeof message !== "string" || new TextEncoder().encode(message).byteLength > MAX_MESSAGE) { ws.close(1008, "Signaling messages only"); return; }
+    const now = Date.now();
+    if (now - info.budgetAt > 10000) { info.budgetAt = now; info.messages = 0; }
+    if (++info.messages > 120) { ws.close(1008, "Signaling rate exceeded"); return; }
+    info.lastSeen = now; ws.serializeAttachment(info);
+    let value: Record<string, unknown>;
+    try { value = JSON.parse(message); } catch { ws.close(1008, "Invalid signaling JSON"); return; }
+    if (!value || typeof value !== "object") { ws.close(1008, "Invalid signaling message"); return; }
+    if (value.type === "catalog") {
+      const services = previewCatalog(value.services, info.device);
+      if (!services) { ws.close(1008, "Invalid preview catalog"); return; }
+      this.state.storage.sql.exec("INSERT OR REPLACE INTO preview_catalog(device, services) VALUES (?, ?)", info.device, JSON.stringify(services));
+      this.broadcast({ type: "catalog", device: info.device, services }, ws);
+    } else if (value.type === "signal" && typeof value.to === "string" && ID.test(value.to) && value.to !== info.device) {
+      const signal = previewSignal(value.signal);
+      if (!signal) { ws.close(1008, "Invalid preview signaling"); return; }
+      const target = this.sockets().find(peer => this.info(peer).device === value.to);
+      if (target) this.send(target, { type: "signal", from: info.device, signal });
+      else this.send(ws, { type: "gone", device: value.to });
+    } else { ws.close(1008, "Unsupported preview message"); }
+  }
+  async webSocketClose(ws: WebSocket): Promise<void> { await this.remove(ws); }
+  async webSocketError(ws: WebSocket): Promise<void> { await this.remove(ws); }
+  async alarm(): Promise<void> {
+    const now = Date.now();
+    for (const ws of this.sockets()) {
+      const info = this.info(ws);
+      const pong = this.state.getWebSocketAutoResponseTimestamp(ws)?.getTime() ?? 0;
+      // Periodic reconnect obtains a fresh access token. A half-open device
+      // disappears promptly, including after this object hibernates.
+      if (now - Math.max(info.lastSeen, pong) > 45000 || now - info.connected > 15 * 60000) {
+        await this.remove(ws); ws.close(1000, "Refresh device presence");
+      }
+    }
+    if (this.sockets().some(ws => this.info(ws).device)) await this.state.storage.setAlarm(now + 30000);
+  }
+  private catalog(device: string): Service[] {
+    const row = this.state.storage.sql.exec<{ services: string }>("SELECT services FROM preview_catalog WHERE device = ?", device).toArray()[0];
+    return row ? JSON.parse(row.services) as Service[] : [];
+  }
+  private sockets(): WebSocket[] { return this.state.getWebSockets().filter(ws => this.info(ws)?.device); }
+  private info(ws: WebSocket): Attachment { return ws.deserializeAttachment() as Attachment; }
+  private send(ws: WebSocket, value: object): void { try { ws.send(JSON.stringify(value)); } catch { ws.close(1011, "Signaling disconnected"); } }
+  private broadcast(value: object, except: WebSocket): void { for (const ws of this.sockets()) if (ws !== except) this.send(ws, value); }
+  private async remove(ws: WebSocket): Promise<void> {
+    const info = this.info(ws);
+    if (!info?.device) return;
+    const device = info.device; ws.serializeAttachment({ ...info, device: "" });
+    this.state.storage.sql.exec("DELETE FROM preview_catalog WHERE device = ?", device);
+    this.broadcast({ type: "gone", device }, ws);
+  }
+}

--- a/edge/src/preview-route.ts
+++ b/edge/src/preview-route.ts
@@ -1,0 +1,17 @@
+import type { Verified } from "./auth";
+import { AUTH_USER_HEADER, ROOM_KIND_HEADER, type Env } from "./env";
+/** Route identity comes exclusively from verified JWT claims. */
+export function previewRoute(request: Request, env: Pick<Env, "PREVIEW_ROOMS">, auth: Verified): Promise<Response> | Response | undefined {
+  const url = new URL(request.url);
+  const parts = url.pathname.split("/").filter(Boolean);
+  const id = /^[A-Za-z0-9_-]{1,128}$/;
+  if (parts[0] !== "preview" || parts.length !== 3 || !id.test(parts[1]) || parts[2] !== "ws") return;
+  if (auth.orgId !== parts[1]) return new Response("Forbidden", { status: 403 });
+  const device = url.searchParams.get("device") ?? "";
+  if (!id.test(device)) return new Response("Invalid device", { status: 400 });
+  const room = env.PREVIEW_ROOMS.get(env.PREVIEW_ROOMS.idFromName(`preview1/${parts[1]}/${auth.userId}`));
+  url.pathname = "/ws"; url.search = `?device=${device}`;
+  const headers = new Headers(request.headers);
+  headers.set(AUTH_USER_HEADER, auth.userId); headers.delete(ROOM_KIND_HEADER);
+  return room.fetch(new Request(url, { method: request.method, headers }));
+}

--- a/edge/test/workerd/env.d.ts
+++ b/edge/test/workerd/env.d.ts
@@ -3,5 +3,6 @@
 declare module "cloudflare:test" {
   interface ProvidedEnv {
     TEST_LOG: DurableObjectNamespace;
+    PREVIEW_ROOMS: DurableObjectNamespace;
   }
 }

--- a/edge/test/workerd/fixture.ts
+++ b/edge/test/workerd/fixture.ts
@@ -1,3 +1,5 @@
+import { previewRoute } from "../../src/preview-route";
+export { PreviewRoom } from "../../src/preview-room";
 import { DurableObject } from "cloudflare:workers";
 
 /** Bare SQLite-backed DO; tests reach its real `ctx.storage.sql` via
@@ -5,7 +7,12 @@ import { DurableObject } from "cloudflare:workers";
 export class TestLogRoom extends DurableObject {}
 
 export default {
-  fetch(): Response {
-    return new Response("test fixture", { status: 404 });
+  fetch(request: Request, env: { PREVIEW_ROOMS: DurableObjectNamespace }): Response | Promise<Response> {
+    // Test credentials exercise the production routing seam without loading
+    // the unrelated session-room WASM inside the Workers test runner.
+    const bearer = request.headers.get("authorization");
+    if (!bearer?.startsWith("Bearer ")) return new Response("Unauthorized", { status: 401 });
+    const [userId, orgId] = bearer.slice(7).split("@");
+    return previewRoute(request, env, { userId, orgId }) ?? new Response("test fixture", { status: 404 });
   }
 };

--- a/edge/test/workerd/preview.workerd.test.ts
+++ b/edge/test/workerd/preview.workerd.test.ts
@@ -1,0 +1,34 @@
+import { SELF, env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+function next(ws: WebSocket): Promise<Record<string, any>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("signaling timed out")), 2000);
+    ws.addEventListener("message", event => { clearTimeout(timeout); resolve(JSON.parse(event.data as string)); }, { once: true });
+  });
+}
+async function connect(user: string, device: string, org = "org") {
+  const response = await SELF.fetch(`https://test/preview/${org}/ws?device=${device}`, { headers: { authorization: `Bearer ${user}@${org}`, upgrade: "websocket", "x-zeron-auth-user": "spoofed" } });
+  expect(response.status).toBe(101); const ws = response.webSocket!; ws.accept(); return ws;
+}
+describe("authenticated preview coordination on workerd", () => {
+  it("checks organization membership before routing", async () => {
+    expect((await SELF.fetch("https://test/preview/foreign/ws?device=a", { headers: { authorization: "Bearer user@org", upgrade: "websocket" } })).status).toBe(403);
+    expect((await SELF.fetch("https://test/preview/org/ws?device=a", { headers: { upgrade: "websocket" } })).status).toBe(401);
+  });
+  it("stamps sender identity, isolates users, removes departed devices and rejects bytes", async () => {
+    const user = crypto.randomUUID(); const a = await connect(user, "a");
+    const aCatalog = next(a); const b = await connect(user, "b"); const bCatalog = next(b);
+    expect((await aCatalog).device).toBe("b"); expect((await bCatalog).device).toBe("a");
+    const other = await connect(`${user}-other`, "b");
+    const received = next(b);
+    a.send(JSON.stringify({ type: "signal", to: "b", from: "spoofed", signal: { kind: "connect", session: "session" } }));
+    expect(await received).toEqual({ type: "signal", from: "a", signal: { kind: "connect", session: "session" } });
+    const room = env.PREVIEW_ROOMS.get(env.PREVIEW_ROOMS.idFromName(`preview1/org/${user}`));
+    await runInDurableObject(room, (_instance, state) => { expect(state.getWebSockets().length).toBe(2); });
+    const gone = next(a); b.send(new Uint8Array([1,2,3]));
+    // The close handshake completes before presence is removed.
+    await new Promise<void>(resolve => b.addEventListener("close", () => resolve(), { once: true }));
+    b.close(); expect((await gone).type).toBe("gone");
+    a.close(); other.close();
+  });
+});

--- a/edge/vitest.workerd.config.ts
+++ b/edge/vitest.workerd.config.ts
@@ -19,7 +19,8 @@ export default defineConfig({
       miniflare: {
         compatibilityDate: "2026-07-01",
         durableObjects: {
-          TEST_LOG: { className: "TestLogRoom", useSQLite: true }
+          TEST_LOG: { className: "TestLogRoom", useSQLite: true },
+          PREVIEW_ROOMS: { className: "PreviewRoom", useSQLite: true }
         }
       }
     })

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -39,6 +39,7 @@
     "bindings": [
       { "name": "SESSION_ROOMS", "class_name": "SessionRoom" },
       { "name": "DEVICE_ROOMS", "class_name": "DeviceRoom" },
+      { "name": "PREVIEW_ROOMS", "class_name": "PreviewRoom" },
       { "name": "REGISTRY_ROOMS", "class_name": "RegistryRoom" },
       { "name": "CHAT_ROOMS", "class_name": "ChatRoom" }
     ]
@@ -59,7 +60,8 @@
       // replace SessionRoom's loro-aware s2 rooms.
       "tag": "v3",
       "new_sqlite_classes": ["ChatRoom"]
-    }
+    },
+    { "tag": "v4", "new_sqlite_classes": ["PreviewRoom"] }
   ],
   "r2_buckets": [
     {


### PR DESCRIPTION
Running a project dev server now makes it appear in a new Browser tab, with one-click opening through a persistent `device.project.localhost:7331` address. Restarting on a different port keeps the address. Additional services receive persistent names, and the list follows the session’s current project live.

The daemon discovers project-owned HTTP listeners on Linux/macOS and proxies streaming HTTP and WebSocket/HMR through a bounded, cancellable stream multiplexer. The same protocol runs over local sockets or authenticated WebRTC DataChannels. A per-user Durable Object coordinates presence, service catalogs and SDP/ICE; application traffic stays peer-to-peer.

Validation includes real process/cwd isolation, non-HTTP exclusion, port changes, large streaming bodies, cancellation, WebSockets, concurrent WebRTC streams, and a two-client local Worker → signaling → WebRTC → remote HTTP integration. Engine subscription tests and all 51 edge tests pass. Native Linux and macOS fixtures pass discovery, Open, Vite HMR, disappearance and restart with the same URL, including scoped WebKit hostname routing on macOS. The compact monochrome rows follow the empty sidebar picker; both the Open control and row click are validated locally. CI is rerunning for this final styling update.

Cross-device previews require deploying the Worker’s v4 migration. There is no TURN fallback in this version; restrictive NAT/firewalls can prevent direct connections. The two-peer integration was validated on one Linux host, not across independent networks.

Screenshots and the continuous native recording below are GitHub user attachments; no media files are committed. The recording shows Open, HMR, and a server restart onto a new port while retaining the stable URL.

![Compact project previews without icons](https://github.com/user-attachments/assets/b6fd3661-b404-48b4-b72b-6771ad990d5b)

![Vite opened through its stable preview URL](https://github.com/user-attachments/assets/882b90be-f5e9-4ea4-adbd-5b1cc757b4cb)

![Project previews in light mode](https://github.com/user-attachments/assets/0577450a-7220-4676-ac5b-1a0f13c15b8f)

https://github.com/user-attachments/assets/13925d59-1ac9-4b35-b76a-98bd09ffe9d5