### PR TITLE
feat(worktrees): optional Rift isolated checkouts

### DIFF
--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -2281,6 +2281,7 @@ impl DocHost {
         }
     }
 
+
     /// Composer path: append an immutable pending command entry (rule 1). Durable by
     /// construction — the change subscription kicks the drain, so a local host executes
     /// immediately and an offline doc simply holds the entry until it syncs.
@@ -4347,7 +4348,7 @@ impl DocHost {
             && let Ok(Some(chat)) = ws.chat(chat_id)
             && let Some(cwd) = chat.cwd
             && cwd != spec.repo_path
-            && crate::workspace_host::linked_worktree_root(std::path::Path::new(&cwd)).as_deref()
+            && crate::workspace_host::isolated_checkout_root(std::path::Path::new(&cwd)).as_deref()
                 == Some(spec.repo_path.as_str())
         {
             tracing::info!(chat = %chat_id, cwd = %cwd, "worktree spec: reusing the chat's existing worktree");

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -26,6 +26,7 @@ pub mod local_import;
 pub mod profile;
 pub mod registry;
 pub mod repos;
+pub mod rift;
 pub mod rpc;
 pub mod run_journal;
 pub mod sessions;

--- a/crates/engine/src/repos.rs
+++ b/crates/engine/src/repos.rs
@@ -7,6 +7,8 @@
 //! created under `~/.zeron/worktrees/<repoName>/<worktreeName>` (NOT the data
 //! dir — worktrees are user-facing working checkouts), with an auto-generated name +
 //! matching `zeron/<name>` branch. `ZERON_WORKTREES_DIR` overrides the root.
+//! Isolated checkouts default to git worktrees; Settings can opt a device into
+//! [Rift](https://github.com/anomalyco/rift) copy-on-write clones instead.
 //!
 //! All git access is via subprocess (`tokio::process`) — never libgit2.
 
@@ -19,9 +21,9 @@ use futures::{StreamExt, stream};
 use sha2::{Digest, Sha256};
 
 use zeron_proto::{
-    DriveEntry, FileSearchMatch, FolderEntry, FolderListing, GitHistoryCommit,
-    GitHistoryComparison, GitHistoryPage, GitHistoryRef, GitHistoryRefKind, Repo, RepoRef,
-    Worktree,
+    CheckoutIsolation, CheckoutIsolationStatus, DriveEntry, FileSearchMatch, FolderEntry,
+    FolderListing, GitHistoryCommit, GitHistoryComparison, GitHistoryPage, GitHistoryRef,
+    GitHistoryRefKind, Repo, RepoRef, Worktree,
 };
 
 use crate::EngineError;
@@ -91,10 +93,32 @@ fn default_worktrees_root() -> PathBuf {
         .unwrap_or_else(|| home_dir().join(".zeron").join("worktrees"))
 }
 
+const ISOLATION_FILE: &str = "checkout-isolation.json";
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct IsolationFile {
+    #[serde(default)]
+    isolation: CheckoutIsolation,
+}
+
+fn isolation_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(ISOLATION_FILE)
+}
+
+fn load_isolation(data_dir: &Path) -> CheckoutIsolation {
+    std::fs::read_to_string(isolation_path(data_dir))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<IsolationFile>(&raw).ok())
+        .map(|file| file.isolation)
+        .unwrap_or_default()
+}
+
 struct ReposInner {
     data_dir: PathBuf,
     device_id: String,
     worktrees_root: PathBuf,
+    isolation: std::sync::Mutex<CheckoutIsolation>,
     file_searches: std::sync::Mutex<HashMap<PathBuf, std::sync::Weak<tokio::sync::Mutex<()>>>>,
     http: reqwest::Client,
     github_avatars: std::sync::Mutex<HashMap<String, String>>,
@@ -134,6 +158,7 @@ impl Repos {
                 data_dir: data_dir.to_path_buf(),
                 device_id: device_id.to_string(),
                 worktrees_root,
+                isolation: std::sync::Mutex::new(load_isolation(data_dir)),
                 file_searches: std::sync::Mutex::new(HashMap::new()),
                 http: reqwest::Client::builder()
                     .timeout(GITHUB_AVATAR_TIMEOUT)
@@ -145,6 +170,46 @@ impl Repos {
                 file_index: std::sync::Mutex::new(HashMap::new()),
             }),
         }
+    }
+
+    pub fn isolation(&self) -> CheckoutIsolation {
+        *self
+            .inner
+            .isolation
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    pub fn isolation_status(&self) -> CheckoutIsolationStatus {
+        CheckoutIsolationStatus {
+            isolation: self.isolation(),
+            rift_supported: crate::rift::available(),
+        }
+    }
+
+    pub fn set_isolation(
+        &self,
+        isolation: CheckoutIsolation,
+    ) -> Result<CheckoutIsolationStatus, EngineError> {
+        if isolation == CheckoutIsolation::Rift && !crate::rift::available() {
+            return Err(EngineError::Other(
+                "Install the rift CLI to use Rift checkouts (https://github.com/anomalyco/rift). Needs btrfs, a Linux filesystem with reflinks, or APFS.".into(),
+            ));
+        }
+        let file = IsolationFile { isolation };
+        let json = serde_json::to_string_pretty(&file)
+            .map_err(|e| EngineError::Other(format!("checkout isolation serialize: {e}")))?;
+        std::fs::create_dir_all(&self.inner.data_dir)?;
+        let path = isolation_path(&self.inner.data_dir);
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, json)?;
+        std::fs::rename(&tmp, &path)?;
+        *self
+            .inner
+            .isolation
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = isolation;
+        Ok(self.isolation_status())
     }
 
     // ── registry (repos.json) ───────────────────────────────────────────────
@@ -466,6 +531,7 @@ impl Repos {
         // main checkout — excluded (it's `current`, not a linked worktree).
         let mut worktrees: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
+        let mut isolation_by_path: HashMap<String, CheckoutIsolation> = HashMap::new();
         if let Ok(out) = self
             .git(&["worktree", "list", "--porcelain"], Some(repo_path))
             .await
@@ -480,18 +546,48 @@ impl Repos {
                 } else if let Some(branch) = line.strip_prefix("branch refs/heads/")
                     && let Some(path) = path.take()
                 {
+                    isolation_by_path.insert(path.clone(), CheckoutIsolation::Git);
                     worktrees.insert(branch.to_string(), path);
                 }
             }
         }
-        Ok(names
+        let mut extra: Vec<RepoRef> = Vec::new();
+        for rift in self.list_rift_checkouts(repo_path).await {
+            let branch = self
+                .current_branch(&rift)
+                .await
+                .unwrap_or_else(|_| "HEAD".into());
+            let path = rift.to_string_lossy().into_owned();
+            isolation_by_path.insert(path.clone(), CheckoutIsolation::Rift);
+            if names.iter().any(|name| name == &branch) {
+                worktrees.entry(branch).or_insert(path);
+            } else {
+                extra.push(RepoRef {
+                    current: false,
+                    worktree_path: Some(path),
+                    isolation: CheckoutIsolation::Rift,
+                    name: branch,
+                });
+            }
+        }
+        let mut refs: Vec<RepoRef> = names
             .into_iter()
-            .map(|name| RepoRef {
-                current: current.as_deref() == Some(name.as_str()),
-                worktree_path: worktrees.get(&name).cloned(),
-                name,
+            .map(|name| {
+                let worktree_path = worktrees.get(&name).cloned();
+                let isolation = worktree_path
+                    .as_ref()
+                    .and_then(|path| isolation_by_path.get(path).copied())
+                    .unwrap_or_default();
+                RepoRef {
+                    current: current.as_deref() == Some(name.as_str()),
+                    worktree_path,
+                    isolation,
+                    name,
+                }
             })
-            .collect())
+            .collect();
+        refs.extend(extra);
+        Ok(refs)
     }
 
     /// Public commit history in topological order. Only user-facing branches,
@@ -1042,20 +1138,26 @@ impl Repos {
 
     // ── worktrees ───────────────────────────────────────────────────────────
 
-    /// `git worktree add` an isolated checkout under
-    /// `{worktrees_root}/<repoName>/<generatedName>`, on a fresh `zeron/<name>`
-    /// branch off `branch`.
+    /// Isolated checkout under `{worktrees_root}/<repoName>/<generatedName>`.
+    /// Git worktrees mint a fresh `zeron/<name>` branch off `branch`. Rift
+    /// clones the source workspace, then creates that same branch in the copy.
     pub async fn create_worktree(
         &self,
         repo_path: &Path,
         branch: &str,
     ) -> Result<Worktree, EngineError> {
-        let repo_name = repo_path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "repo".to_string());
-        let base = self.inner.worktrees_root.join(&repo_name);
-        std::fs::create_dir_all(&base)?;
+        match self.isolation() {
+            CheckoutIsolation::Git => self.create_git_worktree(repo_path, branch).await,
+            CheckoutIsolation::Rift => self.create_rift_checkout(repo_path, branch).await,
+        }
+    }
+
+    async fn allocate_checkout_name(
+        &self,
+        repo_path: &Path,
+        base: &Path,
+    ) -> Result<String, EngineError> {
+        std::fs::create_dir_all(base)?;
         // Auto-generate a name colliding with neither an existing dir nor branch.
         let existing: HashSet<String> = self
             .branches(repo_path)
@@ -1081,8 +1183,20 @@ impl Repos {
                 break;
             }
         }
-        let name =
-            name.ok_or_else(|| EngineError::Other("Could not allocate a worktree name".into()))?;
+        name.ok_or_else(|| EngineError::Other("Could not allocate a worktree name".into()))
+    }
+
+    async fn create_git_worktree(
+        &self,
+        repo_path: &Path,
+        branch: &str,
+    ) -> Result<Worktree, EngineError> {
+        let repo_name = repo_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "repo".to_string());
+        let base = self.inner.worktrees_root.join(&repo_name);
+        let name = self.allocate_checkout_name(repo_path, &base).await?;
         let path = base.join(&name);
         let branch_name = format!("zeron/{name}");
         self.git(
@@ -1097,6 +1211,60 @@ impl Repos {
             Some(repo_path),
         )
         .await?;
+        self.finish_worktree(repo_path, path, branch_name, name, CheckoutIsolation::Git)
+            .await
+    }
+
+    async fn create_rift_checkout(
+        &self,
+        repo_path: &Path,
+        branch: &str,
+    ) -> Result<Worktree, EngineError> {
+        if !crate::rift::available() {
+            return Err(EngineError::Other(
+                "Install the rift CLI to use Rift checkouts (https://github.com/anomalyco/rift). Needs btrfs, a Linux filesystem with reflinks, or APFS.".into(),
+            ));
+        }
+        let repo_name = repo_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "repo".to_string());
+        let base = self.inner.worktrees_root.join(&repo_name);
+        let name = self.allocate_checkout_name(repo_path, &base).await?;
+        let repo_path_owned = repo_path.to_path_buf();
+        let into = base.clone();
+        let clone_name = name.clone();
+        let path = tokio::task::spawn_blocking(move || {
+            crate::rift::create(&repo_path_owned, &clone_name, &into)
+        })
+        .await
+        .map_err(|e| EngineError::Other(format!("rift create join: {e}")))??;
+        let cleanup =
+            |path: PathBuf| tokio::task::spawn_blocking(move || crate::rift::remove(&path));
+        if let Err(err) = crate::rift::write_marker(&path, repo_path) {
+            let _ = cleanup(path).await;
+            return Err(err);
+        }
+        let branch_name = format!("zeron/{name}");
+        if let Err(err) = self
+            .git(&["checkout", "-B", &branch_name, branch], Some(&path))
+            .await
+        {
+            let _ = cleanup(path).await;
+            return Err(err);
+        }
+        self.finish_worktree(repo_path, path, branch_name, name, CheckoutIsolation::Rift)
+            .await
+    }
+
+    async fn finish_worktree(
+        &self,
+        repo_path: &Path,
+        path: PathBuf,
+        branch_name: String,
+        name: String,
+        isolation: CheckoutIsolation,
+    ) -> Result<Worktree, EngineError> {
         let checkout = self.checkout_identity(&path).await?;
         Ok(Worktree {
             repo_path: repo_path.to_string_lossy().to_string(),
@@ -1104,7 +1272,26 @@ impl Repos {
             branch: branch_name,
             name,
             checkout_id: Some(checkout.id),
+            isolation,
         })
+    }
+
+    async fn list_rift_checkouts(&self, repo_path: &Path) -> Vec<PathBuf> {
+        let repo_name = repo_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "repo".to_string());
+        let base = self.inner.worktrees_root.join(repo_name);
+        let mut paths = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&base) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if crate::rift::source_root_matches(&path, repo_path) {
+                    paths.push(path);
+                }
+            }
+        }
+        paths
     }
 
     async fn branch_exists(&self, path: &Path, branch: &str) -> bool {
@@ -1177,12 +1364,22 @@ impl Repos {
         repo_path: &Path,
         worktree_path: &Path,
     ) -> Result<(), EngineError> {
+        let is_rift = crate::rift::is_checkout(worktree_path)
+            || crate::rift::source_root(worktree_path).is_some();
         let branch = if worktree_path.exists() {
             self.current_branch(worktree_path).await.unwrap_or_default()
         } else {
             String::new()
         };
-        if worktree_path.exists() {
+        if is_rift {
+            let path = worktree_path.to_path_buf();
+            let removed = tokio::task::spawn_blocking(move || crate::rift::remove(&path))
+                .await
+                .map_err(|e| EngineError::Other(format!("rift remove join: {e}")))?;
+            if removed.is_err() && worktree_path.exists() {
+                let _ = std::fs::remove_dir_all(worktree_path);
+            }
+        } else if worktree_path.exists() {
             let removed = self
                 .git(
                     &[
@@ -1198,8 +1395,8 @@ impl Repos {
                 // git refused (or the dir is half-gone) — delete the folder directly.
                 let _ = std::fs::remove_dir_all(worktree_path);
             }
+            let _ = self.git(&["worktree", "prune"], Some(repo_path)).await;
         }
-        let _ = self.git(&["worktree", "prune"], Some(repo_path)).await;
         if branch.starts_with("zeron/") {
             let _ = self.git(&["branch", "-D", &branch], Some(repo_path)).await;
         }
@@ -2478,5 +2675,60 @@ tmpfs /run tmpfs rw 0 0
 
         assert_eq!(alpha.unwrap()[0].path, "alpha.rs");
         assert_eq!(beta.unwrap()[0].path, "beta.rs");
+    }
+
+    #[test]
+    fn checkout_isolation_defaults_to_git_and_persists() {
+        let data = tempfile::tempdir().unwrap();
+        let repos =
+            Repos::with_worktrees_root(data.path(), "device", data.path().join("worktrees"));
+        assert_eq!(repos.isolation(), CheckoutIsolation::Git);
+        assert_eq!(repos.isolation_status().isolation, CheckoutIsolation::Git);
+
+        if crate::rift::available() {
+            let status = repos.set_isolation(CheckoutIsolation::Rift).unwrap();
+            assert_eq!(status.isolation, CheckoutIsolation::Rift);
+            let reloaded =
+                Repos::with_worktrees_root(data.path(), "device", data.path().join("worktrees"));
+            assert_eq!(reloaded.isolation(), CheckoutIsolation::Rift);
+            reloaded
+                .set_isolation(CheckoutIsolation::Git)
+                .expect("back to git");
+            assert_eq!(reloaded.isolation(), CheckoutIsolation::Git);
+        } else {
+            assert!(repos.set_isolation(CheckoutIsolation::Rift).is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn git_worktree_create_stays_the_default() {
+        let data = tempfile::tempdir().unwrap();
+        let repo = data.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "{}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.email", "t@example.com"]);
+        git(&["config", "user.name", "Test"]);
+        std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-m", "init"]);
+
+        let repos =
+            Repos::with_worktrees_root(data.path(), "device", data.path().join("worktrees"));
+        let worktree = repos.create_worktree(&repo, "main").await.unwrap();
+        assert_eq!(worktree.isolation, CheckoutIsolation::Git);
+        assert!(PathBuf::from(&worktree.path).join(".git").is_file());
+        assert!(!crate::rift::is_checkout(Path::new(&worktree.path)));
     }
 }

--- a/crates/engine/src/rift.rs
+++ b/crates/engine/src/rift.rs
@@ -1,0 +1,186 @@
+//! Optional [Rift](https://github.com/anomalyco/rift) backend for isolated
+//! session checkouts. Git worktrees stay the default; this path is an opt-in
+//! copy-on-write clone of the source workspace, driven through the `rift` CLI
+//! so Comet does not have to take Rift's rusqlite as a crate dependency.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::EngineError;
+
+/// Compiled-in support. Does not probe the current disk; a create still fails
+/// when the filesystem cannot clone, or when `rift` is not on PATH.
+pub fn supported() -> bool {
+    cfg!(any(target_os = "linux", target_os = "macos"))
+}
+
+/// Whether the `rift` binary is on PATH (or `ZERON_RIFT_BIN`).
+pub fn available() -> bool {
+    if !supported() {
+        return false;
+    }
+    Command::new(rift_bin())
+        .arg("--help")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+pub fn is_checkout(path: &Path) -> bool {
+    path.join(".rift").is_file()
+}
+
+/// Marker Comet writes next to Rift's `.rift` id so claim/reuse can attribute
+/// the clone back to the source repo without opening Rift's sqlite registry.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckoutMarker {
+    pub repo_path: String,
+    #[serde(default)]
+    pub isolation: zeron_proto::CheckoutIsolation,
+}
+
+pub const MARKER_FILE: &str = ".zeron-checkout.json";
+
+pub fn read_marker(path: &Path) -> Option<CheckoutMarker> {
+    let raw = std::fs::read_to_string(path.join(MARKER_FILE)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+pub fn write_marker(path: &Path, repo_path: &Path) -> Result<(), EngineError> {
+    let marker = CheckoutMarker {
+        repo_path: repo_path.to_string_lossy().into_owned(),
+        isolation: zeron_proto::CheckoutIsolation::Rift,
+    };
+    let json = serde_json::to_string_pretty(&marker)
+        .map_err(|e| EngineError::Other(format!("rift marker serialize: {e}")))?;
+    std::fs::write(path.join(MARKER_FILE), json)?;
+    hide_from_git(path, MARKER_FILE)?;
+    Ok(())
+}
+
+fn hide_from_git(workspace: &Path, entry: &str) -> Result<(), EngineError> {
+    let git = workspace.join(".git");
+    if !git.is_dir() {
+        return Ok(());
+    }
+    let info = git.join("info");
+    std::fs::create_dir_all(&info)?;
+    let exclude = info.join("exclude");
+    let existing = match std::fs::read_to_string(&exclude) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error.into()),
+    };
+    let line = format!("/{entry}");
+    if existing.lines().any(|row| row.trim() == line) {
+        return Ok(());
+    }
+    let separator = if existing.is_empty() || existing.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    std::fs::write(exclude, format!("{existing}{separator}{line}\n"))?;
+    Ok(())
+}
+
+pub fn source_root(path: &Path) -> Option<String> {
+    read_marker(path).map(|marker| marker.repo_path)
+}
+
+pub fn source_root_matches(path: &Path, repo_path: &Path) -> bool {
+    let Some(root) = source_root(path) else {
+        return false;
+    };
+    let marked = Path::new(&root);
+    match (
+        std::fs::canonicalize(marked),
+        std::fs::canonicalize(repo_path),
+    ) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => marked == repo_path,
+    }
+}
+
+fn rift_bin() -> PathBuf {
+    std::env::var_os("ZERON_RIFT_BIN")
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("rift"))
+}
+
+fn database_args() -> Vec<String> {
+    match std::env::var("ZERON_RIFT_DATABASE") {
+        Ok(path) if !path.is_empty() => vec!["--database".into(), path],
+        _ => Vec::new(),
+    }
+}
+
+fn run_rift(args: &[&str]) -> Result<String, EngineError> {
+    let mut cmd = Command::new(rift_bin());
+    cmd.args(database_args());
+    cmd.args(args);
+    cmd.stdin(std::process::Stdio::null());
+    let output = cmd
+        .output()
+        .map_err(|e| EngineError::Other(format!("rift spawn failed: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let message = stderr.trim();
+        let message = if message.is_empty() {
+            stdout.trim()
+        } else {
+            message
+        };
+        return Err(EngineError::Other(if message.is_empty() {
+            format!(
+                "rift {} failed ({})",
+                args.first().unwrap_or(&"?"),
+                output.status
+            )
+        } else {
+            format!("rift: {message}")
+        }));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+pub fn create(from: &Path, name: &str, into: &Path) -> Result<PathBuf, EngineError> {
+    if !supported() {
+        return Err(EngineError::Other(
+            "Rift is not available on this platform".into(),
+        ));
+    }
+    std::fs::create_dir_all(into)?;
+    run_rift(&["init", "--here", &from.to_string_lossy()])?;
+    let out = run_rift(&[
+        "create",
+        &from.to_string_lossy(),
+        "--name",
+        name,
+        "--into",
+        &into.to_string_lossy(),
+        "--copy-all",
+        "--no-hooks",
+    ])?;
+    let path = PathBuf::from(out.lines().last().unwrap_or(&out).trim());
+    if path.as_os_str().is_empty() {
+        return Err(EngineError::Other("rift create returned no path".into()));
+    }
+    Ok(path)
+}
+
+pub fn remove(path: &Path) -> Result<(), EngineError> {
+    if !supported() {
+        return Err(EngineError::Other(
+            "Rift is not available on this platform".into(),
+        ));
+    }
+    run_rift(&["remove", "--no-hooks", &path.to_string_lossy()])?;
+    Ok(())
+}

--- a/crates/engine/src/rpc.rs
+++ b/crates/engine/src/rpc.rs
@@ -21,7 +21,8 @@
 //! - Repos (§3.5): `ListRepos`, `AddRepo {path}`, `CloneRepo {url}`,
 //!   `CreateRepo {name}`, `ListBranches {repoPath}` (default branch first),
 //!   `ListFolders {path?}`, `CreateWorktree {repoPath, branch}`, `DeleteWorktree
-//!   {repoPath, worktreePath}`; `WatchCheckoutDiffs` → stream of `CheckoutDiff[]`
+//!   {repoPath, worktreePath}`, `GetCheckoutIsolation`, `SetCheckoutIsolation
+//!   {isolation}`; `WatchCheckoutDiffs` → stream of `CheckoutDiff[]`
 //! - Workspace files: lazy directory listing, recursive path search, bounded text
 //!   reads, hash-guarded writes, and a checkout-scoped filesystem change stream.
 //! - Terminals (§3.4): `OpenTerminal {chatId, cols, rows}` → `TerminalSession`,
@@ -224,6 +225,12 @@ struct DeleteWorktreeParams {
     repo_path: String,
     #[serde(alias = "path")]
     worktree_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetCheckoutIsolationParams {
+    isolation: zeron_proto::CheckoutIsolation,
 }
 
 #[derive(Debug, Deserialize)]
@@ -932,7 +939,7 @@ fn forwardable(method: &str) -> bool {
             | methods::REMOVE_QUEUED_MESSAGE
             | methods::SEND_QUEUED_MESSAGE_NOW
             | methods::STEER_QUEUED_MESSAGE_NOW
-            // Repos/worktrees/folders are device-local filesystem state.
+            // Repos/worktrees/folders/isolation are device-local filesystem state.
             | methods::LIST_REPOS
             | methods::ADD_REPO
             | methods::CLONE_REPO
@@ -954,6 +961,8 @@ fn forwardable(method: &str) -> bool {
             | methods::WATCH_WORKSPACE_FILES
             | methods::CREATE_WORKTREE
             | methods::DELETE_WORKTREE
+            | methods::GET_CHECKOUT_ISOLATION
+            | methods::SET_CHECKOUT_ISOLATION
             // Checkout diffs are produced on the device holding the checkout.
             | methods::WATCH_CHECKOUT_DIFFS
             | methods::WATCH_CHECKOUT_CHANGE_REQUEST
@@ -2123,6 +2132,15 @@ impl RpcService for EngineRpc {
                     .await
                     .map_err(|e| RpcError::Failed(e.to_string()))?;
                 RpcReply::value(&serde_json::json!({ "ok": true }))
+            }
+            methods::GET_CHECKOUT_ISOLATION => RpcReply::value(&self.repos.isolation_status()),
+            methods::SET_CHECKOUT_ISOLATION => {
+                let p: SetCheckoutIsolationParams = parse_params(params)?;
+                let status = self
+                    .repos
+                    .set_isolation(p.isolation)
+                    .map_err(|e| RpcError::Failed(e.to_string()))?;
+                RpcReply::value(&status)
             }
             methods::OPEN_TERMINAL => {
                 let p: OpenTerminalParams = parse_params(params)?;

--- a/crates/engine/src/workspace_host.rs
+++ b/crates/engine/src/workspace_host.rs
@@ -738,7 +738,7 @@ impl WorkspaceHost {
         {
             return Ok(space.id.clone());
         }
-        let root = linked_worktree_root(std::path::Path::new(path));
+        let root = isolated_checkout_root(std::path::Path::new(path));
         if let Some(root) = root.as_deref()
             && let Some(space) = spaces
                 .iter()
@@ -1254,6 +1254,18 @@ impl WorkspaceHostInner {
     }
 }
 
+/// Parent checkout root of an isolated session directory: a linked git
+/// worktree, or a Rift clone stamped with `.zeron-checkout.json`. `None` for a
+/// primary checkout (`.git` is a directory), a non-repo folder, or any other
+/// layout (bare-repo worktrees have no `<root>` working copy to attribute to).
+/// Pure fs reads — no git subprocess; this runs on the synchronous claim path.
+pub(crate) fn isolated_checkout_root(path: &std::path::Path) -> Option<String> {
+    if let Some(root) = crate::rift::source_root(path) {
+        return Some(root);
+    }
+    linked_worktree_root(path)
+}
+
 /// The parent checkout root of a linked git worktree: `<path>/.git` is a FILE
 /// containing `gitdir: <root>/.git/worktrees/<name>`. `None` for a primary
 /// checkout (`.git` is a directory), a non-repo folder, or any other layout
@@ -1565,7 +1577,7 @@ impl zeron_sync::RegistryTransport for WsDerivedRegistryTransport {
 
 #[cfg(test)]
 mod tests {
-    use super::{device_name_on_boot, linked_worktree_root};
+    use super::{device_name_on_boot, isolated_checkout_root, linked_worktree_root};
 
     #[tokio::test]
     async fn presence_publish_keeps_unchanged_lists_quiet_and_late_subscribers_current() {
@@ -1636,6 +1648,27 @@ mod tests {
         assert_eq!(
             device_name_on_boot(Some("Work laptop"), "MacBook Pro"),
             "Work laptop"
+        );
+    }
+
+    #[test]
+    fn rift_clone_resolves_to_the_source_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("proj");
+        let clone = dir.path().join("keen-raven");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&clone).unwrap();
+        std::fs::write(
+            clone.join(crate::rift::MARKER_FILE),
+            format!(
+                "{{\n  \"repoPath\": \"{}\",\n  \"isolation\": \"rift\"\n}}\n",
+                root.display()
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            isolated_checkout_root(&clone).as_deref(),
+            Some(root.to_str().unwrap())
         );
     }
 

--- a/crates/engine/tests/m5_repos_diffs_terminals.rs
+++ b/crates/engine/tests/m5_repos_diffs_terminals.rs
@@ -111,6 +111,59 @@ async fn drain_until(
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
+async fn checkout_isolation_rpc_defaults_to_git() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let core = assemble(&tmp.path().join("data"));
+    let client = zeron_rpc::memory_client(core.rpc_service());
+
+    let isolation = client
+        .call(methods::GET_CHECKOUT_ISOLATION, serde_json::json!({}))
+        .await
+        .expect("GetCheckoutIsolation");
+    assert_eq!(isolation["isolation"], "git");
+    assert!(isolation["riftSupported"].is_boolean());
+
+    let isolation = client
+        .call(
+            methods::SET_CHECKOUT_ISOLATION,
+            serde_json::json!({ "isolation": "git" }),
+        )
+        .await
+        .expect("SetCheckoutIsolation git");
+    assert_eq!(isolation["isolation"], "git");
+
+    if isolation["riftSupported"] == true {
+        let rift = client
+            .call(
+                methods::SET_CHECKOUT_ISOLATION,
+                serde_json::json!({ "isolation": "rift" }),
+            )
+            .await
+            .expect("SetCheckoutIsolation rift");
+        assert_eq!(rift["isolation"], "rift");
+        let git = client
+            .call(
+                methods::SET_CHECKOUT_ISOLATION,
+                serde_json::json!({ "isolation": "git" }),
+            )
+            .await
+            .expect("restore git");
+        assert_eq!(git["isolation"], "git");
+    } else {
+        assert!(
+            client
+                .call(
+                    methods::SET_CHECKOUT_ISOLATION,
+                    serde_json::json!({ "isolation": "rift" }),
+                )
+                .await
+                .is_err(),
+            "rift without the CLI must fail"
+        );
+    }
+}
+
+#[tokio::test]
 async fn repos_round_trip_add_branches_worktrees() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo_dir = tmp.path().join("myrepo");
@@ -195,6 +248,11 @@ async fn repos_round_trip_add_branches_worktrees() {
     );
     let plain_ref = by_name("feature/x");
     assert!(!plain_ref.current && plain_ref.worktree_path.is_none());
+    assert_eq!(worktree.isolation, zeron_proto::CheckoutIsolation::Git);
+    assert_eq!(
+        by_name(&worktree.branch).isolation,
+        zeron_proto::CheckoutIsolation::Git
+    );
 
     // Worktree checkout identity differs from the main checkout's.
     let main_identity = repos

--- a/crates/proto/src/entities.rs
+++ b/crates/proto/src/entities.rs
@@ -252,6 +252,10 @@ pub struct RepoRef {
     /// Path of the linked worktree this branch is checked out in, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_path: Option<String>,
+    /// How this checkout was created. Meaningful when [`Self::worktree_path`]
+    /// is set; omitted by older engines.
+    #[serde(default, skip_serializing_if = "CheckoutIsolation::is_git")]
+    pub isolation: CheckoutIsolation,
 }
 
 /// Public Git reference attached to a commit in the history graph.
@@ -331,6 +335,39 @@ pub struct Worktree {
     /// Canonical checkout identity (device-scoped hash of the git dir).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checkout_id: Option<String>,
+    /// Git worktree (default) or a Rift copy-on-write clone.
+    #[serde(default, skip_serializing_if = "CheckoutIsolation::is_git")]
+    pub isolation: CheckoutIsolation,
+}
+
+/// How this device materializes an isolated session checkout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum CheckoutIsolation {
+    /// `git worktree add` under `~/.zeron/worktrees` (the default).
+    #[default]
+    Git,
+    /// [Rift](https://github.com/anomalyco/rift) copy-on-write clone. Needs
+    /// btrfs, a reflink-capable Linux filesystem, or APFS.
+    Rift,
+}
+
+impl CheckoutIsolation {
+    pub fn is_git(&self) -> bool {
+        matches!(self, Self::Git)
+    }
+}
+
+/// This device's isolated-checkout setting, plus whether Rift can even be
+/// attempted on the platform.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckoutIsolationStatus {
+    pub isolation: CheckoutIsolation,
+    /// The `rift` CLI is present on this device. Does not mean the current
+    /// disk can actually clone; create still fails with a filesystem error
+    /// if it cannot.
+    pub rift_supported: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/proto/src/view.rs
+++ b/crates/proto/src/view.rs
@@ -606,6 +606,7 @@ mod checkout_tests {
             name: name.into(),
             current: false,
             worktree_path: None,
+            isolation: crate::CheckoutIsolation::Git,
         }
     }
 
@@ -614,6 +615,7 @@ mod checkout_tests {
             name: name.into(),
             current: false,
             worktree_path: Some(path.into()),
+            isolation: crate::CheckoutIsolation::Git,
         }
     }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -157,6 +157,10 @@ pub mod methods {
     pub const WATCH_WORKSPACE_FILES: &str = "WatchWorkspaceFiles";
     pub const CREATE_WORKTREE: &str = "CreateWorktree";
     pub const DELETE_WORKTREE: &str = "DeleteWorktree";
+    /// This device's isolated-checkout backend (git worktrees or Rift).
+    pub const GET_CHECKOUT_ISOLATION: &str = "GetCheckoutIsolation";
+    /// Persist the isolated-checkout backend. `{ isolation: "git" | "rift" }`.
+    pub const SET_CHECKOUT_ISOLATION: &str = "SetCheckoutIsolation";
     // Terminals (ControlRpc, relay-forwardable; SubscribeTerminal streams).
     pub const OPEN_TERMINAL: &str = "OpenTerminal";
     pub const SUBSCRIBE_TERMINAL: &str = "SubscribeTerminal";

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -24,6 +24,7 @@ pub mod harnesses;
 pub mod notifications;
 pub mod shortcuts;
 pub mod widgets;
+pub mod worktrees;
 
 /// Sidebar drag-resize bounds (px).
 pub const SIDEBAR_MIN: f32 = 208.0;

--- a/crates/ui/src/settings/worktrees.rs
+++ b/crates/ui/src/settings/worktrees.rs
@@ -1,0 +1,728 @@
+//! Settings → Worktrees: inspect and remove isolated session checkouts on
+//! each registered device, and pick git worktrees or Rift as the backend.
+
+use gpui::{
+    AnyElement, Context, Entity, IntoElement, Render, SharedString, Task, Window, div, prelude::*,
+    px,
+};
+
+use zeron_proto::{Chat, CheckoutIsolation, CheckoutIsolationStatus, Repo, RepoRef, Space};
+use zeron_rpc::methods;
+
+use crate::popover::{self, Loadable};
+use crate::settings::widgets;
+use crate::state::AppState;
+use crate::theme::Theme;
+
+#[derive(Debug, Clone)]
+struct WorktreeRow {
+    repo_path: String,
+    repo_name: String,
+    branch: String,
+    path: String,
+    isolation: CheckoutIsolation,
+}
+
+pub struct WorktreesPage {
+    state: Entity<AppState>,
+    worktrees: Loadable<Vec<WorktreeRow>>,
+    isolation: Loadable<CheckoutIsolationStatus>,
+    target_device: Option<String>,
+    device_menu_open: bool,
+    device_menu_pressed_open: bool,
+    confirm_delete: Option<String>,
+    busy: Option<String>,
+    error: Option<String>,
+    load_task: Option<Task<()>>,
+    delete_task: Option<Task<()>>,
+    isolation_task: Option<Task<()>>,
+}
+
+impl WorktreesPage {
+    fn repos_from_spaces(spaces: &[Space], device_id: Option<&str>) -> Vec<Repo> {
+        let mut seen = std::collections::HashSet::new();
+        spaces
+            .iter()
+            .filter(|space| {
+                space.git_detected
+                    && device_id.is_some_and(|device_id| space.device_id == device_id)
+                    && seen.insert(space.path.clone())
+            })
+            .map(|space| Repo {
+                path: space.path.clone(),
+                name: space.display_name().to_owned(),
+                default_branch: None,
+            })
+            .collect()
+    }
+
+    pub fn new(state: Entity<AppState>, cx: &mut Context<Self>) -> Self {
+        let mut page = Self {
+            state,
+            worktrees: Loadable::Idle,
+            isolation: Loadable::Idle,
+            target_device: None,
+            device_menu_open: false,
+            device_menu_pressed_open: false,
+            confirm_delete: None,
+            busy: None,
+            error: None,
+            load_task: None,
+            delete_task: None,
+            isolation_task: None,
+        };
+        page.load(cx);
+        page
+    }
+
+    fn with_target(target: Option<&str>, mut value: serde_json::Value) -> serde_json::Value {
+        if let (Some(target), Some(object)) = (target, value.as_object_mut()) {
+            object.insert("targetDeviceId".into(), serde_json::json!(target));
+        }
+        value
+    }
+
+    fn set_target_device(&mut self, target: Option<String>, cx: &mut Context<Self>) {
+        self.device_menu_open = false;
+        if self.target_device == target {
+            cx.notify();
+            return;
+        }
+        self.target_device = target;
+        self.confirm_delete = None;
+        self.error = None;
+        self.worktrees = Loadable::Idle;
+        self.isolation = Loadable::Idle;
+        self.load(cx);
+        cx.notify();
+    }
+
+    fn load(&mut self, cx: &mut Context<Self>) {
+        let Some(engine) = self.state.read(cx).engine().cloned() else {
+            self.worktrees = Loadable::Error("Engine not connected".into());
+            cx.notify();
+            return;
+        };
+        let target = self.target_device.clone();
+        let space_repos = {
+            let state = self.state.read(cx);
+            let device_id = target.as_deref().or(state.local_device_id.as_deref());
+            Self::repos_from_spaces(&state.spaces, device_id)
+        };
+        self.error = None;
+        self.worktrees = Loadable::Loading;
+        self.isolation = Loadable::Loading;
+        self.load_isolation(cx);
+        self.load_task = Some(cx.spawn(async move |this, cx| {
+            let result: Result<Vec<WorktreeRow>, String> = async {
+                let value = engine
+                    .client()
+                    .call(
+                        methods::LIST_REPOS,
+                        Self::with_target(target.as_deref(), serde_json::json!({})),
+                    )
+                    .await
+                    .map_err(|err| err.to_string())?;
+                let mut repos = serde_json::from_value::<Vec<Repo>>(value)
+                    .map_err(|err| format!("Could not decode repositories: {err}"))?;
+                let mut paths = repos
+                    .iter()
+                    .map(|repo| repo.path.clone())
+                    .collect::<std::collections::HashSet<_>>();
+                repos.extend(
+                    space_repos
+                        .into_iter()
+                        .filter(|repo| paths.insert(repo.path.clone())),
+                );
+                let mut rows = Vec::new();
+                for repo in repos {
+                    let value = engine
+                        .client()
+                        .call(
+                            methods::LIST_REFS,
+                            Self::with_target(
+                                target.as_deref(),
+                                serde_json::json!({ "repoPath": repo.path }),
+                            ),
+                        )
+                        .await
+                        .map_err(|err| format!("{}: {err}", repo.name))?;
+                    let refs = serde_json::from_value::<Vec<RepoRef>>(value)
+                        .map_err(|err| format!("Could not decode refs for {}: {err}", repo.name))?;
+                    rows.extend(refs.into_iter().filter_map(|git_ref| {
+                        git_ref.worktree_path.map(|path| WorktreeRow {
+                            repo_path: repo.path.clone(),
+                            repo_name: repo.name.clone(),
+                            branch: git_ref.name,
+                            isolation: git_ref.isolation,
+                            path,
+                        })
+                    }));
+                }
+                rows.sort_by(|a, b| {
+                    a.repo_name
+                        .cmp(&b.repo_name)
+                        .then_with(|| a.branch.cmp(&b.branch))
+                        .then_with(|| a.path.cmp(&b.path))
+                });
+                Ok(rows)
+            }
+            .await;
+            this.update(cx, |page, cx| {
+                page.worktrees = match result {
+                    Ok(rows) => Loadable::Ready(rows),
+                    Err(err) => Loadable::Error(err),
+                };
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    fn load_isolation(&mut self, cx: &mut Context<Self>) {
+        let Some(engine) = self.state.read(cx).engine().cloned() else {
+            self.isolation = Loadable::Error("Engine not connected".into());
+            return;
+        };
+        let params = Self::with_target(self.target_device.as_deref(), serde_json::json!({}));
+        self.isolation_task = Some(cx.spawn(async move |this, cx| {
+            let result = engine
+                .client()
+                .call(methods::GET_CHECKOUT_ISOLATION, params)
+                .await;
+            this.update(cx, |page, cx| {
+                page.isolation = match result {
+                    Ok(value) => match serde_json::from_value::<CheckoutIsolationStatus>(value) {
+                        Ok(status) => Loadable::Ready(status),
+                        Err(err) => Loadable::Error(format!("Could not decode isolation: {err}")),
+                    },
+                    Err(err) => Loadable::Error(err.to_string()),
+                };
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    fn set_rift(&mut self, enabled: bool, cx: &mut Context<Self>) {
+        let Some(engine) = self.state.read(cx).engine().cloned() else {
+            self.error = Some("Engine not connected".into());
+            cx.notify();
+            return;
+        };
+        let isolation = if enabled {
+            CheckoutIsolation::Rift
+        } else {
+            CheckoutIsolation::Git
+        };
+        let params = Self::with_target(
+            self.target_device.as_deref(),
+            serde_json::json!({ "isolation": isolation }),
+        );
+        self.error = None;
+        self.isolation_task = Some(cx.spawn(async move |this, cx| {
+            let result = engine
+                .client()
+                .call(methods::SET_CHECKOUT_ISOLATION, params)
+                .await;
+            this.update(cx, |page, cx| {
+                match result {
+                    Ok(value) => match serde_json::from_value::<CheckoutIsolationStatus>(value) {
+                        Ok(status) => page.isolation = Loadable::Ready(status),
+                        Err(err) => page.error = Some(format!("Could not decode isolation: {err}")),
+                    },
+                    Err(err) => page.error = Some(err.to_string()),
+                }
+                cx.notify();
+            })
+            .ok();
+        }));
+        cx.notify();
+    }
+
+    fn delete(&mut self, row: WorktreeRow, cx: &mut Context<Self>) {
+        if self.confirm_delete.as_deref() != Some(row.path.as_str()) {
+            self.confirm_delete = Some(row.path);
+            cx.notify();
+            return;
+        }
+        let Some(engine) = self.state.read(cx).engine().cloned() else {
+            self.error = Some("Engine not connected".into());
+            cx.notify();
+            return;
+        };
+        let target = self.target_device.clone();
+        let path = row.path.clone();
+        let params = Self::with_target(
+            target.as_deref(),
+            serde_json::json!({
+                "repoPath": row.repo_path,
+                "worktreePath": row.path,
+            }),
+        );
+        self.busy = Some(path);
+        self.error = None;
+        self.delete_task = Some(cx.spawn(async move |this, cx| {
+            let result = engine.client().call(methods::DELETE_WORKTREE, params).await;
+            this.update(cx, |page, cx| {
+                page.busy = None;
+                match result {
+                    Ok(_) => {
+                        page.confirm_delete = None;
+                        page.load(cx);
+                    }
+                    Err(err) => page.error = Some(format!("Delete failed: {err}")),
+                }
+                cx.notify();
+            })
+            .ok();
+        }));
+        cx.notify();
+    }
+
+    fn effective_device_id(&self, cx: &Context<Self>) -> Option<String> {
+        self.target_device
+            .clone()
+            .or_else(|| self.state.read(cx).local_device_id.clone())
+    }
+
+    fn chat_uses_worktree(chat: &Chat, path: &str) -> bool {
+        let worktree = std::path::Path::new(path);
+        chat.cwd
+            .as_deref()
+            .is_some_and(|cwd| std::path::Path::new(cwd).starts_with(worktree))
+            || chat
+                .harness_session_cwd
+                .as_deref()
+                .is_some_and(|cwd| std::path::Path::new(cwd).starts_with(worktree))
+    }
+
+    fn usage(
+        &self,
+        path: &str,
+        cx: &Context<Self>,
+    ) -> (usize, Option<chrono::DateTime<chrono::Utc>>) {
+        let device_id = self.effective_device_id(cx);
+        let state = self.state.read(cx);
+        let mut count = 0usize;
+        let mut latest: Option<chrono::DateTime<chrono::Utc>> = None;
+        for chat in &state.chats {
+            if device_id.as_deref() != Some(chat.device_id.as_str())
+                || !Self::chat_uses_worktree(chat, path)
+            {
+                continue;
+            }
+            count += 1;
+            let used = chat.last_message_at.unwrap_or(chat.created_at);
+            latest = Some(latest.map_or(used, |current| current.max(used)));
+        }
+        (count, latest)
+    }
+
+    fn render_device_switcher(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+        use crate::icons::{self, icon};
+        let (mut devices, local_id) = {
+            let state = self.state.read(cx);
+            (state.devices.clone(), state.local_device_id.clone())
+        };
+        devices.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        let effective = self.target_device.clone().or_else(|| local_id.clone());
+        let selected = devices
+            .iter()
+            .find(|device| Some(device.id.as_str()) == effective.as_deref())
+            .cloned();
+        let platform_glyph = |platform: &str| match platform {
+            "macos" | "darwin" => icons::LAPTOP,
+            "ios" | "android" => icons::SMARTPHONE,
+            _ => icons::MONITOR,
+        };
+        let trigger_glyph = platform_glyph(
+            selected
+                .as_ref()
+                .map(|device| device.platform.as_str())
+                .unwrap_or("macos"),
+        );
+        let trigger_label: SharedString = selected
+            .as_ref()
+            .map(|device| device.name.clone().into())
+            .unwrap_or_else(|| SharedString::from("This device"));
+        let open = self.device_menu_open;
+        let mut trigger = div()
+            .id("worktrees-device-switcher")
+            .flex_none()
+            .h(px(28.0))
+            .px(px(8.0))
+            .rounded(px(6.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(6.0))
+            .cursor_pointer()
+            .bg(if open {
+                crate::theme::ink(0.06)
+            } else {
+                gpui::transparent_black()
+            })
+            .when(!open, |el| {
+                el.hover(|style| style.bg(crate::theme::ink(0.04)))
+            })
+            .on_mouse_down(
+                gpui::MouseButton::Left,
+                cx.listener(|this, _, _, _| {
+                    this.device_menu_pressed_open = this.device_menu_open;
+                }),
+            )
+            .on_click(cx.listener(|this, _, _, cx| {
+                let pressed_open = std::mem::take(&mut this.device_menu_pressed_open);
+                this.device_menu_open = !pressed_open && !this.device_menu_open;
+                cx.notify();
+            }))
+            .child(
+                icon(trigger_glyph)
+                    .size(px(16.0))
+                    .flex_none()
+                    .text_color(theme.text_muted),
+            )
+            .child(
+                div()
+                    .min_w_0()
+                    .truncate()
+                    .text_size(crate::typography::ui_rems(12.5))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_color(theme.text)
+                    .child(trigger_label),
+            )
+            .child(
+                icon(icons::SORT_VERTICAL)
+                    .size(px(14.0))
+                    .flex_none()
+                    .text_color(theme.text_muted.opacity(if open { 0.9 } else { 0.4 })),
+            );
+
+        if open {
+            let menu = popover::popover_card(theme)
+                .w(px(220.0))
+                .on_mouse_down_out(cx.listener(|this, _, _, cx| {
+                    this.device_menu_open = false;
+                    cx.notify();
+                }))
+                .flex()
+                .flex_col()
+                .gap(px(2.0))
+                .child(popover::menu_heading(theme, "Devices"))
+                .children(devices.into_iter().enumerate().map(|(ix, device)| {
+                    let is_active = Some(device.id.as_str()) == effective.as_deref();
+                    let is_local = local_id.as_deref() == Some(device.id.as_str());
+                    let glyph = platform_glyph(&device.platform);
+                    let name: SharedString = device.name.clone().into();
+                    let pick_id = device.id.clone();
+                    popover::menu_row(theme, is_active, format!("worktrees-device-row-{ix}"))
+                        .id(("worktrees-device-row", ix))
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.set_target_device((!is_local).then(|| pick_id.clone()), cx);
+                        }))
+                        .child(
+                            icon(glyph)
+                                .size(px(16.0))
+                                .flex_none()
+                                .text_color(theme.text_muted),
+                        )
+                        .child(div().flex_1().min_w_0().truncate().child(name))
+                }))
+                .into_any_element();
+            trigger = trigger.child(popover::anchored_menu("worktrees-device-menu", menu, None));
+        }
+        trigger.into_any_element()
+    }
+
+    fn rows(&mut self, cx: &mut Context<Self>) -> Vec<AnyElement> {
+        let theme = Theme::of(cx).clone();
+        let Loadable::Ready(rows) = &self.worktrees else {
+            return Vec::new();
+        };
+        let rows = rows.clone();
+        let now = chrono::Utc::now();
+        rows.into_iter()
+            .enumerate()
+            .map(|(ix, row)| {
+                let (session_count, latest) = self.usage(&row.path, cx);
+                let confirmed = self.confirm_delete.as_deref() == Some(row.path.as_str());
+                let busy = self.busy.as_deref() == Some(row.path.as_str());
+                let mut meta = vec![
+                    div()
+                        .child(SharedString::from(row.repo_name.clone()))
+                        .into_any_element(),
+                    div()
+                        .child(SharedString::from(match row.isolation {
+                            CheckoutIsolation::Rift => "Rift",
+                            CheckoutIsolation::Git => "Git worktree",
+                        }))
+                        .into_any_element(),
+                    div()
+                        .child(SharedString::from(row.path.clone()))
+                        .into_any_element(),
+                ];
+                if let Some(latest) = latest {
+                    meta.push(
+                        div()
+                            .child(SharedString::from(format!(
+                                "last used {}",
+                                crate::state::format_time_ago(latest, now)
+                            )))
+                            .into_any_element(),
+                    );
+                }
+                let action_row = row.clone();
+                let action = widgets::ghost_action(&theme)
+                    .id(("worktree-delete", ix))
+                    .when(!busy, |el| {
+                        el.hover(|style| widgets::ghost_hover(&theme, style))
+                    })
+                    .when(confirmed, |el| el.text_color(theme.danger_muted))
+                    .when(!busy, |el| {
+                        el.on_click(cx.listener(move |this, _, _, cx| {
+                            this.delete(action_row.clone(), cx);
+                        }))
+                    })
+                    .child(
+                        crate::icons::icon(crate::icons::TRASH_BIN_MINIMALISTIC)
+                            .size(px(14.0))
+                            .text_color(if confirmed {
+                                theme.danger_muted
+                            } else {
+                                theme.text_muted
+                            }),
+                    )
+                    .child(SharedString::from(if busy {
+                        "Deleting…"
+                    } else if confirmed {
+                        "Confirm delete"
+                    } else {
+                        "Delete"
+                    }));
+
+                widgets::card_row(&theme, ix == 0)
+                    .child(widgets::row_tile(&theme, crate::icons::FOLDER_WITH_FILES))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .flex()
+                            .flex_col()
+                            .child(widgets::row_title(&theme, row.branch.clone()))
+                            .child(widgets::meta_line(&theme, meta)),
+                    )
+                    .child(if session_count == 0 {
+                        widgets::badge(&theme, "Unused").into_any_element()
+                    } else {
+                        widgets::badge(
+                            &theme,
+                            if session_count == 1 {
+                                "1 session".to_string()
+                            } else {
+                                format!("{session_count} sessions")
+                            },
+                        )
+                        .into_any_element()
+                    })
+                    .child(action)
+                    .into_any_element()
+            })
+            .collect()
+    }
+
+    fn render_isolation_card(&mut self, theme: &Theme, cx: &mut Context<Self>) -> AnyElement {
+        let (rift_on, rift_supported, isolation_error) = match &self.isolation {
+            Loadable::Ready(status) => (
+                status.isolation == CheckoutIsolation::Rift,
+                status.rift_supported,
+                None,
+            ),
+            Loadable::Error(message) => (false, false, Some(message.clone())),
+            Loadable::Idle | Loadable::Loading => (false, false, None),
+        };
+        let interactive = isolation_error.is_none() && (rift_on || rift_supported);
+        let description = if let Some(message) = isolation_error {
+            message
+        } else if rift_supported {
+            "Use Rift instead of git worktrees for new isolated sessions. Existing checkouts stay as they are. Needs btrfs, a Linux filesystem with reflinks, or APFS. On btrfs, the first clone converts the project folder into a subvolume.".into()
+        } else {
+            "Install the rift CLI to enable this. Needs btrfs, a Linux filesystem with reflinks, or APFS. New isolated sessions keep using git worktrees until then.".into()
+        };
+        widgets::section_card(theme)
+            .child(
+                widgets::card_row(theme, true)
+                    .child(widgets::row_tile(theme, crate::icons::FOLDER_WITH_FILES))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .flex()
+                            .flex_col()
+                            .child(widgets::row_title(theme, "Use Rift"))
+                            .child(widgets::meta_line(
+                                theme,
+                                vec![div().child(description).into_any_element()],
+                            )),
+                    )
+                    .child(
+                        widgets::toggle_switch(theme, rift_on)
+                            .id("worktrees-rift-toggle")
+                            .when(interactive, |el| {
+                                el.cursor_pointer()
+                                    .on_click(cx.listener(move |this, _, _, cx| {
+                                        this.set_rift(!rift_on, cx);
+                                    }))
+                            }),
+                    ),
+            )
+            .into_any_element()
+    }
+}
+
+impl Render for WorktreesPage {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = Theme::of(cx).clone();
+        let count = match &self.worktrees {
+            Loadable::Ready(rows) => Some(rows.len()),
+            _ => None,
+        };
+        let body: AnyElement = match &self.worktrees {
+            Loadable::Idle | Loadable::Loading => widgets::section_card(&theme)
+                .p(px(16.0))
+                .child(popover::skeleton_rows(
+                    "worktrees-skeleton",
+                    &theme,
+                    4,
+                    cx.entity_id(),
+                    cx,
+                ))
+                .into_any_element(),
+            Loadable::Error(message) => div()
+                .child(widgets::error_strip(&theme, message.clone()))
+                .child(
+                    widgets::ghost_action(&theme)
+                        .id("worktrees-retry")
+                        .mt(px(8.0))
+                        .hover(|style| widgets::ghost_hover(&theme, style))
+                        .on_click(cx.listener(|page, _, _, cx| page.load(cx)))
+                        .child(SharedString::from("Retry")),
+                )
+                .into_any_element(),
+            Loadable::Ready(rows) if rows.is_empty() => widgets::section_card(&theme)
+                .p(px(20.0))
+                .text_size(crate::typography::ui_rems(13.0))
+                .text_color(theme.text_muted)
+                .child(SharedString::from("No isolated checkouts on this device."))
+                .into_any_element(),
+            Loadable::Ready(_) => widgets::section_card(&theme)
+                .children(self.rows(cx))
+                .into_any_element(),
+        };
+        let error = self
+            .error
+            .clone()
+            .map(|message| widgets::error_strip(&theme, message).into_any_element());
+        let switcher = self.render_device_switcher(&theme, cx);
+        let isolation_card = self.render_isolation_card(&theme, cx);
+
+        div()
+            .id("worktrees-page")
+            .size_full()
+            .overflow_y_scroll()
+            .child(
+                widgets::page_column()
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .justify_between()
+                            .child(widgets::page_header(&theme, "Worktrees", count))
+                            .child(
+                                div()
+                                    .flex()
+                                    .flex_row()
+                                    .items_center()
+                                    .gap(px(6.0))
+                                    .child(
+                                        widgets::ghost_action(&theme)
+                                            .id("worktrees-refresh")
+                                            .hover(|style| widgets::ghost_hover(&theme, style))
+                                            .on_click(cx.listener(|page, _, _, cx| page.load(cx)))
+                                            .child(
+                                                crate::icons::icon(crate::icons::REFRESH)
+                                                    .size(px(14.0)),
+                                            )
+                                            .child(SharedString::from("Refresh")),
+                                    )
+                                    .child(switcher),
+                            ),
+                    )
+                    .child(
+                        widgets::page_subtitle(
+                            &theme,
+                            "Isolated session checkouts can accumulate as sessions create them. \
+                             Git worktrees are the default. Rift is an optional copy-on-write clone \
+                             for filesystems that can do it.",
+                        )
+                        .max_w(px(560.0))
+                        .line_height(px(20.0)),
+                    )
+                    .child(isolation_card)
+                    .children(error)
+                    .child(body),
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+
+    fn space(device_id: &str, path: &str, git_detected: bool) -> Space {
+        Space {
+            id: format!("{device_id}:{path}"),
+            device_id: device_id.to_owned(),
+            path: path.to_owned(),
+            name: None,
+            git_detected,
+            git_checked_at: None,
+            checkout_id: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn worktree_discovery_uses_git_spaces_for_the_selected_device() {
+        let spaces = vec![
+            space("omicron", "/code/AbiNotes", true),
+            space("omicron", "/code/not-a-repo", false),
+            space("phone", "/code/mobile", true),
+        ];
+
+        let repos = WorktreesPage::repos_from_spaces(&spaces, Some("omicron"));
+
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].path, "/code/AbiNotes");
+        assert_eq!(repos[0].name, "AbiNotes");
+    }
+
+    #[test]
+    fn worktree_discovery_deduplicates_spaces_by_path() {
+        let spaces = vec![
+            space("omicron", "/code/AbiNotes", true),
+            space("omicron", "/code/AbiNotes", true),
+        ];
+
+        let repos = WorktreesPage::repos_from_spaces(&spaces, Some("omicron"));
+
+        assert_eq!(repos.len(), 1);
+    }
+}

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -43,6 +43,7 @@ use crate::settings::files::{FilesSettingsEvent, FilesSettingsPage};
 use crate::settings::harnesses::HarnessesPage;
 use crate::settings::notifications::{NotificationsEvent, NotificationsPage};
 use crate::settings::shortcuts::{ShortcutsEvent, ShortcutsPage};
+use crate::settings::worktrees::WorktreesPage;
 use crate::settings::{
     self, CHAT_PANEL_MIN, ComposerSendBehavior, JUMP_SLOTS, KeymapConfig, RIGHT_PANE_DEFAULT,
     RIGHT_PANE_MIN, SIDEBAR_DEFAULT, SIDEBAR_MAX, SIDEBAR_MIN, SavePolicy, ShortcutId,
@@ -391,11 +392,12 @@ pub enum SettingsSection {
     Files,
     Notifications,
     Shortcuts,
+    Worktrees,
     Archived,
 }
 
 impl SettingsSection {
-    pub const ALL: [SettingsSection; 8] = [
+    pub const ALL: [SettingsSection; 9] = [
         SettingsSection::Devices,
         SettingsSection::Harnesses,
         SettingsSection::Agents,
@@ -403,6 +405,7 @@ impl SettingsSection {
         SettingsSection::Files,
         SettingsSection::Notifications,
         SettingsSection::Shortcuts,
+        SettingsSection::Worktrees,
         SettingsSection::Archived,
     ];
 
@@ -417,6 +420,7 @@ impl SettingsSection {
             SettingsSection::Files => "Files",
             SettingsSection::Notifications => "Notifications",
             SettingsSection::Shortcuts => "Shortcuts",
+            SettingsSection::Worktrees => "Worktrees",
             SettingsSection::Archived => "Archived sessions",
         }
     }
@@ -1196,6 +1200,7 @@ pub struct Shell {
     shortcuts_page: Option<Entity<ShortcutsPage>>,
     accounts_page: Option<Entity<AccountsPage>>,
     harnesses_page: Option<Entity<HarnessesPage>>,
+    worktrees_page: Option<Entity<WorktreesPage>>,
     shortcuts_sub: Option<Subscription>,
     notifications_sub: Option<Subscription>,
     files_settings_sub: Option<Subscription>,
@@ -1447,6 +1452,7 @@ impl Shell {
             Some("settings/appearance") => Route::Settings(SettingsSection::Appearance),
             Some("settings/notifications") => Route::Settings(SettingsSection::Notifications),
             Some("settings/shortcuts") => Route::Settings(SettingsSection::Shortcuts),
+            Some("settings/worktrees") => Route::Settings(SettingsSection::Worktrees),
             Some("settings/archived") => Route::Settings(SettingsSection::Archived),
             // `new` pins the new-chat canvas (suppresses boot auto-select).
             Some("new") => {
@@ -1537,6 +1543,7 @@ impl Shell {
             shortcuts_page: None,
             accounts_page: None,
             harnesses_page: None,
+            worktrees_page: None,
             shortcuts_sub: None,
             notifications_sub: None,
             files_settings_sub: None,
@@ -3318,6 +3325,16 @@ impl Shell {
                     None => Empty.into_any_element(),
                 }
             }
+            SettingsSection::Worktrees => {
+                if self.worktrees_page.is_none() {
+                    let state = self.state.clone();
+                    self.worktrees_page = Some(cx.new(|cx| WorktreesPage::new(state, cx)));
+                }
+                match &self.worktrees_page {
+                    Some(page) => page.clone().into_any_element(),
+                    None => Empty.into_any_element(),
+                }
+            }
             SettingsSection::Archived => {
                 if self.archived_page.is_none() {
                     let state = self.state.clone();
@@ -4585,6 +4602,7 @@ impl Shell {
             SettingsSection::Files => icons::FOLDER,
             SettingsSection::Notifications => icons::BELL,
             SettingsSection::Shortcuts => icons::KEYBOARD,
+            SettingsSection::Worktrees => icons::FOLDER_WITH_FILES,
             SettingsSection::Archived => icons::ARCHIVE_MINIMALISTIC,
         };
         // Match the user's dragged sidebar width — the pane container clips to


### PR DESCRIPTION
Grok 4.6 in Grok Build TUI responding on behalf of Mine13zoom.

## Summary

Git worktrees stay the default for isolated sessions. This adds a Settings → Worktrees page with a **Use Rift** toggle so a device can switch *new* isolated checkouts to [Rift](https://github.com/anomalyco/rift) copy-on-write clones.

Rift is still experimental. It is a CoW directory clone (btrfs snapshots, Linux reflinks, or APFS `clonefile`), not a linked git worktree. Comet talks to the `rift` CLI rather than linking the crate, because Rift's rusqlite cannot share a binary with Comet's.

- Default remains `git worktree add` under `~/.zeron/worktrees/<repo>/<name>` on a `zeron/<name>` branch.
- The host reads the per-device setting when a run carries a `WorktreeSpec`. Existing sessions keep whatever checkout they already have.
- A Rift clone lands in the same worktrees root, gets `.zeron-checkout.json` so Comet can attribute it back to the source repo, then `git checkout -B zeron/<name> <base>` inside the clone.
- The settings page lists and deletes both git worktrees and Rift clones. The toggle stays off unless the `rift` CLI is on PATH.
- First create on btrfs can convert the project folder into a subvolume. The settings copy says that.

## Test plan

- [x] `cargo test -p zeron-engine --lib -- checkout_isolation git_worktree_create rift_clone`
- [x] `cargo test -p zeron-engine --test m5_repos_diffs_terminals -- checkout_isolation_rpc_defaults_to_git`
- [x] `cargo test -p zeron-engine --test worktree_on_run` on the originating branch (git-worktree host materialize + reuse)
- [ ] Live Rift create on btrfs / APFS / a reflink-capable Linux filesystem. This machine is ext4, so create is expected to fail there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791671383&installation_model_id=425430&pr_number=315&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F315&signature=3e430c7df4a499443886fd6836892156b4acb8cf0be108a7c2e05ecd10016d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->