### PR TITLE
Fix Codex v1 subagent breadcrumbs and stabilize v2 transcripts

### DIFF
--- a/crates/doc/src/parts.rs
+++ b/crates/doc/src/parts.rs
@@ -403,10 +403,11 @@ pub fn fold_event_into_parts(out: &mut Vec<MessagePart>, event: &AgentEvent) {
                     zeron_proto::DoneStatus::Errored => SubagentStatus::Failed,
                     _ => SubagentStatus::Done,
                 }),
-                // A steer RESURRECTS a settled chip — it announces more work
-                // (claude: a queued SendMessage relaunches the agent), so
-                // this is the one event allowed past the no-regress guard.
-                AgentEvent::UserMessage { .. } => Some(SubagentStatus::Running),
+                // A new assignment reopens a settled chip. Providers may
+                // announce it with user text or a confirmed turn boundary.
+                AgentEvent::UserMessage { .. } | AgentEvent::Steered { .. } => {
+                    Some(SubagentStatus::Running)
+                }
                 _ => None,
             };
             for p in out.iter_mut() {
@@ -1153,6 +1154,24 @@ mod tests {
             } => assert_eq!(*subagent_status, Some(SubagentStatus::Done)),
             other => panic!("{other:?}"),
         }
+        // A confirmed follow-up can reopen the same chip without user text.
+        fold_event_into_parts(
+            &mut parts,
+            &AgentEvent::Subagent {
+                parent_tool_use_id: "toolu_sub".into(),
+                event: Box::new(AgentEvent::Steered {
+                    assistant_message_id: None,
+                    next_assistant_message_id: None,
+                }),
+            },
+        );
+        assert!(matches!(
+            &parts[0],
+            MessagePart::Tool {
+                subagent_status: Some(SubagentStatus::Running),
+                ..
+            }
+        ));
         // Content never leaked into the parent parts.
         assert_eq!(parts.len(), 1);
     }

--- a/crates/engine/src/sessions.rs
+++ b/crates/engine/src/sessions.rs
@@ -1611,7 +1611,10 @@ async fn drive_run(
         } = &event
         {
             inner.publish(&chat_id, &event);
-            let is_steer = matches!(sub_event.as_ref(), AgentEvent::UserMessage { .. });
+            let is_steer = matches!(
+                sub_event.as_ref(),
+                AgentEvent::UserMessage { .. } | AgentEvent::Steered { .. }
+            );
             if is_steer {
                 settled_subagents.remove(parent_tool_use_id);
             } else if settled_subagents.contains(parent_tool_use_id)

--- a/crates/engine/tests/codex_subagents.rs
+++ b/crates/engine/tests/codex_subagents.rs
@@ -1,0 +1,237 @@
+//! Actual CodexHarness JSON-RPC decoding through the engine's document writer.
+//! Fixtures run offline; no installed agent or model account is involved.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use zeron_doc::{MessagePart, MessageRole, MessageStatus, SessionMessageEntry, SubagentStatus};
+use zeron_engine::{EngineCore, EngineProfile, HarnessRegistry};
+use zeron_harness::CodexHarness;
+use zeron_proto::{HarnessId, RunRequest, SandboxLevel, SessionStatus};
+
+const CHAT: &str = "codex-subagents";
+
+fn assemble(dir: &Path) -> (EngineCore, EngineProfile) {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../harness/tests/fixtures/fake-codex.sh");
+    let registry = Arc::new(HarnessRegistry::new());
+    registry.register(Arc::new(CodexHarness::new().with_executable(fixture)));
+    let profile = EngineProfile::development(dir, "test-org", "test-user");
+    let core = EngineCore::assemble_with_profile(profile.clone(), registry, HarnessId::Codex, None)
+        .unwrap();
+    (core, profile)
+}
+
+fn entries(core: &EngineCore, doc: &str) -> Vec<SessionMessageEntry> {
+    core.doc_host
+        .open(doc)
+        .unwrap()
+        .doc()
+        .read_entries()
+        .unwrap_or_default()
+}
+
+fn text(entries: &[SessionMessageEntry], role: MessageRole) -> String {
+    entries
+        .iter()
+        .filter(|e| e.role == role)
+        .flat_map(|e| &e.parts)
+        .filter_map(|p| match p {
+            MessagePart::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+async fn check_persistence(
+    scenario: &str,
+    alpha_status: SubagentStatus,
+    alpha_text: &str,
+    alpha_users: &str,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let (core, profile) = assemble(dir.path());
+    let request = RunRequest {
+        prompt: format!("scenario:{scenario}"),
+        harness: None,
+        model: None,
+        reasoning: None,
+        model_options: Default::default(),
+        cwd: dir.path().display().to_string(),
+        sandbox: SandboxLevel::ReadOnly,
+        auto_approve: true,
+        attachments: vec![],
+        worktree: None,
+        resume: None,
+    };
+    core.sessions
+        .dispatch(
+            CHAT,
+            HarnessId::Codex,
+            request.clone(),
+            Some("user-prompt".into()),
+        )
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if core
+                .sessions
+                .session_status(CHAT)
+                .is_some_and(|s| s.status == SessionStatus::Idle)
+                && entries(&core, CHAT).iter().any(|e| {
+                    e.role == MessageRole::Assistant && e.status == Some(MessageStatus::Complete)
+                })
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("parent completes");
+    let parent = entries(&core, CHAT);
+    let chips: Vec<_> = parent
+        .iter()
+        .flat_map(|e| &e.parts)
+        .filter_map(|p| match p {
+            MessagePart::Tool {
+                id,
+                call,
+                subagent_ref,
+                subagent_status,
+                ..
+            } if call.is_subagent_spawn() => {
+                Some((id.clone(), subagent_ref.clone(), *subagent_status))
+            }
+            _ => None,
+        })
+        .collect();
+    let alpha_doc = format!("{CHAT}--sub--spawn-alpha");
+    let beta_doc = format!("{CHAT}--sub--spawn-beta");
+    assert_eq!(
+        chips,
+        [
+            (
+                "spawn-alpha".into(),
+                Some(alpha_doc.clone()),
+                Some(alpha_status)
+            ),
+            (
+                "spawn-beta".into(),
+                Some(beta_doc.clone()),
+                Some(SubagentStatus::Done)
+            ),
+        ]
+    );
+    for part in parent.iter().flat_map(|e| &e.parts) {
+        if let MessagePart::Tool {
+            call, subagent_ref, ..
+        } = part
+            && !call.is_subagent_spawn()
+        {
+            assert!(subagent_ref.is_none());
+        }
+    }
+    assert!(!text(&parent, MessageRole::Assistant).contains("alpha"));
+    assert!(!text(&parent, MessageRole::Assistant).contains("beta"));
+    let alpha = entries(&core, &alpha_doc);
+    let beta = entries(&core, &beta_doc);
+    assert_eq!(text(&alpha, MessageRole::Assistant), alpha_text);
+    assert_eq!(text(&alpha, MessageRole::User), alpha_users);
+    assert!(text(&beta, MessageRole::Assistant).contains("beta answer"));
+    assert!(
+        alpha
+            .iter()
+            .chain(&beta)
+            .all(|e| e.status == Some(MessageStatus::Complete))
+    );
+    core.shutdown().await;
+    drop(core);
+
+    // Check persisted identities directly without opening phantom documents.
+    let db = rusqlite::Connection::open(profile.store_root().join("docs.sqlite3")).unwrap();
+    let ids: Vec<String> = db.prepare("SELECT doc_id FROM snapshots WHERE doc_id LIKE 'codex-subagents--sub--%' ORDER BY doc_id").unwrap()
+        .query_map([], |r| r.get(0)).unwrap().collect::<Result<_, _>>().unwrap();
+    assert_eq!(ids, [alpha_doc.clone(), beta_doc.clone()]);
+    drop(db);
+    let (reopened, _) = assemble(dir.path());
+    assert_eq!(entries(&reopened, &alpha_doc), alpha);
+    assert_eq!(entries(&reopened, &beta_doc), beta);
+    let mut request = request;
+    request.prompt = "scenario:resumed-child".into();
+    request.resume = Some(
+        if scenario.starts_with("v1") {
+            "resume-with-child-v1"
+        } else {
+            "resume-with-child-v2"
+        }
+        .into(),
+    );
+    reopened
+        .sessions
+        .dispatch(
+            CHAT,
+            HarnessId::Codex,
+            request,
+            Some("user-followup".into()),
+        )
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if text(&entries(&reopened, &alpha_doc), MessageRole::Assistant)
+                .ends_with("resumed alpha\n\n")
+                && reopened
+                    .sessions
+                    .session_status(CHAT)
+                    .is_some_and(|s| s.status == SessionStatus::Idle)
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("resumed child appends to its original document");
+    assert_eq!(
+        text(&entries(&reopened, &alpha_doc), MessageRole::Assistant),
+        format!("{alpha_text}resumed alpha\n\n")
+    );
+    let parent = entries(&reopened, CHAT);
+    assert_eq!(
+        parent
+            .iter()
+            .flat_map(|e| &e.parts)
+            .filter(|p| matches!(p, MessagePart::Tool { call, .. } if call.is_subagent_spawn()))
+            .count(),
+        2
+    );
+    assert!(parent.iter().flat_map(|e| &e.parts).any(|p| matches!(p,
+        MessagePart::Tool { id, subagent_status: Some(SubagentStatus::Done), .. } if id == "spawn-alpha"
+    )));
+    reopened.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn v1_children_persist_under_their_spawn_chips() {
+    check_persistence(
+        "v1-subagents",
+        SubagentStatus::Done,
+        "alpha answer",
+        "Inspect alpha",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn v2_followup_appends_to_the_original_document_and_updates_the_original_chip() {
+    check_persistence(
+        "v2-lifecycle",
+        SubagentStatus::Failed,
+        "first alpha\n\nsecond alpha\n\n",
+        "First assignment",
+    )
+    .await;
+}

--- a/crates/harness/src/codex/mod.rs
+++ b/crates/harness/src/codex/mod.rs
@@ -62,9 +62,8 @@ use crate::jsonrpc::{Incoming, RpcClient};
 use crate::{Harness, HarnessError, RunControls};
 use catalog::{REASONING_LEVELS, sandbox_mode, sandbox_policy_value, static_models, to_effort};
 use normalize::{
-    ChildRoute, Phase, ReasoningStream, delta_text, item_id, item_type, map_item,
-    notification_thread_id, route_child_notification, turn_error_message, turn_id, usage_event,
-    user_message_text,
+    ChildRoute, Phase, ReasoningStream, delta_text, item_id, item_type, notification_thread_id,
+    route_child_notification, turn_error_message, turn_id, usage_event,
 };
 
 /// Locate the device's installed Codex CLI: `CODEX_EXECUTABLE`, then our own
@@ -1038,107 +1037,7 @@ async fn run_session(session: Session) {
                         }
                         ChildRoute::Consumed => continue,
                         ChildRoute::Subagent => {
-                            let events: Vec<AgentEvent> = match method.as_str() {
-                                // The child settling its turn IS the
-                                // subagent finishing its assignment —
-                                // the chip's terminal state.
-                                "turn/completed" => vec![AgentEvent::Done {
-                                    status: if turn_error_message(&params).is_some()
-                                        || params
-                                            .pointer("/turn/status")
-                                            .and_then(Value::as_str)
-                                            == Some("failed")
-                                    {
-                                        DoneStatus::Errored
-                                    } else {
-                                        DoneStatus::Completed
-                                    },
-                                    result: None,
-                                    error: None,
-                                    session_id: Some(nthread.clone()),
-                                }],
-                                "turn/failed" => vec![AgentEvent::Done {
-                                    status: DoneStatus::Errored,
-                                    result: None,
-                                    error: turn_error_message(&params),
-                                    session_id: Some(nthread.clone()),
-                                }],
-                                "turn/aborted" => vec![AgentEvent::Done {
-                                    status: DoneStatus::Interrupted,
-                                    result: None,
-                                    error: None,
-                                    session_id: Some(nthread.clone()),
-                                }],
-                                "item/agentMessage/delta" => delta_text(&params)
-                                    .map(|text| AgentEvent::TextDelta { text })
-                                    .into_iter()
-                                    .collect(),
-                                "item/reasoning/textDelta"
-                                | "item/reasoning/summaryTextDelta"
-                                | "item/reasoning/summaryPartAdded" => reasoning_streams
-                                    .entry(nthread.clone()).or_default().map(&method, &params),
-                                "item/started" | "item/completed" => {
-                                    let phase = if method == "item/started" {
-                                        Phase::Started
-                                    } else {
-                                        Phase::Completed
-                                    };
-                                    let item =
-                                        params.get("item").cloned().unwrap_or(Value::Null);
-                                    // Same paragraphing as the parent:
-                                    // a child's completed message ends
-                                    // a paragraph in its transcript.
-                                    if phase == Phase::Completed
-                                        && matches!(
-                                            item_type(&item),
-                                            "agentMessage" | "agent_message"
-                                        )
-                                    {
-                                        vec![AgentEvent::TextDelta {
-                                            text: "\n\n".into(),
-                                        }]
-                                    } else if matches!(
-                                        item_type(&item),
-                                        "userMessage" | "user_message"
-                                    ) {
-                                        // A CHILD thread's user message
-                                        // is the parent steering it (the
-                                        // collab send_message path) —
-                                        // its own entry in the subagent
-                                        // doc. Completed only: both
-                                        // lifecycle events carry the
-                                        // full item.
-                                        if phase == Phase::Completed {
-                                            user_message_text(&item)
-                                                .map(|text| AgentEvent::UserMessage { text })
-                                                .into_iter()
-                                                .collect()
-                                        } else {
-                                            Vec::new()
-                                        }
-                                    } else {
-                                        map_item(phase, &item)
-                                    }
-                                }
-                                "error" => vec![AgentEvent::Error {
-                                    message: params
-                                        .pointer("/error/message")
-                                        .and_then(Value::as_str)
-                                        .or_else(|| {
-                                            params.get("message").and_then(Value::as_str)
-                                        })
-                                        .unwrap_or("Codex subagent error")
-                                        .to_owned(),
-                                }],
-                                "thread/closed" => vec![AgentEvent::Done {
-                                    status: DoneStatus::Completed,
-                                    result: None,
-                                    error: None,
-                                    session_id: Some(nthread.clone()),
-                                }],
-                                _ => Vec::new(),
-                            };
-                            for event in children.route(&nthread, events) {
+                            for event in children.notification(&nthread, &method, &params) {
                                 if !send(&event_tx, event).await {
                                     break 'main;
                                 }
@@ -1177,42 +1076,6 @@ async fn run_session(session: Session) {
                             Phase::Completed
                         };
                         let item = params.get("item").cloned().unwrap_or(Value::Null);
-                        let mut buffered_child_events = Vec::new();
-                        if let Some(child) = normalize::collab_spawn_child(&item) {
-                            if child == thread_id { continue; }
-                            let call = item.get("id").and_then(Value::as_str).unwrap_or("");
-                            buffered_child_events = children.bind(child, call);
-                        }
-                        // Only a spawn establishes ownership. Later activity ids
-                        // must never replace the id used by the child's document.
-                        if matches!(
-                            item_type(&item),
-                            "subAgentActivity" | "sub_agent_activity"
-                        ) {
-                            let child = item
-                                .get("agentThreadId")
-                                .and_then(Value::as_str)
-                                .unwrap_or("");
-                            let path = item
-                                .get("agentPath")
-                                .and_then(Value::as_str)
-                                .unwrap_or("");
-                            let call = item.get("id").and_then(Value::as_str).unwrap_or("");
-                            if !child.is_empty()
-                                && child != thread_id
-                                && path != "/root"
-                                && path != "/"
-                                && !call.is_empty()
-                            {
-                                if matches!(item.get("kind").and_then(Value::as_str), Some("started" | "spawned")) {
-                                    buffered_child_events = children.bind(child, call);
-                                }
-                            } else if child == thread_id || path == "/root" || path == "/" {
-                                // The root's own activity marker: no chip, no
-                                // registration — it is not a subagent.
-                                continue;
-                            }
-                        }
                         if matches!(item_type(&item), "agentMessage" | "agent_message") {
                             if phase == Phase::Completed {
                                 // Fallback for non-streamed messages only.
@@ -1257,7 +1120,7 @@ async fn run_session(session: Session) {
                                 }
                             }
                         } else {
-                            for ev in map_item(phase, &item).into_iter().chain(buffered_child_events) {
+                            for ev in children.parent_item(phase, &item) {
                                 if !send(&event_tx, ev).await {
                                     break 'main;
                                 }

--- a/crates/harness/src/codex/mod.rs
+++ b/crates/harness/src/codex/mod.rs
@@ -1178,6 +1178,11 @@ async fn run_session(session: Session) {
                         };
                         let item = params.get("item").cloned().unwrap_or(Value::Null);
                         let mut buffered_child_events = Vec::new();
+                        if let Some(child) = normalize::collab_spawn_child(&item) {
+                            if child == thread_id { continue; }
+                            let call = item.get("id").and_then(Value::as_str).unwrap_or("");
+                            buffered_child_events = children.bind(child, call);
+                        }
                         // Only a spawn establishes ownership. Later activity ids
                         // must never replace the id used by the child's document.
                         if matches!(

--- a/crates/harness/src/codex/mod.rs
+++ b/crates/harness/src/codex/mod.rs
@@ -20,8 +20,8 @@
 //!   `item/commandExecution/requestApproval` +
 //!   `item/fileChange/requestApproval` still round-trip through
 //!   [`RunControls::request_input`] as a synthesized yes/no question.
-//! - Subagents are full child app-server threads (`thread/started` with
-//!   `source.subAgent.thread_spawn`, `subAgentActivity` items on the parent).
+//! - Subagents are full child app-server threads. Parent spawn items establish
+//!   their stable ownership; content arriving before the spawn is buffered.
 //!   A registered child's notifications route through an EXPLICIT table
 //!   ([`normalize::route_child_notification`]) — item lifecycles/errors become
 //!   tagged [`AgentEvent::Subagent`] events, child turn bookkeeping is
@@ -37,6 +37,7 @@
 
 pub(crate) mod catalog;
 mod normalize;
+mod subagents;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
@@ -983,11 +984,7 @@ async fn run_session(session: Session) {
     }
 
     let mut router = TurnRouter::default();
-    // Child app-server threads (multi-agent v2): child thread id → the
-    // parent-feed spawn call id its traffic is attributed to. Registered
-    // from `subAgentActivity` items on the parent thread and from a child
-    // `thread/started` carrying a spawn source.
-    let mut children: HashMap<String, String> = HashMap::new();
+    let mut children = subagents::Subagents::new(thread_id.clone());
     match start_turn(&client, turn_params(&request.prompt)).await {
         Ok(id) => router.adopt_started(id),
         Err(e) => {
@@ -1033,19 +1030,6 @@ async fn run_session(session: Session) {
                     && !nthread.is_empty()
                     && nthread != thread_id
                 {
-                    // Registration path: a child thread/started with an
-                    // explicit spawn source. The spawn-call mapping from a
-                    // subAgentActivity item wins (that id IS the parent
-                    // chip); this only seeds a fallback.
-                    if method == "thread/started"
-                        && params
-                            .pointer("/thread/source/subAgent/thread_spawn")
-                            .is_some()
-                    {
-                        children
-                            .entry(nthread.clone())
-                            .or_insert_with(|| nthread.clone());
-                    }
                     match route_child_notification(&method) {
                         ChildRoute::Parent => {
                             // Unknown/parent-owned: fall through so a codex
@@ -1054,120 +1038,109 @@ async fn run_session(session: Session) {
                         }
                         ChildRoute::Consumed => continue,
                         ChildRoute::Subagent => {
-                            // Attributed child traffic — but only for a
-                            // REGISTERED child; pre-registration lifecycle
-                            // (captured ordering: a child's status change
-                            // can precede its registration) is dropped, not
-                            // passed to the parent path.
-                            if let Some(parent_call) = children.get(&nthread).cloned() {
-                                let events: Vec<AgentEvent> = match method.as_str() {
-                                    // The child settling its turn IS the
-                                    // subagent finishing its assignment —
-                                    // the chip's terminal state.
-                                    "turn/completed" => vec![AgentEvent::Done {
-                                        status: if turn_error_message(&params).is_some()
-                                            || params
-                                                .pointer("/turn/status")
-                                                .and_then(Value::as_str)
-                                                == Some("failed")
-                                        {
-                                            DoneStatus::Errored
-                                        } else {
-                                            DoneStatus::Completed
-                                        },
-                                        result: None,
-                                        error: None,
-                                        session_id: Some(nthread.clone()),
-                                    }],
-                                    "turn/failed" => vec![AgentEvent::Done {
-                                        status: DoneStatus::Errored,
-                                        result: None,
-                                        error: turn_error_message(&params),
-                                        session_id: Some(nthread.clone()),
-                                    }],
-                                    "turn/aborted" => vec![AgentEvent::Done {
-                                        status: DoneStatus::Interrupted,
-                                        result: None,
-                                        error: None,
-                                        session_id: Some(nthread.clone()),
-                                    }],
-                                    "item/agentMessage/delta" => delta_text(&params)
-                                        .map(|text| AgentEvent::TextDelta { text })
-                                        .into_iter()
-                                        .collect(),
-                                    "item/reasoning/textDelta"
-                                    | "item/reasoning/summaryTextDelta"
-                                    | "item/reasoning/summaryPartAdded" => reasoning_streams
-                                        .entry(nthread.clone()).or_default().map(&method, &params),
-                                    "item/started" | "item/completed" => {
-                                        let phase = if method == "item/started" {
-                                            Phase::Started
-                                        } else {
-                                            Phase::Completed
-                                        };
-                                        let item =
-                                            params.get("item").cloned().unwrap_or(Value::Null);
-                                        // Same paragraphing as the parent:
-                                        // a child's completed message ends
-                                        // a paragraph in its transcript.
-                                        if phase == Phase::Completed
-                                            && matches!(
-                                                item_type(&item),
-                                                "agentMessage" | "agent_message"
-                                            )
-                                        {
-                                            vec![AgentEvent::TextDelta {
-                                                text: "\n\n".into(),
-                                            }]
-                                        } else if matches!(
-                                            item_type(&item),
-                                            "userMessage" | "user_message"
-                                        ) {
-                                            // A CHILD thread's user message
-                                            // is the parent steering it (the
-                                            // collab send_message path) —
-                                            // its own entry in the subagent
-                                            // doc. Completed only: both
-                                            // lifecycle events carry the
-                                            // full item.
-                                            if phase == Phase::Completed {
-                                                user_message_text(&item)
-                                                    .map(|text| AgentEvent::UserMessage { text })
-                                                    .into_iter()
-                                                    .collect()
-                                            } else {
-                                                Vec::new()
-                                            }
-                                        } else {
-                                            map_item(phase, &item)
-                                        }
-                                    }
-                                    "error" => vec![AgentEvent::Error {
-                                        message: params
-                                            .pointer("/error/message")
+                            let events: Vec<AgentEvent> = match method.as_str() {
+                                // The child settling its turn IS the
+                                // subagent finishing its assignment —
+                                // the chip's terminal state.
+                                "turn/completed" => vec![AgentEvent::Done {
+                                    status: if turn_error_message(&params).is_some()
+                                        || params
+                                            .pointer("/turn/status")
                                             .and_then(Value::as_str)
-                                            .or_else(|| {
-                                                params.get("message").and_then(Value::as_str)
-                                            })
-                                            .unwrap_or("Codex subagent error")
-                                            .to_owned(),
-                                    }],
-                                    "thread/closed" => vec![AgentEvent::Done {
-                                        status: DoneStatus::Completed,
-                                        result: None,
-                                        error: None,
-                                        session_id: Some(nthread.clone()),
-                                    }],
-                                    _ => Vec::new(),
-                                };
-                                for ev in events {
-                                    let wrapped = AgentEvent::Subagent {
-                                        parent_tool_use_id: parent_call.clone(),
-                                        event: Box::new(ev),
+                                            == Some("failed")
+                                    {
+                                        DoneStatus::Errored
+                                    } else {
+                                        DoneStatus::Completed
+                                    },
+                                    result: None,
+                                    error: None,
+                                    session_id: Some(nthread.clone()),
+                                }],
+                                "turn/failed" => vec![AgentEvent::Done {
+                                    status: DoneStatus::Errored,
+                                    result: None,
+                                    error: turn_error_message(&params),
+                                    session_id: Some(nthread.clone()),
+                                }],
+                                "turn/aborted" => vec![AgentEvent::Done {
+                                    status: DoneStatus::Interrupted,
+                                    result: None,
+                                    error: None,
+                                    session_id: Some(nthread.clone()),
+                                }],
+                                "item/agentMessage/delta" => delta_text(&params)
+                                    .map(|text| AgentEvent::TextDelta { text })
+                                    .into_iter()
+                                    .collect(),
+                                "item/reasoning/textDelta"
+                                | "item/reasoning/summaryTextDelta"
+                                | "item/reasoning/summaryPartAdded" => reasoning_streams
+                                    .entry(nthread.clone()).or_default().map(&method, &params),
+                                "item/started" | "item/completed" => {
+                                    let phase = if method == "item/started" {
+                                        Phase::Started
+                                    } else {
+                                        Phase::Completed
                                     };
-                                    if !send(&event_tx, wrapped).await {
-                                        break 'main;
+                                    let item =
+                                        params.get("item").cloned().unwrap_or(Value::Null);
+                                    // Same paragraphing as the parent:
+                                    // a child's completed message ends
+                                    // a paragraph in its transcript.
+                                    if phase == Phase::Completed
+                                        && matches!(
+                                            item_type(&item),
+                                            "agentMessage" | "agent_message"
+                                        )
+                                    {
+                                        vec![AgentEvent::TextDelta {
+                                            text: "\n\n".into(),
+                                        }]
+                                    } else if matches!(
+                                        item_type(&item),
+                                        "userMessage" | "user_message"
+                                    ) {
+                                        // A CHILD thread's user message
+                                        // is the parent steering it (the
+                                        // collab send_message path) —
+                                        // its own entry in the subagent
+                                        // doc. Completed only: both
+                                        // lifecycle events carry the
+                                        // full item.
+                                        if phase == Phase::Completed {
+                                            user_message_text(&item)
+                                                .map(|text| AgentEvent::UserMessage { text })
+                                                .into_iter()
+                                                .collect()
+                                        } else {
+                                            Vec::new()
+                                        }
+                                    } else {
+                                        map_item(phase, &item)
                                     }
+                                }
+                                "error" => vec![AgentEvent::Error {
+                                    message: params
+                                        .pointer("/error/message")
+                                        .and_then(Value::as_str)
+                                        .or_else(|| {
+                                            params.get("message").and_then(Value::as_str)
+                                        })
+                                        .unwrap_or("Codex subagent error")
+                                        .to_owned(),
+                                }],
+                                "thread/closed" => vec![AgentEvent::Done {
+                                    status: DoneStatus::Completed,
+                                    result: None,
+                                    error: None,
+                                    session_id: Some(nthread.clone()),
+                                }],
+                                _ => Vec::new(),
+                            };
+                            for event in children.route(&nthread, events) {
+                                if !send(&event_tx, event).await {
+                                    break 'main;
                                 }
                             }
                             continue;
@@ -1204,14 +1177,9 @@ async fn run_session(session: Session) {
                             Phase::Completed
                         };
                         let item = params.get("item").cloned().unwrap_or(Value::Null);
-                        // A subAgentActivity item on the parent thread names a
-                        // child: register it (its call id = the parent chip
-                        // its traffic is attributed to). NEVER the root
-                        // thread itself — the wire emits subAgentActivity
-                        // about the root during collab runs, and registering
-                        // it would intercept every subsequent root
-                        // notification including turn/completed (the thread
-                        // would hang Working after the fleet finished).
+                        let mut buffered_child_events = Vec::new();
+                        // Only a spawn establishes ownership. Later activity ids
+                        // must never replace the id used by the child's document.
                         if matches!(
                             item_type(&item),
                             "subAgentActivity" | "sub_agent_activity"
@@ -1231,7 +1199,9 @@ async fn run_session(session: Session) {
                                 && path != "/"
                                 && !call.is_empty()
                             {
-                                children.insert(child.to_owned(), call.to_owned());
+                                if matches!(item.get("kind").and_then(Value::as_str), Some("started" | "spawned")) {
+                                    buffered_child_events = children.bind(child, call);
+                                }
                             } else if child == thread_id || path == "/root" || path == "/" {
                                 // The root's own activity marker: no chip, no
                                 // registration — it is not a subagent.
@@ -1282,7 +1252,7 @@ async fn run_session(session: Session) {
                                 }
                             }
                         } else {
-                            for ev in map_item(phase, &item) {
+                            for ev in map_item(phase, &item).into_iter().chain(buffered_child_events) {
                                 if !send(&event_tx, ev).await {
                                     break 'main;
                                 }

--- a/crates/harness/src/codex/mod.rs
+++ b/crates/harness/src/codex/mod.rs
@@ -3,7 +3,7 @@
 //! uses. Resurrected from the pre-ACP driver and modernized.
 //!
 //! VERSION PIN: the app-server API is EXPERIMENTAL (`capabilities.
-//! experimentalApi`); this driver is validated against codex-cli 0.149.0 —
+//! experimentalApi`); this driver is validated against codex-cli 0.153.4 —
 //! revalidate the method/notification surface when bumping past it.
 //!
 //! - `initialize` handshake (clientInfo + `capabilities.experimentalApi`) then
@@ -23,8 +23,8 @@
 //! - Subagents are full child app-server threads. Parent spawn items establish
 //!   their stable ownership; content arriving before the spawn is buffered.
 //!   A registered child's notifications route through an EXPLICIT table
-//!   ([`normalize::route_child_notification`]) — item lifecycles/errors become
-//!   tagged [`AgentEvent::Subagent`] events, child turn bookkeeping is
+//!   ([`normalize::route_child_notification`]) — content, errors and child turns
+//!   become tagged [`AgentEvent::Subagent`] events; unrelated child bookkeeping is
 //!   consumed so it can never settle the parent turn, and unknown methods
 //!   fall through to the parent path (fail open, never silent loss).
 //! - Steering: `turn/steer { expectedTurnId }` into the live turn; a rejected
@@ -906,9 +906,11 @@ async fn run_session(session: Session) {
                 .await?
         };
         let thread_id = thread["thread"]["id"].as_str().unwrap_or("").to_owned();
-        Ok::<String, HarnessError>(thread_id)
+        let mut children = subagents::Subagents::new(thread_id.clone());
+        children.restore(&thread["thread"]);
+        Ok::<_, HarnessError>((thread_id, children))
     };
-    let thread_id = tokio::select! {
+    let (thread_id, mut children) = tokio::select! {
         res = setup => match res {
             Ok(thread_id) => thread_id,
             Err(e) => {
@@ -983,7 +985,6 @@ async fn run_session(session: Session) {
     }
 
     let mut router = TurnRouter::default();
-    let mut children = subagents::Subagents::new(thread_id.clone());
     match start_turn(&client, turn_params(&request.prompt)).await {
         Ok(id) => router.adopt_started(id),
         Err(e) => {

--- a/crates/harness/src/codex/normalize.rs
+++ b/crates/harness/src/codex/normalize.rs
@@ -205,6 +205,34 @@ pub(crate) fn item_type(item: &Value) -> &str {
     item.get("type").and_then(Value::as_str).unwrap_or("")
 }
 
+pub(super) fn is_collab_spawn(item: &Value) -> bool {
+    matches!(
+        item_type(item),
+        "collabAgentToolCall" | "collab_agent_tool_call"
+    ) && matches!(
+        item.get("tool").and_then(Value::as_str),
+        Some("spawnAgent" | "spawn_agent")
+    )
+}
+
+/// A v1 spawn names its child in the completed result. Other collaboration
+/// tools can address several receivers, but only a spawn owns a transcript.
+pub(super) fn collab_spawn_child(item: &Value) -> Option<&str> {
+    if !is_collab_spawn(item)
+        || matches!(
+            item.get("status").and_then(Value::as_str),
+            Some("failed" | "errored")
+        )
+    {
+        return None;
+    }
+    let receivers = field(item, &["receiverThreadIds", "receiver_thread_ids"])?.as_array()?;
+    match receivers.as_slice() {
+        [child] => child.as_str().filter(|id| !id.is_empty()),
+        _ => None,
+    }
+}
+
 /// Map one `item/started` or `item/completed` payload's item to events.
 /// `agentMessage` and `reasoning` flow through their delta channels and are
 /// handled by the session loop, not here.
@@ -299,6 +327,29 @@ pub(crate) fn map_item(phase: Phase, item: &Value) -> Vec<AgentEvent> {
         "error" => vec![AgentEvent::Error {
             message: str_field(item, &["message"]),
         }],
+        "collabAgentToolCall" | "collab_agent_tool_call" => {
+            let tool = str_field(item, &["tool"]);
+            let name = if is_collab_spawn(item) {
+                "Agent".to_owned()
+            } else {
+                match tool.as_str() {
+                    "sendInput" | "send_input" => "Send agent message".to_owned(),
+                    "wait" => "Wait for agents".to_owned(),
+                    "closeAgent" | "close_agent" => "Close agent".to_owned(),
+                    "resumeAgent" | "resume_agent" => "Resume agent".to_owned(),
+                    _ => format!("Agent control: {tool}"),
+                }
+            };
+            tool_lifecycle(
+                phase,
+                id,
+                ToolCall::Unknown {
+                    name,
+                    input: Some(item.clone()),
+                },
+                matches!(status.as_str(), "failed" | "errored"),
+            )
+        }
         // A subagent spawn/lifecycle marker on the PARENT thread (multi-agent
         // v2, codex 0.146.x): the parent-feed chip for the child thread. The
         // child's own traffic routes separately (see `route_child_notification`
@@ -591,6 +642,54 @@ mod tests {
     }
 
     #[test]
+    fn v1_spawns_and_controls_have_distinct_roles() {
+        for tool in ["spawnAgent", "spawn_agent"] {
+            let mut item = json!({"type":"collabAgentToolCall", "id":"spawn", "tool":tool,
+                "status":"completed", "receiverThreadIds":["child"], "model":"child-model"});
+            assert_eq!(collab_spawn_child(&item), Some("child"));
+            let events = map_item(Phase::Completed, &item);
+            assert!(matches!(&events[0], AgentEvent::ToolCall { call, .. }
+                if call.is_subagent_spawn() && call.subagent_model() == Some("child-model")));
+            assert!(matches!(
+                &events[1],
+                AgentEvent::ToolResult {
+                    is_error: false,
+                    ..
+                }
+            ));
+            item["status"] = "failed".into();
+            assert_eq!(collab_spawn_child(&item), None);
+            assert!(matches!(
+                map_item(Phase::Completed, &item).last(),
+                Some(AgentEvent::ToolResult { is_error: true, .. })
+            ));
+        }
+        for tool in [
+            "sendInput",
+            "send_input",
+            "wait",
+            "closeAgent",
+            "resumeAgent",
+            "futureControl",
+        ] {
+            let item = json!({"type":"collabAgentToolCall", "id":"control", "tool":tool,
+                "receiverThreadIds":["child"]});
+            assert_eq!(collab_spawn_child(&item), None);
+            assert!(
+                matches!(&map_item(Phase::Started, &item)[0], AgentEvent::ToolCall { call, .. } if !call.is_subagent_spawn())
+            );
+        }
+        for receivers in [json!([]), json!(["one", "two"]), json!([""])] {
+            assert_eq!(
+                collab_spawn_child(
+                    &json!({"type":"collabAgentToolCall", "tool":"spawnAgent", "receiverThreadIds":receivers})
+                ),
+                None
+            );
+        }
+    }
+
+    #[test]
     fn sub_agent_activity_maps_to_a_named_parent_chip() {
         let started = map_item(
             Phase::Started,
@@ -660,10 +759,16 @@ mod tests {
             Some("th-c".into())
         );
         assert_eq!(
-            notification_thread_id("turn/completed", &json!({"threadId": "th-1", "turn": {"id": "t"}})),
+            notification_thread_id(
+                "turn/completed",
+                &json!({"threadId": "th-1", "turn": {"id": "t"}})
+            ),
             Some("th-1".into())
         );
-        assert_eq!(notification_thread_id("error", &json!({"message": "x"})), None);
+        assert_eq!(
+            notification_thread_id("error", &json!({"message": "x"})),
+            None
+        );
     }
 
     #[test]

--- a/crates/harness/src/codex/normalize.rs
+++ b/crates/harness/src/codex/normalize.rs
@@ -6,7 +6,7 @@
 //! types) are accepted, and unknown item types map to nothing.
 
 use serde_json::Value;
-use zeron_proto::{AgentEvent, TodoItem, ToolCall};
+use zeron_proto::{AgentEvent, DoneStatus, TodoItem, ToolCall};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Phase {
@@ -355,6 +355,14 @@ pub(crate) fn map_item(phase: Phase, item: &Value) -> Vec<AgentEvent> {
         // child's own traffic routes separately (see `route_child_notification`
         // in mod.rs); this is only the spawn tool call the chip folds from.
         "subAgentActivity" | "sub_agent_activity" => {
+            // A lifecycle marker has its own item id. It is not another
+            // spawn; the child's turn notifications carry its terminal state.
+            if !matches!(
+                item.get("kind").and_then(Value::as_str),
+                Some("started" | "spawned")
+            ) {
+                return Vec::new();
+            }
             let name = str_field(item, &["agentPath"])
                 .rsplit('/')
                 .find(|s| !s.is_empty())
@@ -396,6 +404,139 @@ pub(crate) fn user_message_text(item: &Value) -> Option<String> {
         .collect::<Vec<_>>()
         .join("\n\n");
     (!joined.trim().is_empty()).then_some(joined)
+}
+
+/// Per-child stream state, retained across parent turns and follow-up tasks.
+/// Completion-only messages need the same text fallback as the root. Replayed
+/// user items must not reopen a finished document or duplicate a steering entry.
+#[derive(Default)]
+pub(super) struct ChildStream {
+    reasoning: ReasoningStream,
+    streamed_text: std::collections::HashSet<String>,
+    completed_items: std::collections::VecDeque<String>,
+    completed_turns: std::collections::VecDeque<String>,
+    settled: bool,
+}
+
+fn remember(ids: &mut std::collections::VecDeque<String>, id: String) -> bool {
+    if id.is_empty() {
+        return true;
+    }
+    if ids.contains(&id) {
+        return false;
+    }
+    if ids.len() == 256 {
+        ids.pop_front();
+    }
+    ids.push_back(id);
+    true
+}
+
+impl ChildStream {
+    pub(super) fn map(&mut self, child: &str, method: &str, params: &Value) -> Vec<AgentEvent> {
+        if matches!(method, "item/started" | "item/completed") {
+            let item = params.get("item").unwrap_or(&Value::Null);
+            let phase = if method == "item/started" {
+                Phase::Started
+            } else {
+                Phase::Completed
+            };
+            if phase == Phase::Completed
+                && !remember(&mut self.completed_items, str_field(item, &["id"]))
+            {
+                return Vec::new();
+            }
+            if matches!(item_type(item), "userMessage" | "user_message") {
+                return if phase == Phase::Completed {
+                    user_message_text(item)
+                        .map(|text| {
+                            self.settled = false;
+                            AgentEvent::UserMessage { text }
+                        })
+                        .into_iter()
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+            }
+            if self.settled {
+                return Vec::new();
+            }
+            if matches!(item_type(item), "agentMessage" | "agent_message") {
+                if phase == Phase::Started {
+                    return Vec::new();
+                }
+                let mut events = Vec::new();
+                if !self.streamed_text.remove(&str_field(item, &["id"])) {
+                    let text = str_field(item, &["text"]);
+                    if !text.is_empty() {
+                        events.push(AgentEvent::TextDelta { text });
+                    }
+                }
+                events.push(AgentEvent::TextDelta {
+                    text: "\n\n".into(),
+                });
+                return events;
+            }
+            return map_item(phase, item);
+        }
+        if self.settled {
+            return Vec::new();
+        }
+        match method {
+            "item/agentMessage/delta" => {
+                let id = item_id(params);
+                if !id.is_empty() && self.completed_items.contains(&id) {
+                    return Vec::new();
+                }
+                self.streamed_text.insert(id);
+                delta_text(params)
+                    .map(|text| AgentEvent::TextDelta { text })
+                    .into_iter()
+                    .collect()
+            }
+            "item/reasoning/textDelta"
+            | "item/reasoning/summaryTextDelta"
+            | "item/reasoning/summaryPartAdded" => self.reasoning.map(method, params),
+            "turn/completed" | "turn/failed" | "turn/aborted" | "thread/closed" => {
+                if method != "thread/closed"
+                    && !remember(&mut self.completed_turns, turn_id(params))
+                {
+                    return Vec::new();
+                }
+                self.settled = true;
+                self.streamed_text.clear();
+                let error = turn_error_message(params);
+                let status = if method == "turn/failed"
+                    || error.is_some()
+                    || params.pointer("/turn/status").and_then(Value::as_str) == Some("failed")
+                {
+                    DoneStatus::Errored
+                } else if method == "turn/aborted"
+                    || params.pointer("/turn/status").and_then(Value::as_str) == Some("interrupted")
+                {
+                    DoneStatus::Interrupted
+                } else {
+                    DoneStatus::Completed
+                };
+                vec![AgentEvent::Done {
+                    status,
+                    result: None,
+                    error,
+                    session_id: Some(child.to_owned()),
+                }]
+            }
+            "error" => vec![AgentEvent::Error {
+                message: params
+                    .pointer("/error/message")
+                    .and_then(Value::as_str)
+                    .or_else(|| params.get("message").and_then(Value::as_str))
+                    .unwrap_or("Codex subagent error")
+                    .to_owned(),
+            }],
+            _ => Vec::new(),
+        }
+    }
 }
 
 /// The thread a notification is addressed to: `thread/started` carries it at
@@ -690,6 +831,22 @@ mod tests {
     }
 
     #[test]
+    fn activity_updates_are_not_spawns_in_either_item_phase() {
+        for kind in [
+            "interacted",
+            "completed",
+            "failed",
+            "errored",
+            "futureActivity",
+        ] {
+            let item = json!({"type":"subAgentActivity", "id":"activity", "kind":kind,
+                "agentThreadId":"child", "agentPath":"/root/alpha"});
+            assert!(map_item(Phase::Started, &item).is_empty());
+            assert!(map_item(Phase::Completed, &item).is_empty());
+        }
+    }
+
+    #[test]
     fn sub_agent_activity_maps_to_a_named_parent_chip() {
         let started = map_item(
             Phase::Started,
@@ -704,7 +861,7 @@ mod tests {
         ));
         let completed = map_item(
             Phase::Completed,
-            &json!({"type": "subAgentActivity", "id": "call_1", "kind": "completed",
+            &json!({"type": "subAgentActivity", "id": "call_1", "kind": "started",
                     "agentThreadId": "child-1", "agentPath": "/root/alpha"}),
         );
         assert!(matches!(

--- a/crates/harness/src/codex/normalize.rs
+++ b/crates/harness/src/codex/normalize.rs
@@ -434,6 +434,23 @@ fn remember(ids: &mut std::collections::VecDeque<String>, id: String) -> bool {
 
 impl ChildStream {
     pub(super) fn map(&mut self, child: &str, method: &str, params: &Value) -> Vec<AgentEvent> {
+        if method == "turn/started" {
+            let id = turn_id(params);
+            if !id.is_empty() && self.completed_turns.contains(&id) {
+                return Vec::new();
+            }
+            if self.settled {
+                self.settled = false;
+                // v2 followup_task starts a new child turn without echoing a
+                // userMessage. Reopen the existing document without inventing
+                // a user prompt or attributing an activity id as a new spawn.
+                return vec![AgentEvent::Steered {
+                    assistant_message_id: None,
+                    next_assistant_message_id: None,
+                }];
+            }
+            return Vec::new();
+        }
         if matches!(method, "item/started" | "item/completed") {
             let item = params.get("item").unwrap_or(&Value::Null);
             let phase = if method == "item/started" {
@@ -593,16 +610,16 @@ pub(crate) fn route_child_notification(method: &str) -> ChildRoute {
         | "item/reasoning/textDelta"
         | "item/reasoning/summaryTextDelta"
         | "item/reasoning/summaryPartAdded"
+        | "turn/started"
         | "turn/completed"
         | "turn/failed"
         | "turn/aborted"
         | "error"
         | "thread/closed" => ChildRoute::Subagent,
-        // Child turn/status bookkeeping with no subagent meaning: consumed
+        // Child status bookkeeping with no subagent meaning: consumed
         // so it can never settle the PARENT turn (the exact bug class the
         // explicit table exists for).
-        "turn/started"
-        | "thread/status/changed"
+        "thread/status/changed"
         | "thread/tokenUsage/updated"
         // Child chatter with no consumer on this wire.
         | "item/commandExecution/outputDelta"
@@ -888,11 +905,11 @@ mod tests {
         for m in ["turn/completed", "turn/aborted", "turn/failed"] {
             assert_eq!(route_child_notification(m), ChildRoute::Subagent, "{m}");
         }
-        // …while turn/started stays consumed — and NONE of them may reach
-        // the parent turn router.
+        // A child turn start can reopen a completed assignment. It must never
+        // reach the parent turn router.
         assert_eq!(
             route_child_notification("turn/started"),
-            ChildRoute::Consumed
+            ChildRoute::Subagent
         );
         // Child-owned thread lifecycle would rewrite parent state — consumed.
         for m in ["thread/archived", "thread/compacted", "thread/started"] {

--- a/crates/harness/src/codex/subagents.rs
+++ b/crates/harness/src/codex/subagents.rs
@@ -1,0 +1,149 @@
+//! Stable ownership of child traffic. A thread belongs to its original spawn
+//! call; activity ids and early thread notifications are never document ids.
+
+use std::collections::HashMap;
+
+use zeron_proto::AgentEvent;
+
+const MAX_PENDING_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Default)]
+struct Pending {
+    events: Vec<AgentEvent>,
+    bytes: usize,
+}
+
+pub(super) struct Subagents {
+    root: String,
+    spawns: HashMap<String, String>,
+    pending: HashMap<String, Pending>,
+    pending_bytes: usize,
+    warned_overflow: bool,
+}
+
+impl Subagents {
+    pub(super) fn new(root: String) -> Self {
+        Self {
+            root,
+            spawns: HashMap::new(),
+            pending: HashMap::new(),
+            pending_bytes: 0,
+            warned_overflow: false,
+        }
+    }
+
+    /// Call only for a spawn. Emit its parent chip BEFORE the returned events,
+    /// so even a child that finished before registration binds to a real chip.
+    pub(super) fn bind(&mut self, child: &str, spawn: &str) -> Vec<AgentEvent> {
+        if child.is_empty() || child == self.root || spawn.is_empty() {
+            return Vec::new();
+        }
+        let owner = self
+            .spawns
+            .entry(child.to_owned())
+            .or_insert_with(|| spawn.to_owned());
+        let Some(pending) = self.pending.remove(child) else {
+            return Vec::new();
+        };
+        self.pending_bytes -= pending.bytes;
+        pending.events.into_iter().map(|e| tag(owner, e)).collect()
+    }
+
+    pub(super) fn route(&mut self, child: &str, events: Vec<AgentEvent>) -> Vec<AgentEvent> {
+        if child.is_empty() || child == self.root {
+            return Vec::new();
+        }
+        if let Some(owner) = self.spawns.get(child) {
+            return events.into_iter().map(|e| tag(owner, e)).collect();
+        }
+        // A child's output may beat both thread/started and the spawn result.
+        // Bound the aggregate backlog for threads that never acquire a spawn.
+        for event in events {
+            let bytes = serde_json::to_vec(&event).map_or(MAX_PENDING_BYTES, |v| v.len());
+            if self.pending_bytes.saturating_add(bytes) > MAX_PENDING_BYTES {
+                if !self.warned_overflow {
+                    tracing::warn!("Codex unbound child backlog full; dropping excess events");
+                    self.warned_overflow = true;
+                }
+                continue;
+            }
+            self.pending_bytes += bytes;
+            let pending = self.pending.entry(child.to_owned()).or_default();
+            pending.bytes += bytes;
+            pending.events.push(event);
+        }
+        Vec::new()
+    }
+}
+
+fn tag(spawn: &str, event: AgentEvent) -> AgentEvent {
+    AgentEvent::Subagent {
+        parent_tool_use_id: spawn.to_owned(),
+        event: Box::new(event),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(text: &str) -> AgentEvent {
+        AgentEvent::TextDelta { text: text.into() }
+    }
+
+    #[test]
+    fn binding_is_stable_and_children_are_independent() {
+        let mut children = Subagents::new("root".into());
+        children.bind("alpha", "spawn-alpha");
+        children.bind("beta", "spawn-beta");
+        children.bind("alpha", "later-activity");
+        assert_eq!(
+            children.route("alpha", vec![text("a")]),
+            vec![tag("spawn-alpha", text("a"))]
+        );
+        assert_eq!(
+            children.route("beta", vec![text("b")]),
+            vec![tag("spawn-beta", text("b"))]
+        );
+    }
+
+    #[test]
+    fn early_content_waits_for_the_spawn_and_drains_once_in_order() {
+        let mut children = Subagents::new("root".into());
+        assert!(
+            children
+                .route("alpha", vec![text("first"), text("second")])
+                .is_empty()
+        );
+        assert_eq!(
+            children.bind("alpha", "spawn"),
+            vec![tag("spawn", text("first")), tag("spawn", text("second"))]
+        );
+        assert!(children.bind("alpha", "spawn").is_empty());
+        assert_eq!(children.pending_bytes, 0);
+    }
+
+    #[test]
+    fn root_and_missing_ids_never_bind_or_buffer() {
+        let mut children = Subagents::new("root".into());
+        for child in ["root", ""] {
+            assert!(children.bind(child, "spawn").is_empty());
+            assert!(children.route(child, vec![text("noise")]).is_empty());
+        }
+        children.bind("alpha", "");
+        assert!(children.spawns.is_empty());
+        assert!(children.pending.is_empty());
+    }
+
+    #[test]
+    fn unbound_backlog_is_bounded_without_affecting_known_children() {
+        let mut children = Subagents::new("root".into());
+        children.route("unknown", vec![text(&"x".repeat(MAX_PENDING_BYTES))]);
+        assert!(children.pending.is_empty());
+        children.bind("alpha", "spawn");
+        assert_eq!(
+            children.route("alpha", vec![text("ok")]),
+            vec![tag("spawn", text("ok"))]
+        );
+    }
+}

--- a/crates/harness/src/codex/subagents.rs
+++ b/crates/harness/src/codex/subagents.rs
@@ -41,6 +41,29 @@ impl Subagents {
         }
     }
 
+    /// thread/resume returns the stored parent items. Rebuild ownership without
+    /// replaying chips or content that already lives in Zeron's documents.
+    pub(super) fn restore(&mut self, thread: &Value) {
+        for item in thread
+            .get("turns")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .flat_map(|turn| {
+                turn.get("items")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+            })
+        {
+            if super::normalize::is_collab_spawn(item)
+                || matches!(item_type(item), "subAgentActivity" | "sub_agent_activity")
+            {
+                self.parent_item(Phase::Completed, item);
+            }
+        }
+    }
+
     pub(super) fn notification(
         &mut self,
         child: &str,

--- a/crates/harness/src/codex/subagents.rs
+++ b/crates/harness/src/codex/subagents.rs
@@ -1,9 +1,12 @@
 //! Stable ownership of child traffic. A thread belongs to its original spawn
 //! call; activity ids and early thread notifications are never document ids.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use serde_json::Value;
 use zeron_proto::AgentEvent;
+
+use super::normalize::{ChildStream, Phase, collab_spawn_child, item_type, map_item};
 
 const MAX_PENDING_BYTES: usize = 4 * 1024 * 1024;
 
@@ -19,6 +22,9 @@ pub(super) struct Subagents {
     pending: HashMap<String, Pending>,
     pending_bytes: usize,
     warned_overflow: bool,
+    streams: HashMap<String, ChildStream>,
+    emitted_spawns: HashSet<String>,
+    resolved_spawns: HashSet<String>,
 }
 
 impl Subagents {
@@ -29,7 +35,75 @@ impl Subagents {
             pending: HashMap::new(),
             pending_bytes: 0,
             warned_overflow: false,
+            streams: HashMap::new(),
+            emitted_spawns: HashSet::new(),
+            resolved_spawns: HashSet::new(),
         }
+    }
+
+    pub(super) fn notification(
+        &mut self,
+        child: &str,
+        method: &str,
+        params: &Value,
+    ) -> Vec<AgentEvent> {
+        let events = self
+            .streams
+            .entry(child.to_owned())
+            .or_default()
+            .map(child, method, params);
+        self.route(child, events)
+    }
+
+    pub(super) fn parent_item(&mut self, phase: Phase, item: &Value) -> Vec<AgentEvent> {
+        let activity = matches!(item_type(item), "subAgentActivity" | "sub_agent_activity");
+        let child = if activity {
+            let path = item.get("agentPath").and_then(Value::as_str).unwrap_or("");
+            if matches!(path, "/" | "/root") {
+                return Vec::new();
+            }
+            if !matches!(
+                item.get("kind").and_then(Value::as_str),
+                Some("started" | "spawned")
+            ) {
+                return Vec::new();
+            }
+            item.get("agentThreadId").and_then(Value::as_str)
+        } else {
+            collab_spawn_child(item)
+        };
+        if child == Some(self.root.as_str()) {
+            return Vec::new();
+        }
+        let mut item = item.clone();
+        let mut buffered = Vec::new();
+        if let Some(child) = child {
+            let call = item
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned();
+            buffered = self.bind(child, &call);
+            if let Some(owner) = self.spawns.get(child) {
+                item["id"] = owner.clone().into();
+            }
+        }
+        let mut events: Vec<_> = map_item(phase, &item)
+            .into_iter()
+            .filter(|event| match event {
+                // Completed items refresh tool metadata, but a spawn chip must
+                // appear once even when its parent text segment has already ended.
+                AgentEvent::ToolCall { id, call } if call.is_subagent_spawn() => {
+                    self.emitted_spawns.insert(id.clone())
+                }
+                AgentEvent::ToolResult { id, .. } if self.emitted_spawns.contains(id) => {
+                    self.resolved_spawns.insert(id.clone())
+                }
+                _ => true,
+            })
+            .collect();
+        events.extend(buffered);
+        events
     }
 
     /// Call only for a spawn. Emit its parent chip BEFORE the returned events,

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -641,6 +641,58 @@ async fn models_discovers_visible_catalog_with_pagination() {
 }
 
 #[tokio::test]
+async fn v2_lifecycle_reuses_chips_and_reopens_the_same_child_for_followup() {
+    let (controls, _steer, _token) = controls("Yes");
+    let events = run_to_end(&harness(), request("scenario:v2-lifecycle"), controls).await;
+    let spawns: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::ToolCall { id, call } if call.is_subagent_spawn() => Some(id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(spawns, ["spawn-alpha", "spawn-beta"]);
+    let mut alpha_text = String::new();
+    let mut alpha_users = Vec::new();
+    let mut alpha_done = Vec::new();
+    for e in &events {
+        if let AgentEvent::Subagent {
+            parent_tool_use_id,
+            event,
+        } = e
+        {
+            assert!(spawns.contains(&parent_tool_use_id.as_str()));
+            if parent_tool_use_id == "spawn-alpha" {
+                match event.as_ref() {
+                    AgentEvent::TextDelta { text } => alpha_text.push_str(text),
+                    AgentEvent::UserMessage { text } => alpha_users.push(text.as_str()),
+                    AgentEvent::Done { status, error, .. } => {
+                        alpha_done.push((*status, error.as_deref()))
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    assert_eq!(alpha_text, "first alpha\n\nsecond alpha\n\n");
+    assert_eq!(alpha_users, ["First assignment", "Second assignment"]);
+    assert_eq!(
+        alpha_done,
+        [
+            (DoneStatus::Completed, None),
+            (DoneStatus::Errored, Some("followup failed"))
+        ]
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::Done { .. }))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn v1_spawns_bind_children_and_controls_do_not_create_agents() {
     let (controls, _steer, _token) = controls("Yes");
     let events = run_to_end(&harness(), request("scenario:v1-subagents"), controls).await;

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -641,6 +641,67 @@ async fn models_discovers_visible_catalog_with_pagination() {
 }
 
 #[tokio::test]
+async fn child_identity_survives_early_output_and_later_activity_ids() {
+    let (controls, _steer, _token) = controls("Yes");
+    let events = run_to_end(&harness(), request("scenario:child-identity"), controls).await;
+    let spawn = events
+        .iter()
+        .position(|e| {
+            matches!(e,
+                AgentEvent::ToolCall { id, .. } if id == "spawn-alpha"
+            )
+        })
+        .unwrap();
+    let early = events.iter().position(|e| matches!(e,
+        AgentEvent::Subagent { parent_tool_use_id, event }
+        if parent_tool_use_id == "spawn-alpha"
+            && matches!(event.as_ref(), AgentEvent::TextDelta { text } if text == "early alpha")
+    )).unwrap();
+    assert!(
+        spawn < early,
+        "the chip must exist before buffered traffic binds"
+    );
+    let mut alpha = String::new();
+    let mut beta = String::new();
+    for e in &events {
+        if let AgentEvent::Subagent {
+            parent_tool_use_id,
+            event,
+        } = e
+        {
+            assert!(matches!(
+                parent_tool_use_id.as_str(),
+                "spawn-alpha" | "spawn-beta"
+            ));
+            if let AgentEvent::TextDelta { text } = event.as_ref() {
+                if parent_tool_use_id == "spawn-alpha" {
+                    alpha.push_str(text);
+                } else {
+                    beta.push_str(text);
+                }
+            }
+        }
+    }
+    assert_eq!(alpha, "early alphalater alpha");
+    assert_eq!(beta, "beta outputbeta continues");
+    let parent: String = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::TextDelta { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(parent, "parent output");
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::Done { .. }))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn child_thread_routing_tags_and_never_settles_parent() {
     let (controls, _steer, _token) = controls("Yes");
     let events = run_to_end(&harness(), request("scenario:subagent"), controls).await;

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -641,6 +641,57 @@ async fn models_discovers_visible_catalog_with_pagination() {
 }
 
 #[tokio::test]
+async fn v1_spawns_bind_children_and_controls_do_not_create_agents() {
+    let (controls, _steer, _token) = controls("Yes");
+    let events = run_to_end(&harness(), request("scenario:v1-subagents"), controls).await;
+    let spawns: std::collections::HashSet<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::ToolCall { id, call } if call.is_subagent_spawn() => Some(id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        spawns,
+        std::collections::HashSet::from(["spawn-alpha", "spawn-beta"])
+    );
+    for e in &events {
+        if let AgentEvent::Subagent {
+            parent_tool_use_id, ..
+        } = e
+        {
+            assert!(spawns.contains(parent_tool_use_id.as_str()), "{e:?}");
+        }
+    }
+    for (owner, text) in [
+        ("spawn-alpha", "alpha answer"),
+        ("spawn-beta", "beta answer"),
+    ] {
+        assert!(events.iter().any(|e| matches!(e,
+            AgentEvent::Subagent { parent_tool_use_id, event }
+            if parent_tool_use_id == owner && matches!(event.as_ref(), AgentEvent::TextDelta { text: t } if t == text)
+        )));
+    }
+    assert!(events.iter().any(|e| matches!(e,
+        AgentEvent::Subagent { parent_tool_use_id, event }
+        if parent_tool_use_id == "spawn-beta" && matches!(event.as_ref(), AgentEvent::ToolCall { id, .. } if id == "beta-tool")
+    )));
+    assert!(events.iter().any(|e| matches!(e,
+        AgentEvent::Subagent { parent_tool_use_id, event }
+        if parent_tool_use_id == "spawn-beta" && matches!(event.as_ref(), AgentEvent::UserMessage { text } if text == "Also check gamma")
+    )));
+    assert_eq!(events.iter().filter(|e| matches!(e, AgentEvent::Subagent { event, .. } if matches!(event.as_ref(), AgentEvent::Done { .. }))).count(), 2);
+    let parent: String = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::TextDelta { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(parent, "parent answer");
+}
+
+#[tokio::test]
 async fn child_identity_survives_early_output_and_later_activity_ids() {
     let (controls, _steer, _token) = controls("Yes");
     let events = run_to_end(&harness(), request("scenario:child-identity"), controls).await;

--- a/crates/harness/tests/codex.rs
+++ b/crates/harness/tests/codex.rs
@@ -641,6 +641,25 @@ async fn models_discovers_visible_catalog_with_pagination() {
 }
 
 #[tokio::test]
+async fn resumed_parent_recovers_v1_and_v2_child_owners_without_replaying_chips() {
+    for mode in ["v1", "v2"] {
+        let mut req = request("scenario:resumed-child");
+        req.resume = Some(format!("resume-with-child-{mode}"));
+        let (controls, _steer, _token) = controls("Yes");
+        let events = run_to_end(&harness(), req, controls).await;
+        assert!(
+            !events.iter().any(
+                |e| matches!(e, AgentEvent::ToolCall { call, .. } if call.is_subagent_spawn())
+            )
+        );
+        assert!(events.iter().any(|e| matches!(e,
+            AgentEvent::Subagent { parent_tool_use_id, event }
+            if parent_tool_use_id == "spawn-alpha" && matches!(event.as_ref(), AgentEvent::TextDelta { text } if text == "resumed alpha")
+        )), "{mode}: {events:?}");
+    }
+}
+
+#[tokio::test]
 async fn v2_lifecycle_reuses_chips_and_reopens_the_same_child_for_followup() {
     let (controls, _steer, _token) = controls("Yes");
     let events = run_to_end(&harness(), request("scenario:v2-lifecycle"), controls).await;
@@ -675,7 +694,7 @@ async fn v2_lifecycle_reuses_chips_and_reopens_the_same_child_for_followup() {
         }
     }
     assert_eq!(alpha_text, "first alpha\n\nsecond alpha\n\n");
-    assert_eq!(alpha_users, ["First assignment", "Second assignment"]);
+    assert_eq!(alpha_users, ["First assignment"]);
     assert_eq!(
         alpha_done,
         [
@@ -934,7 +953,141 @@ async fn child_thread_routing_tags_and_never_settles_parent() {
     assert!(child_done < late_parent_delta, "{events:?}");
 }
 
-/// Live smoke against the REAL codex app-server (0.146.x, installed + authed):
+/// Run once per multi-agent mode using a wrapper supplied via
+/// CODEX_SUBAGENT_TEST_EXECUTABLE. The wrapper can set feature flags for its
+/// process without changing the user's config. This deliberately consumes
+/// model calls and is never part of the offline suite.
+#[tokio::test]
+#[ignore = "real Codex spawn, followup and resume; needs install, auth and network"]
+async fn live_subagent_spawn_and_followup_keep_one_transcript() {
+    let executable = std::env::var_os("CODEX_SUBAGENT_TEST_EXECUTABLE")
+        .expect("set CODEX_SUBAGENT_TEST_EXECUTABLE to a wrapper selecting v1 or v2");
+    let harness = CodexHarness::new().with_executable(executable);
+    let cwd = tempfile::tempdir().unwrap();
+    let mut req = request(
+        "This is an integration smoke test. Spawn EXACTLY ONE subagent (name it alpha if naming is supported). Its entire task is: reply exactly child-first. It must not use any tools or spawn agents. Wait for it to finish, then reply exactly parent-first. Do not close the child; we will reuse it. Do not inspect or change any files.",
+    );
+    req.cwd = cwd.path().display().to_string();
+    req.reasoning = Some(ReasoningLevel::Low);
+    if let Ok(model) = std::env::var("CODEX_SUBAGENT_TEST_MODEL") {
+        req.model = Some(model);
+    }
+    let (run_controls, mut steer, mut interrupt) = controls("Yes");
+    let mut stream = harness
+        .run(req.clone(), run_controls)
+        .await
+        .expect("run starts");
+    let mut events = Vec::new();
+    for turn in 0..3 {
+        if turn == 1 {
+            steer.send(SteerMessage {
+                prompt: "Reuse the SAME existing subagent for one more task: reply exactly child-second. Use followup_task if available, otherwise send_input. Do not spawn a new agent. Wait for it to finish, then reply exactly parent-second. Do not inspect or change files.".into(),
+                message_id: None,
+            }).await.unwrap();
+        }
+        if turn == 2 {
+            // End the first app-server process while idle, then resume the
+            // parent in a fresh process and address its already-known child.
+            interrupt.cancel();
+            tokio::time::timeout(Duration::from_secs(10), async {
+                while stream.next().await.is_some() {}
+            })
+            .await
+            .expect("old app-server stops");
+            req.resume = events.iter().find_map(|e| match e {
+                AgentEvent::SessionStarted { session_id, .. } => Some(session_id.clone()),
+                _ => None,
+            });
+            req.prompt = "The app-server has restarted. Reuse the SAME existing subagent again: reply exactly child-third. Use followup_task if available. Otherwise first use resume_agent with the existing child's id to reactivate it, then send_input. Do not spawn another agent. Wait for its actual child-third reply before replying exactly parent-third. If a tool fails, recover using the same child id; never claim the child finished without its reply. Do not inspect or change files.".into();
+            let (run_controls, new_steer, new_interrupt) = controls("Yes");
+            steer = new_steer;
+            interrupt = new_interrupt;
+            stream = harness
+                .run(req.clone(), run_controls)
+                .await
+                .expect("parent resumes");
+        }
+        let result = tokio::time::timeout(Duration::from_secs(120), async {
+            while let Some(event) = stream.next().await {
+                let event = event.expect("stream event");
+                let done = matches!(event, AgentEvent::Done { .. });
+                let failed = matches!(
+                    event,
+                    AgentEvent::Done {
+                        status: DoneStatus::Errored | DoneStatus::Interrupted,
+                        ..
+                    }
+                );
+                events.push(event);
+                assert!(!failed, "parent failed: {:?}", events.last());
+                if done {
+                    return;
+                }
+            }
+            panic!("stream ended before parent completion");
+        })
+        .await;
+        if result.is_err() {
+            interrupt.cancel();
+        }
+        result.expect("live turn finishes within 120 seconds");
+    }
+    drop(stream);
+    if let Some(path) = std::env::var_os("CODEX_SUBAGENT_TEST_CAPTURE") {
+        std::fs::write(path, serde_json::to_vec_pretty(&events).unwrap()).unwrap();
+    }
+    let spawns: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::ToolCall { id, call } if call.is_subagent_spawn() => Some(id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(spawns.len(), 1, "one original spawn: {spawns:?}");
+    if let Ok(mode) = std::env::var("CODEX_SUBAGENT_TEST_MODE") {
+        let expected = match mode.as_str() {
+            "v1" => "collabAgentToolCall",
+            "v2" => "subAgentActivity",
+            _ => panic!("unknown mode {mode}"),
+        };
+        assert!(
+            events.iter().any(|e| matches!(e,
+                AgentEvent::ToolCall { call: ToolCall::Unknown { input: Some(input), .. }, .. }
+                if input.get("type").and_then(serde_json::Value::as_str) == Some(expected)
+            )),
+            "the model must actually use {mode}"
+        );
+    }
+    let mut text = String::new();
+    let mut terminals = 0;
+    for event in &events {
+        if let AgentEvent::Subagent {
+            parent_tool_use_id,
+            event,
+        } = event
+        {
+            assert_eq!(parent_tool_use_id, spawns[0]);
+            if let AgentEvent::TextDelta { text: delta } = event.as_ref() {
+                text.push_str(delta);
+            }
+            if matches!(
+                event.as_ref(),
+                AgentEvent::Done {
+                    status: DoneStatus::Completed,
+                    ..
+                }
+            ) {
+                terminals += 1;
+            }
+        }
+    }
+    for reply in ["child-first", "child-second", "child-third"] {
+        assert_eq!(text.matches(reply).count(), 1, "child transcript: {text:?}");
+    }
+    assert_eq!(terminals, 3, "one child completion per assignment");
+}
+
+/// Live smoke against the REAL codex app-server (installed + authed):
 /// one trivial turn, ending on turn/completed.
 /// `cargo test -p zeron-harness --test codex -- --ignored`.
 #[tokio::test]

--- a/crates/harness/tests/fixtures/codex/child-identity.jsonl
+++ b/crates/harness/tests/fixtures/codex/child-identity.jsonl
@@ -1,0 +1,14 @@
+{"method":"thread/started","params":{"thread":{"id":"child-alpha","source":{"subAgent":{"thread_spawn":{"parent_thread_id":"th-1"}}}}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"child-alpha","itemId":"early","delta":"early alpha"}}
+{"method":"item/started","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"spawn-alpha","kind":"started","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"spawn-alpha","kind":"started","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"item/started","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"spawn-beta","kind":"started","agentThreadId":"child-beta","agentPath":"/root/beta"}}}
+{"method":"item/started","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"message-alpha","kind":"interacted","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"child-alpha","itemId":"later","delta":"later alpha"}}
+{"method":"item/agentMessage/delta","params":{"threadId":"child-beta","itemId":"beta","delta":"beta output"}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"subagent-completed-alpha","kind":"completed","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"turn/completed","params":{"threadId":"child-alpha","turn":{"id":"alpha-turn","status":"completed"}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"child-beta","itemId":"beta","delta":"beta continues"}}
+{"method":"turn/completed","params":{"threadId":"child-beta","turn":{"id":"beta-turn","status":"completed"}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"th-1","itemId":"parent","delta":"parent output"}}
+{"method":"turn/completed","params":{"threadId":"th-1","turn":{"id":"t-1","status":"completed"}}}

--- a/crates/harness/tests/fixtures/codex/v1-subagents.jsonl
+++ b/crates/harness/tests/fixtures/codex/v1-subagents.jsonl
@@ -1,0 +1,17 @@
+{"method":"item/started","params":{"threadId":"th-1","item":{"type":"collabAgentToolCall","id":"spawn-alpha","tool":"spawnAgent","status":"inProgress","receiverThreadIds":[],"prompt":"Inspect alpha","model":"child-model"}}}
+{"method":"thread/started","params":{"thread":{"id":"child-alpha","source":{"subAgent":{"thread_spawn":{"parent_thread_id":"th-1"}}}}}}
+{"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"userMessage","id":"alpha-input","text":"Inspect alpha"}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"child-alpha","itemId":"alpha-message","delta":"alpha answer"}}
+{"method":"turn/completed","params":{"threadId":"child-alpha","turn":{"id":"alpha-turn","status":"completed"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"collabAgentToolCall","id":"spawn-alpha","tool":"spawnAgent","status":"completed","receiverThreadIds":["child-alpha"],"prompt":"Inspect alpha","model":"child-model"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"collabAgentToolCall","id":"spawn-beta","tool":"spawnAgent","status":"completed","receiverThreadIds":["child-beta"],"prompt":"Inspect beta"}}}
+{"method":"item/completed","params":{"threadId":"child-beta","item":{"type":"userMessage","id":"beta-input","text":"Inspect beta"}}}
+{"method":"item/started","params":{"threadId":"child-beta","item":{"type":"commandExecution","id":"beta-tool","command":"echo beta"}}}
+{"method":"item/completed","params":{"threadId":"child-beta","item":{"type":"commandExecution","id":"beta-tool","command":"echo beta","status":"completed","exitCode":0}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"collabAgentToolCall","id":"message-beta","tool":"sendInput","status":"completed","receiverThreadIds":["child-beta"],"prompt":"Also check gamma"}}}
+{"method":"item/completed","params":{"threadId":"child-beta","item":{"type":"userMessage","id":"beta-steer","text":"Also check gamma"}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"child-beta","itemId":"beta-message","delta":"beta answer"}}
+{"method":"turn/completed","params":{"threadId":"child-beta","turn":{"id":"beta-turn","status":"completed"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"collabAgentToolCall","id":"wait-both","tool":"wait","status":"completed","receiverThreadIds":["child-alpha","child-beta"]}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"th-1","itemId":"parent-message","delta":"parent answer"}}
+{"method":"turn/completed","params":{"threadId":"th-1","turn":{"id":"t-1","status":"completed"}}}

--- a/crates/harness/tests/fixtures/codex/v2-lifecycle.jsonl
+++ b/crates/harness/tests/fixtures/codex/v2-lifecycle.jsonl
@@ -1,0 +1,29 @@
+{"method":"item/started","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"spawn-alpha","kind":"started","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"spawn-alpha","kind":"started","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"userMessage","id":"alpha-input-1","text":"First assignment"}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"child-alpha","itemId":"alpha-answer-1","delta":"first alpha"}}
+{"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"agentMessage","id":"alpha-answer-1","text":"first alpha"}}}
+{"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"agentMessage","id":"alpha-answer-1","text":"first alpha"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"agentMessage","id":"parent-progress","text":"parent progress"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"spawn-alpha","kind":"started","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"subagent-completed-alpha-turn-1","kind":"completed","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"turn/completed","params":{"threadId":"child-alpha","turn":{"id":"alpha-turn-1","status":"completed"}}}
+{"method":"turn/completed","params":{"threadId":"child-alpha","turn":{"id":"alpha-turn-1","status":"completed"}}}
+{"method":"thread/closed","params":{"threadId":"child-alpha"}}
+{"method":"item/started","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"spawn-beta","kind":"started","agentThreadId":"child-beta","agentPath":"/root/beta"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"spawn-beta","kind":"started","agentThreadId":"child-beta","agentPath":"/root/beta"}}}
+{"method":"item/completed","params":{"threadId":"child-beta","item":{"type":"userMessage","id":"beta-input","text":"Inspect beta"}}}
+{"method":"item/completed","params":{"threadId":"child-beta","item":{"type":"agentMessage","id":"beta-answer","text":"beta answer"}}}
+{"method":"turn/completed","params":{"threadId":"child-beta","turn":{"id":"beta-turn","status":"completed"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"message-alpha","kind":"interacted","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"userMessage","id":"alpha-input-2","text":"Second assignment"}}}
+{"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"userMessage","id":"alpha-input-1","text":"First assignment"}}}
+{"method":"turn/completed","params":{"threadId":"child-alpha","turn":{"id":"alpha-turn-1","status":"completed"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"followup-alpha","kind":"started","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"agentMessage","id":"alpha-answer-2","text":"second alpha"}}}
+{"method":"turn/completed","params":{"threadId":"child-alpha","turn":{"id":"alpha-turn-2","status":"failed","error":{"message":"followup failed"}}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"failed-alpha","kind":"failed","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
+{"method":"thread/closed","params":{"threadId":"child-alpha"}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"root-activity","kind":"started","agentThreadId":"th-1","agentPath":"/root"}}}
+{"method":"item/completed","params":{"threadId":"th-1","item":{"type":"agentMessage","id":"parent-answer","text":"parent answer"}}}
+{"method":"turn/completed","params":{"threadId":"th-1","turn":{"id":"t-1","status":"completed"}}}

--- a/crates/harness/tests/fixtures/codex/v2-lifecycle.jsonl
+++ b/crates/harness/tests/fixtures/codex/v2-lifecycle.jsonl
@@ -16,7 +16,7 @@
 {"method":"item/completed","params":{"threadId":"child-beta","item":{"type":"agentMessage","id":"beta-answer","text":"beta answer"}}}
 {"method":"turn/completed","params":{"threadId":"child-beta","turn":{"id":"beta-turn","status":"completed"}}}
 {"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"message-alpha","kind":"interacted","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}
-{"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"userMessage","id":"alpha-input-2","text":"Second assignment"}}}
+{"method":"turn/started","params":{"threadId":"child-alpha","turn":{"id":"alpha-turn-2","status":"inProgress"}}}
 {"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"userMessage","id":"alpha-input-1","text":"First assignment"}}}
 {"method":"turn/completed","params":{"threadId":"child-alpha","turn":{"id":"alpha-turn-1","status":"completed"}}}
 {"method":"item/completed","params":{"threadId":"th-1","item":{"type":"subAgentActivity","id":"followup-alpha","kind":"started","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -144,6 +144,11 @@ case "$turnline" in
   cat "$(dirname "$0")/codex/child-identity.jsonl"
   ;;
 
+*scenario:v1-subagents*)
+  emit "{\"id\":$tid,\"result\":{\"turn\":{\"id\":\"t-1\"}}}"
+  cat "$(dirname "$0")/codex/v1-subagents.jsonl"
+  ;;
+
 *scenario:subagent*)
   # Multi-agent v2 child-thread routing: registration via subAgentActivity,
   # tagged child items, consumed child turn bookkeeping (must never settle

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -149,6 +149,11 @@ case "$turnline" in
   cat "$(dirname "$0")/codex/v1-subagents.jsonl"
   ;;
 
+*scenario:v2-lifecycle*)
+  emit "{\"id\":$tid,\"result\":{\"turn\":{\"id\":\"t-1\"}}}"
+  cat "$(dirname "$0")/codex/v2-lifecycle.jsonl"
+  ;;
+
 *scenario:subagent*)
   # Multi-agent v2 child-thread routing: registration via subAgentActivity,
   # tagged child items, consumed child turn bookkeeping (must never settle
@@ -157,6 +162,7 @@ case "$turnline" in
   emit '{"method":"turn/started","params":{"threadId":"th-1","turn":{"id":"t-1"}}}'
   # Parent spawn item registers the child (call id = the parent chip).
   emit '{"method":"item/started","params":{"threadId":"th-1","item":{"id":"call_alpha","type":"subAgentActivity","kind":"started","agentThreadId":"child-1","agentPath":"/root/alpha"}}}'
+  emit '{"method":"item/completed","params":{"threadId":"th-1","item":{"id":"call_alpha","type":"subAgentActivity","kind":"started","agentThreadId":"child-1","agentPath":"/root/alpha"}}}'
   # The wire also emits subAgentActivity about the ROOT during collab runs:
   # no chip, no registration.
   emit '{"method":"item/started","params":{"threadId":"th-1","item":{"id":"call_root","type":"subAgentActivity","kind":"interacted","agentThreadId":"th-1","agentPath":"/root"}}}'
@@ -176,7 +182,7 @@ case "$turnline" in
   emit '{"method":"thread/somethingBrandNew","params":{"threadId":"child-1"}}'
   # Child closes → tagged terminal; the spawn chip resolves on the parent.
   emit '{"method":"thread/closed","params":{"threadId":"child-1"}}'
-  emit '{"method":"item/completed","params":{"threadId":"th-1","item":{"id":"call_alpha","type":"subAgentActivity","kind":"completed","agentThreadId":"child-1","agentPath":"/root/alpha"}}}'
+  emit '{"method":"item/completed","params":{"threadId":"th-1","item":{"id":"subagent-completed-alpha","type":"subAgentActivity","kind":"completed","agentThreadId":"child-1","agentPath":"/root/alpha"}}}'
   emit '{"method":"turn/completed","params":{"threadId":"th-1","turn":{"id":"t-1"}}}'
   ;;
 

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -50,7 +50,11 @@ if has "$line" '"method":"model/list"'; then
   exec sleep 30
 fi
 if has "$line" '"method":"thread/resume"'; then
-  if has "$line" '"threadId":"resume-fail"'; then
+  if has "$line" '"threadId":"resume-with-child-v1"'; then
+    emit "{\"id\":$(rid "$line"),\"result\":{\"thread\":{\"id\":\"th-resumed\",\"turns\":[{\"items\":[{\"type\":\"collabAgentToolCall\",\"id\":\"spawn-alpha\",\"tool\":\"spawnAgent\",\"status\":\"completed\",\"receiverThreadIds\":[\"child-alpha\"]}]}]}}}"
+  elif has "$line" '"threadId":"resume-with-child-v2"'; then
+    emit "{\"id\":$(rid "$line"),\"result\":{\"thread\":{\"id\":\"th-resumed\",\"turns\":[{\"items\":[{\"type\":\"subAgentActivity\",\"id\":\"spawn-alpha\",\"kind\":\"started\",\"agentThreadId\":\"child-alpha\",\"agentPath\":\"/root/alpha\"},{\"type\":\"subAgentActivity\",\"id\":\"subagent-completed-old\",\"kind\":\"completed\",\"agentThreadId\":\"child-alpha\",\"agentPath\":\"/root/alpha\"}]}]}}}"
+  elif has "$line" '"threadId":"resume-fail"'; then
     # Missing/foreign rollout: reject, expect the fresh-start fallback.
     emit "{\"id\":$(rid "$line"),\"error\":{\"code\":-32600,\"message\":\"rollout not found\"}}"
     read -r line || exit 1
@@ -286,6 +290,15 @@ case "$turnline" in
   emit "{\"id\":$tid,\"result\":{\"turn\":{\"id\":\"t-1\"}}}"
   emit '{"method":"turn/started","params":{"turn":{"id":"t-1"}}}'
   emit '{"method":"turn/failed","params":{"turn":{"id":"t-1","error":{"message":"boom"}}}}'
+  ;;
+
+*scenario:resumed-child*)
+  emit "{\"id\":$tid,\"result\":{\"turn\":{\"id\":\"t-2\"}}}"
+  emit '{"method":"turn/started","params":{"threadId":"child-alpha","turn":{"id":"alpha-resumed"}}}'
+  emit '{"method":"item/completed","params":{"threadId":"th-resumed","item":{"type":"subAgentActivity","id":"resumed-interaction","kind":"interacted","agentThreadId":"child-alpha","agentPath":"/root/alpha"}}}'
+  emit '{"method":"item/completed","params":{"threadId":"child-alpha","item":{"type":"agentMessage","id":"resumed-answer","text":"resumed alpha"}}}'
+  emit '{"method":"turn/completed","params":{"threadId":"child-alpha","turn":{"id":"alpha-resumed","status":"completed"}}}'
+  emit '{"method":"turn/completed","params":{"threadId":"th-resumed","turn":{"id":"t-2","status":"completed"}}}'
   ;;
 
 *scenario:resumed*)

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -139,6 +139,11 @@ case "$turnline" in
   emit '{"method":"turn/completed","params":{"turn":{"id":"t-1"}}}'
   ;;
 
+*scenario:child-identity*)
+  emit "{\"id\":$tid,\"result\":{\"turn\":{\"id\":\"t-1\"}}}"
+  cat "$(dirname "$0")/codex/child-identity.jsonl"
+  ;;
+
 *scenario:subagent*)
   # Multi-agent v2 child-thread routing: registration via subAgentActivity,
   # tagged child items, consumed child turn bookkeeping (must never settle

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -402,6 +402,8 @@ pub enum AgentEvent {
     InputResolved {
         request_id: String,
     },
+    /// A confirmed new assignment. When tagged as Subagent, this reopens the
+    /// same child transcript even if the provider does not echo the user text.
     #[serde(rename_all = "camelCase")]
     Steered {
         assistant_message_id: Option<String>,

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -6117,6 +6117,7 @@ fn tool_icon_path(call: &ToolCall) -> &'static str {
         ToolCall::WebFetch { .. } | ToolCall::WebSearch { .. } => crate::icons::GLOBAL,
         ToolCall::Todo { .. } => crate::icons::CHECKLIST,
         call if is_agent_call(call) => crate::icons::BOT,
+        ToolCall::Unknown { name, .. } if name == "Wait for agents" => crate::icons::BOT,
         ToolCall::Mcp { .. } | ToolCall::Unknown { .. } => crate::icons::WIDGET,
     }
 }

--- a/docs/research/codex-subagents.md
+++ b/docs/research/codex-subagents.md
@@ -1,0 +1,80 @@
+# Codex subagent transcripts
+
+The Codex adapter uses the original spawn call id as the stable owner of each
+child thread. The engine keeps its existing document format:
+`{chatId}--sub--{spawnCallId}`. No document schema migration or historical
+transcript merging is performed.
+
+## Wire contracts
+
+- v1 publishes `collabAgentToolCall` with `tool: spawnAgent`. The child id can
+  appear only in the completed item's `receiverThreadIds`. Spawn cards appear
+  once; `sendInput`, `wait`, `resumeAgent` and `closeAgent` remain control tools.
+- v2 publishes `subAgentActivity`. `kind: started` (or `spawned`) establishes
+  ownership. Later activities have independent ids, including
+  `subagent-completed-{turnId}`. They must not create cards or replace ownership.
+- Child content arriving before registration is buffered and emitted after the
+  parent card exists. The unbound event backlog has a 4 MiB aggregate limit;
+  overflow is logged and excess events are dropped.
+- Child turn completion settles the assignment. Parent activity completion
+  must not truncate child output. Duplicate message and turn completions are
+  ignored; completion-only assistant messages retain their full text.
+- A follow-up can start a new child turn without a `userMessage` echo (observed
+  with v2). A tagged `Steered` boundary reopens the same document and updates
+  its card to running without fabricating user text. Actual child user messages
+  are still persisted when supplied by the provider.
+- On `thread/resume`, stored parent spawn items rebuild the child ownership
+  table without replaying cards or content into Zeron's existing documents.
+- Root self-activity never registers a child or produces a spawn card.
+
+## Offline regression coverage
+
+Fixtures in `crates/harness/tests/fixtures/codex/` use anonymized ids and short
+test content. They cover the 0.153.4 v1/v2 shapes, early output, distinct activity
+ids, completion-only messages, follow-ups, duplicate terminals and resume.
+
+`crates/engine/tests/codex_subagents.rs` runs the actual adapter against the fake
+app-server, verifies two persisted documents for two children, checks parent
+content isolation and final card status, then restarts the engine and appends a
+resumed child's output to the original document.
+
+```sh
+cargo test --locked -p zeron-harness -p zeron-doc -p zeron-proto
+cargo test --locked -p zeron-engine --lib --test e2e --test codex_subagents
+```
+
+## Live validation
+
+Codex CLI 0.153.4 was checked on 2026-09-10. The local model catalog advertises
+`multi_agent_version: v1` for `gpt-5.6-luna` and `v2` for `gpt-5.6-sol` and
+`gpt-5.6-terra`. Feature flags alone do not force a v2 model onto the v1 protocol.
+Setting `agents.enabled=false` disables agent tools, so it cannot select v1.
+
+The ignored test `live_subagent_spawn_and_followup_keep_one_transcript` asks one
+child for three short replies: initial assignment, follow-up, and another
+follow-up after restarting the app-server and resuming the parent. It asserts
+one original spawn, one owner for all child output, and three child completions.
+It uses a temporary working directory and consumes real model calls.
+Both modes passed, including the restart. With v1, the parent must reactivate
+the existing child using `resume_agent` before `send_input` after the app-server
+restarts; otherwise Codex reports `notFound`. The v2 `followup_task` reactivates
+the child directly. Neither operation establishes a new transcript owner.
+
+Supply an executable wrapper that forwards `"$@"` to the installed Codex CLI.
+For v1, the validated flags are `-c features.multi_agent=true
+-c features.multi_agent_v2=false -c project_doc_max_bytes=0`; for v2, use
+`-c features.multi_agent=true -c features.multi_agent_v2=true
+-c agents.enabled=true -c project_doc_max_bytes=0`. These are per-process
+overrides; the test does not edit the user's Codex config.
+
+```sh
+CODEX_SUBAGENT_TEST_MODE=v1 \
+CODEX_SUBAGENT_TEST_MODEL=gpt-5.6-luna \
+CODEX_SUBAGENT_TEST_EXECUTABLE=/absolute/path/to/v1-wrapper \
+cargo test --locked -p zeron-harness --test codex \
+  live_subagent_spawn_and_followup_keep_one_transcript -- --ignored --nocapture
+```
+
+Repeat with mode `v2`, model `gpt-5.6-sol` and the v2 wrapper. Optionally set
+`CODEX_SUBAGENT_TEST_CAPTURE` to save normalized events for inspection. Model
+availability and advertised agent versions should be checked again on upgrades.


### PR DESCRIPTION
Codex v1 subagent spawns were not recognized, leaving child transcripts without breadcrumbs. In v2, later activity IDs could replace the original spawn identity and create multiple transcripts for the same child.

Bind each child thread to its original spawn call and buffer output that arrives before registration. Recognize v1 spawn events separately from control tools, and distinguish v2 spawns from lifecycle updates. Deduplicate spawn and completion events, preserve completion-only messages, and reopen the same transcript for follow-up assignments, including when Codex does not echo a user message. Restore ownership from the parent history when resuming an app-server session.

The document ID format stays unchanged. Existing historical transcripts are not merged. Protocol details and live test instructions are documented in `docs/research/codex-subagents.md`.

Validation:

- Passed `cargo test --locked -p zeron-harness -p zeron-doc -p zeron-proto` and `cargo test --locked -p zeron-engine --lib --test e2e --test codex_subagents`.
- Added adapter fixtures and engine persistence regressions covering early output, independent children, lifecycle IDs, duplicate completions, follow-ups, and app-server/engine resume. Re-ran the affected tests after the resume changes.
- Passed live tests against Codex CLI 0.153.4 with both v1 and v2: one spawn, three assignments, and one transcript owner across an app-server restart.
- Formatting and diff checks pass for the changed files. Targeted Clippy checks for the Codex and persistence integration tests pass; the broader Clippy run hits two pre-existing `unused_io_amount` errors in `crates/harness/src/opencode/tests.rs` at lines 208 and 237.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791658052&installation_model_id=425430&pr_number=312&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F312&signature=88dc9b6429acc68304631d00fee25f817bddd4fa407e9e7d4e795f8fe44f723f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->