### PR TITLE
Fix browser sidebar resize input and white edge artifacts

### DIFF
--- a/crates/ui/examples/browser-fixture.rs
+++ b/crates/ui/examples/browser-fixture.rs
@@ -353,11 +353,16 @@ fn main() -> anyhow::Result<()> {
                     let (left,top)=first.read_with(cx,|b,_|b.fixture_origin());
                     // Real resize-handle drag, including crossing into the native page.
                     eprintln!("Browser fixture: starting resize drag");
-                    let start=gpui::point(px(left-2.),px(top+120.));
+                    // Both halves must reach GPUI before a drag exists.
+                    for offset in [-6., -2., 0., 3., 4.5] {
+                        anyhow::ensure!(!first.read_with(cx,|b,_|b.fixture_page_hit((left+offset) as f64,(top+120.) as f64)),"native page stole the resize target at offset {offset}");
+                    }
+                    anyhow::ensure!(first.read_with(cx,|b,_|b.fixture_page_hit((left+6.) as f64,(top+120.) as f64)),"resize target blocked adjacent page content");
+                    let start=gpui::point(px(left+3.),px(top+120.));
                     gpui::AnyWindowHandle::from(window).update(cx,|_,w,cx| {w.dispatch_event(gpui::PlatformInput::MouseDown(gpui::MouseDownEvent{position:start,button:gpui::MouseButton::Left,click_count:1,..Default::default()}),cx);})?;
                     let mut widths=Vec::new();
                     for delta in [10.,30.,60.,100.,140.,180.,140.,100.,60.,20.,-20.,-60.,-100.,-140.,-180.,-140.,-100.,-60.,-20.,0.] {
-                        let pos=gpui::point(px(left-2.+delta),start.y);
+                        let pos=gpui::point(px(left+3.+delta),start.y);
                         first.read_with(cx,|b,_|b.fixture_move_cursor(f32::from(pos.x) as f64,f32::from(pos.y) as f64));
                         gpui::AnyWindowHandle::from(window).update(cx,|_,w,cx| {w.dispatch_event(gpui::PlatformInput::MouseMove(gpui::MouseMoveEvent{position:pos,pressed_button:Some(gpui::MouseButton::Left),modifiers:Default::default()}),cx);})?;
                         pause(cx,100).await;
@@ -443,9 +448,14 @@ fn main() -> anyhow::Result<()> {
                     anyhow::ensure!(std::fs::metadata(output.join("browser-layout.mov"))?.len()>10000,"layout recording is empty");
                     validate_blur(&output,regions[0],window_width)?;
                 }
-                for width in [380., 640., 520.] {
+                for width in [380.25, 640.5, 520.75] {
                     window.update(cx, |shell, _, cx| shell.fixture_resize_browser(width, cx))?;
                     pause(cx, 150).await;
+                    #[cfg(target_os = "macos")]
+                    {
+                        let (layout,native,clip)=first.read_with(cx,|b,_|b.fixture_geometry());
+                        anyhow::ensure!((layout-native).abs()<0.01 && (clip-native).abs()<0.01,"fractional resize left a gap between the page and clip: {layout}/{native}/{clip}");
+                    }
                 }
                 window.update(cx, |shell, _, cx| shell.fixture_expand_browser(cx))?;
                 pause(cx, 400).await;

--- a/crates/ui/src/browser/macos.rs
+++ b/crates/ui/src/browser/macos.rs
@@ -245,6 +245,7 @@ impl Observer {
 struct ClipState {
     dragging: Cell<bool>,
     region: Cell<objc2_foundation::NSRect>,
+    resize_inset: Cell<f64>,
 }
 
 // Clips native content to GPUI's current paint mask. During app drags the
@@ -260,7 +261,7 @@ define_class!(
         fn hit_test(&self, point: objc2_foundation::NSPoint) -> *mut NSView {
             let region = self.ivars().region.get();
             if self.ivars().dragging.get()
-                || point.x < region.origin.x || point.x >= region.origin.x + region.size.width
+                || point.x < region.origin.x + self.ivars().resize_inset.get() || point.x >= region.origin.x + region.size.width
                 || point.y < region.origin.y || point.y >= region.origin.y + region.size.height
             { std::ptr::null_mut() }
             else { unsafe { msg_send![super(self), hitTest: point] } }
@@ -316,6 +317,7 @@ impl NativePage {
             let object = mtm.alloc().set_ivars(ClipState {
                 dragging: Cell::new(false),
                 region: Cell::new(objc2_foundation::NSRect::ZERO),
+                resize_inset: Cell::new(0.0),
             });
             msg_send![super(object), initWithFrame: objc2_foundation::NSRect::ZERO]
         };
@@ -528,7 +530,13 @@ fn has_focus(view: &NSView) -> bool {
 }
 
 impl Host {
-    pub fn sync(&mut self, bounds: Bounds<Pixels>, mask: Bounds<Pixels>, dragging: bool) {
+    pub fn sync(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        mask: Bounds<Pixels>,
+        dragging: bool,
+        resize_inset: Pixels,
+    ) {
         // WebKit may fill newly exposed tiles a frame after a viewport change.
         // Match its page background beneath those tiles instead of exposing
         // the application's dark window background at the resize edge.
@@ -551,6 +559,10 @@ impl Host {
         }
         let visible = bounds.intersect(&mask);
         self.clip.ivars().dragging.set(dragging);
+        self.clip
+            .ivars()
+            .resize_inset
+            .set(f64::from(f32::from(resize_inset)));
         if self.bounds != Some(bounds) || self.visible_bounds != Some(visible) {
             self.bounds = Some(bounds);
             self.visible_bounds = Some(visible);
@@ -579,19 +591,23 @@ impl Host {
             unsafe {
                 let _: () = msg_send![&*self.clip_mask, setFrame: region];
             }
-            let rect = wry::Rect {
-                position: wry::dpi::LogicalPosition::new(
-                    f64::from(f32::from(bounds.origin.x)),
-                    f64::from(f32::from(bounds.origin.y)),
-                )
-                .into(),
-                size: wry::dpi::LogicalSize::new(
-                    f64::from(f32::from(bounds.size.width)),
-                    f64::from(f32::from(bounds.size.height)),
-                )
-                .into(),
+            // Wry's set_bounds rounds logical origins and sizes to whole points. GPUI
+            // uses fractional points, so that leaves uncovered background
+            // strips between the WKWebView and its clip after a resize.
+            let web_height = f64::from(f32::from(bounds.size.height)).max(0.);
+            let web_y = f64::from(f32::from(bounds.origin.y));
+            let web_y = if self.parent.isFlipped() {
+                web_y
+            } else {
+                self.parent.bounds().size.height - web_y - web_height
             };
-            let _ = self.web.set_bounds(rect);
+            self.view.setFrame(objc2_foundation::NSRect::new(
+                objc2_foundation::NSPoint::new(f64::from(f32::from(bounds.origin.x)), web_y),
+                objc2_foundation::NSSize::new(
+                    f64::from(f32::from(bounds.size.width)).max(0.),
+                    web_height,
+                ),
+            ));
             unsafe {
                 // Leave the implicit transaction open for the matching Metal
                 // presentation. Committing here would expose native geometry early.

--- a/crates/ui/src/browser/mod.rs
+++ b/crates/ui/src/browser/mod.rs
@@ -90,6 +90,8 @@ pub struct BrowserSurface {
     #[cfg(feature = "browser-fixture")]
     fixture_preview_open: std::rc::Rc<std::cell::Cell<Option<gpui::Point<gpui::Pixels>>>>,
     presentation: Presentation,
+    #[cfg(target_os = "macos")]
+    resize_inset: gpui::Pixels,
     _input_sub: Subscription,
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     native: Option<native::NativePage>,
@@ -164,6 +166,8 @@ impl BrowserSurface {
             #[cfg(feature = "browser-fixture")]
             fixture_preview_open: Default::default(),
             presentation: Presentation::Hidden,
+            #[cfg(target_os = "macos")]
+            resize_inset: gpui::px(0.0),
             _input_sub: input_sub,
             #[cfg(any(target_os = "macos", target_os = "linux"))]
             native: None,
@@ -206,6 +210,15 @@ impl BrowserSurface {
         }
         window.focus(&self.address.focus_handle(cx), cx);
         window.dispatch_action(Box::new(crate::composer::SelectAll), cx);
+    }
+
+    /// Reserve the overlapping part of the shell divider for GPUI hit testing.
+    #[cfg(target_os = "macos")]
+    pub fn set_resize_inset(&mut self, inset: gpui::Pixels, cx: &mut Context<Self>) {
+        if self.resize_inset != inset {
+            self.resize_inset = inset;
+            cx.notify();
+        }
     }
 
     pub fn set_presentation(&mut self, presentation: Presentation, cx: &mut Context<Self>) {

--- a/crates/ui/src/browser/view.rs
+++ b/crates/ui/src/browser/view.rs
@@ -519,6 +519,7 @@ impl Render for BrowserSurface {
                 body.child(self.empty_body(&theme, cx))
             } else {
                 let native = native.handle();
+                let resize_inset = self.resize_inset;
                 body.child(
                     gpui::canvas(
                         |_, _, _| (),
@@ -528,7 +529,9 @@ impl Render for BrowserSurface {
                             let dragging = cx.has_active_drag();
                             window.on_present(move || {
                                 if let Some(native) = native.upgrade() {
-                                    native.borrow_mut().sync(bounds, mask, dragging);
+                                    native
+                                        .borrow_mut()
+                                        .sync(bounds, mask, dragging, resize_inset);
                                 }
                             });
                         },

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -170,6 +170,7 @@ impl SidebarDisclosureMotion {
 /// Vertical pane resize hitboxes yield the global titlebar. Keeping this in
 /// the shared constructor makes left/right seams mirror each other and avoids
 /// relying on paint order when chrome crosses an animated pane boundary.
+const PANE_RESIZE_HITBOX_HALF_WIDTH: f32 = 6.0;
 const PANE_RESIZE_HITBOX_TOP: f32 = Theme::TITLEBAR_HEIGHT;
 
 fn stable_panel_content_width(target: f32, transition: Option<(f32, f32)>) -> f32 {
@@ -6348,8 +6349,9 @@ impl Shell {
             .absolute()
             .top(px(PANE_RESIZE_HITBOX_TOP))
             .bottom_0()
-            .w(px(12.0))
+            .w(px(PANE_RESIZE_HITBOX_HALF_WIDTH * 2.0))
             .flex_none()
+            .occlude()
             .cursor_col_resize()
             .on_hover(motion::hover_listener(fade_key))
             // Codex-style seam feedback: the existing 1px panel border stays
@@ -8457,6 +8459,16 @@ impl Render for Shell {
         // Native clipping follows the animated GPUI mask. Drags only transfer
         // pointer ownership; the browser continues rendering and reflowing.
         let browser_dragging = cx.has_active_drag();
+        #[cfg(target_os = "macos")]
+        let browser_resize_inset = if self.right_pane_open(cx)
+            && !self.right_pane_expanded
+            && !self.tween_active(self.right_tween)
+        {
+            // The browser starts inside the panel's one-point left border.
+            px(PANE_RESIZE_HITBOX_HALF_WIDTH - 1.0)
+        } else {
+            px(0.0)
+        };
         let selected_surface = self.resolved_right_active(cx);
         for (id, browser) in &self.browsers {
             let presentation = crate::browser::model::presentation(
@@ -8464,6 +8476,8 @@ impl Render for Shell {
                 browser_dragging,
             );
             browser.update(cx, |browser, cx| {
+                #[cfg(target_os = "macos")]
+                browser.set_resize_inset(browser_resize_inset, cx);
                 browser.set_shortcuts(&self.settings.keymap);
                 browser.set_presentation(presentation, cx);
             });
@@ -8724,7 +8738,7 @@ impl Render for Shell {
                     )
                     // A forgiving transparent hit target centered on the
                     // seam; the panel's 1px border remains the visual divider.
-                    .left(px(-6.0))
+                    .left(px(-PANE_RESIZE_HITBOX_HALF_WIDTH))
                 });
                 let right: AnyElement = if on_chat {
                     self.render_right_pane(cx)
@@ -8774,12 +8788,16 @@ impl Render for Shell {
                 // Keep the right resize target outside the pane's
                 // overflow-hidden width container. This mirrors the sidebar
                 // seam and lets the target straddle both adjacent panes.
+                // Paint it after the page so page input cannot occlude the
+                // inner half. A deferred draw would capture all native input.
                 let right_seam: AnyElement = if let Some(handle) = right_handle {
                     div()
                         .w(px(0.0))
                         .h_full()
                         .flex_none()
-                        .relative()
+                        .absolute()
+                        .left_0()
+                        .top_0()
                         .child(handle)
                         .into_any_element()
                 } else {
@@ -8819,8 +8837,14 @@ impl Render for Shell {
                             .child(sidebar)
                             .child(sidebar_seam)
                             .child(card)
-                            .child(right_seam)
-                            .child(right),
+                            .child(
+                                div()
+                                    .h_full()
+                                    .flex_none()
+                                    .relative()
+                                    .child(right)
+                                    .child(right_seam),
+                            ),
                     )
                     .child(div().absolute().top_0().left_0().right_0().child(title_bar))
                     .child(self.render_titlebar_cluster(cx))


### PR DESCRIPTION
An open webpage could intercept the inner half of the right sidebar resize handle, leaving the resize cursor visible without starting a drag. Paint the handle after the pane and reserve its overlap in native WebKit hit testing so both halves start resizing.

Set the WebKit frame with fractional coordinates and dimensions to match the GPUI clip, avoiding exposed background strips caused by whole-point rounding. Extend the browser fixture to check divider hit testing and fractional resize geometry.

Validation: cargo check -p zeron-ui --features browser-fixture --examples --offline and git diff --check passed. The macOS WebKit interaction and visual fixture could not be run in this Linux workspace.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791619555&installation_model_id=425430&pr_number=304&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F304&signature=eae05527d7da983f489d7035e8ab32cd2533759d0f250422a88e74b90fbb9d35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->