### PR TITLE
Add a setting for opening pull requests in Linear or Graphite

### DIFF
--- a/crates/ui/src/change_requests.rs
+++ b/crates/ui/src/change_requests.rs
@@ -9,7 +9,87 @@ use std::collections::{HashMap, HashSet};
 use gpui::{AnyElement, Context, Render, SharedString, Window, div, prelude::*, px};
 use zeron_proto::{ChangeRequestSummary, Chat, CheckoutChangeRequestStatus, Space};
 
+use crate::settings::PullRequestLinkTarget;
 use crate::theme::Theme;
+
+/// The parts of a GitHub pull request link that review tools key on.
+struct GitHubPullRequest<'a> {
+    owner: &'a str,
+    repo: &'a str,
+    number: &'a str,
+    /// Whatever follows the number: a sub-page, query, or fragment, or nothing.
+    rest: &'a str,
+}
+
+/// Parse `https://github.com/{owner}/{repo}/pull/{number}…`.
+///
+/// Other hosts and other GitHub pages (issues, compare views) return `None`
+/// so callers keep the original link instead of sending the user to a page a
+/// review tool cannot show.
+fn github_pull_request(url: &str) -> Option<GitHubPullRequest<'_>> {
+    let path = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("https://www.github.com/"))?;
+    let mut segments = path.splitn(4, '/');
+    let owner = segments.next().filter(|segment| !segment.is_empty())?;
+    let repo = segments.next().filter(|segment| !segment.is_empty())?;
+    if segments.next()? != "pull" {
+        return None;
+    }
+    let tail = segments.next()?;
+    let digits = tail.bytes().take_while(u8::is_ascii_digit).count();
+    if digits == 0 {
+        return None;
+    }
+    let (number, rest) = tail.split_at(digits);
+    match rest.as_bytes().first() {
+        None | Some(b'/' | b'?' | b'#') => {}
+        Some(_) => return None,
+    }
+    Some(GitHubPullRequest {
+        owner,
+        repo,
+        number,
+        rest,
+    })
+}
+
+/// Linear's review page for a GitHub pull request. Linear mirrors GitHub's
+/// path, so a sub-page, query, or fragment survives the rewrite.
+pub fn linear_review_url(url: &str) -> Option<String> {
+    let pr = github_pull_request(url)?;
+    Some(format!(
+        "https://linear.review/{}/{}/pull/{}{}",
+        pr.owner, pr.repo, pr.number, pr.rest
+    ))
+}
+
+/// Graphite's review page for a GitHub pull request. Graphite has its own
+/// page layout, so only the pull request identity carries over.
+pub fn graphite_url(url: &str) -> Option<String> {
+    let pr = github_pull_request(url)?;
+    Some(format!(
+        "https://app.graphite.com/github/pr/{}/{}/{}",
+        pr.owner, pr.repo, pr.number
+    ))
+}
+
+/// The link a pull request badge opens for the configured target. Links a
+/// review tool cannot rewrite fall back to the original page.
+pub fn pull_request_link(url: &str, target: PullRequestLinkTarget) -> String {
+    let rewritten = match target {
+        PullRequestLinkTarget::GitHub => None,
+        PullRequestLinkTarget::Linear => linear_review_url(url),
+        PullRequestLinkTarget::Graphite => graphite_url(url),
+    };
+    rewritten.unwrap_or_else(|| url.to_owned())
+}
+
+/// The tooltip's destination hint when the badge leaves the provider site.
+fn destination_label(url: &str, target: PullRequestLinkTarget) -> Option<SharedString> {
+    (target != PullRequestLinkTarget::GitHub && pull_request_link(url, target) != url)
+        .then(|| SharedString::from(format!("Opens in {}", target.label())))
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ChangeRequestBadgeTone {
@@ -56,12 +136,14 @@ impl ChangeRequestBadgeModel {
 
 pub(crate) struct ChangeRequestTooltip {
     model: ChangeRequestBadgeModel,
+    destination: Option<SharedString>,
 }
 
 impl ChangeRequestTooltip {
-    pub fn new(summary: &ChangeRequestSummary) -> Self {
+    pub fn new(summary: &ChangeRequestSummary, target: PullRequestLinkTarget) -> Self {
         Self {
             model: ChangeRequestBadgeModel::from_summary(summary),
+            destination: destination_label(&summary.url, target),
         }
     }
 }
@@ -103,7 +185,15 @@ impl Render for ChangeRequestTooltip {
                     .text_size(px(11.0))
                     .text_color(theme.text_muted)
                     .child(self.model.title.clone()),
-            );
+            )
+            .when_some(self.destination.clone(), |card, destination| {
+                card.child(
+                    div()
+                        .text_size(px(10.0))
+                        .text_color(theme.text_muted.opacity(0.7))
+                        .child(destination),
+                )
+            });
         crate::frost::frosted(6.0, crate::frost::MENU_BLUR, card)
     }
 }
@@ -142,12 +232,16 @@ pub(crate) fn pull_request_badge(
         .text_color(color.opacity(0.85))
         .cursor_pointer()
         .hover(move |style| style.bg(color.opacity(0.16)).text_color(color))
+        // The target is read at click time rather than captured at render so a
+        // settings flip applies to badges already on screen.
         .on_click(move |_, _, cx| {
             cx.stop_propagation();
-            cx.open_url(&url);
+            let target = crate::settings::pull_request_link_target(cx);
+            cx.open_url(&pull_request_link(&url, target));
         })
         .tooltip(move |_, cx| {
-            cx.new(|_| ChangeRequestTooltip::new(&tooltip_summary))
+            let target = crate::settings::pull_request_link_target(cx);
+            cx.new(|_| ChangeRequestTooltip::new(&tooltip_summary, target))
                 .into()
         })
         .tooltip_show_delay(std::time::Duration::from_millis(350))
@@ -589,6 +683,85 @@ mod tests {
                 "branch": "feature/pr",
                 "targetDeviceId": "host"
             })
+        );
+    }
+
+    #[test]
+    fn github_pull_request_links_rewrite_to_linear_review() {
+        assert_eq!(
+            linear_review_url("https://github.com/acme/zeron/pull/90").as_deref(),
+            Some("https://linear.review/acme/zeron/pull/90")
+        );
+        assert_eq!(
+            linear_review_url("https://www.github.com/acme/zeron/pull/90/files?diff=split#top")
+                .as_deref(),
+            Some("https://linear.review/acme/zeron/pull/90/files?diff=split#top")
+        );
+    }
+
+    #[test]
+    fn github_pull_request_links_rewrite_to_graphite() {
+        assert_eq!(
+            graphite_url("https://github.com/acme/zeron/pull/90").as_deref(),
+            Some("https://app.graphite.com/github/pr/acme/zeron/90")
+        );
+        // Graphite has its own page layout: GitHub sub-pages do not carry over.
+        assert_eq!(
+            graphite_url("https://www.github.com/acme/zeron/pull/90/files?diff=split#top")
+                .as_deref(),
+            Some("https://app.graphite.com/github/pr/acme/zeron/90")
+        );
+    }
+
+    #[test]
+    fn non_pull_request_links_are_left_alone() {
+        for url in [
+            "https://github.com/acme/zeron/issues/90",
+            "https://github.com/acme/zeron/pull",
+            "https://github.com/acme/zeron/pull/",
+            "https://github.com/acme/zeron/pull/next",
+            "https://github.com/acme/zeron/pull/90abc",
+            "https://github.com//zeron/pull/90",
+            "https://github.com/acme",
+            "https://gitlab.com/acme/zeron/-/merge_requests/90",
+            "https://github.example.com/acme/zeron/pull/90",
+            "http://github.com/acme/zeron/pull/90",
+        ] {
+            assert_eq!(linear_review_url(url), None, "{url}");
+            assert_eq!(graphite_url(url), None, "{url}");
+            for target in PullRequestLinkTarget::ALL {
+                assert_eq!(pull_request_link(url, target), url, "{url} via {target:?}");
+                assert_eq!(destination_label(url, target), None, "{url} via {target:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn pull_request_link_follows_the_target() {
+        let github = "https://github.com/acme/zeron/pull/90";
+        assert_eq!(
+            pull_request_link(github, PullRequestLinkTarget::GitHub),
+            github
+        );
+        assert_eq!(
+            pull_request_link(github, PullRequestLinkTarget::Linear),
+            "https://linear.review/acme/zeron/pull/90"
+        );
+        assert_eq!(
+            pull_request_link(github, PullRequestLinkTarget::Graphite),
+            "https://app.graphite.com/github/pr/acme/zeron/90"
+        );
+        assert_eq!(
+            destination_label(github, PullRequestLinkTarget::GitHub),
+            None
+        );
+        assert_eq!(
+            destination_label(github, PullRequestLinkTarget::Linear).as_deref(),
+            Some("Opens in Linear")
+        );
+        assert_eq!(
+            destination_label(github, PullRequestLinkTarget::Graphite).as_deref(),
+            Some("Opens in Graphite")
         );
     }
 

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -23,6 +23,7 @@ pub mod files;
 pub mod harnesses;
 pub mod notifications;
 pub mod shortcuts;
+pub mod source_control;
 pub mod widgets;
 
 /// Sidebar drag-resize bounds (px).
@@ -224,6 +225,14 @@ pub fn current(cx: &App) -> UiSettings {
         .unwrap_or_default()
 }
 
+/// Where pull request badges open, read at click time so a settings flip
+/// applies to badges that were rendered before it.
+pub fn pull_request_link_target(cx: &App) -> PullRequestLinkTarget {
+    cx.try_global::<SettingsStore>()
+        .map(|store| store.current.pull_request_link_target)
+        .unwrap_or_default()
+}
+
 /// Monotonic id of the global code-fence layout choice. Every transcript
 /// compares this during render so inactive subagent tabs can observe all mode
 /// transitions when they next become visible.
@@ -292,6 +301,35 @@ pub enum ComposerSendBehavior {
     ModEnter,
 }
 
+/// Where a pull request badge opens its link.
+///
+/// Linear and Graphite only rewrite GitHub pull request links; anything else
+/// keeps its own page (`change_requests::pull_request_link`).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PullRequestLinkTarget {
+    /// The pull request's own page on github.com.
+    #[default]
+    GitHub,
+    /// Linear's review surface (`linear.review`).
+    Linear,
+    /// Graphite's review surface (`app.graphite.com`).
+    Graphite,
+}
+
+impl PullRequestLinkTarget {
+    /// Selector order on the Source control settings page.
+    pub const ALL: [Self; 3] = [Self::GitHub, Self::Linear, Self::Graphite];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::GitHub => "GitHub",
+            Self::Linear => "Linear",
+            Self::Graphite => "Graphite",
+        }
+    }
+}
+
 /// Persist the latest revision. Safe to call at shutdown.
 pub fn flush(cx: &mut App) {
     if !cx.has_global::<SettingsStore>() {
@@ -358,6 +396,9 @@ pub struct UiSettings {
     pub sidebar_show_harness: bool,
     pub sidebar_show_branch: bool,
     pub sidebar_show_pull_request: bool,
+    /// Where the sidebar and composer pull request badges open. Device-local,
+    /// like the badge visibility flag above.
+    pub pull_request_link_target: PullRequestLinkTarget,
     /// The last selected space — restored on boot when the row still exists;
     /// also the new-tab default when the sidebar filter is "All".
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -454,6 +495,7 @@ impl Default for UiSettings {
             sidebar_show_harness: true,
             sidebar_show_branch: true,
             sidebar_show_pull_request: true,
+            pull_request_link_target: PullRequestLinkTarget::default(),
             last_space_id: None,
             open_tabs: None,
             space_filter: None,
@@ -1097,6 +1139,7 @@ mod tests {
             sidebar_show_harness: false,
             sidebar_show_branch: false,
             sidebar_show_pull_request: false,
+            pull_request_link_target: PullRequestLinkTarget::Graphite,
             last_space_id: Some("space-1".into()),
             open_tabs: Some(vec!["b".to_string(), "a".to_string()]),
             space_filter: Some("space-1".into()),
@@ -1157,6 +1200,32 @@ mod tests {
         assert!(json.contains(r#""diffWrap": true"#));
         assert_eq!(UiSettings::load(dir.path()), settings);
         assert!(json.contains(r#""codeFencesFitContent": true"#));
+        assert!(json.contains(r#""pullRequestLinkTarget": "graphite""#));
+    }
+
+    #[test]
+    fn pull_request_link_target_defaults_to_github_for_old_settings() {
+        let loaded: UiSettings = serde_json::from_str(r#"{"sidebarWidth":300}"#).unwrap();
+        assert_eq!(
+            loaded.pull_request_link_target,
+            PullRequestLinkTarget::GitHub
+        );
+
+        let linear: UiSettings =
+            serde_json::from_str(r#"{"pullRequestLinkTarget":"linear"}"#).unwrap();
+        assert_eq!(
+            linear.pull_request_link_target,
+            PullRequestLinkTarget::Linear
+        );
+
+        assert_eq!(
+            PullRequestLinkTarget::ALL.map(PullRequestLinkTarget::label),
+            ["GitHub", "Linear", "Graphite"]
+        );
+        assert_eq!(
+            PullRequestLinkTarget::ALL[0],
+            PullRequestLinkTarget::default()
+        );
     }
 
     #[test]

--- a/crates/ui/src/settings/source_control.rs
+++ b/crates/ui/src/settings/source_control.rs
@@ -1,0 +1,140 @@
+//! Settings → Source control: how Zeron links to the pull requests behind a
+//! checkout. The badges themselves stay provider-neutral
+//! (`change_requests::pull_request_badge`); this page only picks which review
+//! tool a GitHub link lands in.
+//!
+//! The NotificationsPage arrangement: the page holds a working copy, every
+//! pick emits [`SourceControlEvent`], and the shell persists it. Nothing here
+//! talks RPC — the link target is a device-local UI setting.
+
+use gpui::{Context, EventEmitter, SharedString, Window, div, prelude::*, px};
+
+use super::{PullRequestLinkTarget, widgets};
+use crate::{icons, theme::Theme};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceControlEvent {
+    PullRequestLinkTargetChanged(PullRequestLinkTarget),
+}
+
+pub struct SourceControlPage {
+    pull_request_link_target: PullRequestLinkTarget,
+}
+
+impl EventEmitter<SourceControlEvent> for SourceControlPage {}
+
+impl SourceControlPage {
+    pub fn new(pull_request_link_target: PullRequestLinkTarget, _cx: &mut Context<Self>) -> Self {
+        Self {
+            pull_request_link_target,
+        }
+    }
+
+    fn select_pull_request_link_target(
+        &mut self,
+        target: PullRequestLinkTarget,
+        cx: &mut Context<Self>,
+    ) {
+        if self.pull_request_link_target == target {
+            return;
+        }
+        self.pull_request_link_target = target;
+        cx.emit(SourceControlEvent::PullRequestLinkTargetChanged(target));
+        cx.notify();
+    }
+}
+
+impl Render for SourceControlPage {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = Theme::of(cx).clone();
+        let selected = self.pull_request_link_target;
+        // The Files page's option pills, so the two pages read alike.
+        let options = PullRequestLinkTarget::ALL.into_iter().map(|target| {
+            let active = target == selected;
+            div()
+                .id(SharedString::from(format!(
+                    "source-control-pull-request-{}",
+                    target.label().to_ascii_lowercase()
+                )))
+                .h(px(28.0))
+                .px(px(10.0))
+                .rounded(px(7.0))
+                .border_1()
+                .border_color(if active {
+                    theme.accent.opacity(0.7)
+                } else {
+                    theme.border
+                })
+                .bg(if active {
+                    theme.accent.opacity(0.11)
+                } else {
+                    crate::theme::wash(0.025)
+                })
+                .text_size(px(11.5))
+                .text_color(if active { theme.text } else { theme.text_muted })
+                .flex()
+                .items_center()
+                .cursor_pointer()
+                .hover(|style| style.bg(crate::theme::wash(0.08)))
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.select_pull_request_link_target(target, cx);
+                }))
+                .child(target.label())
+        });
+
+        let card = widgets::section_card(&theme).child(
+            widgets::card_row(&theme, true)
+                .items_start()
+                .child(widgets::row_tile(&theme, icons::PULL_REQUEST))
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .flex()
+                        .flex_col()
+                        .child(widgets::row_title(&theme, "Open pull requests in"))
+                        .child(widgets::meta_line(
+                            &theme,
+                            vec![
+                                // Full width so the sentence wraps instead of
+                                // running past the card at narrow widths.
+                                div()
+                                    .w_full()
+                                    .child(SharedString::from(
+                                        "Applies to the pull request badges in the sidebar \
+                                         and composer. Linear and Graphite only rewrite \
+                                         GitHub pull request links.",
+                                    ))
+                                    .into_any_element(),
+                            ],
+                        ))
+                        .child(
+                            div()
+                                .mt(px(12.0))
+                                .flex()
+                                .flex_wrap()
+                                .gap(px(7.0))
+                                .children(options),
+                        ),
+                ),
+        );
+
+        div()
+            .id("source-control-page")
+            .size_full()
+            .overflow_y_scroll()
+            .child(
+                widgets::page_column()
+                    .child(widgets::page_header(&theme, "Source control", None))
+                    .child(
+                        widgets::page_subtitle(
+                            &theme,
+                            "How Zeron links to the pull requests behind your checkouts.",
+                        )
+                        .max_w(px(512.0))
+                        .line_height(px(20.0)),
+                    )
+                    .child(card),
+            )
+    }
+}

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -43,6 +43,7 @@ use crate::settings::files::{FilesSettingsEvent, FilesSettingsPage};
 use crate::settings::harnesses::HarnessesPage;
 use crate::settings::notifications::{NotificationsEvent, NotificationsPage};
 use crate::settings::shortcuts::{ShortcutsEvent, ShortcutsPage};
+use crate::settings::source_control::{SourceControlEvent, SourceControlPage};
 use crate::settings::{
     self, CHAT_PANEL_MIN, ComposerSendBehavior, JUMP_SLOTS, KeymapConfig, RIGHT_PANE_DEFAULT,
     RIGHT_PANE_MIN, SIDEBAR_DEFAULT, SIDEBAR_MAX, SIDEBAR_MIN, SavePolicy, ShortcutId,
@@ -389,18 +390,21 @@ pub enum SettingsSection {
     Agents,
     Appearance,
     Files,
+    /// Pull request link preferences for checkouts.
+    SourceControl,
     Notifications,
     Shortcuts,
     Archived,
 }
 
 impl SettingsSection {
-    pub const ALL: [SettingsSection; 8] = [
+    pub const ALL: [SettingsSection; 9] = [
         SettingsSection::Devices,
         SettingsSection::Harnesses,
         SettingsSection::Agents,
         SettingsSection::Appearance,
         SettingsSection::Files,
+        SettingsSection::SourceControl,
         SettingsSection::Notifications,
         SettingsSection::Shortcuts,
         SettingsSection::Archived,
@@ -415,6 +419,7 @@ impl SettingsSection {
             SettingsSection::Agents => "Accounts",
             SettingsSection::Appearance => "Appearance",
             SettingsSection::Files => "Files",
+            SettingsSection::SourceControl => "Source control",
             SettingsSection::Notifications => "Notifications",
             SettingsSection::Shortcuts => "Shortcuts",
             SettingsSection::Archived => "Archived sessions",
@@ -1192,6 +1197,7 @@ pub struct Shell {
     archived_page: Option<Entity<ArchivedPage>>,
     appearance_page: Option<Entity<AppearancePage>>,
     files_settings_page: Option<Entity<FilesSettingsPage>>,
+    source_control_page: Option<Entity<SourceControlPage>>,
     notifications_page: Option<Entity<NotificationsPage>>,
     shortcuts_page: Option<Entity<ShortcutsPage>>,
     accounts_page: Option<Entity<AccountsPage>>,
@@ -1199,6 +1205,7 @@ pub struct Shell {
     shortcuts_sub: Option<Subscription>,
     notifications_sub: Option<Subscription>,
     files_settings_sub: Option<Subscription>,
+    source_control_sub: Option<Subscription>,
     /// Session-row context menu, including the Copy submenu.
     chat_menu: popover::Popup<ChatMenuState>,
     rename_dialog: Option<RenameChatDialog>,
@@ -1445,6 +1452,7 @@ impl Shell {
             Some("settings/agents") => Route::Settings(SettingsSection::Agents),
             Some("settings/harnesses") => Route::Settings(SettingsSection::Harnesses),
             Some("settings/appearance") => Route::Settings(SettingsSection::Appearance),
+            Some("settings/source-control") => Route::Settings(SettingsSection::SourceControl),
             Some("settings/notifications") => Route::Settings(SettingsSection::Notifications),
             Some("settings/shortcuts") => Route::Settings(SettingsSection::Shortcuts),
             Some("settings/archived") => Route::Settings(SettingsSection::Archived),
@@ -1533,6 +1541,7 @@ impl Shell {
             archived_page: None,
             appearance_page: None,
             files_settings_page: None,
+            source_control_page: None,
             notifications_page: None,
             shortcuts_page: None,
             accounts_page: None,
@@ -1540,6 +1549,7 @@ impl Shell {
             shortcuts_sub: None,
             notifications_sub: None,
             files_settings_sub: None,
+            source_control_sub: None,
             chat_menu: popover::Popup::default(),
             rename_dialog: None,
             delete_confirm: None,
@@ -3271,6 +3281,29 @@ impl Shell {
                     None => Empty.into_any_element(),
                 }
             }
+            SettingsSection::SourceControl => {
+                if self.source_control_page.is_none() {
+                    let page = cx.new(|cx| {
+                        SourceControlPage::new(self.settings.pull_request_link_target, cx)
+                    });
+                    // Persist the target whenever the page flips it; badges
+                    // read it from the settings store at click time.
+                    self.source_control_sub = Some(cx.subscribe(
+                        &page,
+                        |this: &mut Shell, _, event: &SourceControlEvent, cx| {
+                            let SourceControlEvent::PullRequestLinkTargetChanged(target) = *event;
+                            this.settings.pull_request_link_target = target;
+                            this.schedule_save(cx);
+                            cx.notify();
+                        },
+                    ));
+                    self.source_control_page = Some(page);
+                }
+                match &self.source_control_page {
+                    Some(page) => page.clone().into_any_element(),
+                    None => Empty.into_any_element(),
+                }
+            }
             SettingsSection::Notifications => {
                 if self.notifications_page.is_none() {
                     let page = cx.new(|cx| {
@@ -4604,6 +4637,7 @@ impl Shell {
             SettingsSection::Agents => icons::KEY_MINIMALISTIC,
             SettingsSection::Appearance => icons::TUNING,
             SettingsSection::Files => icons::FOLDER,
+            SettingsSection::SourceControl => icons::PULL_REQUEST,
             SettingsSection::Notifications => icons::BELL,
             SettingsSection::Shortcuts => icons::KEYBOARD,
             SettingsSection::Archived => icons::ARCHIVE_MINIMALISTIC,


### PR DESCRIPTION
## Summary

Pull request badges in the sidebar and composer always opened the provider page. This adds a **Source control** settings page with an "Open pull requests in" choice: **GitHub** (default), **Linear**, or **Graphite**.

- **Linear** rewrites `github.com` to `linear.review` and keeps the rest of the path, query, and fragment.
- **Graphite** opens `https://app.graphite.com/github/pr/{owner}/{repo}/{number}`. GitHub sub-pages don't carry over because Graphite has its own page layout.
- Links that are not GitHub pull requests (issues, compare views, other hosts) keep their own page under every choice.
- The target is read from the settings store at click time, so changing it applies to badges already on screen. The badge tooltip adds "Opens in Linear" / "Opens in Graphite" when a rewrite will actually happen.
- Persisted as `pullRequestLinkTarget` in `ui-settings.json` (`github` / `linear` / `graphite`). Older settings files without the key load as GitHub.
- Dev route: `ZERON_OPEN_ROUTE=settings/source-control`.

The iOS app has its own PR badge but no settings screen, so it is unchanged.

## Test plan

- [x] `cargo test --locked -p zeron-ui --lib -- --test-threads=1` (783 passed). New tests cover the Linear and Graphite rewrites, the non-PR fallbacks for every target, the tooltip hint, and the settings round-trip plus default for older files.
- [x] `cargo clippy -p zeron-ui --tests` reports nothing in the changed files; changed files are rustfmt-clean.
- [x] Booted the debug app on `settings/source-control`, switched between the three options, and confirmed the persisted value.
- [ ] Click a badge with Graphite selected from an account that has Graphite access, to confirm the `app.graphite.com` host resolves the `/github/pr/…` route the same way `app.graphite.dev` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791664841&installation_model_id=425430&pr_number=314&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F314&signature=1711b779460adc55a25ec621a7fa0a9d517be8b21950d90487be493c9a1afcc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->