### PR TITLE
Fix HTTP previews in the packaged macOS browser

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
         run: |
-          target/release/examples/browser-fixture "$RUNNER_TEMP/browser-captures"
+          bash scripts/run-macos-browser-fixture.sh target/release/examples/browser-fixture "$RUNNER_TEMP/browser-captures"
           test -f "$RUNNER_TEMP/browser-captures/result.txt"
       - name: Upload browser screenshots
         if: always()
@@ -99,7 +99,7 @@ jobs:
         env:
           ZERON_PREVIEW_AUTO_OPEN: 1
         run: |
-          VITE_BINARY="$GITHUB_WORKSPACE/edge/node_modules/vite/bin/vite.js" target/release/examples/preview-fixture "$RUNNER_TEMP/preview-captures"
+          VITE_BINARY="$GITHUB_WORKSPACE/edge/node_modules/vite/bin/vite.js" bash scripts/run-macos-browser-fixture.sh target/release/examples/preview-fixture "$RUNNER_TEMP/preview-captures"
           test -f "$RUNNER_TEMP/preview-captures/result.txt"
       - name: Upload preview screenshots
         if: always()

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -8,6 +8,8 @@ on:
       - 'rust-toolchain.toml'
       - 'crates/**'
       - 'scripts/test-linux-browser.sh'
+      - 'scripts/run-macos-browser-fixture.sh'
+      - 'dist/macos/Info.plist'
       - 'apps/ios/**'
       - '.github/workflows/ui-tests.yml'
   push:
@@ -18,6 +20,8 @@ on:
       - 'rust-toolchain.toml'
       - 'crates/**'
       - 'scripts/test-linux-browser.sh'
+      - 'scripts/run-macos-browser-fixture.sh'
+      - 'dist/macos/Info.plist'
       - 'apps/ios/**'
       - '.github/workflows/ui-tests.yml'
   workflow_dispatch:

--- a/crates/ui/examples/preview-fixture.rs
+++ b/crates/ui/examples/preview-fixture.rs
@@ -202,10 +202,14 @@ fn main() -> anyhow::Result<()> {
                 capture(&output,"preview-live-update")?;
                 drop(vite_child.take()); pause(cx,2600).await;
                 anyhow::ensure!(browser.read_with(cx,|b,_|b.fixture_previews().services.len()==1),"stopped Vite remained in discovery");
+                std::fs::write(project.join("index.html"),html.replace("Fieldnotes</title>","Fieldnotes · Restarted</title>"))?;
                 vite_child = Some(Child(std::process::Command::new("node").arg(vite_restart).args(["--host","127.0.0.1","--strictPort","--port",&second_port.to_string()]).current_dir(restart_root).stdout(std::process::Stdio::null()).spawn()?));
                 for _ in 0..150 { if browser.read_with(cx,|b,_|b.fixture_previews().services.iter().any(|s|s.port==second_port)) {break;} pause(cx,100).await; }
                 let after = browser.read_with(cx,|b,_|b.fixture_previews()); anyhow::ensure!(after.services.iter().any(|s|s.port==second_port && s.url(after.proxy_port)==stable),"port change lost stable identity");
-                window.update(cx,|_,w,cx|browser.update(cx,|b,cx|b.navigate(&stable,w,cx)))?; pause(cx,2000).await; capture(&output,"preview-restarted-stable-url")?;
+                window.update(cx,|_,w,cx|browser.update(cx,|b,cx|b.navigate(&stable,w,cx)))?;
+                for _ in 0..150 { if browser.read_with(cx,|b,_|b.page.title=="Fieldnotes · Restarted" && !b.page.loading) { break; } pause(cx,100).await; }
+                anyhow::ensure!(browser.read_with(cx,|b,_|b.page.title=="Fieldnotes · Restarted" && b.page.error.is_none()),"restarted server did not load through its stable URL: {:?}",browser.read_with(cx,|b,_|b.page.clone()));
+                capture(&output,"preview-restarted-stable-url")?;
                 drop(api.take()); pause(cx,2600).await;
                 let (_,empty) = window.update(cx,|shell,w,cx|shell.fixture_open_browser(None,w,cx))?;
                 empty.update(cx,|b,cx|b.watch_previews(handle.clone(),"preview-fixture".into(),cx)); pause(cx,800).await;

--- a/crates/ui/src/browser/macos.rs
+++ b/crates/ui/src/browser/macos.rs
@@ -200,11 +200,17 @@ define_class!(
         }
         #[unsafe(method(webView:didFailProvisionalNavigation:withError:))]
         fn provisional_error(&self, _view: &WKWebView, _navigation: Option<&WKNavigation>, error: &NSError) {
-            if error.code() != -999 { self.fail("Check the address and make sure your server is running, then try again."); }
+            if error.code() != -999 {
+                tracing::warn!(domain = %error.domain(), code = error.code(), "browser provisional navigation failed");
+                self.fail("Check the address and make sure your server is running, then try again.");
+            }
         }
         #[unsafe(method(webView:didFailNavigation:withError:))]
         fn navigation_error(&self, _view: &WKWebView, _navigation: Option<&WKNavigation>, error: &NSError) {
-            if error.code() != -999 { self.fail("The connection was interrupted. Try loading this page again."); }
+            if error.code() != -999 {
+                tracing::warn!(domain = %error.domain(), code = error.code(), "browser navigation failed");
+                self.fail("The connection was interrupted. Try loading this page again.");
+            }
         }
         #[unsafe(method(webViewWebContentProcessDidTerminate:))]
         fn terminated(&self, _view: &WKWebView) {

--- a/crates/ui/src/browser/mod.rs
+++ b/crates/ui/src/browser/mod.rs
@@ -119,7 +119,7 @@ impl BrowserSurface {
     ) -> Self {
         let address = cx.new(|cx| {
             ComposerInput::with_context("Website or localhost:3000", "PaletteSearch", cx)
-                .with_text_metrics(12.0, 18.0)
+                .with_text_metrics(11.0, 16.0)
                 .with_accessibility_role(gpui::Role::TextInput)
         });
         let input_sub = cx.subscribe(&address, |this, _, event, cx| {

--- a/crates/ui/src/browser/mod.rs
+++ b/crates/ui/src/browser/mod.rs
@@ -120,6 +120,7 @@ impl BrowserSurface {
         let address = cx.new(|cx| {
             ComposerInput::with_context("Website or localhost:3000", "PaletteSearch", cx)
                 .with_text_metrics(11.0, 16.0)
+                .with_single_line()
                 .with_accessibility_role(gpui::Role::TextInput)
         });
         let input_sub = cx.subscribe(&address, |this, _, event, cx| {

--- a/crates/ui/src/browser/view.rs
+++ b/crates/ui/src/browser/view.rs
@@ -435,25 +435,11 @@ impl Render for BrowserSurface {
         .when(has_page, |el| {
             el.on_click(cx.listener(|this, _, _, cx| this.reload(cx)))
         });
-        let address = div()
+        let address = surface_chrome::input()
             .id("browser-address")
-            .flex_1()
-            .min_w_0()
-            .h(px(26.0))
-            .px(px(7.0))
-            .rounded(px(6.0))
-            .border_1()
-            .border_color(if self.validation.is_some() {
-                theme.danger
-            } else if focused {
-                theme.border_strong
-            } else {
-                theme.border
+            .when(self.validation.is_some(), |el| {
+                el.border_1().border_color(theme.danger)
             })
-            .bg(theme.surface_raised.opacity(0.65))
-            .flex()
-            .items_center()
-            .gap(px(6.0))
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(|this, _, _, _| {
@@ -475,7 +461,7 @@ impl Render for BrowserSurface {
                 div()
                     .flex_1()
                     .min_w_0()
-                    .h(px(18.0))
+                    .h(px(16.0))
                     .overflow_hidden()
                     .child(self.address.clone()),
             )

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -7931,6 +7931,7 @@ mod tests {
         });
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn layout_cache_reuses_resize_frames_and_invalidates_text_inputs() {
         gpui_platform::headless().run(|cx| {

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -1579,6 +1579,8 @@ pub struct ComposerInput {
     follow_cursor: bool,
     text_size: f32,
     configured_line_height: f32,
+    single_line: bool,
+    scroll_left: f32,
     // -- measured state (written during layout/paint) --
     last_lines: Vec<WrappedLine>,
     line_starts: Vec<usize>,
@@ -1670,6 +1672,8 @@ impl ComposerInput {
             follow_cursor: true,
             text_size: INPUT_TEXT_SIZE,
             configured_line_height: INPUT_LINE_HEIGHT,
+            single_line: false,
+            scroll_left: 0.0,
             last_lines: Vec::new(),
             line_starts: vec![0],
             last_bounds: None,
@@ -1705,6 +1709,12 @@ impl ComposerInput {
         self.configured_line_height = line_height;
         self.line_height = px(line_height);
         self.content_height = line_height;
+        self
+    }
+
+    /// Keep compact fields on one row and reveal the caret horizontally.
+    pub fn with_single_line(mut self) -> Self {
+        self.single_line = true;
         self
     }
 
@@ -1920,12 +1930,16 @@ impl ComposerInput {
     pub fn set_text(&mut self, text: impl Into<String>, cx: &mut Context<Self>) {
         self.invalidate_mention_tooltip();
         self.content = text.into();
+        if self.single_line {
+            self.content = self.content.replace(['\r', '\n'], " ");
+        }
         self.refresh_projection();
         let end = self.content.len();
         self.selected_range = end..end;
         self.selection_reversed = false;
         self.marked_range = None;
         self.scroll_top = 0.0;
+        self.scroll_left = 0.0;
         self.follow_cursor = true;
         // Programmatic replacement (draft load, clear-on-submit) is a new
         // document, not an edit — undo must not reach back past it.
@@ -2504,7 +2518,7 @@ impl ComposerInput {
             return;
         }
         if let Some(text) = item.text() {
-            // Multiline input: newlines are welcome (unlike the single-line example).
+            // Compact fields normalize newlines in the input handler.
             self.replace_text_in_range(None, &text, window, cx);
         }
     }
@@ -2669,7 +2683,7 @@ impl ComposerInput {
             return 0;
         };
         let local = point(
-            position.x - bounds.left(),
+            position.x - bounds.left() + px(self.scroll_left),
             position.y - bounds.top() + px(self.scroll_top),
         );
         self.index_for_point(local)
@@ -2973,7 +2987,13 @@ impl ComposerInput {
 
         let lines = window
             .text_system()
-            .shape_text(display, font_size, &runs, Some(width), None)
+            .shape_text(
+                display,
+                font_size,
+                &runs,
+                (!self.single_line).then_some(width),
+                None,
+            )
             .map(|small| small.into_vec())
             .unwrap_or_default();
 
@@ -3041,6 +3061,17 @@ impl ComposerInput {
 
     /// Keep the cursor visible when content exceeds the element height.
     fn clamp_scroll(&mut self, element_height: f32) -> bool {
+        if self.single_line {
+            let previous = self.scroll_left;
+            let width = (self.last_width - 2.0).max(1.0);
+            if let Some(cursor) = self.point_for_index(self.cursor_offset()) {
+                let x = f32::from(cursor.x);
+                self.scroll_left = self.scroll_left.min(x).max(x - width).max(0.0);
+            }
+            self.scroll_left = self.scroll_left.min((self.max_line_width - width).max(0.0));
+            self.scroll_top = 0.0;
+            return self.scroll_left != previous;
+        }
         let previous = self.scroll_top;
         if self.follow_cursor {
             if let Some(cursor) = self.point_for_index(self.cursor_offset()) {
@@ -3121,6 +3152,13 @@ impl EntityInputHandler for ComposerInput {
         if self.read_only {
             return;
         }
+        let single_line_text;
+        let new_text = if self.single_line {
+            single_line_text = new_text.replace(['\r', '\n'], " ");
+            single_line_text.as_str()
+        } else {
+            new_text
+        };
         let range = range_utf16
             .as_ref()
             .map(|r| self.range_from_utf16(r))
@@ -3158,6 +3196,13 @@ impl EntityInputHandler for ComposerInput {
         if self.read_only {
             return;
         }
+        let single_line_text;
+        let new_text = if self.single_line {
+            single_line_text = new_text.replace(['\r', '\n'], " ");
+            single_line_text.as_str()
+        } else {
+            new_text
+        };
         let range = range_utf16
             .as_ref()
             .map(|r| self.range_from_utf16(r))
@@ -3207,7 +3252,7 @@ impl EntityInputHandler for ComposerInput {
             .normalize_range(self.range_from_utf16(&range_utf16));
         let start = self.point_for_index(range.start)?;
         let origin = point(
-            bounds.left() + start.x,
+            bounds.left() + start.x - px(self.scroll_left),
             bounds.top() + start.y - px(self.scroll_top),
         );
         Some(Bounds::new(origin, size(px(2.0), self.line_height)))
@@ -3344,7 +3389,7 @@ impl gpui::Element for ComposerTextElement {
         let input = self.input.read(cx);
         let paint_bounds = input.paint_bounds(bounds);
         let scroll = px(input.scroll_top);
-        let origin = point(bounds.left(), bounds.top() - scroll);
+        let origin = point(bounds.left() - px(input.scroll_left), bounds.top() - scroll);
         let selection_color = Theme::of(cx).selection;
         let caret_color = Theme::of(cx).caret;
         // The inline-code recipe: chips use the spectrum wash like `code` spans.
@@ -3524,11 +3569,12 @@ impl gpui::Element for ComposerTextElement {
 
         // WrappedLine isn't Clone — temporarily take the shaped lines out of the
         // entity for painting, then put them back for mouse mapping.
-        let (lines, line_height, scroll) = self.input.update(cx, |input, _| {
+        let (lines, line_height, scroll, scroll_left) = self.input.update(cx, |input, _| {
             (
                 std::mem::take(&mut input.last_lines),
                 input.line_height,
                 input.scroll_top,
+                input.scroll_left,
             )
         });
 
@@ -3548,7 +3594,7 @@ impl gpui::Element for ComposerTextElement {
                 for line in &lines {
                     let height = line.size(line_height).height;
                     let _ = line.paint(
-                        point(bounds.left(), y),
+                        point(bounds.left() - px(scroll_left), y),
                         line_height,
                         gpui::TextAlign::Left,
                         Some(bounds),
@@ -7184,9 +7230,7 @@ mod tests {
     use super::*;
 
     #[gpui::test]
-    fn projectless_composer_allows_send_and_enter_submission(
-        cx: &mut gpui::TestAppContext,
-    ) {
+    fn projectless_composer_allows_send_and_enter_submission(cx: &mut gpui::TestAppContext) {
         let state = cx.new(|_| AppState::new());
         let composer = cx.new(|cx| Composer::new(state.clone(), cx));
         // A device with no projects is a valid home-directory target too.
@@ -7827,6 +7871,66 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
+    #[test]
+    fn single_line_address_reveals_caret_and_maps_scrolled_pointer() {
+        gpui_platform::headless().run(|cx| {
+            cx.set_global(Theme::dark());
+            let handle = cx
+                .open_window(gpui::WindowOptions::default(), |_, cx| {
+                    cx.new(|cx| {
+                        ComposerInput::new("Address", cx)
+                            .with_single_line()
+                            .with_text_metrics(11.0, 16.0)
+                    })
+                })
+                .unwrap();
+            handle
+                .update(cx, |input, window, cx| {
+                    let style = window.text_style();
+                    input.set_text(
+                        "http://device.a-very-long-project-name.localhost:7331/path",
+                        cx,
+                    );
+                    input.layout_text(px(100.0), &style, window, cx);
+                    assert_eq!(input.content_height, 16.0, "long hostnames must not wrap");
+                    input.clamp_scroll(16.0);
+                    assert!(input.scroll_left > 0.0);
+                    let bounds = Bounds::new(point(px(10.0), px(20.0)), size(px(100.0), px(16.0)));
+                    input.last_bounds = Some(bounds);
+                    let caret = input
+                        .bounds_for_range(
+                            input.content.len()..input.content.len(),
+                            bounds,
+                            window,
+                            cx,
+                        )
+                        .unwrap();
+                    assert!(caret.left() >= bounds.left() && caret.right() <= bounds.right());
+                    assert_eq!(
+                        input.index_for_mouse_position(caret.origin),
+                        input.content.len()
+                    );
+                    input.selected_range = 0..0;
+                    input.clamp_scroll(16.0);
+                    assert_eq!(input.scroll_left, 0.0, "Home must reveal the URL start");
+                    input.replace_text_in_range(None, "one\r\ntwo", window, cx);
+                    assert!(!input.content.contains(['\r', '\n']));
+                    input.set_text("short", cx);
+                    input.layout_text(px(100.0), &style, window, cx);
+                    input.clamp_scroll(16.0);
+                    assert_eq!(
+                        input.scroll_left, 0.0,
+                        "short replacement must reset scrolling"
+                    );
+                })
+                .unwrap();
+            cx.spawn(async move |cx| {
+                cx.update(|cx| cx.quit());
+            })
+            .detach();
+        });
+    }
+
     #[test]
     fn layout_cache_reuses_resize_frames_and_invalidates_text_inputs() {
         gpui_platform::headless().run(|cx| {

--- a/crates/ui/src/files/mod.rs
+++ b/crates/ui/src/files/mod.rs
@@ -962,17 +962,7 @@ impl FilesSurface {
         let include_ignored = self.tree.include_ignored();
         toolbar(theme)
             .child(
-                div()
-                    .h(px(TOOLBAR_BUTTON_SIZE))
-                    .min_w_0()
-                    .flex_1()
-                    .px(px(8.0))
-                    .rounded(px(TOOLBAR_BUTTON_RADIUS))
-                    .bg(crate::theme::ink(0.035))
-                    .flex()
-                    .items_center()
-                    .gap(px(6.0))
-                    .text_size(px(11.5))
+                crate::surface_chrome::input()
                     .child(
                         crate::icons::icon(crate::icons::MAGNIFER)
                             .size(px(12.0))

--- a/crates/ui/src/surface_chrome.rs
+++ b/crates/ui/src/surface_chrome.rs
@@ -11,6 +11,21 @@ pub(crate) const ICON_SIZE: f32 = 14.0;
 pub(crate) const CONTROL_GAP: f32 = 4.0;
 pub(crate) const EDGE_INSET: f32 = 8.0;
 
+/// Shared field treatment for the file search and browser address controls.
+pub(crate) fn input() -> Div {
+    div()
+        .h(px(CONTROL_SIZE))
+        .min_w_0()
+        .flex_1()
+        .px(px(8.0))
+        .rounded(px(CONTROL_RADIUS))
+        .bg(crate::theme::ink(0.035))
+        .flex()
+        .items_center()
+        .gap(px(6.0))
+        .text_size(px(11.5))
+}
+
 pub(crate) fn toolbar(theme: &Theme) -> Div {
     div()
         .h(px(HEADER_HEIGHT))

--- a/dist/macos/Info.plist
+++ b/dist/macos/Info.plist
@@ -39,6 +39,13 @@
     <string>12.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <!-- Browser tabs load user-selected HTTP dev servers. Keep the exception
+         scoped to WebKit; other app connections retain their ATS policy. -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoadsInWebContent</key>
+        <true/>
+    </dict>
     <key>NSHumanReadableCopyright</key>
     <string>© 2026</string>
     <!-- gpui renders via Metal. -->

--- a/scripts/run-macos-browser-fixture.sh
+++ b/scripts/run-macos-browser-fixture.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Use the release Info.plist: bare executables do not enforce the app's ATS policy.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BINARY="$1"
+shift
+BUNDLE="$(mktemp -d "${TMPDIR:-/tmp}/zeron-browser-fixture.XXXXXX")/Fixture.app"
+trap 'rm -r "$(dirname "$BUNDLE")"' EXIT
+mkdir -p "$BUNDLE/Contents/MacOS"
+cp "$BINARY" "$BUNDLE/Contents/MacOS/fixture"
+sed 's/__VERSION__/1.0.0/g' "$ROOT/dist/macos/Info.plist" > "$BUNDLE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c 'Set :CFBundleExecutable fixture' "$BUNDLE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c 'Set :CFBundleIdentifier sh.zeron.browser-fixture' "$BUNDLE/Contents/Info.plist"
+"$BUNDLE/Contents/MacOS/fixture" "$@"


### PR DESCRIPTION
HTTP previews opened in an external browser but failed inside the packaged macOS app: its Info.plist did not allow HTTP web content, so WebKit rejected navigation with NSURLErrorDomain -1022 before reaching the preview proxy.

Allow HTTP within browser web content while retaining the app's other ATS protections. Run both native browser fixtures inside app bundles using the production Info.plist so CI exercises the shipping security policy. Log native navigation error domains/codes for diagnosis without logging URLs.

The browser address field now shares the Files search field's surface, spacing, height and typography. Long URLs stay on one horizontally scrolling line, including correct caret and pointer positioning.

Validation:
- Reproduced the failure on a physical Mac using the production Info.plist and a remote device's preview URL; the same executable outside the bundle succeeded.
- With the corrected plist, the bundled WebKit probe loaded that remote preview during cold initialization, after initialization, and after adding another proxy domain.
- The actual Zeron sidebar browser component, bundled with the production plist, loaded previews from both a remote Mac dev server and a controlled Linux dev server on a physical Mac. Native navigation reported the expected page titles with no errors.
- Packaged native fixtures passed navigation, live discovery, stable URLs, restart with fresh content and WebSocket HMR. Browser fixtures also cover hover, resize, sidebar toggles and blur.
- A focused address-input regression covers long URLs, horizontal caret/pointer mapping, Home navigation and newline normalization. All [CI checks](https://github.com/zeronsh/comet/actions/runs/34419072668) passed on `de9fd7a`: 795 UI tests, packaged macOS browser/preview tests, Linux X11/Wayland browser tests, frame recovery and iOS tests.

CI screenshots below are uploaded as user attachments; no media files are committed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791588625&installation_model_id=425430&pr_number=297&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F297&signature=96c749da0f2a29685e052670a7ae854b36d04d98932f0427258483be806169de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

![Packaged macOS browser: stable URL and single-line address input](https://github.com/user-attachments/assets/4e6f9ec3-427b-4190-8b47-e68d80ba3ed9)

![Glass new-tab surface with the shared Files search field style](https://github.com/user-attachments/assets/6892f015-14b0-4ffb-832d-c59699b6cc77)



![Linux browser with the shared address input style](https://github.com/user-attachments/assets/a8237f95-b173-4e4f-97f6-2b967186b0cf)

