### PR TITLE
Fix ACP turns ending prematurely during model silence

### DIFF
--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -1401,8 +1401,11 @@ async fn drive_run(
     // RETIRED for native drivers: a harness whose every turn shape ends with
     // a deterministic wire Done (claude/codex/cursor native) needs no
     // quiesce backstop — arming one only risks false parks on long silent
-    // work. The env knob still forces a window on for diagnostics.
+    // work. The env knob can configure a diagnostic window, but a prompt
+    // with an authoritative completion signal must still await that signal.
+    // ACP retains the watchdog only for unowned self-continued activity.
     let deterministic_turn_end = harness.deterministic_turn_end();
+    let authoritative_prompt_end = harness.authoritative_prompt_end();
     let quiesce_after: Option<std::time::Duration> = match std::env::var("ZERON_TURN_QUIESCE_MS")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
@@ -1550,6 +1553,7 @@ async fn drive_run(
                 }
                 last_stream_activity + window
             }), if quiesce_after.is_some()
+                && (self_continued_turn || !authoritative_prompt_end)
                 && idle_since.is_none()
                 && !interrupted
                 && steerable

--- a/crates/engine/tests/acp_lifecycle.rs
+++ b/crates/engine/tests/acp_lifecycle.rs
@@ -1,0 +1,156 @@
+//! #296 through the engine: completed tools must not park a pending ACP turn.
+//! Separate binary because the diagnostic watchdog setting is process-wide.
+use std::{sync::Arc, time::Duration};
+use zeron_doc::{
+    MessagePart, MessageRole, MessageStatus, SessionCommandEntry, SessionCommandPayload,
+    SessionCommandStatus,
+};
+use zeron_engine::{EngineCore, HarnessRegistry};
+use zeron_harness::AcpHarness;
+use zeron_proto::{HarnessId, RunRequest, SandboxLevel, SessionStatus};
+
+async fn wait_for(mut condition: impl FnMut() -> bool) {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        while !condition() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("engine state must advance");
+}
+
+#[tokio::test]
+async fn quiet_acp_prompt_stays_working_until_response() {
+    // SAFETY: this is the only test in this binary, on a current-thread runtime,
+    // and no engine or harness tasks have started yet.
+    unsafe {
+        std::env::set_var("ZERON_TURN_QUIESCE_MS", "100");
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let registry = HarnessRegistry::new();
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../harness/tests/fixtures/acp-lifecycle.py");
+    registry.register(Arc::new(AcpHarness::pi().with_executable(fixture)));
+    let core = EngineCore::assemble(dir.path(), Arc::new(registry), HarnessId::Pi, None).unwrap();
+    let chat = "acp-quiet-regression";
+    let handle = core.doc_host.open(chat).unwrap();
+    let doc = handle.doc();
+    let queue = |id: &str, payload| {
+        doc.queue_command(&SessionCommandEntry {
+            id: id.into(),
+            payload,
+            issued_by: "viewer".into(),
+            issued_at: chrono::Utc::now().timestamp_millis(),
+            based_on: None,
+            expires_at: None,
+            status: SessionCommandStatus::Pending,
+            resolution: None,
+        })
+        .unwrap();
+    };
+    queue(
+        "first",
+        SessionCommandPayload::Run {
+            message_id: "first-user".into(),
+            request: RunRequest {
+                prompt: "tools".into(),
+                harness: None,
+                model: None,
+                reasoning: None,
+                model_options: Default::default(),
+                cwd: dir.path().display().to_string(),
+                sandbox: SandboxLevel::WorkspaceWrite,
+                auto_approve: true,
+                attachments: Vec::new(),
+                worktree: None,
+                resume: None,
+            },
+        },
+    );
+    wait_for(|| {
+        doc.read_entries().unwrap_or_default().iter().any(|entry| {
+            entry.parts.iter().any(
+                |part| matches!(part, MessagePart::Tool { id, resolved: true, .. } if id == "3"),
+            )
+        })
+    })
+    .await;
+    // Observe many watchdog windows during the peer's post-tool model wait.
+    for _ in 0..8 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            core.sessions.session_status(chat).unwrap().status,
+            SessionStatus::Working
+        );
+        assert!(
+            !doc.read_entries()
+                .unwrap()
+                .iter()
+                .any(|entry| entry.role == MessageRole::Assistant
+                    && entry.status == Some(MessageStatus::Complete)),
+            "pending turn was finalized"
+        );
+    }
+    queue(
+        "followup",
+        SessionCommandPayload::Steer {
+            prompt: "second".into(),
+            message_id: Some("second-user".into()),
+        },
+    );
+    wait_for(|| {
+        doc.read_entries().unwrap_or_default().iter().any(|entry| {
+            entry
+                .parts
+                .iter()
+                .any(|part| matches!(part, MessagePart::Text { text, .. } if text == "second"))
+        })
+    })
+    .await;
+    wait_for(|| {
+        core.sessions
+            .session_status(chat)
+            .is_some_and(|s| s.status == SessionStatus::Idle)
+    })
+    .await;
+    let entries = doc.read_entries().unwrap();
+    let assistants: Vec<_> = entries
+        .iter()
+        .filter(|entry| entry.role == MessageRole::Assistant)
+        .collect();
+    assert_eq!(assistants.len(), 2, "{entries:?}");
+    assert!(
+        assistants
+            .iter()
+            .all(|entry| entry.status == Some(MessageStatus::Complete)),
+        "{entries:?}"
+    );
+    assert!(
+        assistants[0].parts.iter().any(
+            |part| matches!(part, MessagePart::Text { text, .. } if text.contains("finished"))
+        ),
+        "original output must stay in its turn: {entries:?}"
+    );
+    // ACP can still emit unowned autonomous activity. It has no pending
+    // session/prompt response, so the existing fallback must remain enabled.
+    queue(
+        "self-continue",
+        SessionCommandPayload::Steer {
+            prompt: "self-continue".into(),
+            message_id: Some("third-user".into()),
+        },
+    );
+    wait_for(|| {
+        doc.read_entries().unwrap_or_default().iter().any(|entry| {
+            entry.status == Some(MessageStatus::Complete)
+                && entry.parts.iter().any(
+                    |part| matches!(part, MessagePart::Text { text, .. } if text == "autonomous"),
+                )
+        })
+    })
+    .await;
+    assert_eq!(
+        core.sessions.session_status(chat).unwrap().status,
+        SessionStatus::Idle
+    );
+}

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -1122,6 +1122,12 @@ impl Harness for AcpHarness {
     fn display_name(&self) -> &str {
         self.spec.display_name
     }
+    fn authoritative_prompt_end(&self) -> bool {
+        // ACP session/prompt owns the turn until its response. The engine's
+        // quiet watchdog must not park a still-pending model request either.
+        true
+    }
+
     fn supports_steering(&self) -> bool {
         true
     }
@@ -1742,7 +1748,6 @@ fn handle_server_request_live(
     method: &str,
     params: &Value,
     request_input: &std::sync::Arc<RequestInputFn>,
-    open_questions: &std::sync::Arc<std::sync::atomic::AtomicUsize>,
 ) -> Vec<AgentEvent> {
     if method != "session/request_permission" {
         return handle_server_request(client, id, method, params);
@@ -1778,10 +1783,6 @@ fn handle_server_request_live(
     };
     let client = client.clone();
     let request_input = std::sync::Arc::clone(request_input);
-    // Pending questions block the agent — the quiet-settle must not read
-    // that silence as a finished turn.
-    let open_questions = std::sync::Arc::clone(open_questions);
-    open_questions.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     tokio::spawn(async move {
         let answers = (request_input)(vec![question.clone()])
             .await
@@ -1803,7 +1804,6 @@ fn handle_server_request_live(
             ),
             None => client.respond(&id, json!({ "outcome": { "outcome": "cancelled" } })),
         }
-        open_questions.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
     });
     Vec::new()
 }
@@ -1884,18 +1884,10 @@ fn prompt_like_request(
     Box::pin(async move { client.request(method, params).await })
 }
 
-/// Track the liveness signals the blanket quiet-settle keys on: content
-/// proves the turn produced something; an open tool call or a pending
-/// question proves silence is legitimate.
-fn track_turn_signals(
-    ev: &AgentEvent,
-    content_seen: &mut bool,
-    open_tools: &mut std::collections::HashSet<String>,
-) {
+/// Track tools to avoid prompting into an unowned self-continued turn.
+fn track_open_tools(ev: &AgentEvent, open_tools: &mut std::collections::HashSet<String>) {
     match ev {
-        AgentEvent::TextDelta { text } if !text.is_empty() => *content_seen = true,
         AgentEvent::ToolCall { id, .. } => {
-            *content_seen = true;
             open_tools.insert(id.clone());
         }
         AgentEvent::ToolResult { id, .. } => {
@@ -2260,39 +2252,12 @@ async fn run_session(session: Session) {
     // the queued steer is promoted to a fresh turn.
     const STARVE_GRACE: Duration = Duration::from_secs(2);
     let mut starve_deadline: Option<tokio::time::Instant> = None;
-    // BLANKET dropped-reply settle, adapter-agnostic: any ACP agent whose
-    // prompt response goes missing must not strand the turn. Signals that
-    // exist in core ACP stand in for the adapter-specific cost frame: once
-    // the turn has streamed content, every tool call it opened has resolved,
-    // no permission/question round-trip is pending, and the stream has been
-    // quiet past the window, the turn is settled through the same recovery
-    // arm. A false settle is only PARTLY recoverable: the engine folds any
-    // later output as a self-continued segment and re-arms Working, but the
-    // turn is orphaned — the real response resolves a closed channel, no
-    // Done ever comes, and the session strands Working until the engine's
-    // quiesce watchdog parks it.
-    //
-    // `ZERON_ACP_QUIET_SETTLE_MS` overrides; 0 disables.
-    let quiet_settle: Option<Duration> = match std::env::var("ZERON_ACP_QUIET_SETTLE_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-    {
-        Some(0) => None,
-        Some(ms) => Some(Duration::from_millis(ms)),
-        None => Some(Duration::from_secs(30)),
-    };
+    // Silence is not a turn boundary: completed tools, text, and usage may
+    // all precede a slow model request. Keep the prompt future alive until
+    // its response (or an authoritative completion extension) arrives.
+    // ZERON_ACP_QUIET_SETTLE_MS is intentionally no longer honored (#296).
     let mut last_update_at = tokio::time::Instant::now();
-    let mut turn_content_seen = false;
-    // A steering injection makes the cost hint unsafe for the REST of the
-    // turn: the adapter emits a cost-bearing usage_update for the injected
-    // message itself, mid-turn, indistinguishable in shape from the
-    // terminal one (verified against 0.66.0 — premature Done exactly one
-    // grace after injection). Steered turns settle off their real response
-    // (healthy in every trace); the engine's quiesce watchdog backstops
-    // them (the quiet settle used to, before the Claude exemption above).
-    let mut steered_this_turn = false;
     let mut open_tools: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let open_questions = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     // PREVENTION, ahead of all the recovery above: never send a
     // `session/prompt` into a session that is visibly mid SELF-CONTINUED
     // turn — that prompt's reply is what the adapter drops (the verified
@@ -2391,7 +2356,6 @@ async fn run_session(session: Session) {
                                 &method,
                                 &params,
                                 &request_input,
-                                &open_questions,
                             ) {
                                 if !send(&event_tx, ev).await {
                                     consumer_gone = true;
@@ -2462,8 +2426,6 @@ async fn run_session(session: Session) {
                         break 'main;
                     }
                     done_current = false;
-                    turn_content_seen = false;
-                    steered_this_turn = false;
                     open_tools.clear();
                     last_update_at = tokio::time::Instant::now();
                     prompt_seq += 1;
@@ -2552,7 +2514,7 @@ async fn run_session(session: Session) {
                     let events =
                         session_update_events(&method, &params, &session_id, &mut subagents);
                     for ev in events {
-                        track_turn_signals(&ev, &mut turn_content_seen, &mut open_tools);
+                        track_open_tools(&ev, &mut open_tools);
                         if !send(&event_tx, ev).await {
                             break 'main;
                         }
@@ -2566,7 +2528,6 @@ async fn run_session(session: Session) {
                         &method,
                         &params,
                         &request_input,
-                        &open_questions,
                     ) {
                         if !send(&event_tx, ev).await {
                             break 'main;
@@ -2647,10 +2608,9 @@ async fn run_session(session: Session) {
                     // and no Done ever coming — the stranded-Working /
                     // eternal-timer bug. Post-turn: nothing left to do.
                     if turn.is_some() {
-                        steered_this_turn = true;
                         // The injection proves the turn is LIVE: any settle
-                        // deadline armed off a cost frame that raced this
-                        // response is invalid evidence.
+                        // deadline armed by an earlier noRunningTurn reply
+                        // is no longer valid.
                         starve_deadline = None;
                         // Pre-injection updates can still sit in `incoming`
                         // (responses bypass that queue): drain them into the
@@ -2677,7 +2637,6 @@ async fn run_session(session: Session) {
                                         &method,
                                         &params,
                                         &request_input,
-                                        &open_questions,
                                     ) {
                                         if !send(&event_tx, ev).await {
                                             consumer_gone = true;
@@ -2748,8 +2707,6 @@ async fn run_session(session: Session) {
                         break 'main;
                     }
                     done_current = false;
-                    turn_content_seen = false;
-                    steered_this_turn = false;
                     open_tools.clear();
                     last_update_at = tokio::time::Instant::now();
                     prompt_seq += 1;
@@ -2799,8 +2756,6 @@ async fn run_session(session: Session) {
                         break 'main;
                     }
                     done_current = false;
-                    turn_content_seen = false;
-                    steered_this_turn = false;
                     open_tools.clear();
                     last_update_at = tokio::time::Instant::now();
                     prompt_seq += 1;
@@ -2820,40 +2775,10 @@ async fn run_session(session: Session) {
                 }
             },
 
-            // BLANKET quiet settle (see `quiet_settle` above), adapter-
-            // agnostic: content streamed, every tool resolved, no question
-            // pending, stream quiet past the window with the prompt still
-            // unsettled. Feeds the recovery arm below by expiring its
-            // deadline — one settle path for all three evidence sources.
-            _ = tokio::time::sleep_until(
-                last_update_at + quiet_settle.unwrap_or_default()
-            ), if quiet_settle.is_some()
-                && starve_deadline.is_none()
-                && turn.is_some()
-                && !interrupted
-                && turn_content_seen
-                && open_tools.is_empty()
-                && open_questions.load(std::sync::atomic::Ordering::SeqCst) == 0 =>
-            {
-                tracing::warn!(
-                    target: "zeron_harness::acp",
-                    quiet_ms = quiet_settle.unwrap_or_default().as_millis() as u64,
-                    "turn quiet past the settle window with completed output; \
-                     treating the prompt response as dropped"
-                );
-                starve_deadline = Some(tokio::time::Instant::now());
-            },
-
-            // Starved-turn recovery: the grace elapsed with the prompt still
-            // unsettled after turn-end evidence — the turn's terminal cost
-            // frame (COST_HINT_GRACE, ~immediate), a steering call answered
-            // noRunningTurn (STARVE_GRACE), or the blanket quiet settle
-            // above. Close the dead turn out
-            // with a Done — its output already streamed as session/updates
-            // and its text was delivered via the CLI's own queue — then
-            // promote any queued steer to a fresh prompt, which settles
-            // normally on a now-idle agent (verified against the real
-            // adapter).
+            // Explicit noRunningTurn from the steering extension proves
+            // the adapter has no running turn. After a grace for its racing
+            // response, recover the stranded prompt. Silence, tool results,
+            // and usage updates must never arm this recovery.
             _ = tokio::time::sleep_until(
                 starve_deadline.unwrap_or_else(tokio::time::Instant::now)
             ), if starve_deadline.is_some() && turn.is_some() && !interrupted => {
@@ -2903,8 +2828,6 @@ async fn run_session(session: Session) {
                         break 'main;
                     }
                     done_current = false;
-                    turn_content_seen = false;
-                    steered_this_turn = false;
                     open_tools.clear();
                     last_update_at = tokio::time::Instant::now();
                     prompt_seq += 1;
@@ -2941,14 +2864,6 @@ async fn run_session(session: Session) {
                         // Mid self-continued turn (see BUSY_RECENT above):
                         // cancel it rather than prompt into the starve.
                         //
-                        // Claude skips this branch ON PURPOSE and prompts
-                        // straight in — its NATIVE semantics: the CLI queues
-                        // the message and folds it into the running turn (no
-                        // work lost, verified from live session data). The
-                        // adapter drops that prompt's reply, and the
-                        // cost-frame settle reconstructs it ~1s after the
-                        // merged turn really ends. Only adapters with no
-                        // verified turn-end frame pay the cancel.
                         tracing::info!(
                             target: "zeron_harness::acp",
                             "steer into a self-continuing session; cancelling \
@@ -2976,8 +2891,6 @@ async fn run_session(session: Session) {
                             break 'main;
                         }
                         done_current = false;
-                        turn_content_seen = false;
-                        steered_this_turn = false;
                         open_tools.clear();
                         last_update_at = tokio::time::Instant::now();
                         prompt_seq += 1;

--- a/crates/harness/src/jsonrpc.rs
+++ b/crates/harness/src/jsonrpc.rs
@@ -146,6 +146,28 @@ fn response_id(id: &Value) -> Option<i64> {
     id.as_f64().filter(|f| f.fract() == 0.0).map(|f| f as i64)
 }
 
+/// Preserve the agent's rejection reason as well as the generic RPC label.
+fn response_error(error: &Value) -> String {
+    let Some(message) = error.get("message").and_then(Value::as_str) else {
+        return error.to_string();
+    };
+    let mut rendered = message.to_owned();
+    if let Some(code) = error.get("code").and_then(Value::as_i64) {
+        rendered.push_str(&format!(" (code {code})"));
+    }
+    if let Some(data) = error.get("data").filter(|v| !v.is_null()) {
+        let detail = data
+            .as_str()
+            .map(str::to_owned)
+            .unwrap_or_else(|| data.to_string());
+        if !detail.is_empty() {
+            rendered.push_str(": ");
+            rendered.push_str(&detail);
+        }
+    }
+    rendered
+}
+
 /// Parse stdout lines: responses resolve the pending map, everything else is
 /// forwarded in order. Non-JSON noise is skipped; on EOF all pending requests
 /// fail (their senders drop) and one final [`Incoming::Eof`] is delivered.
@@ -172,11 +194,7 @@ async fn read_loop(stdout: ChildStdout, pending: Pending, tx: mpsc::Sender<Incom
                     continue;
                 };
                 let outcome = match msg.get("error") {
-                    Some(err) => Err(err
-                        .get("message")
-                        .and_then(Value::as_str)
-                        .map(str::to_owned)
-                        .unwrap_or_else(|| err.to_string())),
+                    Some(err) => Err(response_error(err)),
                     None => Ok(msg.get("result").cloned().unwrap_or(Value::Null)),
                 };
                 let _ = sender.send(outcome);
@@ -208,4 +226,41 @@ async fn read_loop(stdout: ChildStdout, pending: Pending, tx: mpsc::Sender<Incom
     // EOF/read error: fail every awaiting request, then signal the loop.
     pending.lock().expect("pending lock").clear();
     let _ = tx.send(Incoming::Eof).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rpc_error_preserves_string_and_structured_details() {
+        for data in [
+            json!("A prompt is already running"),
+            json!({"reason": "A prompt is already running"}),
+            json!(["busy", 7]),
+        ] {
+            let rendered = response_error(
+                &json!({"code": -32600, "message": "Invalid request", "data": data}),
+            );
+            assert!(rendered.starts_with("Invalid request (code -32600): "));
+            assert!(rendered.ends_with(data.as_str().unwrap_or(&data.to_string())));
+        }
+    }
+
+    #[test]
+    fn rpc_error_handles_missing_null_and_unstructured_fields() {
+        for error in [
+            json!({"message": "busy"}),
+            json!({"message": "busy", "data": null}),
+            json!({"message": "busy", "data": ""}),
+        ] {
+            assert_eq!(response_error(&error), "busy");
+        }
+        for error in [
+            json!({"code": -32600, "data": {"reason": "busy"}}),
+            json!("unstructured error"),
+        ] {
+            assert_eq!(response_error(&error), error.to_string());
+        }
+    }
 }

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -79,6 +79,12 @@ pub trait Harness: Send + Sync {
     fn deterministic_turn_end(&self) -> bool {
         false
     }
+    /// Whether a user-prompted turn has an authoritative completion signal.
+    /// Such turns must never be parked merely because their stream is quiet.
+    /// Unlike deterministic_turn_end, this need not cover autonomous activity.
+    fn authoritative_prompt_end(&self) -> bool {
+        self.deterministic_turn_end()
+    }
     async fn models(&self) -> Result<Vec<Model>, HarnessError>;
     /// Slash commands the agent advertises (ACP `availableCommands`); empty
     /// for harnesses without them. May spawn a short-lived discovery process.

--- a/crates/harness/tests/acp_quiet.rs
+++ b/crates/harness/tests/acp_quiet.rs
@@ -1,8 +1,5 @@
-//! Blanket dropped-reply settle (`ZERON_ACP_QUIET_SETTLE_MS`), tested with
-//! the GROK spec so no adapter-specific evidence (Claude's cost frame,
-//! `noRunningTurn` steering reasons) is in play — this is the path every ACP
-//! agent gets. Own test binary: the env knob is process-global, and every
-//! test here shares the one value.
+//! Regression tests for #296: quiet output never relinquishes a pending prompt.
+//! The retired env knob stays set so reintroducing its old behavior fails fast.
 
 use std::path::PathBuf;
 use std::sync::Once;
@@ -31,7 +28,7 @@ fn fixture_path() -> PathBuf {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("fixtures")
-        .join("fake-acp.sh");
+        .join("acp-lifecycle.py");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -78,101 +75,215 @@ fn controls() -> (RunControls, mpsc::Sender<SteerMessage>, CancellationToken) {
     (controls, steer_tx, token)
 }
 
-async fn run_and_collect(
-    harness: AcpHarness,
-    prompt: &str,
-    timeout: Duration,
-) -> Vec<(std::time::Instant, AgentEvent)> {
-    let (controls, _steer, _token) = controls();
-    let harness = harness.with_executable(fixture_path());
-    let stream = harness
-        .run(request(prompt), controls)
-        .await
-        .expect("run starts");
-    tokio::time::timeout(timeout, async move {
-        let mut stream = stream;
+async fn collect_until_done(
+    stream: &mut futures::stream::BoxStream<
+        'static,
+        Result<AgentEvent, zeron_harness::HarnessError>,
+    >,
+) -> Vec<AgentEvent> {
+    tokio::time::timeout(Duration::from_secs(15), async {
         let mut events = Vec::new();
-        while let Some(ev) = stream.next().await {
-            events.push((std::time::Instant::now(), ev.expect("stream event")));
+        while let Some(event) = stream.next().await {
+            let event = event.expect("stream event");
+            let done = matches!(event, AgentEvent::Done { .. });
+            events.push(event);
+            if done {
+                break;
+            }
         }
         events
     })
     .await
-    .expect("run finished in time")
+    .expect("turn must settle")
 }
 
-fn dones(events: &[(std::time::Instant, AgentEvent)]) -> Vec<(DoneStatus, Option<String>)> {
-    events
+fn assert_done(events: &[AgentEvent], expected: DoneStatus) {
+    let dones: Vec<_> = events
         .iter()
-        .filter_map(|(_, e)| match e {
-            AgentEvent::Done { status, error, .. } => Some((*status, error.clone())),
+        .filter_map(|e| match e {
+            AgentEvent::Done { status, error, .. } => Some((*status, error.as_deref())),
             _ => None,
         })
-        .collect()
+        .collect();
+    assert_eq!(dones.len(), 1, "{events:?}");
+    assert_eq!(dones[0].0, expected, "{events:?}");
+    if expected != DoneStatus::Errored {
+        assert_eq!(dones[0].1, None);
+    }
 }
 
-/// A generic agent whose prompt response is dropped: content streamed, no
-/// open tool, then silence. The blanket settle must produce a clean Done off
-/// the quiet window, well before the fixture's held-open stream ends.
-#[tokio::test]
-async fn generic_dropped_reply_settles_off_the_quiet_window() {
+async fn delayed_turn(scenario: &str) {
     init_env();
-    let started = std::time::Instant::now();
-    let events = run_and_collect(
-        AcpHarness::grok(),
-        "scenario:quiet-starve",
-        Duration::from_secs(20),
-    )
-    .await;
-    assert_eq!(
-        dones(&events),
-        vec![(DoneStatus::Completed, None)],
-        "{events:?}"
-    );
-    let done_at = events
-        .iter()
-        .find(|(_, e)| matches!(e, AgentEvent::Done { .. }))
-        .map(|(t, _)| t.duration_since(started))
-        .expect("done asserted above");
-    // Window is 1.2s; the fixture holds the stream open for 8s. The Done
-    // must come from the settle, not EOF (margin sized for suite load).
+    let harness = AcpHarness::pi().with_executable(fixture_path());
+    assert!(harness.authoritative_prompt_end());
+    let (controls, steer, token) = controls();
+    let mut stream = harness.run(request(scenario), controls).await.unwrap();
+    // Queue multiple follow-ups while the first prompt remains outstanding.
+    steer
+        .send(SteerMessage {
+            message_id: None,
+            prompt: "second".into(),
+        })
+        .await
+        .unwrap();
+    steer
+        .send(SteerMessage {
+            message_id: None,
+            prompt: "third".into(),
+        })
+        .await
+        .unwrap();
+    let first = collect_until_done(&mut stream).await;
+    assert_done(&first, DoneStatus::Completed);
     assert!(
-        done_at < Duration::from_secs(6),
-        "Done at {done_at:?} — should ride the {QUIET_MS}ms quiet window, \
-         not the 8s stream EOF"
+        first
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TextDelta { text } if text == "finished")),
+        "premature Done: {first:?}"
+    );
+    for expected in ["second", "third"] {
+        let events = collect_until_done(&mut stream).await;
+        assert_done(&events, DoneStatus::Completed);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::TextDelta { text } if text == expected)),
+            "{events:?}"
+        );
+    }
+    // A fresh user message after completion also reuses the same session.
+    steer
+        .send(SteerMessage {
+            message_id: None,
+            prompt: "fourth".into(),
+        })
+        .await
+        .unwrap();
+    let fourth = collect_until_done(&mut stream).await;
+    assert_done(&fourth, DoneStatus::Completed);
+    assert!(
+        fourth
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TextDelta { text } if text == "fourth"))
+    );
+    drop(steer);
+    assert!(
+        tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    drop(token);
+}
+
+#[tokio::test]
+async fn completed_tools_then_silence_preserves_prompt_and_followups() {
+    delayed_turn("tools").await;
+}
+#[tokio::test]
+async fn partial_text_then_silence_preserves_prompt_and_followups() {
+    delayed_turn("text").await;
+}
+#[tokio::test]
+async fn usage_is_not_completion() {
+    delayed_turn("usage").await;
+}
+#[tokio::test]
+async fn reasoning_then_silence_preserves_prompt() {
+    delayed_turn("reasoning").await;
+}
+#[tokio::test]
+async fn open_tools_then_silence_preserves_prompt() {
+    delayed_turn("open-tool").await;
+}
+
+async fn cancel_quiet(scenario: &str) {
+    init_env();
+    let (controls, steer, token) = controls();
+    let mut stream = AcpHarness::pi()
+        .with_executable(fixture_path())
+        .run(request(scenario), controls)
+        .await
+        .unwrap();
+    while let Some(e) = stream.next().await {
+        if matches!(e.unwrap(), AgentEvent::ToolResult { id, .. } if id == "3") {
+            break;
+        }
+    }
+    assert!(
+        tokio::time::timeout(Duration::from_millis(QUIET_MS * 2), stream.next())
+            .await
+            .is_err(),
+        "silence must not emit Done"
+    );
+    steer
+        .send(SteerMessage {
+            message_id: None,
+            prompt: "must not run".into(),
+        })
+        .await
+        .unwrap();
+    token.cancel();
+    let events = collect_until_done(&mut stream).await;
+    assert_done(&events, DoneStatus::Interrupted);
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TextDelta { .. }))
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .unwrap()
+            .is_none()
     );
 }
 
-/// The guard: an OPEN tool call makes silence legitimate. The fixture is
-/// quiet for ~3x the settle window mid-tool-call, then finishes normally —
-/// exactly one Done, arriving from the real response, never a premature
-/// synthesized one.
 #[tokio::test]
-async fn open_tool_call_holds_the_quiet_settle_off() {
+async fn quiet_turn_can_be_cancelled_without_promoting_followup() {
+    cancel_quiet("cancel").await;
+}
+#[tokio::test]
+async fn unresponsive_quiet_turn_is_killed_on_cancel() {
+    cancel_quiet("wedge").await;
+}
+
+#[tokio::test]
+async fn missing_response_at_eof_is_error_not_success() {
     init_env();
-    let events = run_and_collect(
-        AcpHarness::grok(),
-        "scenario:quiet-tool-guard",
-        Duration::from_secs(20),
-    )
-    .await;
-    assert_eq!(
-        dones(&events),
-        vec![(DoneStatus::Completed, None)],
-        "{events:?}"
-    );
-    // The "finished" text (streamed after the quiet stretch) must precede
-    // the single Done — a premature settle would have flipped that order.
-    let finished = events
+    let (controls, _steer, _token) = controls();
+    let mut stream = AcpHarness::pi()
+        .with_executable(fixture_path())
+        .run(request("eof"), controls)
+        .await
+        .unwrap();
+    assert_done(&collect_until_done(&mut stream).await, DoneStatus::Errored);
+}
+
+#[tokio::test]
+async fn protocol_error_keeps_code_and_agent_detail() {
+    let (controls, _steer, _token) = controls();
+    let mut stream = AcpHarness::pi()
+        .with_executable(fixture_path())
+        .run(request("error"), controls)
+        .await
+        .unwrap();
+    let events = collect_until_done(&mut stream).await;
+    assert_done(&events, DoneStatus::Errored);
+    let error = events
         .iter()
-        .position(|(_, e)| matches!(e, AgentEvent::TextDelta { text } if text == "finished"))
-        .expect("post-quiet text must fold into the SAME turn: {events:?}");
-    let done = events
-        .iter()
-        .position(|(_, e)| matches!(e, AgentEvent::Done { .. }))
-        .expect("done asserted above");
-    assert!(
-        finished < done,
-        "the turn must survive the quiet stretch intact: {events:?}"
-    );
+        .find_map(|e| match e {
+            AgentEvent::Done { error, .. } => error.as_deref(),
+            _ => None,
+        })
+        .unwrap();
+    for expected in [
+        "session/prompt",
+        "Invalid request",
+        "-32600",
+        "A prompt is already running",
+        "retryable",
+    ] {
+        assert!(error.contains(expected), "{error}");
+    }
 }

--- a/crates/harness/tests/fixtures/acp-lifecycle.py
+++ b/crates/harness/tests/fixtures/acp-lifecycle.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Stateful ACP peer: reject overlapping prompts and expose real error.data."""
+import json
+import select
+import sys
+import time
+
+
+def emit(value):
+    print(json.dumps({"jsonrpc": "2.0", **value}), flush=True)
+
+
+def update(value):
+    emit({"method": "session/update", "params": {"sessionId": "s-1", "update": value}})
+
+
+def reply(request, result):
+    emit({"id": request["id"], "result": result})
+
+
+def error(request, data):
+    emit({"id": request["id"], "error": {"code": -32600, "message": "Invalid request", "data": data}})
+
+
+# Unbuffered reads keep select honest, including multiple queued frames.
+buffer = b""
+
+
+def read(timeout=None):
+    global buffer
+    deadline = None if timeout is None else time.monotonic() + timeout
+    while b"\n" not in buffer:
+        left = None if deadline is None else max(0, deadline - time.monotonic())
+        if not select.select([sys.stdin], [], [], left)[0]:
+            return None
+        import os
+        data = os.read(sys.stdin.fileno(), 65536)
+        if not data:
+            sys.exit(0)
+        buffer += data
+    line, buffer = buffer.split(b"\n", 1)
+    return json.loads(line)
+
+
+turn = 0
+while True:
+    request = read()
+    method = request.get("method")
+    if method == "initialize":
+        reply(request, {"protocolVersion": 1, "agentCapabilities": {}})
+    elif method == "session/new":
+        reply(request, {"sessionId": "s-1"})
+    elif method == "session/prompt":
+        turn += 1
+        scenario = request["params"]["prompt"][0]["text"]
+        if scenario == "error":
+            error(request, {"reason": "A prompt is already running", "retryable": False})
+            continue
+        if turn > 1:
+            update({"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": scenario}})
+            reply(request, {"stopReason": "end_turn"})
+            if scenario == "self-continue":
+                time.sleep(1.3)
+                update({"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "autonomous"}})
+            continue
+        if scenario != "reasoning":
+            update({"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "working"}})
+        if scenario in ("tools", "open-tool", "cancel", "wedge", "eof"):
+            for i in range(4):
+                update({"sessionUpdate": "tool_call", "toolCallId": str(i), "kind": "read", "title": "read source", "status": "pending", "rawInput": {"path": "/tmp/source.rs"}})
+                if scenario != "open-tool":
+                    update({"sessionUpdate": "tool_call_update", "toolCallId": str(i), "status": "completed", "content": []})
+        if scenario == "usage":
+            update({"sessionUpdate": "usage_update", "used": 100, "size": 10000, "cost": {"amount": 0.01, "currency": "USD"}})
+        if scenario == "reasoning":
+            update({"sessionUpdate": "agent_thought_chunk", "content": {"type": "text", "text": "thinking"}})
+        # Three retired quiet windows. Any ordinary prompt during this gap
+        # must fail, just like a real ACP agent that is awaiting its model.
+        deadline = time.monotonic() + 3.6
+        cancelled = False
+        while time.monotonic() < deadline or scenario in ("cancel", "wedge"):
+            incoming = read(max(0, deadline - time.monotonic()) if scenario not in ("cancel", "wedge") else None)
+            if incoming is None:
+                break
+            if incoming.get("method") == "session/cancel":
+                if scenario == "wedge":
+                    continue
+                cancelled = True
+                break
+            if "id" in incoming:
+                error(incoming, {"reason": "A prompt is already running"})
+        if scenario == "eof":
+            sys.exit(0)
+        if not cancelled:
+            update({"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "finished"}})
+        reply(request, {"stopReason": "cancelled" if cancelled else "end_turn"})
+    elif "id" in request:
+        reply(request, {})

--- a/crates/harness/tests/fixtures/fake-acp.sh
+++ b/crates/harness/tests/fixtures/fake-acp.sh
@@ -380,43 +380,6 @@ case "$promptline" in
   emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
   ;;
 
-*scenario:quiet-starve*)
-  # Blanket dropped-reply settle, no adapter-specific evidence: content
-  # streamed, no open tool, then silence — the response never comes. The
-  # harness must settle off the generic quiet window (tests set
-  # ZERON_ACP_QUIET_SETTLE_MS small), well before this stream's 8s EOF.
-  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
-  sleep 8
-  exit 0
-  ;;
-
-*scenario:quiet-tool-guard*)
-  # The guard: an OPEN tool call makes silence legitimate. Quiet stretch is
-  # far past the test's settle window, but the pending tool must hold the
-  # settle off; the turn then ends normally — exactly one Done.
-  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
-  update '{"sessionUpdate":"tool_call","toolCallId":"slow-1","title":"slow build","kind":"execute","status":"pending","rawInput":{"command":"make"}}'
-  sleep 4
-  update '{"sessionUpdate":"tool_call_update","toolCallId":"slow-1","status":"completed","content":[]}'
-  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"finished"}}'
-  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
-  ;;
-
-*scenario:quiet-thinking*)
-  # The 2026-08-13 false settle: every tool RESOLVED, then a long silent
-  # thinking stretch (claude-agent-acp forwards no thinking traffic), then
-  # the turn continues and ends normally. This is exactly the "looks
-  # finished" state the blanket settle keys on; Claude must hold through
-  # it — a false settle here orphans the real turn (its response lands on
-  # a closed channel; the session strands Working).
-  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
-  update '{"sessionUpdate":"tool_call","toolCallId":"th-1","title":"quick read","kind":"read","status":"pending","rawInput":{"path":"/w/src/x.rs"}}'
-  update '{"sessionUpdate":"tool_call_update","toolCallId":"th-1","status":"completed","content":[]}'
-  sleep 4
-  update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"finished"}}'
-  emit "{\"id\":$pid,\"result\":{\"stopReason\":\"end_turn\"}}"
-  ;;
-
 *scenario:interrupt*)
   update '{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}'
   read -r intline || exit 1

--- a/crates/harness/tests/fixtures/pi-slow-model.ts
+++ b/crates/harness/tests/fixtures/pi-slow-model.ts
@@ -1,0 +1,23 @@
+// Load in an isolated Pi agent directory for real_acp_lifecycle.rs.
+// Delay actual model requests AFTER completed tools, not their tool results
+// or the ACP response. This recreates #296 with a genuinely active prompt.
+export default function (pi) {
+  let toolCompleted = false;
+  pi.on('tool_execution_end', () => { toolCompleted = true; });
+  pi.on('before_provider_request', async (_event, ctx) => {
+    if (!toolCompleted) return;
+    toolCompleted = false;
+    const ms = Number(process.env.ACP_TEST_MODEL_DELAY_MS || 35000);
+    process.stderr.write(`ACP_TEST: delaying post-tool model request by ${ms}ms\n`);
+    await new Promise((resolve) => {
+      const finish = () => {
+        clearTimeout(timer);
+        ctx.signal?.removeEventListener('abort', finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, ms);
+      ctx.signal?.addEventListener('abort', finish, { once: true });
+      if (ctx.signal?.aborted) finish();
+    });
+  });
+}

--- a/crates/harness/tests/real_acp_lifecycle.rs
+++ b/crates/harness/tests/real_acp_lifecycle.rs
@@ -1,0 +1,119 @@
+//! Real Pi ACP + model regression for #296. Requires an authenticated Pi and
+//! fixtures/pi-slow-model.ts loaded as a Pi extension (35s delay by default).
+//! PI_ACP_EXECUTABLE and PI_ACP_PI_COMMAND can select isolated installations.
+//! cargo test -p zeron-harness --test real_acp_lifecycle -- --ignored --nocapture
+
+use futures::StreamExt;
+use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, oneshot};
+use zeron_harness::{AcpHarness, CancellationToken, Harness, RunControls, SteerMessage};
+use zeron_proto::{AgentEvent, DoneStatus, RunRequest, SandboxLevel};
+
+async fn live_run(cancel: bool) {
+    let cwd = tempfile::tempdir().unwrap();
+    let (steer, steering) = mpsc::channel(8);
+    let interrupt = CancellationToken::new();
+    let controls = RunControls {
+        steering,
+        interrupt: interrupt.clone(),
+        request_input: Box::new(|_| {
+            let (tx, rx) = oneshot::channel();
+            let _ = tx.send(Vec::new());
+            rx
+        }),
+    };
+    let request = RunRequest {
+        prompt: "Run the shell command `printf ACP-TOOL-OK` exactly once using bash. After seeing its result, reply exactly FIRST-DONE. Do not call any other tools.".into(),
+        harness: None, model: None, reasoning: None,
+        model_options: serde_json::Map::new(), cwd: cwd.path().display().to_string(),
+        sandbox: SandboxLevel::WorkspaceWrite, auto_approve: true,
+        attachments: Vec::new(), worktree: None, resume: None,
+    };
+    let mut stream = AcpHarness::pi()
+        .run(request, controls)
+        .await
+        .expect("real Pi must start");
+    let mut tool_at = None;
+    let mut done_count = 0;
+    let mut text = String::new();
+    let mut cancel_sent = false;
+    let started = Instant::now();
+    let outcome = tokio::time::timeout(Duration::from_secs(240), async {
+        loop {
+            let event = tokio::select! {
+                event = stream.next() => event.expect("stream ended before all turns settled").expect("event"),
+                _ = tokio::time::sleep_until(tool_at.unwrap_or_else(tokio::time::Instant::now) + Duration::from_secs(32)),
+                    if cancel && tool_at.is_some() && !cancel_sent => {
+                        assert_eq!(done_count, 0, "quiet turn must still be active");
+                        cancel_sent = true;
+                        interrupt.cancel();
+                        continue;
+                    }
+            };
+            match event {
+                AgentEvent::ToolResult { .. } if tool_at.is_none() => {
+                    tool_at = Some(tokio::time::Instant::now());
+                    // Both messages must queue until the slow original prompt
+                    // responds. The real adapter rejects overlapping prompts.
+                    for word in ["SECOND-DONE", "THIRD-DONE"] {
+                        steer.send(SteerMessage { prompt: format!("Do not call tools. Reply exactly {word}."), message_id: None }).await.unwrap();
+                    }
+                }
+                AgentEvent::TextDelta { text: delta } => text.push_str(&delta),
+                AgentEvent::Done { status, error, .. } => {
+                    done_count += 1;
+                    if cancel {
+                        assert!(cancel_sent, "premature completion: {status:?} {error:?}");
+                        assert_eq!(status, DoneStatus::Interrupted, "{error:?}");
+                        break;
+                    }
+                    assert_eq!(status, DoneStatus::Completed, "{error:?}");
+                    let expected = ["FIRST-DONE", "SECOND-DONE", "THIRD-DONE"][done_count - 1];
+                    assert!(text.contains(expected), "turn {done_count}: {text:?}");
+                    if done_count == 1 {
+                        let gap = tool_at.expect("model must call a tool").elapsed();
+                        assert!(gap >= Duration::from_secs(35), "delay extension did not run: {gap:?}");
+                        eprintln!("post-tool gap {gap:?}; original prompt settled correctly");
+                    }
+                    text.clear();
+                    if done_count == 3 { break; }
+                }
+                _ => {}
+            }
+        }
+    }).await;
+    if outcome.is_err() {
+        interrupt.cancel();
+    }
+    outcome.expect("live lifecycle test timed out");
+    drop(steer);
+    assert!(
+        tokio::time::timeout(Duration::from_secs(10), stream.next())
+            .await
+            .unwrap()
+            .is_none(),
+        "unexpected events after final turn"
+    );
+    eprintln!(
+        "real Pi lifecycle: cancel={cancel}, dones={done_count}, elapsed={:?}",
+        started.elapsed()
+    );
+}
+
+#[tokio::test]
+#[ignore = "calls an authenticated real model; requires the slow-model Pi extension"]
+async fn real_pi_slow_model_preserves_prompt_and_queued_followups() {
+    let runs = std::env::var("ACP_TEST_RUNS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3);
+    for _ in 0..runs {
+        live_run(false).await;
+    }
+}
+
+#[tokio::test]
+#[ignore = "calls an authenticated real model; requires the slow-model Pi extension"]
+async fn real_pi_cancel_during_post_tool_silence() {
+    live_run(true).await;
+}

--- a/crates/harness/tests/real_quiet_survey.rs
+++ b/crates/harness/tests/real_quiet_survey.rs
@@ -1,15 +1,10 @@
-//! Production-settings survey across ALL harnesses: does a real multi-tool
-//! turn settle exactly once, at the end, and how close do its silent gaps
-//! come to the 30s blanket quiet-settle window? Run explicitly:
+//! Production-settings survey: real multi-tool turns must settle exactly
+//! once with no orphaned output. Silent gaps are measured for diagnostics;
+//! silence is never proof that an ACP prompt has completed (#296).
 //!
-//!   SURVEY_RUNS=3 cargo test -p zeron-harness --test real_quiet_survey -- --ignored --nocapture
-//!
-//! No env knob is set here — this binary runs the DEFAULTS the app ships:
-//! Claude exempt from the blanket settle, every other adapter on the 30s
-//! window. For each installed+authenticated agent CLI it reports, per run:
-//! the Done count, content events after the first Done (orphan signature),
-//! and the maximum inter-event silent gap — the safety margin against the
-//! window. Uninstalled/unauthenticated agents are skipped by name.
+//! SURVEY_RUNS=3 cargo test -p zeron-harness --test real_quiet_survey -- --ignored --nocapture
+//! Uninstalled/unauthenticated agents are skipped. For mandatory live Pi
+//! regression coverage with an injected delay, use real_acp_lifecycle.rs.
 
 use std::time::Duration;
 
@@ -219,7 +214,7 @@ async fn real_all_harnesses_quiet_survey() {
                 && o.finished;
             println!(
                 "[{name}] run {i}/{runs}: dones={:?} after_first_done={} finished={} \
-                 max_live_gap={:.3}s (window margin {:.1}x) → {}",
+                 max_live_gap={:.3}s → {}",
                 o.dones
                     .iter()
                     .map(|(s, _)| format!("{s:?}"))
@@ -227,7 +222,6 @@ async fn real_all_harnesses_quiet_survey() {
                 o.after_first_done,
                 o.finished,
                 o.max_gap.as_secs_f64(),
-                30.0 / o.max_gap.as_secs_f64().max(0.001),
                 if clean { "CLEAN" } else { "VIOLATION" }
             );
             if !clean {

--- a/docs/research/acp.md
+++ b/docs/research/acp.md
@@ -169,3 +169,54 @@ agentclientprotocol.com (v1 spec + schema), agentclientprotocol org repos
 (claude-agent-acp v0.66.0, codex-acp v1.1.14 — steering wire shape),
 agent-client-protocol-schema 1.3.0 (serde tags), ACP registry entry
 `grok-build`, live `grok agent stdio` initialize handshake (2026-08-07).
+
+## Pending prompts and silence (#296, 2026-09-09)
+
+A completed tool result, partial assistant message, or usage update can precede
+another model request. None proves that `session/prompt` has finished. The old
+30-second blanket quiet settlement discarded the outstanding response future,
+then allowed another prompt into an agent that was still busy. The next request
+could fail with `Invalid request` and its specific `error.data` was discarded.
+
+The ACP quiet timer and `ZERON_ACP_QUIET_SETTLE_MS` override are retired. Pending
+prompts retain their response futures; boundary steers remain queued. Explicit
+completion extensions and `noRunningTurn` recovery retain their existing roles.
+Cancellation still sends `session/cancel`, awaits completion, and escalates to
+process termination if needed. The engine also exempts authoritative pending
+prompts from its quiet watchdog, including when a diagnostic window is set;
+unowned self-continued activity retains its fallback. RPC errors include their
+code and non-null data, preserving the agent's explanation in the terminal event.
+
+Regression checks:
+
+```sh
+cargo test -p zeron-harness
+cargo test -p zeron-engine --test acp_lifecycle
+```
+
+The stateful Python peer rejects overlapping prompts. Coverage includes quiet
+periods after four completed reads, partial text, reasoning, usage, open tools,
+multiple queued follow-ups, EOF without a response, cancellation, an unresponsive
+agent, and structured error details. The engine test checks Working status and
+transcript boundaries with a 100ms watchdog, then verifies autonomous activity
+still settles.
+
+For real-model testing, configure an isolated authenticated Pi agent directory,
+select a model in its settings, and load
+`crates/harness/tests/fixtures/pi-slow-model.ts` (for example, symlink it into that
+agent directory's `extensions/` directory). The extension waits 35 seconds before
+sending the next model request after a completed tool. It does not delay tool
+results or synthesize an ACP completion. Then run:
+
+```sh
+PI_CODING_AGENT_DIR=/path/to/isolated/pi-agent \
+PI_ACP_PI_COMMAND=/path/to/pi \
+ACP_TEST_RUNS=3 \
+cargo test -p zeron-harness --test real_acp_lifecycle -- --ignored --nocapture
+```
+
+These tests require successful real calls; missing authentication or an unloaded
+delay extension fails rather than skips. Verified locally with pi-acp 0.0.33,
+Pi 0.85.1, and `gpt-5.6-luna`: three sessions each completed the original turn and
+two queued follow-ups after 36.6–36.8-second post-tool gaps; cancellation during a
+32-second post-tool gap also completed as Interrupted.


### PR DESCRIPTION
Completed tools followed by a slow model request could trigger ACP’s 30-second quiet timer, discard the pending prompt response, and send the next prompt into a still-busy agent. This removes silence-based ACP settlement and prevents the engine watchdog from parking authoritative pending prompts. Follow-ups stay queued until completion; cancellation and autonomous-activity recovery remain available. JSON-RPC errors now preserve the code and `error.data` explanation.

Closes #296.

Validation:
- 191 harness tests passed; 165 engine unit tests, 18 engine end-to-end tests, and the new ACP engine regression passed.
- Nine lifecycle regressions passed ten consecutive runs (90 checks): delayed tool/text/reasoning/usage output, queued follow-ups, cancellation, forced termination, missing responses, and detailed errors.
- The completed-tools regression fails against unmodified main with the original premature `Done`.
- Real pi-acp 0.0.33 + Pi 0.85.1 + gpt-5.6-luna: three sessions survived injected 36.6–36.8-second post-tool model waits and each completed two queued follow-ups. Cancellation during a 32-second quiet gap also passed.
- Engine regression uses a 100ms watchdog and checks Working status, transcript boundaries, and autonomous-activity settlement. Formatting and diff checks passed.

Three engine unit tests initially exhausted `/tmp` file entries; all 165 passed when rerun with `TMPDIR` on a roomy temporary mount. Real-model tests are opt-in; reproduction instructions and the delay extension are included in `docs/research/acp.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791590734&installation_model_id=425430&pr_number=298&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F298&signature=43073b7cc7df0a6326f9026cdd5b9ecf8ead8d80cf6e0328744973d39e0f8548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->