### PR TITLE
Close the active right-pane surface before the window on Cmd+W

### DIFF
--- a/crates/ui/src/app_menus.rs
+++ b/crates/ui/src/app_menus.rs
@@ -106,6 +106,12 @@ fn close_active_window(cx: &mut App) {
         if let Some(window) = window.downcast::<shell::Shell>() {
             window
                 .update(cx, |shell, window, cx| {
+                    // ⌘W closes the right pane's active surface first (the tab
+                    // the user just opened); an empty or closed pane falls
+                    // through to the window close, unsaved-file gate and all.
+                    if shell.close_active_surface(window, cx) {
+                        return;
+                    }
                     if shell.prepare_window_close(cx) {
                         window.remove_window();
                     }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -2805,6 +2805,36 @@ impl Shell {
         self.prepare_exit(PendingExit::CloseWindow, cx)
     }
 
+    /// The first rung of `⌘W` / Window > Close Window: when the right pane is
+    /// open on a real surface (the file / diff / terminal / browser tab the
+    /// user just opened), close THAT and leave the window alone. Returns true
+    /// when the close was consumed by the pane.
+    ///
+    /// The pane's empty picker state and a closed pane both yield false, so the
+    /// caller falls through to [`Self::prepare_window_close`] and the window
+    /// closes — the same cascade browsers use. The native traffic-light close
+    /// deliberately skips this rung: it always closes the window.
+    pub fn close_active_surface(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        let Some(surface) = self.closable_right_surface(cx) else {
+            return false;
+        };
+        self.close_right_surface(surface, window, cx);
+        true
+    }
+
+    /// The right pane's closable surface for the `⌘W` cascade: the resolved
+    /// active surface while the pane is open, or `None` on the picker empty
+    /// state / a closed pane / the new-session canvas.
+    fn closable_right_surface(&self, cx: &App) -> Option<RightSurface> {
+        if !self.right_pane_open(cx) {
+            return None;
+        }
+        match self.resolved_right_active(cx) {
+            RightSurface::Picker => None,
+            surface => Some(surface),
+        }
+    }
+
     pub fn prepare_quit(&mut self, cx: &mut Context<Self>) -> bool {
         self.prepare_exit(PendingExit::Quit, cx)
     }
@@ -10086,6 +10116,68 @@ mod exit_regressions {
             weak.upgrade().is_none(),
             "closed browser retained by callbacks"
         );
+    }
+
+    #[gpui::test]
+    fn cmd_w_closes_the_active_right_pane_surface_before_the_window(cx: &mut TestAppContext) {
+        let dir = tempfile::tempdir().unwrap();
+        cx.update(|cx| {
+            gpui_base::init(cx);
+            cx.set_global(Theme::default());
+            crate::app_menus::init(cx);
+        });
+        let window = cx.add_window(|_, cx| {
+            let state = cx.new(|_| AppState::new());
+            Shell::new(
+                state,
+                EngineBootConfig {
+                    data_dir: dir.path().into(),
+                    ipc_port: 0,
+                    edge_url: "http://127.0.0.1:1".into(),
+                    edge_token: None,
+                    org_id: None,
+                    workos_client_id: None,
+                    default_harness: zeron_proto::HarnessId::Mock,
+                },
+                cx,
+            )
+        });
+        window
+            .update(cx, |shell, window, cx| {
+                shell.active_chat = "session".into();
+                shell.toggle_right_pane(cx);
+                assert!(shell.right_pane_open(cx));
+
+                shell.add_browser_surface(None, window, cx);
+                let first = shell.browser_seq;
+                shell.add_browser_surface(None, window, cx);
+                let second = shell.browser_seq;
+                assert_eq!(
+                    shell.resolved_right_active(cx),
+                    RightSurface::Browser(second)
+                );
+
+                // ⌘W closes the active tab, not the window.
+                assert!(shell.close_active_surface(window, cx));
+                assert_eq!(
+                    shell.resolved_right_active(cx),
+                    RightSurface::Browser(first)
+                );
+
+                // …and again for the last tab.
+                assert!(shell.close_active_surface(window, cx));
+                assert_eq!(shell.resolved_right_active(cx), RightSurface::Picker);
+
+                // An open pane with nothing left to close falls through to the
+                // window-close rung instead of being consumed.
+                assert!(!shell.close_active_surface(window, cx));
+
+                // So does an already-closed pane.
+                shell.toggle_right_pane(cx);
+                assert!(!shell.right_pane_open(cx));
+                assert!(!shell.close_active_surface(window, cx));
+            })
+            .unwrap();
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Summary

Cmd+W was bound globally to `CloseWindow`, so with the right pane open on a file / diff / terminal / browser tab it tore the whole window down while the user only meant to close what they had just opened (see #306).

This routes Cmd+W through the pane first: when the right pane is open on a real surface, close that surface and leave the window alone. The close reuses the tab's own path, so the unsaved-file confirmation still appears. The pane's empty picker state and a closed pane fall through to the existing window-close flow, so Cmd+W now cascades pane → window like a browser.

Closes #306.

| Cmd+W | Before | After |
| --- | --- | --- |
| Right pane open on a tab | window closed | active tab closes |
| Right pane empty / closed | window closed | window closed (unchanged) |
| Native traffic-light close | window closed | window closed (unchanged) |

## Changes

- `crates/ui/src/shell.rs`: add `Shell::close_active_surface()` (plus the `closable_right_surface()` helper) — close the resolved active surface when the pane is open on a real tab, and report whether the close was consumed.
- `crates/ui/src/app_menus.rs`: `close_active_window` tries the pane first, then falls back to the existing `prepare_window_close()`.
- New unit test `cmd_w_closes_the_active_right_pane_surface_before_the_window`.

The Window menu's "Close Window" item shares the same handler, so it keeps the same behavior as Cmd+W.

## Validation

- `cargo check --locked -p zeron-ui --lib --tests` — clean
- `cargo test --locked -p zeron-ui --lib -- --test-threads=1` — 779 passed, 0 failed
- `cargo test --locked -p zeron-ui --lib exit_regressions` — 7 passed
- `cargo test --locked -p zeron-ui --lib app_menus::tests` — 6 passed
- `rustfmt --check` on both changed files; `git diff --check` — clean

Interactive visual verification was not performed.

---

## 中文说明

### 概述

`Cmd+W` 之前全局绑定在 `CloseWindow` 上，所以在右侧面板打开着文件 / diff / 终端 / 浏览器标签页时，按 `Cmd+W` 会把整个窗口关掉，而用户本意只是关掉刚打开的那个标签页（见 #306）。

这个改动让 `Cmd+W` 先经过面板：右侧面板开着真实标签页时，关闭该标签页并保留窗口；关闭走标签页自身的逻辑，因此**未保存文件的确认提示照旧**。面板停在空选择态或本身已关闭时，才落到原有的关闭窗口流程——于是 `Cmd+W` 现在是「面板 → 窗口」的逐层级联，和浏览器一致。

### 行为对照

| Cmd+W 场景 | 改动前 | 改动后 |
| --- | --- | --- |
| 右侧面板开着标签页 | 关闭窗口 | 关闭当前标签页 |
| 面板为空 / 已关闭 | 关闭窗口 | 关闭窗口（不变） |
| 红绿灯关闭按钮 | 关闭窗口 | 关闭窗口（不变） |

### 改动

- `crates/ui/src/shell.rs`：新增 `Shell::close_active_surface()`（及 `closable_right_surface()` 辅助方法）——面板开着真实标签页时关闭当前激活的 surface，并返回是否已消费本次关闭。
- `crates/ui/src/app_menus.rs`：`close_active_window` 先尝试关闭面板，未消费时再走原有的 `prepare_window_close()`。
- 新增单测 `cmd_w_closes_the_active_right_pane_surface_before_the_window`。

Window 菜单里的 “Close Window” 与 `Cmd+W` 共用同一 handler，因此行为保持一致。

### 验证

- `cargo check --locked -p zeron-ui --lib --tests` —— 通过
- `cargo test --locked -p zeron-ui --lib -- --test-threads=1` —— **779 passed, 0 failed**
- `cargo test --locked -p zeron-ui --lib exit_regressions` —— 7 passed
- `cargo test --locked -p zeron-ui --lib app_menus::tests` —— 6 passed
- 两个改动文件 `rustfmt --check`、`git diff --check` —— 通过

交互式肉眼验证尚未进行。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791637891&installation_model_id=425430&pr_number=307&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F307&signature=2a6d0b6d488bced66a132e29dd14b2802607bb17a93780c48b789173502e47b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->