### PR TITLE
Persist model, reasoning, and option picks as new-session defaults

### DIFF
--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -757,17 +757,46 @@ impl Pickers {
     }
 
     /// The explicit (non-default) option picks: the chat's persisted
-    /// selections for existing chats, the draft's for the new-chat canvas.
+    /// selections for existing chats; for the new-chat canvas the remembered
+    /// last-used picks (clamped to what the selected model offers) overlaid
+    /// with this canvas's draft picks.
     fn explicit_options(&self, cx: &App) -> serde_json::Map<String, serde_json::Value> {
-        match self
+        if let Some(config) = self
             .state
             .read(cx)
             .selected_chat_row()
             .and_then(|c| c.config.as_ref())
         {
-            Some(config) => config.model_options.clone(),
-            None => self.config.model_options.clone(),
+            return config.model_options.clone();
         }
+        let mut options = match self.selected_model(cx) {
+            Some(model) => {
+                let mut clamped = serde_json::Map::new();
+                for option in &model.options {
+                    if let Some(choice) = self
+                        .defaults
+                        .model_options
+                        .get(&option.id)
+                        .and_then(|v| v.as_str())
+                        && choice != option.default_choice
+                        && option.choices.iter().any(|c| c.id == choice)
+                    {
+                        clamped.insert(
+                            option.id.clone(),
+                            serde_json::Value::String(choice.to_string()),
+                        );
+                    }
+                }
+                clamped
+            }
+            // Catalog not loaded yet: trust the memory as-is (same stance as
+            // the offline model id in `resolved`).
+            None => self.defaults.model_options.clone(),
+        };
+        for (id, choice) in &self.config.model_options {
+            options.insert(id.clone(), choice.clone());
+        }
+        options
     }
 
     /// The catalog is loaded and offers nothing runnable — the no-agents
@@ -1337,36 +1366,38 @@ impl Pickers {
         // The card stays open on a pick (user request): model and traits
         // share one popover now, and adjusting the tray right after choosing
         // a model is the expected flow. Esc, click-out, or the chip close it.
+        // Every pick becomes the sticky new-session default for its harness,
+        // whether made on the new-chat canvas or inside an existing chat.
+        if let Some(harness) = self.effective_harness(cx) {
+            let label = self
+                .models
+                .get(&harness)
+                .and_then(|l| l.ready())
+                .and_then(|models| models.iter().find(|m| m.id == model_id))
+                .map(|m| m.label.clone())
+                .unwrap_or_else(|| model_id.clone());
+            self.defaults.remember_model(harness, model_id.clone(), label);
+            self.save_defaults();
+        }
         if self.state.read(cx).selected_chat.is_some() {
             // Existing chat: persist to the chat row (Mutate setChatConfig) —
             // survives restarts and syncs; next runs in this chat use it.
             self.update_chat_config(cx, move |config| config.model = Some(model_id));
         } else {
-            // New chat: draft pick + sticky last-used memory for this harness.
-            self.config.model = Some(model_id.clone());
-            if let Some(harness) = self.effective_harness(cx) {
-                let label = self
-                    .models
-                    .get(&harness)
-                    .and_then(|l| l.ready())
-                    .and_then(|models| models.iter().find(|m| m.id == model_id))
-                    .map(|m| m.label.clone())
-                    .unwrap_or_else(|| model_id.clone());
-                self.defaults.remember_model(harness, model_id, label);
-                self.save_defaults();
-            }
+            self.config.model = Some(model_id);
         }
         cx.notify();
     }
 
     fn pick_reasoning(&mut self, level: ReasoningLevel, cx: &mut Context<Self>) {
-        // Always a concrete selection (no toggle-back-to-default).
+        // Always a concrete selection (no toggle-back-to-default); remembered
+        // as the new-session default regardless of where it was picked.
+        self.defaults.reasoning = Some(level);
+        self.save_defaults();
         if self.state.read(cx).selected_chat.is_some() {
             self.update_chat_config(cx, move |config| config.reasoning = Some(level));
         } else {
             self.config.reasoning = Some(level);
-            self.defaults.reasoning = Some(level);
-            self.save_defaults();
         }
         cx.notify();
     }
@@ -1378,6 +1409,17 @@ impl Pickers {
         default: bool,
         cx: &mut Context<Self>,
     ) {
+        // Remember the pick for new sessions; a default pick clears the
+        // memory (absence already resolves to the option's default).
+        if default {
+            self.defaults.model_options.remove(&option_id);
+        } else {
+            self.defaults.model_options.insert(
+                option_id.clone(),
+                serde_json::Value::String(choice_id.clone()),
+            );
+        }
+        self.save_defaults();
         if self.state.read(cx).selected_chat.is_some() {
             self.update_chat_config(cx, move |config| {
                 if default {

--- a/crates/ui/src/settings/composer.rs
+++ b/crates/ui/src/settings/composer.rs
@@ -60,6 +60,10 @@ pub struct ComposerDefaults {
     pub no_project: bool,
     /// Starred models (the picker's favorites rail), in starring order.
     pub favorites: Vec<FavoriteModel>,
+    /// Last non-default model-option picks (option id → choice id), e.g.
+    /// context window or fast mode. Applied to new sessions when the selected
+    /// model offers the option; absence means the option's default.
+    pub model_options: serde_json::Map<String, serde_json::Value>,
 }
 
 impl ComposerDefaults {
@@ -185,6 +189,10 @@ mod tests {
             "Fable 5".into(),
         );
         defaults.remember_model(HarnessId::Codex, "gpt-5.2-codex".into(), "GPT-5.2".into());
+        defaults.model_options.insert(
+            "contextWindow".into(),
+            serde_json::Value::String("1m".into()),
+        );
         defaults.save(dir.path()).unwrap();
         let loaded = ComposerDefaults::load(dir.path());
         assert_eq!(loaded, defaults);


### PR DESCRIPTION
## Summary
- Model-option picks (context window, fast mode) now persist to `composer-defaults.json` alongside the already-remembered model, harness, and reasoning, so they survive restarts.
- Picks made inside an existing chat now update the sticky new-session defaults too — previously only new-chat-canvas picks were remembered.
- The new-chat canvas seeds its model options from the remembered picks, clamped to what the selected model actually offers (an option or choice the model doesn't have is dropped), overlaid with any draft picks. The chip summary, traits tray, and `createChat` config all read through the same resolution, so remembered choices show as selected and get recorded on the new chat.
- Picking an option's default choice clears the memory for it (absence already resolves to the default).

## Testing
- `cargo check -p zeron-ui` passes
- `cargo test -p zeron-ui composer` — 66 passed, including a new round-trip case covering `modelOptions`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791580355&installation_model_id=425430&pr_number=293&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F293&signature=f9b2f5c50e7e35098ce15f0fa7945a4e3c683e377dc8f8aadd84e0fe8cab39a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->