### PR TITLE
Fix click-away focus behavior for inputs

### DIFF
--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -4028,6 +4028,7 @@ pub struct Composer {
     route_snap_until: Option<Instant>,
     _observe: Subscription,
     _pickers_observe: Subscription,
+    _picker_focus: Subscription,
     _input_events: Subscription,
 }
 
@@ -4072,6 +4073,13 @@ impl Composer {
         // by the composer from picker state — a pickers-side notify (refs
         // loaded, popover toggled, pick made) must repaint the composer too.
         let pickers_observe = cx.observe(&pickers, |_, _, cx| cx.notify());
+        let picker_focus = cx.subscribe(
+            &pickers,
+            |this: &mut Self, _, _: &crate::pickers::ReturnComposerFocus, cx| {
+                this.focus_pending = true;
+                cx.notify();
+            },
+        );
         let observe = cx.observe(&state, |this: &mut Self, _, cx| this.on_state_changed(cx));
         let input_events = cx.subscribe(&input, |this: &mut Self, _, event, cx| match event {
             ComposerInputEvent::Submitted => this.on_submit(cx),
@@ -4176,6 +4184,7 @@ impl Composer {
             route_snap_until: None,
             _observe: observe,
             _pickers_observe: pickers_observe,
+            _picker_focus: picker_focus,
             _input_events: input_events,
         };
         // Dev knob: pre-stage attachments (drop/paste can't be synthesized on
@@ -4251,6 +4260,7 @@ impl Composer {
             .entry(self.current_key.clone())
             .or_default()
             .extend(staged);
+        self.focus_pending = true;
         cx.notify();
     }
 
@@ -4460,10 +4470,16 @@ impl Composer {
             prompt: Some("Attach".into()),
         });
         self.picker_task = Some(cx.spawn(async move |this, cx| {
-            if let Ok(Ok(Some(paths))) = rx.await {
-                this.update(cx, |composer, cx| composer.add_paths(paths, cx))
-                    .ok();
-            }
+            let result = rx.await;
+            this.update(cx, |composer, cx| {
+                if let Ok(Ok(Some(paths))) = result {
+                    composer.add_paths(paths, cx);
+                }
+                // Both Attach and Cancel return to the draft.
+                composer.focus_pending = true;
+                cx.notify();
+            })
+            .ok();
         }));
     }
 
@@ -7030,6 +7046,16 @@ impl Render for Composer {
         // shows through as an inner glow (theme.rs's card_selected_shadows
         // lesson; user report).
         let pill = div()
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    // Padding and action controls are part of the text composer.
+                    // Open menus keep their own keyboard/search focus.
+                    if !this.pickers.read(cx).is_open() {
+                        window.focus(&this.input.focus_handle(cx), cx);
+                    }
+                }),
+            )
             .rounded(px(COMPOSER_RADIUS))
             .bg(pill_bg)
             .border_1()
@@ -7249,6 +7275,154 @@ impl Render for Composer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn composer_focus_window(
+        cx: &mut gpui::TestAppContext,
+    ) -> (tempfile::TempDir, gpui::WindowHandle<Composer>) {
+        let dir = tempfile::tempdir().unwrap();
+        cx.update(|cx| {
+            gpui_base::init(cx);
+            cx.set_global(Theme::dark());
+            crate::app_menus::init(cx);
+            crate::history::init(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                cx,
+            );
+            crate::settings::init(crate::settings::UiSettings::default(), dir.path(), cx);
+        });
+        let window = cx.add_window(|_, cx| {
+            let state = cx.new(|_| AppState::new());
+            Composer::new(state, cx)
+        });
+        cx.update_window(window.into(), |_, window, cx| window.draw(cx).clear())
+            .unwrap();
+        (dir, window)
+    }
+
+    #[gpui::test]
+    fn composer_padding_and_file_prompt_restore_focus(cx: &mut gpui::TestAppContext) {
+        let (dir, handle) = composer_focus_window(cx);
+        let image_path = dir.path().join("attachment.png");
+        let png = base64::Engine::decode(&base64::engine::general_purpose::STANDARD,
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF1cAAAAASUVORK5CYII=").unwrap();
+        std::fs::write(&image_path, png).unwrap();
+        let input = handle
+            .read_with(cx, |composer, _| composer.input.clone())
+            .unwrap();
+        cx.update_window(handle.into(), |_, window, cx| {
+            window.blur();
+            window.draw(cx).clear();
+            let bounds = input.read(cx).last_bounds.unwrap();
+            // Click padding immediately left of the actual editor.
+            let position = point(bounds.left() - px(4.0), bounds.center().y);
+            window.dispatch_event(
+                gpui::PlatformInput::MouseDown(MouseDownEvent {
+                    button: MouseButton::Left,
+                    position,
+                    click_count: 1,
+                    ..Default::default()
+                }),
+                cx,
+            );
+            assert!(input.read(cx).focus_handle.is_focused(window));
+            window.dispatch_event(
+                gpui::PlatformInput::MouseUp(MouseUpEvent {
+                    button: MouseButton::Left,
+                    position,
+                    ..Default::default()
+                }),
+                cx,
+            );
+        })
+        .unwrap();
+        for accepted in [false, true] {
+            handle
+                .update(cx, |composer, window, cx| {
+                    composer
+                        .input
+                        .update(cx, |input, cx| input.set_text("Keep this draft", cx));
+                    window.blur();
+                    composer.open_file_picker(cx);
+                })
+                .unwrap();
+            assert!(cx.did_prompt_for_paths());
+            let path = image_path.clone();
+            cx.simulate_path_prompt_response(move |_| accepted.then(|| vec![path]));
+            cx.run_until_parked();
+            cx.update_window(handle.into(), |_, window, cx| {
+                window.draw(cx).clear();
+                assert!(input.read(cx).focus_handle.is_focused(window));
+                assert_eq!(input.read(cx).text(), "Keep this draft");
+            })
+            .unwrap();
+            assert_eq!(
+                handle
+                    .read_with(cx, |composer, _| composer.staged().len())
+                    .unwrap(),
+                usize::from(accepted)
+            );
+        }
+        // The same staging path handles external file drops.
+        handle
+            .update(cx, |composer, window, cx| {
+                window.blur();
+                composer.add_paths(vec![image_path], cx);
+            })
+            .unwrap();
+        cx.update_window(handle.into(), |_, window, cx| {
+            window.draw(cx).clear();
+            assert!(input.read(cx).focus_handle.is_focused(window));
+        })
+        .unwrap();
+    }
+
+    #[gpui::test]
+    fn composer_picker_escape_restores_focus_but_click_away_does_not(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let (_dir, handle) = composer_focus_window(cx);
+        let input = handle
+            .read_with(cx, |composer, _| composer.input.clone())
+            .unwrap();
+        for escape in [true, false] {
+            handle
+                .update(cx, |composer, window, cx| {
+                    composer
+                        .pickers
+                        .update(cx, |pickers, cx| pickers.open_model_menu(window, cx));
+                })
+                .unwrap();
+            cx.update_window(handle.into(), |_, window, cx| {
+                window.draw(cx).clear();
+                assert!(!input.read(cx).focus_handle.is_focused(window));
+            })
+            .unwrap();
+            if escape {
+                cx.simulate_keystrokes(handle.into(), "escape");
+            } else {
+                cx.update_window(handle.into(), |_, window, cx| {
+                    window.dispatch_event(
+                        gpui::PlatformInput::MouseDown(MouseDownEvent {
+                            button: MouseButton::Left,
+                            position: point(px(5.0), window.viewport_size().height - px(1.0)),
+                            click_count: 1,
+                            ..Default::default()
+                        }),
+                        cx,
+                    );
+                })
+                .unwrap();
+            }
+            cx.update_window(handle.into(), |_, window, cx| {
+                window.draw(cx).clear();
+                assert_eq!(input.read(cx).focus_handle.is_focused(window), escape);
+            })
+            .unwrap();
+        }
+    }
 
     #[gpui::test]
     fn inputs_release_focus_on_click_away(cx: &mut gpui::TestAppContext) {

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -3700,6 +3700,13 @@ impl Render for ComposerInput {
             .on_action(cx.listener(Self::redo))
             .on_key_down(cx.listener(Self::on_key_down))
             .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
+            .on_mouse_down_out(cx.listener(|this, event: &MouseDownEvent, window, _| {
+                // Capture runs before the clicked control handles the press, so
+                // another input can take focus normally during bubbling.
+                if event.button == MouseButton::Left && this.focus_handle.is_focused(window) {
+                    window.blur();
+                }
+            }))
             .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
             .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_mouse_up))
             .on_scroll_wheel(cx.listener(Self::on_scroll_wheel))
@@ -4682,6 +4689,14 @@ impl Composer {
             .w_full()
             .max_h(px(320.0))
             .overflow_hidden()
+            // Completion choices belong to the input. Keep it focused until
+            // mouse-up can accept a choice (or while dragging the scrollbar).
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    window.focus(&this.input.focus_handle(cx), cx);
+                }),
+            )
             // GPUI dispatches this captured stream while the thumb is
             // dragged, including when the pointer has left the popup.
             .on_drag_move(cx.listener(Self::on_popup_bar_drag_move))
@@ -4999,6 +5014,12 @@ impl Composer {
             .w_full()
             .max_h(px(320.0))
             .overflow_hidden()
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    window.focus(&this.input.focus_handle(cx), cx);
+                }),
+            )
             // GPUI dispatches this captured stream while the thumb is
             // dragged, including when the pointer has left the popup.
             .on_drag_move(cx.listener(Self::on_popup_bar_drag_move))
@@ -7228,6 +7249,71 @@ impl Render for Composer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[gpui::test]
+    fn inputs_release_focus_on_click_away(cx: &mut gpui::TestAppContext) {
+        struct Inputs(Vec<Entity<ComposerInput>>);
+        impl Render for Inputs {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                div().size_full().flex().flex_col().children(
+                    self.0
+                        .iter()
+                        .map(|input| div().w(px(200.0)).child(input.clone())),
+                )
+            }
+        }
+        cx.update(|cx| cx.set_global(Theme::dark()));
+        let host = cx.add_window(|_, cx| {
+            Inputs(vec![
+                cx.new(|cx| ComposerInput::new("Composer", cx)),
+                cx.new(|cx| ComposerInput::new("URL", cx).with_single_line()),
+            ])
+        });
+        cx.run_until_parked();
+        cx.update_window(host.into(), |_, window, cx| window.draw(cx).clear())
+            .unwrap();
+        let inputs = host.read_with(cx, |host, _| host.0.clone()).unwrap();
+        // Visit both fields and return to the first: click-away capture must
+        // never clear focus acquired by the clicked input during bubbling.
+        for index in [0, 1, 0] {
+            let position =
+                inputs[index].read_with(cx, |input, _| input.last_bounds.unwrap().center());
+            cx.update_window(host.into(), |_, window, cx| {
+                window.dispatch_event(
+                    gpui::PlatformInput::MouseDown(MouseDownEvent {
+                        button: MouseButton::Left,
+                        position,
+                        click_count: 1,
+                        ..Default::default()
+                    }),
+                    cx,
+                );
+                assert!(inputs[index].read(cx).focus_handle.is_focused(window));
+                window.dispatch_event(
+                    gpui::PlatformInput::MouseUp(MouseUpEvent {
+                        button: MouseButton::Left,
+                        position,
+                        ..Default::default()
+                    }),
+                    cx,
+                );
+            })
+            .unwrap();
+        }
+        cx.update_window(host.into(), |_, window, cx| {
+            window.dispatch_event(
+                gpui::PlatformInput::MouseDown(MouseDownEvent {
+                    button: MouseButton::Left,
+                    position: point(px(400.0), px(300.0)),
+                    click_count: 1,
+                    ..Default::default()
+                }),
+                cx,
+            );
+            assert!(window.focused(cx).is_none());
+        })
+        .unwrap();
+    }
 
     #[gpui::test]
     fn projectless_composer_allows_send_and_enter_submission(cx: &mut gpui::TestAppContext) {

--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -3975,8 +3975,8 @@ pub struct Composer {
     pub(crate) queue_edit_finishing: bool,
     pub(crate) queue_edit_task: Option<Task<()>>,
     pub(crate) queue_edit_renew_task: Option<Task<()>>,
-    /// Apply focus on the next render after opening or closing an edit.
-    pub(crate) queue_edit_focus_pending: bool,
+    /// Focus once on mount, navigation, or after opening/closing a queue edit.
+    pub(crate) focus_pending: bool,
     /// Live drag over the queue panel: which row, and where it would land.
     pub(crate) queue_drag: Option<crate::queue::QueueDragState>,
     pub(crate) queue_scroll: gpui::ScrollHandle,
@@ -4155,7 +4155,7 @@ impl Composer {
             queue_edit_finishing: false,
             queue_edit_task: None,
             queue_edit_renew_task: None,
-            queue_edit_focus_pending: false,
+            focus_pending: true,
             queue_drag: None,
             queue_scroll: gpui::ScrollHandle::new(),
             queue_removing: HashSet::new(),
@@ -6592,8 +6592,8 @@ impl Focusable for Composer {
 
 impl Render for Composer {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        if self.queue_edit_focus_pending {
-            self.queue_edit_focus_pending = false;
+        if self.focus_pending {
+            self.focus_pending = false;
             let focus = self.input.focus_handle(cx);
             window.focus(&focus, cx);
         }

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -431,6 +431,10 @@ pub enum PickerKind {
     Device,
 }
 
+pub(crate) struct ReturnComposerFocus;
+
+impl gpui::EventEmitter<ReturnComposerFocus> for Pickers {}
+
 pub struct Pickers {
     state: Entity<AppState>,
     config: DraftConfig,
@@ -817,10 +821,19 @@ impl Pickers {
 
     /// Begin the exit animation (shared by every close path).
     fn animate_close(&mut self, cx: &mut Context<Self>) {
+        if self.is_open() {
+            cx.emit(ReturnComposerFocus);
+        }
+        self.dismiss(cx);
+    }
+
+    /// Outside clicks and navigation keep focus at the clicked destination.
+    fn dismiss(&mut self, cx: &mut Context<Self>) {
         self.model_bar = popover::MenuScrollbarState::default();
         if self.open.begin_close() {
             popover::reap_popup(cx, |pickers: &mut Self| &mut pickers.open);
         }
+        cx.notify();
     }
 
     fn close(&mut self, cx: &mut Context<Self>) {
@@ -860,6 +873,9 @@ impl Pickers {
         let pressed_open = self.open.take_press_was_open();
         if self.open_kind() == Some(kind) || pressed_open {
             self.animate_close(cx);
+            if pressed_open {
+                cx.emit(ReturnComposerFocus);
+            }
             cx.notify();
             return;
         }
@@ -2006,7 +2022,7 @@ impl Pickers {
         let new_project = popover::menu_row_nav(&theme, false, false, "project-new".to_string())
             .id("project-new")
             .on_click(cx.listener(|this, _, window, cx| {
-                this.close(cx);
+                this.dismiss(cx);
                 window.dispatch_action(Box::new(crate::shell::AddSpacePalette), cx);
             }))
             .child(
@@ -2599,7 +2615,20 @@ impl Pickers {
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
                 this.on_key_down(event, window, cx)
             }))
-            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.close(cx)))
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    if this.is_open() && !this.focus.contains_focused(window, cx) {
+                        window.focus(&this.focus, cx);
+                    }
+                }),
+            )
+            .on_mouse_down_out(cx.listener(|this, _, window, cx| {
+                this.dismiss(cx);
+                if this.focus.contains_focused(window, cx) {
+                    window.blur();
+                }
+            }))
             .flex()
             .flex_col()
             .child(content)
@@ -2622,7 +2651,20 @@ impl Pickers {
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
                 this.on_key_down(event, window, cx)
             }))
-            .on_mouse_down_out(cx.listener(|this, _, _, cx| this.close(cx)))
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    if this.is_open() && !this.focus.contains_focused(window, cx) {
+                        window.focus(&this.focus, cx);
+                    }
+                }),
+            )
+            .on_mouse_down_out(cx.listener(|this, _, window, cx| {
+                this.dismiss(cx);
+                if this.focus.contains_focused(window, cx) {
+                    window.blur();
+                }
+            }))
             .flex()
             .flex_col()
             .child(content)
@@ -3966,6 +4008,18 @@ impl Render for Pickers {
             }
         }
 
+        if self.is_open() {
+            let search = self.search.focus_handle(cx);
+            let frame = self.focus.clone();
+            window.defer(cx, move |window, cx| {
+                // Loading, empty, and error states can omit the search box.
+                // Keep Escape/arrow keys on the mounted menu in those states.
+                if search.is_focused(window) && !frame.contains(&search, window) {
+                    window.focus(&frame, cx);
+                }
+            });
+        }
+
         // Eager-load the harness catalog + every offered harness's models so
         // the chip reads "Fable 5" (a concrete pick) before any popover
         // opens, and rail switches inside the picker are instant.
@@ -4140,6 +4194,61 @@ impl Render for Pickers {
 mod tests {
     use super::*;
     use zeron_proto::{FolderEntry, Model, ModelOption, ModelOptionChoice};
+
+    #[gpui::test]
+    fn picker_completion_and_dismissal_have_distinct_focus_behavior(cx: &mut gpui::TestAppContext) {
+        use std::cell::Cell;
+        use std::rc::Rc;
+        cx.update(|cx| cx.set_global(Theme::dark()));
+        let handle = cx.add_window(|_, cx| {
+            let state = cx.new(|_| AppState::new());
+            Pickers::new(state, cx)
+        });
+        let returned = Rc::new(Cell::new(0));
+        let observed = returned.clone();
+        let _sub = cx.update(|cx| {
+            cx.subscribe(
+                &handle.entity(cx).unwrap(),
+                move |_, _: &ReturnComposerFocus, _| observed.set(observed.get() + 1),
+            )
+        });
+        handle
+            .update(cx, |pickers, _, cx| {
+                pickers.open.open(PickerKind::Checkout);
+                pickers.pick_checkout(CheckoutKind::Local, cx);
+            })
+            .unwrap();
+        assert_eq!(returned.get(), 1);
+        handle
+            .update(cx, |pickers, _, cx| {
+                pickers.open.open(PickerKind::HarnessModel);
+                pickers.pick_model("test-model".into(), cx);
+                assert!(
+                    pickers.is_open(),
+                    "model options remain available after a selection"
+                );
+                pickers.dismiss(cx);
+            })
+            .unwrap();
+        assert_eq!(
+            returned.get(),
+            1,
+            "outside clicks must not request composer focus"
+        );
+        handle
+            .update(cx, |pickers, window, cx| {
+                pickers.open.open(PickerKind::Checkout);
+                pickers.open.note_trigger_press();
+                pickers.dismiss(cx); // Capture closes before the trigger's click.
+                pickers.toggle(PickerKind::Checkout, window, cx);
+            })
+            .unwrap();
+        assert_eq!(
+            returned.get(),
+            2,
+            "closing via the trigger returns to the composer"
+        );
+    }
 
     #[gpui::test]
     fn projectless_picker_clears_checkout_and_supports_keyboard_selection(

--- a/crates/ui/src/queue.rs
+++ b/crates/ui/src/queue.rs
@@ -1020,7 +1020,7 @@ impl Composer {
                             composer.attachments.remove(&composer.current_key).unwrap_or_default(),
                         ));
                         composer.attachments.insert(composer.current_key.clone(), loaded_attachments);
-                        composer.queue_edit_focus_pending = true;
+                        composer.focus_pending = true;
                         composer.input.update(cx, |input, cx| input.set_text(text, cx));
                         composer.start_queue_edit_renewal(engine.clone(), cx);
                     }
@@ -1095,7 +1095,7 @@ impl Composer {
             self.attachments
                 .insert(self.current_key.clone(), attachments);
         }
-        self.queue_edit_focus_pending = true;
+        self.focus_pending = true;
         cx.notify();
     }
 

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -2187,7 +2187,12 @@ impl Shell {
             }
             RightSurface::Terminal(tab) => {
                 let panel = self.right_terminal_panel(cx);
-                panel.update(cx, |panel, cx| panel.select_tab_by_key(tab, cx));
+                self.composer
+                    .update(cx, |composer, _| composer.focus_pending = false);
+                panel.update(cx, |panel, cx| {
+                    panel.select_tab_by_key(tab, cx);
+                    panel.request_focus(cx);
+                });
             }
             RightSurface::Diff(id) => {
                 if let Some(changes) = self.diffs.get(&id).cloned() {
@@ -2923,6 +2928,9 @@ impl Shell {
         let panel = self.terminal_panel(cx);
         panel.update(cx, |panel, cx| panel.set_open(open, cx));
         if open {
+            self.composer
+                .update(cx, |composer, _| composer.focus_pending = false);
+            panel.update(cx, |panel, cx| panel.request_focus(cx));
             // Opening lands keyboard focus IN the shell — typing goes straight
             // to the prompt, no click needed (zeron terminal-panel.tsx: the
             // visible+active effect calls `terminal.focus()` on every open).
@@ -9742,6 +9750,91 @@ mod exit_regressions {
                 assert_eq!(shell.eval_tween(tween, 0.), 0.);
             })
             .unwrap();
+    }
+
+    #[gpui::test]
+    fn opening_terminals_focuses_the_terminal_once(cx: &mut TestAppContext) {
+        let dir = tempfile::tempdir().unwrap();
+        cx.update(|cx| {
+            gpui_base::init(cx);
+            cx.set_global(Theme::default());
+            crate::app_menus::init(cx);
+            crate::history::init(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                cx,
+            );
+            settings::init(settings::UiSettings::default(), dir.path(), cx);
+        });
+        let window = cx.add_window(|_, cx| {
+            let state = cx.new(|_| AppState::new());
+            Shell::new(
+                state,
+                EngineBootConfig {
+                    data_dir: dir.path().into(),
+                    ipc_port: 0,
+                    edge_url: "http://127.0.0.1:1".into(),
+                    edge_token: None,
+                    org_id: None,
+                    workos_client_id: None,
+                    default_harness: zeron_proto::HarnessId::Mock,
+                },
+                cx,
+            )
+        });
+        let mut drawer_window = None;
+        for embedded in [false, false, true] {
+            let panel = window
+                .update(cx, |shell, window, cx| {
+                    shell.open_chat("terminal-session".into(), cx);
+                    shell.active_chat = "terminal-session".into();
+                    let panel = if embedded {
+                        shell.add_terminal_surface(cx);
+                        shell.right_terminal.clone().unwrap()
+                    } else {
+                        shell.toggle_terminal(window, cx);
+                        shell.terminal.clone().unwrap()
+                    };
+                    assert!(!shell.composer.read(cx).focus_pending);
+                    panel
+                })
+                .unwrap();
+            let terminal_window = if !embedded && drawer_window.is_some() {
+                drawer_window.unwrap()
+            } else {
+                let handle = cx.update(|cx| {
+                    cx.open_window(gpui::WindowOptions::default(), |_, _| panel.clone())
+                        .unwrap()
+                });
+                if !embedded {
+                    drawer_window = Some(handle);
+                }
+                handle
+            };
+            cx.update_window(terminal_window.into(), |_, window, cx| {
+                window.draw(cx).clear();
+                assert!(
+                    panel.read(cx).focus_handle().is_focused(window),
+                    "embedded: {embedded}"
+                );
+                // Ordinary redraws must not steal focus from another control.
+                let other_input = cx.focus_handle();
+                window.focus(&other_input, cx);
+                window.draw(cx).clear();
+                assert!(other_input.is_focused(window));
+            })
+            .unwrap();
+            if !embedded {
+                window
+                    .update(cx, |shell, window, cx| {
+                        shell.toggle_terminal(window, cx);
+                        assert!(shell.composer.focus_handle(cx).is_focused(window));
+                    })
+                    .unwrap();
+            }
+        }
     }
 
     #[gpui::test]

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -3116,6 +3116,7 @@ impl Shell {
 
     fn close_settings(&mut self, cx: &mut Context<Self>) {
         self.route = Route::Chat;
+        self.focus_composer(cx);
         self.nav.push(NavEntry::Chat(self.active_chat.clone()));
         cx.notify();
     }
@@ -3141,6 +3142,7 @@ impl Shell {
         match entry {
             NavEntry::Chat(chat_id) => {
                 self.route = Route::Chat;
+                self.focus_composer(cx);
                 let target = (!chat_id.is_empty()).then_some(chat_id);
                 if self.state.read(cx).selected_chat != target {
                     self.state.update(cx, |s, cx| s.select_chat(target, cx));
@@ -9740,6 +9742,77 @@ mod exit_regressions {
                 assert_eq!(shell.eval_tween(tween, 0.), 0.);
             })
             .unwrap();
+    }
+
+    #[gpui::test]
+    fn session_navigation_focuses_composer_once(cx: &mut TestAppContext) {
+        let dir = tempfile::tempdir().unwrap();
+        cx.update(|cx| {
+            gpui_base::init(cx);
+            cx.set_global(Theme::default());
+            crate::app_menus::init(cx);
+            crate::history::init(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                cx,
+            );
+            settings::init(settings::UiSettings::default(), dir.path(), cx);
+        });
+        let window = cx.add_window(|_, cx| {
+            let state = cx.new(|_| AppState::new());
+            Shell::new(
+                state,
+                EngineBootConfig {
+                    data_dir: dir.path().into(),
+                    ipc_port: 0,
+                    edge_url: "http://127.0.0.1:1".into(),
+                    edge_token: None,
+                    org_id: None,
+                    workos_client_id: None,
+                    default_harness: zeron_proto::HarnessId::Mock,
+                },
+                cx,
+            )
+        });
+        // Render the real composer in its own window to exercise mounting
+        // without the shell's boot/connection gate hiding the destination.
+        let composer_window = cx.update(|cx| {
+            let composer = window.read(cx).unwrap().composer.clone();
+            cx.open_window(gpui::WindowOptions::default(), |_, _| composer)
+                .unwrap()
+        });
+        for destination in ["initial", "chat", "chat", "new", "new", "back", "settings"] {
+            window
+                .update(cx, |shell, _, cx| match destination {
+                    "chat" => shell.open_chat("existing-session".into(), cx),
+                    "new" => shell.open_new_session(cx),
+                    "back" => shell.apply_nav(NavEntry::Chat("existing-session".into()), cx),
+                    "settings" => {
+                        shell.open_settings(SettingsSection::Devices, cx);
+                        shell.close_settings(cx);
+                    }
+                    _ => {}
+                })
+                .unwrap();
+            cx.update_window(composer_window.into(), |composer, window, cx| {
+                window.draw(cx).clear();
+                assert!(
+                    composer
+                        .downcast::<Composer>()
+                        .unwrap()
+                        .focus_handle(cx)
+                        .is_focused(window),
+                    "{destination}"
+                );
+                // Subsequent renders after a click-away must not reclaim it.
+                window.blur();
+                window.draw(cx).clear();
+                assert!(window.focused(cx).is_none(), "{destination}");
+            })
+            .unwrap();
+        }
     }
 
     #[gpui::test]

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -99,12 +99,21 @@ pub(crate) fn restore_focus_if_empty_on_next_frame<T: 'static>(
 fn restore_mounted_focus(
     root: &FocusHandle,
     preferred: &FocusHandle,
+    unfocused: &FocusHandle,
     window: &mut Window,
     cx: &mut App,
 ) {
     let preferred_mounted = root.contains(preferred, window);
     if !root.contains_focused(window, cx) || (root.is_focused(window) && preferred_mounted) {
-        let target = if preferred_mounted { preferred } else { root };
+        // Explicit blur keeps shortcuts active without returning the caret to
+        // an input. The root remains the temporary fallback for stale handles.
+        let target = if window.focused(cx).is_none() {
+            unfocused
+        } else if preferred_mounted {
+            preferred
+        } else {
+            root
+        };
         window.focus(target, cx);
     }
 }
@@ -1325,6 +1334,8 @@ pub struct Shell {
     /// settle, preserving focus on mounted controls.
     focus_sub: Option<Subscription>,
     shortcut_focus: FocusHandle,
+    /// Neutral shortcut target after clicking away from an input.
+    unfocused: FocusHandle,
     /// Clears the jump hints when the window deactivates: a Cmd+Tab away
     /// swallows the key-up, so without this the chips stay on screen for good.
     activation_sub: Option<Subscription>,
@@ -1590,6 +1601,7 @@ impl Shell {
             splash_task: None,
             focus_sub: None,
             shortcut_focus: cx.focus_handle(),
+            unfocused: cx.focus_handle(),
             activation_sub: None,
             _ticker: ticker,
             _state_observation: observation,
@@ -8491,17 +8503,19 @@ impl Render for Shell {
         if self.focus_sub.is_none() {
             self.focus_sub = Some(cx.on_focus_lost(window, |this: &mut Shell, window, cx| {
                 let root = this.shortcut_focus.clone();
+                let unfocused = this.unfocused.clone();
                 let preferred = this.composer.focus_handle(cx);
                 window.on_next_frame(move |window, cx| {
-                    restore_mounted_focus(&root, &preferred, window, cx);
+                    restore_mounted_focus(&root, &preferred, &unfocused, window, cx);
                 });
                 cx.notify();
             }));
         }
         let shortcut_focus = self.shortcut_focus.clone();
+        let unfocused = self.unfocused.clone();
         let preferred_focus = self.composer.focus_handle(cx);
         window.defer(cx, move |window, cx| {
-            restore_mounted_focus(&shortcut_focus, &preferred_focus, window, cx);
+            restore_mounted_focus(&shortcut_focus, &preferred_focus, &unfocused, window, cx);
         });
 
         // Modifier events follow focus too. Reconcile from the window's input
@@ -8517,6 +8531,7 @@ impl Render for Shell {
         let root = div()
             .id("shell-root")
             .track_focus(&self.shortcut_focus)
+            .child(div().track_focus(&self.unfocused))
             .relative()
             .flex()
             .flex_row()
@@ -10027,6 +10042,7 @@ mod shortcut_focus_regressions {
 
     struct ShortcutHost {
         root: FocusHandle,
+        unfocused: FocusHandle,
         editor: FocusHandle,
         show_editor: bool,
         jumps: usize,
@@ -10035,13 +10051,15 @@ mod shortcut_focus_regressions {
     impl Render for ShortcutHost {
         fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
             let root = self.root.clone();
+            let unfocused = self.unfocused.clone();
             let preferred = self.editor.clone();
             window.defer(cx, move |window, cx| {
-                restore_mounted_focus(&root, &preferred, window, cx);
+                restore_mounted_focus(&root, &preferred, &unfocused, window, cx);
             });
             div()
                 .size_full()
                 .track_focus(&self.root)
+                .child(div().track_focus(&self.unfocused))
                 .on_mouse_down(
                     MouseButton::Left,
                     cx.listener(|this, event: &MouseDownEvent, window, cx| {
@@ -10064,6 +10082,30 @@ mod shortcut_focus_regressions {
     }
 
     #[gpui::test]
+    fn explicit_blur_does_not_refocus_a_mounted_input(cx: &mut TestAppContext) {
+        let host = cx.add_window(|_, cx| ShortcutHost {
+            root: cx.focus_handle(),
+            unfocused: cx.focus_handle(),
+            editor: cx.focus_handle(),
+            show_editor: true,
+            jumps: 0,
+        });
+        cx.run_until_parked();
+        cx.update_window(host.into(), |_, window, cx| window.draw(cx).clear())
+            .unwrap();
+        host.update(cx, |host, window, cx| {
+            window.focus(&host.editor, cx);
+            window.blur();
+            restore_mounted_focus(&host.root, &host.editor, &host.unfocused, window, cx);
+            assert!(host.unfocused.is_focused(window));
+            // Subsequent renders must keep the neutral shortcut focus too.
+            restore_mounted_focus(&host.root, &host.editor, &host.unfocused, window, cx);
+            assert!(host.unfocused.is_focused(window));
+        })
+        .unwrap();
+    }
+
+    #[gpui::test]
     fn shortcuts_recover_from_retained_editor_focus(cx: &mut TestAppContext) {
         cx.update(|cx| {
             cx.bind_keys([KeyBinding::new(
@@ -10074,6 +10116,7 @@ mod shortcut_focus_regressions {
         });
         let host = cx.add_window(|_, cx| ShortcutHost {
             root: cx.focus_handle(),
+            unfocused: cx.focus_handle(),
             editor: cx.focus_handle(),
             show_editor: true,
             jumps: 0,
@@ -10090,7 +10133,7 @@ mod shortcut_focus_regressions {
             cx.update_window(host.into(), |_, window, cx| window.draw(cx).clear())
                 .unwrap();
             host.update(cx, |host, window, cx| {
-                restore_mounted_focus(&host.root, &host.editor, window, cx);
+                restore_mounted_focus(&host.root, &host.editor, &host.unfocused, window, cx);
                 assert!(host.root.contains_focused(window, cx));
                 assert_eq!(host.editor.is_focused(window), show_editor);
             })
@@ -10100,8 +10143,8 @@ mod shortcut_focus_regressions {
         host.update(cx, |host, window, cx| {
             assert_eq!(host.jumps, 4);
             window.blur();
-            restore_mounted_focus(&host.root, &host.editor, window, cx);
-            assert!(host.root.is_focused(window));
+            restore_mounted_focus(&host.root, &host.editor, &host.unfocused, window, cx);
+            assert!(host.unfocused.is_focused(window));
         })
         .unwrap();
     }
@@ -10117,6 +10160,7 @@ mod shortcut_focus_regressions {
         });
         let host = cx.add_window(|_, cx| ShortcutHost {
             root: cx.focus_handle(),
+            unfocused: cx.focus_handle(),
             editor: cx.focus_handle(),
             show_editor: true,
             jumps: 0,

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -389,6 +389,7 @@ impl Shell {
     /// new-session canvas there.
     pub(super) fn land_in_space(&mut self, space_id: String, cx: &mut Context<Self>) {
         self.route = Route::Chat;
+        self.focus_composer(cx);
         self.settings.space_filter = Some(space_id.clone());
         self.settings.last_space_id = Some(space_id.clone());
         self.state.update(cx, |s, cx| {

--- a/crates/ui/src/shell/tabs.rs
+++ b/crates/ui/src/shell/tabs.rs
@@ -40,6 +40,14 @@ pub(super) fn right_pane_expand_icon(expanded: bool) -> &'static str {
 }
 
 impl Shell {
+    /// Navigation requests focus once the destination composer renders.
+    pub(super) fn focus_composer(&mut self, cx: &mut Context<Self>) {
+        self.composer.update(cx, |composer, cx| {
+            composer.focus_pending = true;
+            cx.notify();
+        });
+    }
+
     /// Ctrl+Tab / Ctrl+Shift+Tab: step through the sidebar's Sessions list in
     /// the order it is drawn. Selection is immediate (no MRU overlay held open
     /// on the modifier) — one press, one session.
@@ -78,6 +86,7 @@ impl Shell {
                 .map(|(_, c)| c.id.clone())
         };
         if let Some(first) = first {
+            self.focus_composer(cx);
             self.state
                 .update(cx, |s, cx| s.select_chat(Some(first), cx));
         }
@@ -86,6 +95,7 @@ impl Shell {
     /// Open a session from the sidebar: select it, the main area follows.
     pub(super) fn open_chat(&mut self, chat_id: String, cx: &mut Context<Self>) {
         self.route = Route::Chat;
+        self.focus_composer(cx);
         self.state
             .update(cx, |s, cx| s.select_chat(Some(chat_id), cx));
         cx.notify();
@@ -96,6 +106,7 @@ impl Shell {
     /// (the last selected project, restored from composer defaults) stands.
     pub(super) fn open_new_session(&mut self, cx: &mut Context<Self>) {
         self.route = Route::Chat;
+        self.focus_composer(cx);
         let target = {
             let state = self.state.read(cx);
             self.settings

--- a/crates/ui/src/terminal/panel.rs
+++ b/crates/ui/src/terminal/panel.rs
@@ -356,6 +356,7 @@ impl Render for TabGhost {
 pub struct TerminalPanel {
     state: Entity<AppState>,
     focus_handle: FocusHandle,
+    focus_pending: bool,
     chats: HashMap<String, ChatTabs>,
     /// Shell-driven visibility gate: no RPC happens while closed (lazy).
     open: bool,
@@ -393,6 +394,7 @@ impl TerminalPanel {
         Self {
             state,
             focus_handle: cx.focus_handle(),
+            focus_pending: false,
             chats: HashMap::new(),
             open: false,
             embedded: false,
@@ -421,6 +423,12 @@ impl TerminalPanel {
         self.focus_handle.clone()
     }
 
+    /// Claim focus once the terminal body mounts, after opening or selecting it.
+    pub fn request_focus(&mut self, cx: &mut Context<Self>) {
+        self.focus_pending = true;
+        cx.notify();
+    }
+
     pub fn set_resize_suspended(&mut self, suspended: bool) {
         self.resize_suspended = suspended;
     }
@@ -430,6 +438,9 @@ impl TerminalPanel {
     /// keeps every session alive (detach ≠ close).
     pub fn set_open(&mut self, open: bool, cx: &mut Context<Self>) {
         self.open = open;
+        if !open {
+            self.focus_pending = false;
+        }
         if open && !self.embedded {
             self.ensure_tab(cx);
         }
@@ -470,6 +481,7 @@ impl TerminalPanel {
     pub fn open_tab_for_selected(&mut self, cx: &mut Context<Self>) -> Option<u64> {
         let chat = self.selected_chat(cx)?;
         self.open_tab(chat, cx);
+        self.request_focus(cx);
         Some(self.tab_seq)
     }
 
@@ -1518,6 +1530,7 @@ impl TerminalPanel {
                             .cursor_pointer()
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.select_tab(&chat_select, ix, cx);
+                                this.request_focus(cx);
                             }))
                             // Middle-click closes (§1.10).
                             .on_mouse_down(
@@ -1594,6 +1607,7 @@ impl TerminalPanel {
                     .on_click(cx.listener(|this, _, _, cx| {
                         if let Some(chat) = this.selected_chat(cx) {
                             this.open_tab(chat, cx);
+                            this.request_focus(cx);
                         }
                     }))
                     .child(
@@ -1661,6 +1675,9 @@ impl Render for TerminalPanel {
                 .child(SharedString::from("Select a chat to open a terminal"))
                 .into_any_element();
         };
+        if std::mem::take(&mut self.focus_pending) && self.open {
+            window.focus(&self.focus_handle, cx);
+        }
         let focused = self.focus_handle.is_focused(window);
         let scrollbar = self.render_scrollbar(&theme, cx);
 


### PR DESCRIPTION
Clicking outside the composer, browser URL bar, or other shared text inputs now releases input focus. The shell keeps keyboard shortcuts active without restoring the composer caret, while retaining focus recovery for editors that mount or disappear.

Opening a session or the new-session page explicitly focuses the composer once, including repeated navigation to the same destination. Initial mount, history navigation, and returning from Settings also focus it. Opening or selecting a terminal focuses its body when it mounts; closing the bottom drawer returns to the composer.

Composer interaction improvements:

- Padding and action controls keep the composer ready for typing.
- Completed picker choices, Escape, and closing a picker via its trigger return focus to the composer. Outside clicks and navigation preserve the clicked destination.
- The model menu remains open for adjusting model options, and loading/empty/error states retain a mounted keyboard target.
- Both Attach and Cancel in the native file chooser restore composer focus and retain the draft. Successful image drops also focus the composer.
- Mention and slash-command suggestions preserve input focus through mouse-up.

Validation (all pass, using `CARGO_INCREMENTAL=0 cargo test -p zeron-ui --lib <filter> -- --test-threads=1`):

- `composer::tests`: 69 tests
- `pickers::tests`: 20 tests
- `focus`: 10 regression tests

Tests include rendered click/keyboard interactions and simulated file chooser responses. Native macOS interactions have not been manually tested.
