### PR TITLE
Fix false completion notifications when sending queued messages

### DIFF
--- a/crates/doc/src/registry.rs
+++ b/crates/doc/src/registry.rs
@@ -1159,6 +1159,7 @@ impl RegistryDoc {
             ("chatId", json!(session.chat_id)),
             ("deviceId", json!(session.device_id)),
             ("status", serde_json::to_value(session.status)?),
+            ("lastCompletedTurn", json!(session.last_completed_turn)),
             ("startedAt", opt_ms(session.started_at)),
             ("updatedAt", json!(session.updated_at.timestamp_millis())),
         ]);
@@ -1294,6 +1295,7 @@ impl RegistryDoc {
                     ("chatId", json!(session.chat_id)),
                     ("deviceId", json!(session.device_id)),
                     ("status", serde_json::to_value(session.status)?),
+                    ("lastCompletedTurn", json!(session.last_completed_turn)),
                     ("startedAt", opt_ms(session.started_at)),
                     ("updatedAt", json!(session.updated_at.timestamp_millis())),
                 ]),

--- a/crates/doc/src/registry/tests.rs
+++ b/crates/doc/src/registry/tests.rs
@@ -292,6 +292,7 @@ fn space(id: &str, device_id: &str, path: &str) -> Space {
 
 fn session(chat_id: &str, device_id: &str, status: SessionStatus) -> Session {
     Session {
+        last_completed_turn: None,
         chat_id: chat_id.into(),
         device_id: device_id.into(),
         status,
@@ -880,4 +881,21 @@ fn migration_seeds_pending_upserts_that_lose_to_live_writes() {
         doc.chat("chat-1").unwrap().unwrap().title.as_deref(),
         Some("live rename")
     );
+}
+
+#[test]
+fn completion_marker_replicates_and_survives_next_turn() {
+    let mut source = RegistryDoc::new("dev-a");
+    let mut viewer = RegistryDoc::new("dev-b");
+    let mut server = HashMap::new();
+    let mut seq = 0;
+    let mut row = session("chat-1", "dev-a", SessionStatus::Idle);
+    row.last_completed_turn = Some("turn-one".into());
+    source.upsert_session(&row).unwrap();
+    server_round(&mut server, &mut seq, &mut [&mut source, &mut viewer]);
+    assert_eq!(viewer.read_sessions().unwrap(), vec![row.clone()]);
+    row.status = SessionStatus::Working;
+    source.upsert_session(&row).unwrap();
+    server_round(&mut server, &mut seq, &mut [&mut source, &mut viewer]);
+    assert_eq!(viewer.read_sessions().unwrap(), vec![row]);
 }

--- a/crates/doc/src/workspace.rs
+++ b/crates/doc/src/workspace.rs
@@ -467,6 +467,11 @@ impl WorkspaceDoc {
         row.insert("chatId", session.chat_id.as_str())?;
         row.insert("deviceId", session.device_id.as_str())?;
         row.insert("status", status_str(session.status))?;
+        set_opt_str(
+            &row,
+            "lastCompletedTurn",
+            session.last_completed_turn.as_deref(),
+        )?;
         set_opt_ms(&row, "startedAt", session.started_at)?;
         row.insert("updatedAt", session.updated_at.timestamp_millis())?;
         self.doc.commit();
@@ -738,6 +743,8 @@ impl From<RawChat> for Chat {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RawSession {
+    #[serde(default)]
+    last_completed_turn: Option<String>,
     chat_id: String,
     device_id: String,
     status: SessionStatus,
@@ -750,6 +757,7 @@ pub(crate) struct RawSession {
 impl From<RawSession> for Session {
     fn from(raw: RawSession) -> Self {
         Session {
+            last_completed_turn: raw.last_completed_turn,
             chat_id: raw.chat_id,
             device_id: raw.device_id,
             status: raw.status,
@@ -823,6 +831,7 @@ mod tests {
 
     fn session(chat_id: &str, device_id: &str, status: SessionStatus) -> Session {
         Session {
+            last_completed_turn: None,
             chat_id: chat_id.into(),
             device_id: device_id.into(),
             status,
@@ -885,6 +894,23 @@ mod tests {
         assert_eq!(row.source_context, Some(context));
         assert_eq!(row.branch.as_deref(), Some("feature/sidebar"));
         assert_eq!(row.checkout_id.as_deref(), Some("checkout-a"));
+    }
+
+    #[test]
+    fn completion_marker_survives_workspace_sync_and_legacy_rows() {
+        let ws = WorkspaceDoc::new();
+        let mut row = session("chat-1", "dev-a", SessionStatus::Idle);
+        row.last_completed_turn = Some("turn-one".into());
+        ws.upsert_session(&row).unwrap();
+        assert_eq!(ws.read_sessions().unwrap(), vec![row.clone()]);
+        row.status = SessionStatus::Working;
+        ws.upsert_session(&row).unwrap();
+        assert_eq!(ws.read_sessions().unwrap(), vec![row]);
+        ws.row("sessions", "chat-1")
+            .unwrap()
+            .delete("lastCompletedTurn")
+            .unwrap();
+        assert_eq!(ws.read_sessions().unwrap()[0].last_completed_turn, None);
     }
 
     #[test]

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -362,20 +362,28 @@ impl SessionsEngine {
             )
         });
         if let Some((run_id, steerable, same_runtime, steer_tx, ledger)) = routed {
-            let message = SteerMessage {
-                prompt: request.prompt.clone(),
-                message_id: message_id.clone(),
-            };
-            if steerable && same_runtime && steer_tx.try_send(message).is_ok() {
-                // The run can vanish between the send and here (the idle
-                // reaper, a parked child death): the ledger entry below is
-                // the at-least-once guarantee — the run task's exit drain
-                // re-dispatches any accepted steer no `Steered` confirmed.
-                let user_id = message_id.clone().unwrap_or_else(new_id);
-                lock(&ledger).push_back(RoutedSteer {
+            let user_id = message_id.clone().unwrap_or_else(new_id);
+            let accepted = if steerable && same_runtime {
+                // Warm dispatch uses the same mailbox as explicit steering.
+                // Register acceptance before a fast boundary can retire it.
+                let mut pending = lock(&ledger);
+                let message = SteerMessage {
                     prompt: request.prompt.clone(),
-                    message_id: user_id.clone(),
-                });
+                    message_id: Some(user_id.clone()),
+                };
+                if steer_tx.try_send(message).is_ok() {
+                    pending.push_back(RoutedSteer {
+                        prompt: request.prompt.clone(),
+                        message_id: user_id.clone(),
+                    });
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if accepted {
                 let handle = self.doc_handle(chat_id)?;
                 handle.write_user_message(&user_id, &request.prompt, now_ms())?;
                 if self.is_live(chat_id, &run_id) {
@@ -533,23 +541,23 @@ impl SessionsEngine {
         let Some((run_id, steer_tx, ledger)) = target else {
             return Ok(SteerOutcome::NotSteerable);
         };
+        let user_id = message_id.unwrap_or_else(new_id);
         let message = SteerMessage {
             prompt: prompt.to_string(),
-            message_id: message_id.clone(),
+            message_id: Some(user_id.clone()),
         };
-        if steer_tx.try_send(message).is_err() {
-            return Ok(SteerOutcome::NotSteerable);
+        {
+            // Serialize mailbox acceptance with confirmation and Done-time
+            // inspection: a fast consumer must never outrun its ledger entry.
+            let mut pending = lock(&ledger);
+            if steer_tx.try_send(message).is_err() {
+                return Ok(SteerOutcome::NotSteerable);
+            }
+            pending.push_back(RoutedSteer {
+                prompt: prompt.to_string(),
+                message_id: user_id.clone(),
+            });
         }
-        // Accepted: ledger first (at-least-once across a dying run), then the
-        // user entry (client-minted id), then Working BEFORE the
-        // lastMessageAt bump — same causal-order invariant as the dispatch
-        // route (an observer must never hold [new message, settled status]:
-        // the phantom "completed" flash, 2026-07-31).
-        let user_id = message_id.unwrap_or_else(new_id);
-        lock(&ledger).push_back(RoutedSteer {
-            prompt: prompt.to_string(),
-            message_id: user_id.clone(),
-        });
         let handle = self.doc_handle(chat_id)?;
         handle.write_user_message(&user_id, prompt, now_ms())?;
         // A routed steer is a turn too. Fired here (not only on the confirmed
@@ -845,12 +853,32 @@ impl Inner {
     }
 
     fn set_status(&self, chat_id: &str, status: SessionStatus, fresh_start: bool) {
+        self.set_status_with_completion(chat_id, status, fresh_start, None);
+    }
+
+    fn has_pending_steers(&self, chat_id: &str, run_id: &str) -> bool {
+        lock(&self.runs)
+            .get(chat_id)
+            .filter(|h| h.run_id == run_id)
+            .is_some_and(|h| !lock(&h.routed_steers).is_empty())
+    }
+
+    /// Publish the completion marker atomically with the settled status. Keep
+    /// it on subsequent Working/heartbeat rows for coalesced and remote watches.
+    fn set_status_with_completion(
+        &self,
+        chat_id: &str,
+        status: SessionStatus,
+        fresh_start: bool,
+        completed_turn: Option<String>,
+    ) {
         let now = Utc::now();
         let session = {
             let mut statuses = lock(&self.statuses);
             let entry = statuses
                 .entry(chat_id.to_string())
                 .or_insert_with(|| Session {
+                    last_completed_turn: None,
                     chat_id: chat_id.to_string(),
                     device_id: self.device_id.clone(),
                     status,
@@ -867,6 +895,9 @@ impl Inner {
                 entry.status,
                 SessionStatus::Working | SessionStatus::AwaitingInput
             );
+            if let Some(turn) = completed_turn {
+                entry.last_completed_turn = Some(turn);
+            }
             entry.status = status;
             entry.updated_at = now;
             match status {
@@ -1448,6 +1479,7 @@ async fn drive_run(
     let mut subagents: std::collections::HashMap<String, SubagentSink> =
         std::collections::HashMap::new();
 
+    let mut final_completed_turn = None;
     let final_status = loop {
         let event: AgentEvent = tokio::select! {
             biased;
@@ -1571,6 +1603,13 @@ async fn drive_run(
                     "turn quiesced: stream silent after completed output with no \
                      turn-end; parking (suspected missing harness Done)"
                 );
+                // Some adapters close a completed response through this
+                // engine watchdog instead of a native Done. Preserve that
+                // completion notice, but never notify for an empty boundary
+                // or while an accepted steer still awaits delivery.
+                let completed_turn = ((!folded.is_empty() || writer.is_some())
+                    && !inner.has_pending_steers(&chat_id, &run_id))
+                    .then(|| entry_id.clone());
                 if !folded.is_empty() || writer.is_some() {
                     if let Err(err) = finish_segment(
                         doc_ref,
@@ -1591,7 +1630,9 @@ async fn drive_run(
                 segment_started = now_ms();
                 idle_since = Some(tokio::time::Instant::now());
                 self_continued_turn = false;
-                inner.set_status(&chat_id, SessionStatus::Idle, false);
+                inner.set_status_with_completion(
+                    &chat_id, SessionStatus::Idle, false, completed_turn,
+                );
                 continue;
             }
         };
@@ -1810,6 +1851,7 @@ async fn drive_run(
         // self-continued turn starts a whole new agent round trip (seconds
         // at minimum, minutes in the incident). Inside the gate everything
         // non-boundary stays inert, exactly as before.
+        let turn_was_active = idle_since.is_none();
         const RESUME_GATE: std::time::Duration = std::time::Duration::from_secs(1);
         if idle_since.is_some() {
             let self_continued = idle_since
@@ -2099,6 +2141,15 @@ async fn drive_run(
             {
                 titles.maybe_generate(&chat_id, harness_id, &user_prompt, &run_cwd);
             }
+            // An accepted steer awaiting its boundary owns the continuation:
+            // the previous Done is an internal handoff, not a completion ping.
+            // Ordinary queued rows are not in this ledger and still notify.
+            let pending_steer = inner.has_pending_steers(&chat_id, &run_id);
+            let completed_turn = (*status == DoneStatus::Completed
+                && !interrupted
+                && turn_was_active
+                && !pending_steer)
+                .then(|| entry_id.clone());
             // PERSISTENT SESSION: a cleanly completed turn on a steerable
             // harness PARKS instead of ending — child + mailbox stay warm for
             // the next routed dispatch; per-turn state resets for it.
@@ -2111,9 +2162,15 @@ async fn drive_run(
                 saw_session_started = true;
                 idle_since = Some(tokio::time::Instant::now());
                 self_continued_turn = false;
-                inner.set_status(&chat_id, SessionStatus::Idle, false);
+                inner.set_status_with_completion(
+                    &chat_id,
+                    SessionStatus::Idle,
+                    false,
+                    completed_turn,
+                );
                 continue;
             }
+            final_completed_turn = completed_turn;
             break match status {
                 DoneStatus::Errored => SessionStatus::Errored,
                 _ => SessionStatus::Idle,
@@ -2155,7 +2212,7 @@ async fn drive_run(
         .map(|h| std::mem::take(&mut *lock(&h.routed_steers)).into())
         .unwrap_or_default();
     inner.remove_run(&chat_id, &run_id);
-    inner.set_status(&chat_id, final_status, false);
+    inner.set_status_with_completion(&chat_id, final_status, false, final_completed_turn);
     if !interrupted && !orphans.is_empty() {
         // The dying run accepted these into its mailbox but never confirmed a
         // Steered boundary (idle-reaper race, a mid-turn error discarding

--- a/crates/engine/tests/e2e.rs
+++ b/crates/engine/tests/e2e.rs
@@ -2207,3 +2207,143 @@ async fn context_usage_settles_after_done_without_reopening_the_turn() {
         "usage does not create transcript rows"
     );
 }
+
+/// Reproduce a steer accepted just before the old turn's Done. The harness
+/// confirms the new boundary later; only its eventual completion may notify.
+#[tokio::test]
+async fn pending_steer_handoff_does_not_publish_a_completion() {
+    struct ControlledHarness(
+        std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<AgentEvent>>>,
+    );
+    #[async_trait]
+    impl Harness for ControlledHarness {
+        fn id(&self) -> HarnessId {
+            HarnessId::Mock
+        }
+        fn display_name(&self) -> &str {
+            "Controlled"
+        }
+        fn supports_steering(&self) -> bool {
+            true
+        }
+        fn steering_mode(&self) -> SteeringMode {
+            SteeringMode::StepBoundary
+        }
+        fn reasoning_levels(&self) -> &[ReasoningLevel] {
+            &[ReasoningLevel::Medium]
+        }
+        async fn models(&self) -> Result<Vec<Model>, HarnessError> {
+            Ok(vec![])
+        }
+        async fn run(
+            &self,
+            _: RunRequest,
+            controls: RunControls,
+        ) -> Result<BoxStream<'static, Result<AgentEvent, HarnessError>>, HarnessError> {
+            let rx = self.0.lock().unwrap().take().unwrap();
+            // Keep the mailbox alive but let the test control confirmation.
+            Ok(
+                futures::stream::unfold((rx, controls), |(mut rx, controls)| async move {
+                    rx.recv().await.map(|event| (Ok(event), (rx, controls)))
+                })
+                .boxed(),
+            )
+        }
+    }
+    for routed_dispatch in [false, true] {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let dir = tempfile::tempdir().unwrap();
+        let core = assemble(
+            dir.path(),
+            Arc::new(ControlledHarness(std::sync::Mutex::new(Some(rx)))),
+        );
+        let handle = core.doc_host.open(CHAT).unwrap();
+        queue_as_viewer(
+            handle.doc(),
+            "cmd-completion",
+            SessionCommandPayload::Run {
+                request: run_request("opening"),
+                message_id: "user-opening".into(),
+            },
+        );
+        tx.send(mock_script()[0].clone()).unwrap();
+        wait_for(
+            || core.sessions.session_status(CHAT).map(|s| s.status) == Some(SessionStatus::Working),
+            "opening run",
+        )
+        .await;
+        if routed_dispatch {
+            core.sessions
+                .dispatch(
+                    CHAT,
+                    HarnessId::Mock,
+                    run_request("redirect"),
+                    Some("user-steer".into()),
+                )
+                .await
+                .unwrap();
+        } else {
+            assert_eq!(
+                core.sessions
+                    .steer(CHAT, "redirect", Some("user-steer".into()))
+                    .await
+                    .unwrap(),
+                zeron_engine::sessions::SteerOutcome::Accepted
+            );
+        }
+        tx.send(done(DoneStatus::Completed)).unwrap();
+        wait_for(
+            || core.sessions.session_status(CHAT).map(|s| s.status) == Some(SessionStatus::Idle),
+            "internal handoff",
+        )
+        .await;
+        assert_eq!(
+            core.sessions
+                .session_status(CHAT)
+                .unwrap()
+                .last_completed_turn,
+            None
+        );
+        tx.send(AgentEvent::Steered {
+            assistant_message_id: Some("a-1".into()),
+            next_assistant_message_id: Some("a-steered".into()),
+        })
+        .unwrap();
+        tx.send(AgentEvent::TextDelta {
+            text: "redirected response".into(),
+        })
+        .unwrap();
+        tx.send(done(DoneStatus::Completed)).unwrap();
+        wait_for(
+            || {
+                core.sessions
+                    .session_status(CHAT)
+                    .and_then(|s| s.last_completed_turn)
+                    .as_deref()
+                    == Some("a-steered")
+            },
+            "real completion",
+        )
+        .await;
+        // A duplicate terminal frame from a parked runtime cannot ring twice.
+        let (_, mut events) = core.sessions.subscribe(CHAT, 0).unwrap();
+        tx.send(done(DoneStatus::Completed)).unwrap();
+        let duplicate = tokio::time::timeout(Duration::from_secs(2), events.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(duplicate.event, AgentEvent::Done { .. }));
+        // drive_run publishes and settles synchronously before polling again.
+        tokio::task::yield_now().await;
+        drop(tx);
+        assert_eq!(
+            core.sessions
+                .session_status(CHAT)
+                .unwrap()
+                .last_completed_turn
+                .as_deref(),
+            Some("a-steered")
+        );
+        core.shutdown().await;
+    }
+}

--- a/crates/engine/tests/message_queue.rs
+++ b/crates/engine/tests/message_queue.rs
@@ -1510,3 +1510,45 @@ async fn queued_turn_uses_current_config_at_turn_end_and_send_now() {
         core.shutdown().await;
     }
 }
+
+/// Normal queued turns each publish a completion; Send now's interrupted
+/// predecessor does not. The replacement's own completion must still arrive.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn queue_completion_markers_distinguish_normal_turns_from_interrupts() {
+    for send_now in [false, true] {
+        let (core, harness, prompts) = setup(SteeringMode::TurnBoundary).await;
+        core.doc_host
+            .queue_message(CHAT, "opening", Vec::new())
+            .unwrap();
+        wait_for(|| prompts.lock().unwrap().len() == 1, "opening turn").await;
+        let id = core
+            .doc_host
+            .queue_message(CHAT, "follow-up", Vec::new())
+            .unwrap();
+        let completion = || {
+            core.sessions
+                .session_status(CHAT)
+                .and_then(|s| s.last_completed_turn)
+        };
+        assert_eq!(completion(), None);
+        if send_now {
+            assert!(core.doc_host.send_queued_now(CHAT, &id).await.unwrap());
+        } else {
+            harness.finish.send(()).unwrap();
+        }
+        wait_for(|| prompts.lock().unwrap().len() == 2, "follow-up turn").await;
+        let first_completion = completion();
+        assert_eq!(
+            first_completion.is_some(),
+            !send_now,
+            "only a naturally completed predecessor should notify"
+        );
+        harness.finish.send(()).unwrap();
+        wait_for(
+            || completion().is_some() && completion() != first_completion,
+            "follow-up completion marker",
+        )
+        .await;
+        core.shutdown().await;
+    }
+}

--- a/crates/engine/tests/turn_quiesce.rs
+++ b/crates/engine/tests/turn_quiesce.rs
@@ -272,6 +272,14 @@ async fn parked_self_continuation_folds_and_requiesces() {
     )
     .await;
 
+    let first_completion = rig
+        .core
+        .sessions
+        .session_status(CHAT)
+        .unwrap()
+        .last_completed_turn;
+    assert!(first_completion.is_some());
+
     // Self-continuation: streamed output with NO turn behind it, arriving
     // well past the resume gate (a real one follows a whole agent round
     // trip — the incident's came five minutes after the park).
@@ -291,6 +299,18 @@ async fn parked_self_continuation_folds_and_requiesces() {
         "watchdog re-parks the self-continued turn",
     )
     .await;
+
+    let second_completion = rig
+        .core
+        .sessions
+        .session_status(CHAT)
+        .unwrap()
+        .last_completed_turn;
+    assert!(second_completion.is_some());
+    assert_ne!(
+        second_completion, first_completion,
+        "engine-settled responses still notify"
+    );
 
     // The self-continued output is in the doc as its own COMPLETE entry —
     // this exact text was lost in the incident.

--- a/crates/engine/tests/workspace_sync.rs
+++ b/crates/engine/tests/workspace_sync.rs
@@ -717,6 +717,7 @@ async fn legacy_workspace_doc_migrates_instantly_on_first_boot() {
             .unwrap();
         legacy
             .upsert_session(&Session {
+                last_completed_turn: None,
                 chat_id: "chat-legacy".into(),
                 device_id: "dev-a".into(),
                 status: SessionStatus::Idle,

--- a/crates/proto/src/entities.rs
+++ b/crates/proto/src/entities.rs
@@ -218,6 +218,11 @@ pub enum SessionStatus {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Session {
+    /// Last successfully completed assistant turn. Retained while the next turn
+    /// runs so coalesced status watches do not lose normal queue completions.
+    /// Interrupts, failures and liveness expiry never advance this marker.
+    #[serde(default)]
+    pub last_completed_turn: Option<String>,
     pub chat_id: String,
     pub device_id: String,
     pub status: SessionStatus,

--- a/crates/sync/tests/registry_client.rs
+++ b/crates/sync/tests/registry_client.rs
@@ -114,6 +114,7 @@ async fn two_clients_converge_and_stream_live_updates() {
     {
         let mut doc = doc_a.lock().unwrap();
         doc.upsert_session(&Session {
+            last_completed_turn: None,
             chat_id: "chat-1".into(),
             device_id: "dev-a".into(),
             status: SessionStatus::Working,
@@ -422,6 +423,7 @@ async fn churn_stays_bounded_no_history_growth() {
         {
             let mut d = doc.lock().unwrap();
             d.upsert_session(&Session {
+                last_completed_turn: None,
                 chat_id: "chat-1".into(),
                 device_id: "dev-a".into(),
                 status: if i % 2 == 0 {

--- a/crates/sync/tests/registry_edge.rs
+++ b/crates/sync/tests/registry_edge.rs
@@ -78,6 +78,7 @@ async fn two_rust_clients_converge_through_a_real_registry_do() {
         let mut doc = doc_a.lock().unwrap();
         doc.upsert_chat(&chat("chat-live", "dev-live-a")).unwrap();
         doc.upsert_session(&Session {
+            last_completed_turn: None,
             chat_id: "chat-live".into(),
             device_id: "dev-live-a".into(),
             status: SessionStatus::Working,
@@ -194,6 +195,7 @@ async fn cursor_delta_and_churn_stay_bounded_on_a_real_do() {
         {
             let mut d = doc.lock().unwrap();
             d.upsert_session(&Session {
+                last_completed_turn: None,
                 chat_id: "chat-churn".into(),
                 device_id: "dev-churn".into(),
                 status: if i % 2 == 0 {

--- a/crates/ui/examples/macos-resource-profile.rs
+++ b/crates/ui/examples/macos-resource-profile.rs
@@ -147,6 +147,7 @@ fn main() -> anyhow::Result<()> {
                             .iter()
                             .any(|entry| entry.status == Some(zeron_doc::MessageStatus::Streaming));
                         state.apply_sessions(vec![zeron_proto::Session {
+                            last_completed_turn: None,
                             chat_id: "profile".into(),
                             device_id: "local".into(),
                             status: if streaming {

--- a/crates/ui/src/queue.rs
+++ b/crates/ui/src/queue.rs
@@ -1304,9 +1304,26 @@ impl Composer {
             cx.notify();
             return;
         }
+        let pending_message = matches!(
+            method,
+            methods::SEND_QUEUED_MESSAGE_NOW | methods::STEER_QUEUED_MESSAGE_NOW
+        )
+        .then(|| {
+            params
+                .get("id")
+                .and_then(|id| id.as_str())
+                .map(str::to_owned)
+        })
+        .flatten();
+        if let Some(id) = &pending_message {
+            self.state.update(cx, |state, cx| {
+                state.begin_pending_send(&chat_id, id, chrono::Utc::now());
+                cx.notify();
+            });
+        }
         let mut params = params;
         if let Some(object) = params.as_object_mut() {
-            object.insert("chatId".into(), serde_json::Value::String(chat_id));
+            object.insert("chatId".into(), serde_json::Value::String(chat_id.clone()));
             if let Some(host) = host_device_id {
                 object.insert("targetDeviceId".into(), serde_json::Value::String(host));
             }
@@ -1317,7 +1334,19 @@ impl Composer {
         // showing an order the doc never got.
         cx.spawn(
             async move |this, cx| match engine.client().call(method, params).await {
-                Ok(reply) if queue_mutation_acknowledged(method, &reply) => {}
+                Ok(reply) if queue_mutation_acknowledged(method, &reply) => {
+                    // The host has adopted this message. Clear even if the
+                    // user switched chats and its transcript is no longer watched.
+                    if let Some(id) = &pending_message {
+                        this.update(cx, |composer, cx| {
+                            composer.state.update(cx, |state, cx| {
+                                state.end_pending_send(&chat_id, id);
+                                cx.notify();
+                            });
+                        })
+                        .ok();
+                    }
+                }
                 Ok(reply) => {
                     tracing::debug!(
                         method,
@@ -1325,6 +1354,12 @@ impl Composer {
                         "queue mutation was not applied; reconciling"
                     );
                     this.update(cx, |composer, cx| {
+                        if let Some(id) = &pending_message {
+                            composer.state.update(cx, |state, cx| {
+                                state.end_pending_send(&chat_id, id);
+                                cx.notify();
+                            });
+                        }
                         composer
                             .state
                             .update(cx, |state, cx| state.refresh_selected_queue(cx));
@@ -1334,6 +1369,12 @@ impl Composer {
                 Err(err) => {
                     tracing::warn!(method, error = %err, "queue mutation failed");
                     this.update(cx, |composer, cx| {
+                        if let Some(id) = &pending_message {
+                            composer.state.update(cx, |state, cx| {
+                                state.end_pending_send(&chat_id, id);
+                                cx.notify();
+                            });
+                        }
                         composer.failure = Some(failure.into());
                         composer
                             .state

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -1228,7 +1228,7 @@ pub struct Shell {
     space_boot_applied: bool,
     /// Last seen session status per chat — the chime trigger compares against
     /// it (a row's FIRST appearance never chimes, so boot stays silent).
-    sound_prev: std::collections::HashMap<String, zeron_proto::SessionStatus>,
+    sound_prev: std::collections::HashMap<String, crate::sound::SessionNotificationState>,
     user_menu: popover::Popup<()>,
     /// Inline sidebar error strip (mutation failures); click dismisses.
     sidebar_notice: Option<SharedString>,
@@ -1720,48 +1720,26 @@ impl Shell {
                 });
             }
         }
-        // Session chimes (herdr semantics, `sound::sound_for_transition`): a
-        // question rings whenever a session flips to AwaitingInput, a
-        // completion rings on the Working→Idle edge — for ANY session on any
-        // device. A row's first appearance only seeds the baseline, so boot
-        // (restored rows) and fresh sends stay silent. Desktop banners
-        // (`notify::post`) ride the SAME edges and gates behind their own
-        // settings flag — one detector, two outputs, so the banner can never
-        // fire where the chime wouldn't.
-        //
-        // STALENESS-GATED like the dot (`effective_indicator`), for the same
-        // reason: raw row statuses include the past. A dead turn's Working row
-        // (host killed mid-run, Idle write lost to a wedged room) seeded
-        // prev=Working here, and the moment the old Idle finally synced in —
-        // typically piggybacked on the round-trip of a fresh send — the chime
-        // heard a phantom Working→Idle and rang "done" on send (user report
-        // 2026-07-31). The dot never showed that ghost; the chime must judge
-        // by the identical clock.
-        //
-        // SEND-PENDING-GATED too (`AppState::send_pending`): a send whose
-        // queued command the host hasn't executed yet can still surface a
-        // phantom Working→Idle (a stale Working row crossing the 45s gate on
-        // the send's own re-render, or a late old Idle row) — the done-chime
-        // stays quiet for that chat until the host acks, while the baseline
-        // keeps tracking silently so the ghost edge never fires later. The
-        // question chime is NOT gated: an instant AwaitingInput ack should
-        // still ring.
+        // Banners and chimes share one detector. Completion markers survive
+        // queue handoffs and never advance for interrupts or stale activity.
+        // A row's first appearance seeds the baseline silently (boot/replay).
+        // Pending sends consume completion changes silently, while questions
+        // still ring immediately. Output settings do not affect the baseline.
         {
             let now = Utc::now();
-            type Ping = (String, zeron_proto::SessionStatus, bool, Option<String>);
+            type Ping = (
+                String,
+                crate::sound::SessionNotificationState,
+                bool,
+                Option<String>,
+            );
             let sessions: Vec<Ping> = {
                 let state = state.read(cx);
                 state
                     .sessions
                     .iter()
                     .map(|s| {
-                        use zeron_proto::view::Indicator;
-                        let status = match zeron_proto::view::effective_indicator(Some(s), now) {
-                            Indicator::Working => zeron_proto::SessionStatus::Working,
-                            Indicator::AwaitingInput => zeron_proto::SessionStatus::AwaitingInput,
-                            Indicator::Errored => zeron_proto::SessionStatus::Errored,
-                            Indicator::None => zeron_proto::SessionStatus::Idle,
-                        };
+                        let status = crate::sound::SessionNotificationState::new(s, now);
                         let send_pending = state.send_pending(&s.chat_id, now);
                         let title = state
                             .chats
@@ -1778,10 +1756,9 @@ impl Shell {
             // Zeron; the sidebar dot carries the rest.
             let app_focused = cx.active_window().is_some();
             for (chat_id, status, send_pending, title) in sessions {
-                let prev = self.sound_prev.insert(chat_id, status);
+                let prev = self.sound_prev.insert(chat_id, status.clone());
                 if let Some(prev) = prev
-                    && let Some(sound) = crate::sound::sound_for_transition(prev, status)
-                    && !(send_pending && sound == crate::sound::Sound::Done)
+                    && let Some(sound) = status.sound_since(&prev, send_pending)
                 {
                     if self.settings.sound_enabled {
                         crate::sound::play(sound);
@@ -2319,7 +2296,9 @@ impl Shell {
         });
         if let Some(handle) = self.state.read(cx).engine().cloned() {
             let chat_id = self.active_chat.clone();
-            browser.update(cx, |browser, cx| browser.watch_previews(handle, chat_id, cx));
+            browser.update(cx, |browser, cx| {
+                browser.watch_previews(handle, chat_id, cx)
+            });
         }
         let owner = key.clone();
         let sub = cx.subscribe_in(&browser, window, move |this, _, event, window, cx| {

--- a/crates/ui/src/sound.rs
+++ b/crates/ui/src/sound.rs
@@ -24,7 +24,7 @@ static SOUND_REQUEST: &[u8] = include_bytes!("../assets/sounds/request.wav");
 /// Which notification chime to play.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Sound {
-    /// A run finished (Working → Idle).
+    /// An agent turn completed successfully.
     Done,
     /// The agent is waiting on a question (→ AwaitingInput).
     Request,
@@ -145,22 +145,50 @@ fn run_checked(program: &str, args: &[&str], path: &Path) -> Result<(), String> 
 }
 
 // ---------------------------------------------------------------------------
-// Transition mapping (pure — herdr's notification_sound_for_state_change)
+// Notification decision (shared by sound and desktop banners)
 // ---------------------------------------------------------------------------
 
-use zeron_proto::SessionStatus;
+use zeron_proto::{
+    Session,
+    view::{Indicator, effective_indicator},
+};
 
-/// Which chime (if any) a session-status transition deserves. Same-state
-/// updates never chime; a question always chimes; a completion chimes on the
-/// Working→Idle edge.
-pub fn sound_for_transition(prev: SessionStatus, new: SessionStatus) -> Option<Sound> {
-    if prev == new {
-        return None;
+/// Notification baseline is separate from the visual activity indicator:
+/// going idle can mean cancellation, expiry, or an internal handoff.
+#[derive(Debug, Clone)]
+pub(crate) struct SessionNotificationState {
+    indicator: Indicator,
+    last_completed_turn: Option<String>,
+    fresh: bool,
+}
+
+impl SessionNotificationState {
+    pub(crate) fn new(session: &Session, now: chrono::DateTime<chrono::Utc>) -> Self {
+        Self {
+            indicator: effective_indicator(Some(session), now),
+            last_completed_turn: session.last_completed_turn.clone(),
+            fresh: now
+                .signed_duration_since(session.updated_at)
+                .num_milliseconds()
+                <= zeron_proto::view::SESSION_STALE_MS,
+        }
     }
-    match new {
-        SessionStatus::AwaitingInput => Some(Sound::Request),
-        SessionStatus::Idle if prev == SessionStatus::Working => Some(Sound::Done),
-        _ => None,
+
+    /// Call after saving the new baseline, including when delivery is pending
+    /// or outputs are disabled. Suppressed pings must never be replayed later.
+    pub(crate) fn sound_since(&self, prev: &Self, send_pending: bool) -> Option<Sound> {
+        if self.indicator == Indicator::AwaitingInput && prev.indicator != Indicator::AwaitingInput
+        {
+            return Some(Sound::Request);
+        }
+        if !send_pending
+            && self.fresh
+            && self.last_completed_turn.is_some()
+            && self.last_completed_turn != prev.last_completed_turn
+        {
+            return Some(Sound::Done);
+        }
+        None
     }
 }
 
@@ -168,26 +196,60 @@ pub fn sound_for_transition(prev: SessionStatus, new: SessionStatus) -> Option<S
 mod tests {
     use super::*;
 
+    fn baseline(indicator: Indicator, turn: Option<&str>) -> SessionNotificationState {
+        SessionNotificationState {
+            indicator,
+            last_completed_turn: turn.map(str::to_owned),
+            fresh: true,
+        }
+    }
+
     #[test]
-    fn transition_mapping_matches_herdr_semantics() {
-        use SessionStatus::*;
-        // A question always chimes, wherever it came from.
+    fn interrupted_and_expired_activity_never_chime() {
+        let working = baseline(Indicator::Working, Some("old"));
+        let idle = baseline(Indicator::None, Some("old"));
+        assert_eq!(idle.sound_since(&working, false), None);
         assert_eq!(
-            sound_for_transition(Working, AwaitingInput),
-            Some(Sound::Request)
+            baseline(Indicator::Errored, Some("old")).sound_since(&working, false),
+            None
         );
+        // An older host without explicit completion metadata is silent too.
         assert_eq!(
-            sound_for_transition(Idle, AwaitingInput),
-            Some(Sound::Request)
+            baseline(Indicator::None, None).sound_since(&baseline(Indicator::Working, None), false),
+            None
         );
-        // Completion = the Working→Idle edge only.
-        assert_eq!(sound_for_transition(Working, Idle), Some(Sound::Done));
-        assert_eq!(sound_for_transition(AwaitingInput, Idle), None);
-        assert_eq!(sound_for_transition(Errored, Idle), None);
-        // Same state / other edges stay silent.
-        assert_eq!(sound_for_transition(Working, Working), None);
-        assert_eq!(sound_for_transition(Idle, Working), None);
-        assert_eq!(sound_for_transition(Working, Errored), None);
+    }
+
+    #[test]
+    fn ordinary_queue_completions_survive_coalesced_working_states() {
+        let first = baseline(Indicator::Working, None);
+        let second = baseline(Indicator::Working, Some("first"));
+        assert_eq!(second.sound_since(&first, false), Some(Sound::Done));
+        assert_eq!(second.sound_since(&second, false), None);
+        let last = baseline(Indicator::None, Some("second"));
+        assert_eq!(last.sound_since(&second, false), Some(Sound::Done));
+        assert_eq!(last.sound_since(&last, false), None);
+    }
+
+    #[test]
+    fn pending_send_consumes_completion_but_preserves_input_requests() {
+        let before = baseline(Indicator::Working, None);
+        let settled = baseline(Indicator::None, Some("first"));
+        assert_eq!(settled.sound_since(&before, true), None);
+        assert_eq!(settled.sound_since(&settled, false), None);
+        let question = baseline(Indicator::AwaitingInput, Some("first"));
+        assert_eq!(question.sound_since(&settled, true), Some(Sound::Request));
+        assert_eq!(question.sound_since(&question, false), None);
+    }
+
+    #[test]
+    fn stale_completion_is_consumed_without_replaying_on_a_heartbeat() {
+        let before = baseline(Indicator::Working, None);
+        let mut stale = baseline(Indicator::None, Some("old"));
+        stale.fresh = false;
+        assert_eq!(stale.sound_since(&before, false), None);
+        let refreshed = baseline(Indicator::Working, Some("old"));
+        assert_eq!(refreshed.sound_since(&stale, false), None);
     }
 
     #[test]

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -2989,6 +2989,7 @@ mod tests {
         now: DateTime<Utc>,
     ) -> Session {
         Session {
+            last_completed_turn: None,
             chat_id: chat_id.into(),
             device_id: "dev".into(),
             status,
@@ -3073,6 +3074,7 @@ mod tests {
         let mut state = AppState::new();
         let now = Utc::now();
         let mut row = Session {
+            last_completed_turn: None,
             chat_id: "chat".into(),
             device_id: "host".into(),
             status: SessionStatus::Working,
@@ -3103,6 +3105,7 @@ mod tests {
         let mut state = AppState::new();
         let now = Utc::now();
         state.sessions = vec![Session {
+            last_completed_turn: None,
             chat_id: "chat".into(),
             device_id: "host".into(),
             status: SessionStatus::Working,

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -8418,6 +8418,7 @@ mod tests {
                     this.rail_enabled = false;
                     this.state.update(cx, |state, _| {
                         state.sessions.push(zeron_proto::Session {
+                            last_completed_turn: None,
                             chat_id: "chat".into(),
                             device_id: "test".into(),
                             status: zeron_proto::SessionStatus::Working,


### PR DESCRIPTION
Sending a queued message immediately interrupts the current response, briefly changing the session from Working to Idle before the replacement starts. The notification detector treated that transition as a successful completion and played the chime and posted “Run finished”.

This change uses a synchronized completion marker to distinguish completed responses from interruptions and steering handoffs. Normal queued turns still notify when they finish, even when the next turn starts before the UI observes Idle. Input requests and responses settled by the engine’s existing quiescence watchdog retain their notifications.

- Persist the last completed turn across session updates and both workspace storage paths; consume stale or duplicate markers silently.
- Track explicit queue sends until the host acknowledges or rejects delivery, including when the user switches chats.
- Serialize steering mailbox acceptance with its pending-delivery ledger in both explicit steering and warm dispatch, preventing a fast confirmation from leaving an orphaned pending entry.

The new session field is optional when reading older rows. Completion notifications from a remote host require that host to emit the new metadata.

Validation: 184 tests passed across the engine lifecycle/queue suites, protocol and document unit tests, and notification tests; one existing engine test was ignored. `cargo check --workspace --all-targets` and `git diff --check` passed. Native sound/banner presentation was not manually exercised.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791652742&installation_model_id=425430&pr_number=309&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F309&signature=a0c237aebf12cb264ead8dbf7f5f5b42f076aaf4d20c2493e5ce84179c1ec24b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->