### PR TITLE
Fix remote preview pairing and empty-tab glass background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11690,6 +11690,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "webrtc",
  "zeron-proto",

--- a/crates/preview/Cargo.toml
+++ b/crates/preview/Cargo.toml
@@ -29,3 +29,4 @@ webrtc = "0.20.2"
 
 [dev-dependencies]
 tempfile.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/preview/examples/peer-probe.rs
+++ b/crates/preview/examples/peer-probe.rs
@@ -1,0 +1,97 @@
+//! Two-device preview diagnostic. Exchange `SIGNAL` lines over an authenticated
+//! channel (for example Zeron terminal RPC); never publish SDP in release logs.
+//! `peer-probe host <localhost-port>` serves that explicit backend; `peer-probe
+//! client` requests it. Each process reads the other process's signals on stdin.
+use std::{sync::Arc, time::Duration};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
+use zeron_preview::{
+    mux::{BoxIo, Connector},
+    peer::{Peers, Signal},
+};
+
+struct Backend(Option<u16>);
+#[async_trait::async_trait]
+impl Connector for Backend {
+    async fn connect(&self, service: &str) -> anyhow::Result<BoxIo> {
+        anyhow::ensure!(service == "diagnostic", "unknown diagnostic service");
+        let port = self
+            .0
+            .ok_or_else(|| anyhow::anyhow!("client has no backend"))?;
+        Ok(Box::new(
+            tokio::net::TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port)).await?,
+        ))
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    let host = args.first().is_some_and(|s| s == "host");
+    anyhow::ensure!(
+        host || args == ["client"],
+        "usage: peer-probe host <port> | client"
+    );
+    let port = if host {
+        Some(
+            args.get(1)
+                .ok_or_else(|| anyhow::anyhow!("missing backend port"))?
+                .parse()?,
+        )
+    } else {
+        None
+    };
+    let stop = CancellationToken::new();
+    let (peers, mut outgoing) = Peers::new(
+        if host { "a" } else { "b" }.into(),
+        Arc::new(Backend(port)),
+        stop.clone(),
+    );
+    let signals = tokio::spawn(async move {
+        while let Some(message) = outgoing.recv().await {
+            println!("SIGNAL {}", serde_json::to_string(&message.signal).unwrap());
+        }
+    });
+    let incoming_peers = peers.clone();
+    let incoming = tokio::spawn(async move {
+        let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
+        while let Some(line) = lines.next_line().await? {
+            let signal: Signal = serde_json::from_str(&line)?;
+            incoming_peers
+                .signal(if host { "b" } else { "a" }, signal)
+                .await?;
+        }
+        Ok::<_, anyhow::Error>(())
+    });
+    let result = if host {
+        incoming.await??;
+        Ok(())
+    } else {
+        let start = std::time::Instant::now();
+        let result = tokio::time::timeout(Duration::from_secs(40), async {
+            let mut stream = peers.open("a", "diagnostic", false).await?;
+            stream
+                .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                .await?;
+            let mut bytes = Vec::new();
+            stream.take(8 * 1024 * 1024).read_to_end(&mut bytes).await?;
+            anyhow::ensure!(
+                bytes.starts_with(b"HTTP/1.0 200") || bytes.starts_with(b"HTTP/1.1 200"),
+                "backend did not return HTTP 200"
+            );
+            println!(
+                "PASS remote HTTP 200: {} bytes in {:.2}s",
+                bytes.len(),
+                start.elapsed().as_secs_f64()
+            );
+            Ok::<_, anyhow::Error>(())
+        })
+        .await?;
+        incoming.abort();
+        result
+    };
+    stop.cancel();
+    peers.clear().await;
+    signals.abort();
+    result
+}

--- a/crates/preview/examples/peer-probe.rs
+++ b/crates/preview/examples/peer-probe.rs
@@ -26,6 +26,10 @@ impl Connector for Backend {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("zeron_preview=debug,webrtc=warn")
+        .with_writer(std::io::stderr)
+        .init();
     let args: Vec<_> = std::env::args().skip(1).collect();
     let host = args.first().is_some_and(|s| s == "host");
     anyhow::ensure!(
@@ -57,6 +61,7 @@ async fn main() -> anyhow::Result<()> {
         let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
         while let Some(line) = lines.next_line().await? {
             let signal: Signal = serde_json::from_str(&line)?;
+            eprintln!("INPUT signal {}", signal.kind);
             incoming_peers
                 .signal(if host { "b" } else { "a" }, signal)
                 .await?;

--- a/crates/preview/src/peer.rs
+++ b/crates/preview/src/peer.rs
@@ -90,6 +90,7 @@ impl Peers {
         tokio::select! { _ = self.0.stop.cancelled() => anyhow::bail!("preview networking stopped"), result = self.0.output.send(OutgoingSignal { to: to.into(), signal }) => { result?; Ok(()) } }
     }
     async fn create(&self, session: String, initiator: bool) -> anyhow::Result<Arc<Peer>> {
+        tracing::debug!(initiator, "creating preview peer");
         let (ready, receiver) = watch::channel(None);
         let (gathered, gathering) = watch::channel(false);
         let stop = self.0.stop.child_token();
@@ -120,6 +121,7 @@ impl Peers {
             let channel = pc.create_data_channel("zeron-preview-v1", None).await?;
             handler.attach(channel);
         }
+        tracing::debug!(initiator, "created preview peer");
         Ok(Arc::new(Peer {
             session,
             pc,
@@ -129,12 +131,14 @@ impl Peers {
         }))
     }
     async fn description(&self, peer: &Peer, offer: bool) -> anyhow::Result<RTCSessionDescription> {
+        tracing::debug!(offer, "creating preview description");
         let description = if offer {
             peer.pc.create_offer(None).await?
         } else {
             peer.pc.create_answer(None).await?
         };
         peer.pc.set_local_description(description).await?;
+        tracing::debug!(offer, "gathering preview candidates");
         // Include candidates gathered so far. A STUN probe on an unreachable
         // interface/server may never report Complete; that must not discard
         // usable host or server-reflexive candidates from the other probes.
@@ -152,6 +156,7 @@ impl Peers {
             .local_description()
             .await
             .context("missing local preview SDP")?;
+        tracing::debug!(offer, "sending preview description");
         anyhow::ensure!(
             description.sdp.contains("a=candidate:"),
             "No local preview connection candidates are available"

--- a/crates/preview/src/peer.rs
+++ b/crates/preview/src/peer.rs
@@ -135,14 +135,28 @@ impl Peers {
             peer.pc.create_answer(None).await?
         };
         peer.pc.set_local_description(description).await?;
-        // Include the gathered ICE candidates in SDP. This avoids candidate /
-        // remote-description races and keeps reconnect messages self-contained.
+        // Include candidates gathered so far. A STUN probe on an unreachable
+        // interface/server may never report Complete; that must not discard
+        // usable host or server-reflexive candidates from the other probes.
         let mut gathered = peer.gathered.clone();
-        tokio::time::timeout(Duration::from_secs(12), gathered.wait_for(|done| *done)).await??;
-        peer.pc
+        match tokio::time::timeout(Duration::from_secs(3), gathered.wait_for(|done| *done)).await {
+            Ok(result) => {
+                result.context("preview candidate gathering stopped")?;
+            }
+            Err(_) => {
+                tracing::warn!("preview STUN discovery incomplete; trying available ICE candidates")
+            }
+        }
+        let description = peer
+            .pc
             .local_description()
             .await
-            .context("missing local preview SDP")
+            .context("missing local preview SDP")?;
+        anyhow::ensure!(
+            description.sdp.contains("a=candidate:"),
+            "No local preview connection candidates are available"
+        );
+        Ok(description)
     }
     async fn offer(&self, device: &str, session: String) -> anyhow::Result<()> {
         let mut peers = self.0.peers.lock().await;
@@ -424,6 +438,52 @@ mod tests {
             });
             Ok(Box::new(client))
         }
+    }
+    #[tokio::test]
+    async fn unreachable_stun_does_not_block_usable_peer_candidates() {
+        // Accept UDP without answering: gathering cannot complete, although
+        // both peers have usable host candidates. This reproduces a laptop
+        // whose STUN requests time out while its remote host is reachable.
+        let blackhole = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let stop = CancellationToken::new();
+        let (mut a, mut a_out) = Peers::new("a".into(), Arc::new(Echo), stop.clone());
+        let (mut b, mut b_out) = Peers::new("b".into(), Arc::new(Echo), stop.clone());
+        let servers = vec![RTCIceServer {
+            urls: vec![format!("stun:{}", blackhole.local_addr().unwrap())],
+            ..Default::default()
+        }];
+        Arc::get_mut(&mut a.0).unwrap().ice_servers = servers.clone();
+        Arc::get_mut(&mut b.0).unwrap().ice_servers = servers;
+        let peer_b = b.clone();
+        let forward_a = tokio::spawn(async move {
+            while let Some(message) = a_out.recv().await {
+                peer_b.signal("a", message.signal).await.unwrap();
+            }
+        });
+        let peer_a = a.clone();
+        let forward_b = tokio::spawn(async move {
+            while let Some(message) = b_out.recv().await {
+                peer_a.signal("b", message.signal).await.unwrap();
+            }
+        });
+        let result = tokio::time::timeout(Duration::from_secs(10), async {
+            let mut stream = b.open("a", "service", false).await.unwrap();
+            stream
+                .write_all(b"preview through available candidates")
+                .await
+                .unwrap();
+            stream.shutdown().await.unwrap();
+            let mut bytes = Vec::new();
+            stream.read_to_end(&mut bytes).await.unwrap();
+            assert_eq!(bytes, b"preview through available candidates");
+        })
+        .await;
+        stop.cancel();
+        a.clear().await;
+        b.clear().await;
+        forward_a.abort();
+        forward_b.abort();
+        result.expect("a failed STUN probe must not prevent peer setup");
     }
     #[tokio::test]
     async fn actual_webrtc_pair_streams_in_both_directions() {

--- a/crates/ui/examples/preview-fixture.rs
+++ b/crates/ui/examples/preview-fixture.rs
@@ -165,7 +165,7 @@ fn main() -> anyhow::Result<()> {
         history::init(settings.git_history_columns, settings.git_history_column_widths, settings.git_history_column_order, settings.git_history_author_display, cx);
         composer::init(cx, settings.composer_send_behavior); terminal::panel::init(cx); app_menus::init(cx);
         let state = cx.new(|_| { let mut s = state::AppState::new(); s.connection = zeron_proto::view::ConnectionStatus::Ready; s.workspace_scope = Some(zeron_proto::WorkspaceScope::Development); s.local_device_id = Some(device.clone()); s.devices = vec![serde_json::from_value(serde_json::json!({"id":device,"name":"This device","platform":std::env::consts::OS,"lastSeenAt":null})).unwrap()]; s.chats = chats; s.spaces = spaces; s.selected_chat = Some("preview-fixture".into()); s.selected_space = Some("project".into()); s.auto_selected = true; s.chats_synced = true; s.spaces_synced = true; s });
-        let window = cx.open_window(WindowOptions { window_bounds: Some(WindowBounds::Windowed(Bounds::new(gpui::point(px(12.),px(30.)),size(px(1100.),px(760.))))), ..Default::default() }, |_,cx| cx.new(|cx| shell::Shell::new(state.clone(),boot,cx))).unwrap();
+        let window = cx.open_window(WindowOptions { window_background: theme::Theme::of(cx).window_background_appearance(), window_bounds: Some(WindowBounds::Windowed(Bounds::new(gpui::point(px(12.),px(30.)),size(px(1100.),px(760.))))), ..Default::default() }, |_,cx| cx.new(|cx| shell::Shell::new(state.clone(),boot,cx))).unwrap();
         state.update(cx, |_,cx| cx.notify()); cx.activate(true);
         cx.spawn(async move |cx| {
             let run: anyhow::Result<()> = async {

--- a/crates/ui/src/browser/view.rs
+++ b/crates/ui/src/browser/view.rs
@@ -524,7 +524,9 @@ impl Render for BrowserSurface {
             .flex_1()
             .min_h_0()
             .overflow_hidden()
-            .bg(theme.bg);
+            // Empty tabs share the shell's glass, like the sidebar tab picker.
+            // Keep an opaque backing while native web content is loading.
+            .when(has_page, |body| body.bg(theme.bg));
         #[cfg(target_os = "macos")]
         let body = if let Some(native) = &self.native {
             if self.page.error.is_some() {


### PR DESCRIPTION
Remote previews could time out with HTTP 502 when one STUN probe failed, even though the peers already had usable connection addresses. This reproduced on the home laptop while the work laptop connected to the same personal-metal server successfully.

Empty browser tabs also inherit the sidebar’s glass background instead of painting an opaque page background. Loaded pages retain their backing during navigation. The native preview fixture uses the same window background treatment as the app.

Bound candidate gathering to three seconds and send the available candidates instead of abandoning negotiation when a probe never completes. Add a regression test with a nonresponding STUN endpoint and a two-device HTTP diagnostic using the production peer transport.

Validation:
- The regression test fails with the previous gathering behavior and passes with this fix.
- Reproduced the released app's HTTP 502 after 30 seconds on the physical home laptop; its logs show STUN TransactionTimeOut. The work laptop reached the same backend successfully.
- Ran the patched production peer transport on the home laptop against personal-metal across their real networks: HTTP 200, 1,894 bytes, in 4.80 seconds. The Mac still reported incomplete STUN discovery, then sent its answer and connected successfully.
- Native UI flow passed after the glass change: Open, HMR, server disappearance/restart, stable URLs, and dark/light captures.
- Full local preview suite passes, including streaming HTTP, WebSocket upgrades, cancellation, discovery and restart tests.

The physical diagnostic exchanged SDP through authenticated Zeron terminal RPC and carried the HTTP request/response directly over WebRTC. It did not replace the running app. This change does not add a TURN relay; networks that cannot establish a direct connection still require a separate fallback.

![Diagnostic output from physical Mac-to-Linux peer test](https://github.com/user-attachments/assets/5db78406-1adf-48c6-993c-22716372723f)

![Empty browser tab on macOS with glass background, dark mode](https://github.com/user-attachments/assets/0d98d3e0-fb65-43ca-90f7-c3a9c1674f9b)

![Empty browser tab on macOS with glass background, light mode](https://github.com/user-attachments/assets/49599521-f765-4f31-912e-d3176c1533c5)