### PR TITLE
Persist session updates across eviction and shutdown

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -34,6 +34,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  session-sync-regressions:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+      - uses: Swatinem/rust-cache@v2
+      - name: Durable session publication and recovery
+        run: |
+          cargo test --locked -p zeron-sync --lib
+          cargo test --locked -p zeron-engine --lib --test session_publication --test restart_resume --test codex_subagents --test local_profiles
+
   ui-tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/crates/engine/src/chat2_host.rs
+++ b/crates/engine/src/chat2_host.rs
@@ -74,6 +74,43 @@ impl EngineChatSink {
 }
 
 impl ChatDocSink for EngineChatSink {
+    fn pending_updates(&self) -> Result<Vec<(String, Vec<u8>)>, String> {
+        let rejected = self
+            .store
+            .rejected_chat_updates(&self.chat_id)
+            .map_err(|e| e.to_string())?;
+        let pending = self
+            .store
+            .pending_chat_updates(&self.chat_id)
+            .map_err(|e| e.to_string())?;
+        let mut updates = Vec::new();
+        for (id, bytes) in pending {
+            if bytes.len() > zeron_sync::chat_client::MAX_PUSH_BYTES {
+                self.store
+                    .reject_chat_update(&self.chat_id, &id)
+                    .map_err(|e| e.to_string())?;
+            } else if !rejected.iter().any(|(r, _)| r == &id) {
+                updates.push((id, bytes));
+            }
+        }
+        Ok(updates)
+    }
+    fn reject_update(&self, batch_id: &str) -> Result<(), String> {
+        self.store
+            .reject_chat_update(&self.chat_id, batch_id)
+            .map_err(|e| e.to_string())
+    }
+    fn persist_update(&self, batch_id: &str, bytes: &[u8]) -> Result<(), String> {
+        self.store
+            .enqueue_chat_update(&self.chat_id, batch_id, bytes)
+            .map_err(|e| e.to_string())
+    }
+    fn acknowledge_update(&self, batch_id: &str) -> Result<(), String> {
+        self.store
+            .acknowledge_chat_update(&self.chat_id, batch_id)
+            .map_err(|e| e.to_string())
+    }
+
     fn apply_row(&self, bytes: &[u8], cursor: u64) -> RowImportOutcome {
         let Some(doc) = self.doc.upgrade() else {
             return RowImportOutcome::Applied;
@@ -454,4 +491,41 @@ mod tests {
                 .is_none()
         );
     }
+}
+
+/// Replay a legacy document in bounded rows. Splitting by operation range
+/// preserves IDs; Loro safely parks cross-peer dependencies until replay completes.
+pub(crate) fn publication_updates(doc: &loro::LoroDoc) -> Result<Vec<Vec<u8>>, String> {
+    fn split(
+        doc: &loro::LoroDoc,
+        peer: u64,
+        start: i32,
+        end: i32,
+        out: &mut Vec<Vec<u8>>,
+    ) -> Result<(), String> {
+        let bytes = doc
+            .export(loro::ExportMode::updates_in_range(vec![loro::IdSpan::new(
+                peer, start, end,
+            )]))
+            .map_err(|e| e.to_string())?;
+        if bytes.len() <= zeron_sync::chat_client::MAX_PUSH_BYTES || end - start <= 1 {
+            // An indivisible oversized op remains durable until checkpointed.
+            out.push(bytes);
+        } else {
+            let middle = start + (end - start) / 2;
+            split(doc, peer, start, middle, out)?;
+            split(doc, peer, middle, end, out)?;
+        }
+        Ok(())
+    }
+    let mut out = Vec::new();
+    let vv = doc.oplog_vv();
+    let mut peers: Vec<_> = vv.iter().collect();
+    peers.sort_by_key(|(peer, _)| **peer);
+    for (&peer, &end) in peers {
+        if end > 0 {
+            split(doc, peer, 0, end, &mut out)?;
+        }
+    }
+    Ok(out)
 }

--- a/crates/engine/src/doc_host.rs
+++ b/crates/engine/src/doc_host.rs
@@ -227,9 +227,12 @@ struct DocHostInner {
     /// runtime replacement, where Edge-capable tasks must stop doing
     /// network work even while something still pins the graph.
     shutdown: CancellationToken,
+    edge_disconnected: AtomicBool,
     /// Tracks every spawned worker so `shutdown_workers` can await them.
     tasks: TaskTracker,
     handles: Mutex<HashMap<String, Arc<ChatDocHandle>>>,
+    /// Serialize cold opens without blocking access to already-live handles.
+    opening: Mutex<()>,
     /// chat2 seeds in flight (one per chat — reopen storms must not race
     /// duplicate rebuild+checkpoint POSTs; benign server-side, wasteful).
     seeding: Mutex<HashSet<String>>,
@@ -530,7 +533,8 @@ pub struct ChatDocHandle {
     /// to a minute; offline, forever): buffered here by the subscription
     /// below and drained into the client on join (review B3 — a user
     /// message typed during the dial must not silently never sync).
-    chat2_pending_local: Mutex<Vec<Vec<u8>>>,
+    chat2_pending_local: Mutex<Vec<(String, Vec<u8>)>>,
+    publication_failed: AtomicBool,
     /// Local-update feed into the chat2 client (drop = unsubscribe).
     chat2_local_sub: Mutex<Option<loro::Subscription>>,
     /// Doc subscription (drop = unsubscribe) — bumps the change watch on every commit.
@@ -706,8 +710,10 @@ impl DocHost {
                 workspace: OnceLock::new(),
                 repos: OnceLock::new(),
                 shutdown: CancellationToken::new(),
+                edge_disconnected: AtomicBool::new(false),
                 tasks: TaskTracker::new(),
                 handles: Mutex::new(HashMap::new()),
+                opening: Mutex::new(()),
                 seeding: Mutex::new(HashSet::new()),
                 seed_waiting: Mutex::new(HashSet::new()),
                 drain_waiting: Mutex::new(HashSet::new()),
@@ -1082,6 +1088,11 @@ impl DocHost {
                 }
             }
         }
+        let opening = lock(&self.inner.opening);
+        if let Some(handle) = lock(&self.inner.handles).get(chat_id) {
+            handle.touch();
+            return Ok(handle.clone());
+        }
         // B2/M5 guard: the LOCAL epoch is the second cutover signal. A crash
         // between the thin save and the registry flip (or a not-yet-synced
         // registry) must NOT route an epoch-2 doc back onto s2 — the s2
@@ -1194,6 +1205,15 @@ impl DocHost {
                 None => SessionDoc::init(chat_id)?,
             }
         };
+        // Recover committed outgoing operations even when the snapshot debounce
+        // did not run before a crash. Imported updates do not echo as local writes.
+        if room_gen >= 2 {
+            for (_, bytes) in self.inner.store.pending_chat_updates(chat_id)? {
+                doc.doc()
+                    .import(&bytes)
+                    .map_err(|e| EngineError::Other(e.to_string()))?;
+            }
+        }
         let doc = Arc::new(doc);
 
         let (changed_tx, changed_rx) = watch::channel(0u64);
@@ -1229,16 +1249,10 @@ impl DocHost {
             checkpointing: Arc::new(AtomicBool::new(false)),
             chat2: Mutex::new(None),
             chat2_pending_local: Mutex::new(Vec::new()),
+            publication_failed: AtomicBool::new(false),
             chat2_local_sub: Mutex::new(None),
             _sub: sub,
         });
-        {
-            let mut handles = lock(&self.inner.handles);
-            if let Some(existing) = handles.get(chat_id) {
-                return Ok(existing.clone()); // racing open — keep the first
-            }
-            handles.insert(chat_id.to_string(), handle.clone());
-        }
         // Snapshot recovery may restore several independently edited rows.
         // Each row needs its own checked expiry wake; otherwise a non-head
         // edit could remain displayed as live indefinitely.
@@ -1260,7 +1274,16 @@ impl DocHost {
                 // commit lands in the client when connected, else in the
                 // pending buffer the join drains — nothing composed during
                 // (or before) the dial is lost to the room.
+                // A one-time full replay heals history stranded by older clients.
+                // Its durable marker is independent of the download cursor.
+                if !self.inner.store.chat_outbox_initialized(chat_id)? {
+                    let updates = crate::chat2_host::publication_updates(doc.doc())
+                        .map_err(EngineError::Other)?;
+                    self.inner.store.initialize_chat_outbox(chat_id, &updates)?;
+                }
                 let weak_push = Arc::downgrade(&handle);
+                let publication_store = self.inner.store.clone();
+                let publication_chat = chat_id.to_string();
                 let sub = doc
                     .doc()
                     .subscribe_local_update(Box::new(move |bytes: &Vec<u8>| {
@@ -1269,10 +1292,15 @@ impl DocHost {
                             // lock (verify pass: releasing it between the None
                             // check and the push let the join's store+drain
                             // slip between, orphaning the update forever).
+                            let batch_id = uuid::Uuid::new_v4().to_string();
+                            if let Err(err) = publication_store.enqueue_chat_update(&publication_chat, &batch_id, bytes) {
+                                handle.publication_failed.store(true, Ordering::Release);
+                                tracing::error!(chat = %publication_chat, %err, "chat2: durable outbox write failed");
+                            }
                             let client_guard = lock(&handle.chat2);
                             match &*client_guard {
-                                Some(client) => client.enqueue_update(bytes.clone()),
-                                None => lock(&handle.chat2_pending_local).push(bytes.clone()),
+                                Some(client) => client.enqueue_batch(batch_id, bytes.clone()),
+                                None => lock(&handle.chat2_pending_local).push((batch_id, bytes.clone())),
                             }
                         }
                         true
@@ -1288,33 +1316,9 @@ impl DocHost {
                 for command in &requeue_commands {
                     let _ = doc.queue_command(command);
                 }
-                // First contact with the room (cursor 0): everything
-                // committed BEFORE the subscription above — SessionDoc::
-                // init's container/meta ops, an adopt's fresh doc — is
-                // invisible to the push path, yet every later commit
-                // causally DEPENDS on it. Rows built on unpushed deps import
-                // into peers' loro pending-buffers and never materialize:
-                // born-chat2 cross-device runs sat invisible on every other
-                // device (host never saw the command, viewers never saw the
-                // transcript). Push the doc's full update log as the join's
-                // first batch; once acked the cursor moves and this never
-                // re-arms.
-                if chat2_cursor == 0 {
-                    match doc
-                        .doc()
-                        .export(loro::ExportMode::updates(&loro::VersionVector::default()))
-                    {
-                        Ok(bytes) if !bytes.is_empty() => {
-                            lock(&handle.chat2_pending_local).push(bytes);
-                        }
-                        Ok(_) => {}
-                        Err(err) => {
-                            tracing::warn!(chat = %chat_id, error = %err,
-                                "chat2 first-contact export failed; peers may stall on missing deps");
-                        }
-                    }
+                if !self.inner.edge_disconnected.load(Ordering::Acquire) {
+                    self.spawn_chat2_join(edge.clone(), &handle, chat2_cursor);
                 }
-                self.spawn_chat2_join(edge.clone(), &handle, chat2_cursor);
             } else {
                 // Straggler gen-1 chat (the s2 client is gone — post-cutover,
                 // no device reads or writes an s2 room). The local fat doc
@@ -1331,6 +1335,9 @@ impl DocHost {
                 }
             }
         }
+        // Publish only after the durable subscription and bootstrap are installed.
+        lock(&self.inner.handles).insert(chat_id.to_string(), handle.clone());
+        drop(opening);
         self.spawn_worker(chat_task(self.clone(), Arc::downgrade(&handle), changed_rx));
         self.evict_over_budget();
         Ok(handle)
@@ -1415,14 +1422,32 @@ impl DocHost {
                             // is either drained here or enqueued directly
                             // after — never dropped between (verify pass).
                             let mut client_slot = lock(&handle.chat2);
-                            let pending: Vec<Vec<u8>> =
+                            if host.inner.edge_disconnected.load(Ordering::Acquire) { return; }
+                            let pending: Vec<(String, Vec<u8>)> =
                                 std::mem::take(&mut *lock(&handle.chat2_pending_local));
-                            for update in pending {
-                                client.enqueue_update(update);
+                            for (batch_id, update) in pending {
+                                client.enqueue_batch(batch_id, update);
                             }
                             *client_slot = Some(client);
                         }
                         tracing::info!(chat = %chat, "chat2 room joined (converged)");
+                        // A missed event, failed POST or actor restart must not
+                        // forget rejected operations. Any author can checkpoint
+                        // its own durable history, including a non-host desktop.
+                        let checkpoint_host = host.clone();
+                        let checkpoint_weak = weak.clone();
+                        host.spawn_worker(async move {
+                            loop {
+                                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                                let Some(handle) = checkpoint_weak.upgrade() else { return };
+                                if checkpoint_host.inner.edge_disconnected.load(Ordering::Acquire) { return; }
+                                let known = lock(&handle.chat2).as_ref().is_some_and(|c|c.stats().server_known);
+                                if known && checkpoint_host.inner.store.rejected_chat_updates(&handle.chat_id).is_ok_and(|v| !v.is_empty()) {
+                                    checkpoint_host.spawn_chat2_checkpoint(&handle, "durable-rejection");
+                                }
+                            }
+                        });
+
                         // Bootstrap heal: a room with NO checkpoint can't
                         // cover its rows' causal deps for cold readers — a
                         // pre-0.1.34 first contact whose init batch never
@@ -1512,7 +1537,7 @@ impl DocHost {
                                     if edge.bearer().await.is_none() {
                                         if let Some(handle) = weak.upgrade() {
                                             lock(&handle.chat2).take();
-                                            lock(&handle.chat2_local_sub).take();
+                                            // Keep journaling local cleanup after credentials disappear.
                                         }
                                         tracing::info!(chat = %chat,
                                             "chat2 credentials removed; leaving room");
@@ -1906,6 +1931,9 @@ impl DocHost {
     /// fresh reader sees only post-reset rows; `PushRejected` — the rejected
     /// ops reach peers only through a checkpoint).
     fn spawn_chat2_checkpoint(&self, handle: &Arc<ChatDocHandle>, reason: &'static str) {
+        if self.inner.edge_disconnected.load(Ordering::Acquire) {
+            return;
+        }
         use base64::Engine as _;
         let Some(edge) = self.inner.config.edge.clone() else {
             return;
@@ -1923,11 +1951,34 @@ impl DocHost {
             return;
         }
         let in_flight = handle.checkpointing.clone();
+        let rejected = self
+            .inner
+            .store
+            .rejected_chat_updates(&chat_id)
+            .unwrap_or_default();
+        let publication_store = self.inner.store.clone();
         let Ok(snapshot) = handle.doc.export_snapshot() else {
             in_flight.store(false, Ordering::Release);
             return;
         };
-        let frontier = handle.doc.doc().oplog_vv().encode();
+        let frontier = match loro::LoroDoc::decode_import_blob_meta(&snapshot, true) {
+            Ok(meta) => meta.partial_end_vv.encode(),
+            Err(err) => {
+                tracing::error!(%err, "chat2: checkpoint metadata decode failed");
+                in_flight.store(false, Ordering::Release);
+                return;
+            }
+        };
+        let snapshot_vv = loro::VersionVector::decode(&frontier).expect("encoded snapshot vector");
+        let covered_rejections: Vec<String> = rejected
+            .into_iter()
+            .filter_map(|(id, bytes)| {
+                loro::LoroDoc::decode_import_blob_meta(&bytes, true)
+                    .ok()
+                    .filter(|m| snapshot_vv.includes_vv(&m.partial_end_vv))
+                    .map(|_| id)
+            })
+            .collect();
         let seq_covered = stats.cursor;
         let http = self.inner.http.clone();
         let weak_note = Arc::downgrade(handle);
@@ -1956,6 +2007,12 @@ impl DocHost {
             {
                 Ok(res) if res.status().is_success() => {
                     tracing::info!(chat = %chat_id, seq_covered, reason, "chat2 checkpoint posted");
+                    for batch_id in &covered_rejections {
+                        if let Err(err) = publication_store.acknowledge_chat_update(&chat_id,batch_id) {
+                            tracing::warn!(%err, "chat2: checkpoint obligation retirement failed; will retry");
+                        }
+                    }
+
                     if let Some(handle) = weak_note.upgrade()
                         && let Some(client) = &*lock(&handle.chat2)
                     {
@@ -2053,6 +2110,11 @@ impl DocHost {
     }
 
     fn pinned(&self, handle: &Arc<ChatDocHandle>) -> bool {
+        // Durable batches may outlive this handle. Only failed disk writes
+        // require retaining the in-memory copy until persistence recovers.
+        if handle.publication_failed.load(Ordering::Acquire) {
+            return true;
+        }
         if handle.messages_tx.receiver_count() > 0 {
             return true;
         }
@@ -4450,10 +4512,11 @@ impl DocHost {
     /// Close all account-scoped room memberships before graceful engine
     /// draining. Auth-aware join supervisors will not install a late client.
     pub fn disconnect_edge(&self) {
+        self.inner.edge_disconnected.store(true, Ordering::Release);
         let handles: Vec<_> = lock(&self.inner.handles).values().cloned().collect();
         for handle in handles {
             lock(&handle.chat2).take();
-            lock(&handle.chat2_local_sub).take();
+            // Retain the durable subscription through agent shutdown cleanup.
         }
     }
 }
@@ -4752,5 +4815,62 @@ async fn chat_task(host: DocHost, weak: Weak<ChatDocHandle>, mut changed_rx: wat
                 host.evict_over_budget();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod publication_eviction_tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn lru_eviction_replays_unacknowledged_updates_after_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(DocsStore::open(dir.path()).unwrap());
+        let host = DocHost::new(
+            store.clone(),
+            DocHostConfig {
+                device_id: "writer".into(),
+                default_harness: HarnessId::Codex,
+                edge: Some(EdgeConfig::with_static_token("http://127.0.0.1:1", "test")),
+            },
+        );
+        let handle = host.open("evicted").unwrap();
+        handle
+            .doc
+            .doc()
+            .get_text("body")
+            .insert(0, "unacknowledged cleanup")
+            .unwrap();
+        handle.doc.doc().commit();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while lock(&handle.chat2).is_none() {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(lock(&handle.chat2).as_ref().unwrap().stats().pending_pushes > 0);
+        for i in 0..WARM_DOC_CAP {
+            host.open(&format!("other-{i}")).unwrap();
+        }
+        handle
+            .last_access
+            .store(now_ms() - 2 * EVICT_MIN_IDLE_MS, Ordering::Relaxed);
+        assert!(
+            !host.pinned(&handle),
+            "durably queued ops need not retain the whole doc in memory"
+        );
+        host.evict_over_budget();
+        assert!(!lock(&host.inner.handles).contains_key("evicted"));
+        drop(handle);
+        let before = store.pending_chat_updates("evicted").unwrap();
+        let reopened = host.open("evicted").unwrap();
+        assert_eq!(
+            reopened.doc.doc().get_text("body").to_string(),
+            "unacknowledged cleanup"
+        );
+        assert_eq!(store.pending_chat_updates("evicted").unwrap(), before);
+        drop(reopened);
+        host.shutdown_workers().await;
     }
 }

--- a/crates/engine/tests/session_publication.rs
+++ b/crates/engine/tests/session_publication.rs
@@ -1,0 +1,625 @@
+//! Real Codex adapter + engine persistence + ChatClient over a loopback relay.
+//! Faults are injected only in temporary profiles and the test relay.
+use futures::{SinkExt, StreamExt, future::BoxFuture};
+use loro::{ExportMode, LoroDoc};
+use std::collections::HashMap;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use zeron_doc::{MessageRole, MessageStatus, SessionDoc};
+use zeron_engine::{
+    EdgeConfig, EngineCore, EngineProfile, HarnessRegistry, chat2_host::EngineChatSink,
+};
+use zeron_harness::CodexHarness;
+use zeron_proto::{HarnessId, ReasoningLevel, RunRequest, SandboxLevel, SessionStatus};
+use zeron_sync::chat_frames::{decode, encode, frame_type};
+use zeron_sync::{
+    ChatClient, ChatDocSink, CheckpointFetcher, DocsStore, SyncError, chat_client::RowImportOutcome,
+};
+const CHAT: &str = "publication-regression";
+
+struct Fetch(Vec<u8>);
+impl CheckpointFetcher for Fetch {
+    fn fetch(&self) -> BoxFuture<'static, Result<Vec<u8>, SyncError>> {
+        let bytes = self.0.clone();
+        Box::pin(async move { Ok(bytes) })
+    }
+}
+#[derive(Default)]
+struct Room {
+    rows: Vec<(String, Vec<u8>)>,
+    ids: HashMap<String, u64>,
+    clients: Vec<mpsc::UnboundedSender<Vec<u8>>>,
+    checkpoint_attempts: usize,
+    checkpoints: Vec<(Vec<u8>, String)>,
+}
+async fn relay(
+    checkpoint: Vec<u8>,
+) -> (
+    String,
+    Arc<Mutex<Room>>,
+    Arc<AtomicBool>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("ws://{}", listener.local_addr().unwrap());
+    let state = Arc::new(Mutex::new(Room::default()));
+    let ack = Arc::new(AtomicBool::new(false));
+    let shared = state.clone();
+    let send_ack = ack.clone();
+    let frontier = LoroDoc::decode_import_blob_meta(&checkpoint, true)
+        .unwrap()
+        .partial_end_vv
+        .encode();
+    let task = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let state = shared.clone();
+            let ack = send_ack.clone();
+            let frontier = frontier.clone();
+            let size = checkpoint.len();
+            tokio::spawn(async move {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut prefix = [0; 5];
+                if stream.peek(&mut prefix).await.unwrap_or(0) == 5 && &prefix == b"POST " {
+                    let mut data = Vec::new();
+                    let header_end = loop {
+                        let mut chunk = [0; 8192];
+                        let n = stream.read(&mut chunk).await.unwrap();
+                        if n == 0 {
+                            return;
+                        }
+                        data.extend_from_slice(&chunk[..n]);
+                        if let Some(i) = data.windows(4).position(|w| w == b"\r\n\r\n") {
+                            break i + 4;
+                        }
+                    };
+                    let headers = String::from_utf8_lossy(&data[..header_end]).to_ascii_lowercase();
+                    let length: usize = headers
+                        .lines()
+                        .find_map(|l| l.strip_prefix("content-length: "))
+                        .unwrap()
+                        .trim()
+                        .parse()
+                        .unwrap();
+                    while data.len() < header_end + length {
+                        let mut chunk = [0; 8192];
+                        let n = stream.read(&mut chunk).await.unwrap();
+                        if n == 0 {
+                            return;
+                        }
+                        data.extend_from_slice(&chunk[..n]);
+                    }
+                    let header_text = String::from_utf8_lossy(&data[..header_end]);
+                    let frontier = header_text
+                        .lines()
+                        .find_map(|l| l.strip_prefix("x-chat2-frontier: "))
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string();
+                    let accepted = {
+                        let mut st = state.lock().unwrap();
+                        st.checkpoint_attempts += 1;
+                        if st.checkpoint_attempts > 1 {
+                            st.checkpoints
+                                .push((data[header_end..header_end + length].to_vec(), frontier));
+                            true
+                        } else {
+                            false
+                        }
+                    };
+                    let reply = if accepted {
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                            .as_slice()
+                    } else {
+                        b"HTTP/1.1 503 Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".as_slice()
+                    };
+                    let _ = stream.write_all(reply).await;
+                    return;
+                }
+                let Ok(ws) = tokio_tungstenite::accept_async(stream).await else {
+                    return;
+                };
+                let (mut tx, mut rx) = ws.split();
+                let (out, mut incoming) = mpsc::unbounded_channel();
+                state.lock().unwrap().clients.push(out.clone());
+                let writer = tokio::spawn(async move {
+                    while let Some(bytes) = incoming.recv().await {
+                        if tx.send(bytes.into()).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+                while let Some(Ok(message)) = rx.next().await {
+                    let Some(frame) = decode(&message.into_data()) else {
+                        continue;
+                    };
+                    let mut st = state.lock().unwrap();
+                    let head = 42 + st.rows.len() as u64;
+                    match frame.kind {
+                        frame_type::HELLO => {
+                            let _ = out.send(encode(frame_type::STATE,&serde_json::json!({"headSeq":head,"seqFloor":42,"checkpointSeq":42,"checkpointSize":size,"rowCount":st.rows.len(),"rowBytes":0}),&frontier));
+                        }
+                        frame_type::ROWS_REQ => {
+                            let after = frame.header["after"].as_u64().unwrap();
+                            for (i, (id, bytes)) in st.rows.iter().enumerate() {
+                                let seq = 43 + i as u64;
+                                if seq > after {
+                                    let _ = out.send(encode(frame_type::ROW,&serde_json::json!({"seq":seq,"device":"writer","batchId":id}),bytes));
+                                }
+                            }
+                            let _ = out.send(encode(
+                                frame_type::ROWS_DONE,
+                                &serde_json::json!({"headSeq":head}),
+                                &[],
+                            ));
+                        }
+                        frame_type::PUSH => {
+                            let id = frame.header["batchId"].as_str().unwrap().to_string();
+                            let seq = if let Some(seq) = st.ids.get(&id) {
+                                *seq
+                            } else {
+                                let seq = 43 + st.rows.len() as u64;
+                                st.ids.insert(id.clone(), seq);
+                                st.rows.push((id.clone(), frame.payload.clone()));
+                                let row = encode(
+                                    frame_type::ROW,
+                                    &serde_json::json!({"seq":seq,"device":"writer","batchId":id}),
+                                    &frame.payload,
+                                );
+                                st.clients.retain(|c| c.send(row.clone()).is_ok());
+                                seq
+                            };
+                            if ack.load(Ordering::SeqCst) {
+                                let _ = out.send(encode(
+                                    frame_type::ACK,
+                                    &serde_json::json!({"batchId":id,"seq":seq}),
+                                    &[],
+                                ));
+                            }
+                        }
+                        frame_type::PROBE => {
+                            let _ = out.send(encode(
+                                frame_type::PROBE_OK,
+                                &serde_json::json!({"headSeq":head}),
+                                &[],
+                            ));
+                        }
+                        _ => {}
+                    }
+                }
+                writer.abort();
+            });
+        }
+    });
+    (url, state, ack, task)
+}
+async fn wait(mut f: impl FnMut() -> bool) {
+    tokio::time::timeout(Duration::from_secs(120), async {
+        while !f() {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("condition converges");
+}
+fn assemble(profile: &EngineProfile, live: bool) -> EngineCore {
+    let harness = if live {
+        CodexHarness::new().with_executable(
+            std::env::var_os("SESSION_SYNC_CODEX")
+                .expect("set SESSION_SYNC_CODEX to installed codex"),
+        )
+    } else {
+        CodexHarness::new().with_executable(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../harness/tests/fixtures/fake-codex.sh"),
+        )
+    };
+    let registry = Arc::new(HarnessRegistry::new());
+    registry.register(Arc::new(harness));
+    // The closed port guarantees no bytes escape to a production relay.
+    EngineCore::assemble_with_profile(
+        profile.clone(),
+        registry,
+        HarnessId::Codex,
+        Some(EdgeConfig::with_static_token("http://127.0.0.1:1", "test")),
+    )
+    .unwrap()
+}
+async fn turn(core: &EngineCore, cwd: &std::path::Path, live: bool, second: bool) {
+    let prompt = if live {
+        if second {
+            "Continue. Reply exactly PUBLICATION-SECOND. Do not use tools or modify files."
+        } else {
+            "Reply exactly PUBLICATION-FIRST. Do not use tools or modify files."
+        }
+    } else if second {
+        "scenario:publication"
+    } else {
+        "scenario:publication"
+    };
+    core.sessions
+        .dispatch(
+            CHAT,
+            HarnessId::Codex,
+            RunRequest {
+                prompt: prompt.into(),
+                harness: None,
+                model: live
+                    .then(|| std::env::var("SESSION_SYNC_MODEL").unwrap_or("gpt-6-astra".into())),
+                reasoning: Some(ReasoningLevel::Medium),
+                model_options: Default::default(),
+                cwd: cwd.display().to_string(),
+                sandbox: SandboxLevel::ReadOnly,
+                auto_approve: true,
+                attachments: vec![],
+                worktree: None,
+                resume: None,
+            },
+            Some(if second { "second-user" } else { "first-user" }.into()),
+        )
+        .await
+        .unwrap();
+    wait(|| {
+        core.sessions
+            .session_status(CHAT)
+            .is_some_and(|s| s.status == SessionStatus::Idle)
+            && core
+                .doc_host
+                .open(CHAT)
+                .unwrap()
+                .doc()
+                .read_entries()
+                .unwrap()
+                .iter()
+                .filter(|e| {
+                    e.role == MessageRole::Assistant && e.status == Some(MessageStatus::Complete)
+                })
+                .count()
+                >= if second { 2 } else { 1 }
+    })
+    .await;
+}
+async fn regression(live: bool) {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = EngineProfile::development(temp.path(), "test-org", "test-user");
+    let core = assemble(&profile, live);
+    turn(&core, temp.path(), live, false).await;
+    println!("first turn complete");
+    core.shutdown().await;
+    drop(core);
+    let store = Arc::new(DocsStore::open(profile.store_root()).unwrap());
+    let old = store.load_snapshot(CHAT).unwrap().unwrap();
+    let old_doc = LoroDoc::new();
+    old_doc.import(&old).unwrap();
+    // The incident's predecessor shape: cleanup after a completed assistant.
+    for i in 0..136 {
+        old_doc
+            .get_map("cleanup")
+            .insert(&format!("subagent-{i}"), "failed")
+            .unwrap();
+        old_doc.commit();
+    }
+    let orphan_snapshot = old_doc.export(ExportMode::Snapshot).unwrap();
+    let before_continue = old_doc.oplog_vv();
+    // Emulate a pre-upgrade snapshot whose memory-only outbox was lost.
+    store.delete_snapshot(CHAT).unwrap();
+    store
+        .save_snapshot_with_cursor(CHAT, &orphan_snapshot, 42, 2)
+        .unwrap();
+    let core = assemble(&profile, live);
+    turn(&core, temp.path(), live, true).await;
+    println!("resumed turn complete");
+    let handle = core.doc_host.open(CHAT).unwrap();
+    if live {
+        let (events, _) = core.sessions.subscribe(CHAT, 0).unwrap();
+        let native_sessions: Vec<_> = events
+            .iter()
+            .filter_map(|e| match &e.event {
+                zeron_proto::AgentEvent::SessionStarted { session_id, .. } => Some(session_id),
+                _ => None,
+            })
+            .collect();
+        assert!(native_sessions.len() >= 2);
+        assert!(
+            native_sessions.iter().all(|id| *id == native_sessions[0]),
+            "real Continue resumes the same native session"
+        );
+    }
+    let expected = handle.doc().read_entries().unwrap();
+    let new_rows = handle
+        .doc()
+        .doc()
+        .export(ExportMode::updates(&before_continue))
+        .unwrap();
+    let desktop = Arc::new(SessionDoc::from_doc(LoroDoc::new()));
+    desktop.doc().import(&old).unwrap();
+    let desktop_dir = tempfile::tempdir().unwrap();
+    let desktop_store = Arc::new(DocsStore::open(desktop_dir.path()).unwrap());
+    let desktop_sink = Arc::new(EngineChatSink::new(&desktop, desktop_store, CHAT));
+    assert_eq!(
+        desktop_sink.apply_row(&new_rows, 43),
+        RowImportOutcome::PendingDependencies
+    );
+    assert!(
+        !desktop
+            .read_entries()
+            .unwrap()
+            .iter()
+            .any(|e| e.id == "second-user"),
+        "old publication behavior hides the successful resumed turn"
+    );
+    println!("reproduced: successful resumed Codex turn is invisible without cleanup predecessors");
+    drop(handle);
+    core.shutdown().await;
+    drop(core);
+    let pending = store.pending_chat_updates(CHAT).unwrap();
+    assert!(!pending.is_empty());
+    let host = Arc::new(SessionDoc::from_doc(LoroDoc::new()));
+    host.doc()
+        .import(&store.load_snapshot(CHAT).unwrap().unwrap())
+        .unwrap();
+    for (_, bytes) in &pending {
+        host.doc().import(bytes).unwrap();
+    }
+    let sink = Arc::new(EngineChatSink::new(&host, store.clone(), CHAT));
+    let (url, room, acks, server) = relay(old.clone()).await;
+    let viewer = ChatClient::connect(
+        &url,
+        desktop_sink,
+        Arc::new(Fetch(old.clone())),
+        "desktop",
+        42,
+    )
+    .await
+    .unwrap();
+    let writer = ChatClient::connect(
+        &url,
+        sink.clone(),
+        Arc::new(Fetch(old.clone())),
+        "writer",
+        42,
+    )
+    .await
+    .unwrap();
+    wait(|| room.lock().unwrap().rows.len() == pending.len()).await;
+    wait(|| desktop.read_entries().unwrap().len() == expected.len()).await;
+    assert_eq!(
+        store.pending_chat_updates(CHAT).unwrap().len(),
+        pending.len(),
+        "lost ACK must retain durable batches"
+    );
+    drop(writer);
+    acks.store(true, Ordering::SeqCst);
+    let writer = ChatClient::connect(&url, sink, Arc::new(Fetch(old)), "writer", 42)
+        .await
+        .unwrap();
+    wait(|| store.pending_chat_updates(CHAT).unwrap().is_empty()).await;
+    assert_eq!(
+        room.lock().unwrap().rows.len(),
+        pending.len(),
+        "recreated actor reuses batch IDs"
+    );
+    let actual = desktop.read_entries().unwrap();
+    assert_eq!(
+        actual, expected,
+        "peer transcript, statuses and parts must all match"
+    );
+    println!(
+        "fixed: durable replay restores both turns; lost-ACK restart adds no duplicate relay rows"
+    );
+    writer.shutdown().await;
+    viewer.shutdown().await;
+    server.abort();
+}
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn codex_adapter_restart_publication() {
+    regression(false).await;
+}
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires installed authenticated Codex; uses only isolated test sessions"]
+async fn real_codex_restart_publication() {
+    regression(true).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn disconnected_cleanup_is_durable_before_snapshot_debounce() {
+    use zeron_engine::{DocHost, DocHostConfig};
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(DocsStore::open(dir.path()).unwrap());
+    let config = || DocHostConfig {
+        device_id: "writer".into(),
+        default_harness: HarnessId::Codex,
+        edge: Some(EdgeConfig::with_static_token("http://127.0.0.1:1", "test")),
+    };
+    let host = DocHost::new(store.clone(), config());
+    let handle = host.open(CHAT).unwrap();
+    let before = handle.doc().export_snapshot().unwrap();
+    host.disconnect_edge();
+    for i in 0..136 {
+        handle
+            .doc()
+            .doc()
+            .get_map("cleanup")
+            .insert(&format!("chip-{i}"), "failed")
+            .unwrap();
+        handle.doc().doc().commit();
+    }
+    let expected = handle.doc().doc().oplog_vv();
+    assert!(store.pending_chat_updates(CHAT).unwrap().len() >= 136);
+    drop(handle);
+    host.shutdown_workers().await;
+    drop(host);
+    // Crash shape: the durable update journal is newer than the last snapshot.
+    store
+        .save_snapshot_with_cursor(CHAT, &before, 42, 2)
+        .unwrap();
+    let reopened = DocHost::new(store.clone(), config());
+    let handle = reopened.open(CHAT).unwrap();
+    assert!(handle.doc().doc().oplog_vv().includes_vv(&expected));
+    assert_eq!(handle.doc().doc().get_map("cleanup").len(), 136);
+    drop(handle);
+    reopened.shutdown_workers().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires private incident snapshot paths; all writes remain in a temporary store"]
+async fn supplied_incident_snapshots_reconcile_via_durable_bootstrap() {
+    use zeron_engine::{DocHost, DocHostConfig};
+    let remote = std::fs::read(std::env::var("SESSION_SYNC_REMOTE_SNAPSHOT").unwrap()).unwrap();
+    let before = std::fs::read(std::env::var("SESSION_SYNC_DESKTOP_SNAPSHOT").unwrap()).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(DocsStore::open(dir.path()).unwrap());
+    store
+        .save_snapshot_with_cursor(CHAT, &remote, 40331, 2)
+        .unwrap();
+    let host = DocHost::new(
+        store.clone(),
+        DocHostConfig {
+            device_id: "test".into(),
+            default_harness: HarnessId::Codex,
+            edge: Some(EdgeConfig::with_static_token("http://127.0.0.1:1", "test")),
+        },
+    );
+    let handle = host.open(CHAT).unwrap();
+    let expected = handle.doc().read_entries().unwrap();
+    let desktop = LoroDoc::new();
+    desktop.import(&before).unwrap();
+    let desktop = Arc::new(SessionDoc::from_doc(desktop));
+    let updates = store.pending_chat_updates(CHAT).unwrap();
+    assert!(!updates.is_empty());
+    for (_, bytes) in &updates {
+        assert!(bytes.len() <= zeron_sync::chat_client::MAX_PUSH_BYTES);
+    }
+    let (url, _, acks, server) = relay(before.clone()).await;
+    acks.store(true, Ordering::SeqCst);
+    let viewer_dir = tempfile::tempdir().unwrap();
+    let viewer_sink = Arc::new(EngineChatSink::new(
+        &desktop,
+        Arc::new(DocsStore::open(viewer_dir.path()).unwrap()),
+        CHAT,
+    ));
+    let viewer = ChatClient::connect(
+        &url,
+        viewer_sink,
+        Arc::new(Fetch(before.clone())),
+        "viewer",
+        42,
+    )
+    .await
+    .unwrap();
+    let source = handle.doc_arc();
+    let writer_sink = Arc::new(EngineChatSink::new(&source, store.clone(), CHAT));
+    let writer = ChatClient::connect(&url, writer_sink, Arc::new(Fetch(before)), "writer", 42)
+        .await
+        .unwrap();
+    wait(|| store.pending_chat_updates(CHAT).unwrap().is_empty()).await;
+    wait(|| {
+        desktop
+            .doc()
+            .oplog_vv()
+            .includes_vv(&source.doc().oplog_vv())
+    })
+    .await;
+    assert!(
+        desktop.read_entries().unwrap() == expected,
+        "incident transcript differs"
+    );
+    assert!(
+        desktop.read_commands().unwrap() == handle.doc().read_commands().unwrap(),
+        "incident commands differ"
+    );
+    assert!(
+        desktop
+            .doc()
+            .oplog_vv()
+            .includes_vv(&handle.doc().doc().oplog_vv())
+    );
+    println!(
+        "incident bootstrap: {} bounded rows, {} bytes, {} messages; exact transcript and commands restored",
+        updates.len(),
+        updates.iter().map(|(_, b)| b.len()).sum::<usize>(),
+        expected.len()
+    );
+    writer.shutdown().await;
+    viewer.shutdown().await;
+    server.abort();
+    drop(handle);
+    host.shutdown_workers().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rejected_update_retries_failed_checkpoint_and_retires_only_after_success() {
+    use base64::Engine as _;
+    use zeron_engine::{DocHost, DocHostConfig};
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(DocsStore::open(dir.path()).unwrap());
+    let initial = SessionDoc::init(CHAT).unwrap().export_snapshot().unwrap();
+    store
+        .save_snapshot_with_cursor(CHAT, &initial, 42, 2)
+        .unwrap();
+    store.initialize_chat_outbox(CHAT, &[]).unwrap();
+    let (url, room, acks, server) = relay(initial).await;
+    acks.store(true, Ordering::SeqCst);
+    let host = DocHost::new(
+        store.clone(),
+        DocHostConfig {
+            device_id: "writer".into(),
+            default_harness: HarnessId::Codex,
+            edge: Some(EdgeConfig::with_static_token(
+                url.replacen("ws", "http", 1),
+                "test",
+            )),
+        },
+    );
+    let handle = host.open(CHAT).unwrap();
+    // Incompressible single map value exceeds the relay row cap. Its operation
+    // cannot be split; checkpoint retry is the durable fallback.
+    let mut state = 0x123456789abcdefu64;
+    let text: String = (0..2_000_000)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (33 + (state % 90) as u8) as char
+        })
+        .collect();
+    handle
+        .doc()
+        .doc()
+        .get_map("large")
+        .insert("value", text)
+        .unwrap();
+    handle.doc().doc().commit();
+    wait(|| room.lock().unwrap().checkpoint_attempts >= 1).await;
+    assert!(
+        !store.rejected_chat_updates(CHAT).unwrap().is_empty(),
+        "failed POST must retain obligation"
+    );
+    wait(|| !room.lock().unwrap().checkpoints.is_empty()).await;
+    wait(|| store.rejected_chat_updates(CHAT).unwrap().is_empty()).await;
+    let (snapshot, frontier) = room.lock().unwrap().checkpoints.last().unwrap().clone();
+    let published = LoroDoc::new();
+    assert!(published.import(&snapshot).unwrap().pending.is_none());
+    assert_eq!(
+        published.get_map("large").get_deep_value(),
+        handle.doc().doc().get_map("large").get_deep_value()
+    );
+    let vv = loro::VersionVector::decode(
+        &base64::engine::general_purpose::STANDARD
+            .decode(frontier)
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        vv,
+        published.oplog_vv(),
+        "frontier must describe the captured bytes"
+    );
+    drop(handle);
+    host.shutdown_workers().await;
+    server.abort();
+}

--- a/crates/harness/tests/fixtures/fake-codex.sh
+++ b/crates/harness/tests/fixtures/fake-codex.sh
@@ -104,6 +104,12 @@ case "$turnline" in
   emit '{"method":"turn/completed","params":{"threadId":"th-1","turn":{"id":"t-1"}}}'
   ;;
 
+*scenario:publication*)
+  emit "{\"id\":$tid,\"result\":{\"turn\":{\"id\":\"publication-turn\"}}}"
+  emit '{"method":"item/agentMessage/delta","params":{"itemId":"publication-answer","delta":"Publication turn completed"}}'
+  emit '{"method":"turn/completed","params":{"turn":{"id":"publication-turn","status":"completed"}}}'
+  ;;
+
 *scenario:happy*)
   # Verify the turn/start + thread/start params the harness must send.
   for want in '"method":"turn/start"' '"effort":"ultra"' '"model":"gpt-5.6-sol"' \

--- a/crates/sync/src/chat_client.rs
+++ b/crates/sync/src/chat_client.rs
@@ -118,6 +118,21 @@ pub enum RowImportOutcome {
 /// every method persists doc content AND the room cursor in one transaction
 /// (`DocsStore::save_snapshot_with_cursor`) so they can never diverge.
 pub trait ChatDocSink: Send + Sync + 'static {
+    /// Durable publication hooks. In-memory/test sinks may use the defaults.
+    fn pending_updates(&self) -> Result<Vec<(String, Vec<u8>)>, String> {
+        Ok(Vec::new())
+    }
+    fn persist_update(&self, _batch_id: &str, _bytes: &[u8]) -> Result<(), String> {
+        Ok(())
+    }
+    fn acknowledge_update(&self, _batch_id: &str) -> Result<(), String> {
+        Ok(())
+    }
+    /// Keep permanently rejected operations durable until checkpointed.
+    fn reject_update(&self, _batch_id: &str) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Import one remote update row with a proposed contiguous cursor. A
     /// pending import must not persist that cursor; the client repairs it.
     fn apply_row(&self, bytes: &[u8], cursor: u64) -> RowImportOutcome;
@@ -280,9 +295,11 @@ async fn pump(
 
 // ── shared client state ─────────────────────────────────────────────────────
 
+#[derive(Clone)]
 struct PendingPush {
     batch_id: String,
     bytes: Vec<u8>,
+    durable: bool,
 }
 
 #[derive(Default)]
@@ -313,6 +330,35 @@ struct Shared {
     needs_checkpoint: bool,
     /// Prevent an overlapping HTTP/socket catch-up from clearing a newer gap.
     causal_gap_generation: u64,
+}
+
+// Retry failed writes before network admission. Do not reinsert already-ACKed
+// batches when the HTTP and socket paths race using cloned pending lists.
+fn ensure_durable(shared: &Mutex<Shared>, sink: &dyn ChatDocSink, push: &PendingPush) -> bool {
+    if push.durable {
+        return true;
+    }
+    let mut shared = lock(shared);
+    let Some(pending) = shared
+        .pending
+        .iter_mut()
+        .find(|p| p.batch_id == push.batch_id)
+    else {
+        return true;
+    };
+    if pending.durable {
+        return true;
+    }
+    match sink.persist_update(&pending.batch_id, &pending.bytes) {
+        Ok(()) => {
+            pending.durable = true;
+            true
+        }
+        Err(err) => {
+            tracing::error!(%err, "chat2: outbox retry failed");
+            false
+        }
+    }
 }
 
 fn apply_remote_row(shared: &Mutex<Shared>, sink: &dyn ChatDocSink, bytes: &[u8], seq: u64) {
@@ -378,6 +424,7 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 
 /// A live chat2-room membership for one chat doc.
 pub struct ChatClient {
+    sink: Arc<dyn ChatDocSink>,
     shared: Arc<Mutex<Shared>>,
     events: broadcast::Sender<ChatEvent>,
     shutdown: watch::Sender<bool>,
@@ -508,13 +555,23 @@ impl ChatClient {
         let (presence_tx, presence_rx) = mpsc::channel(4);
         let shared = Arc::new(Mutex::new(Shared {
             cursor: initial_cursor,
+            pending: sink
+                .pending_updates()
+                .map_err(SyncError::Protocol)?
+                .into_iter()
+                .map(|(batch_id, bytes)| PendingPush {
+                    batch_id,
+                    bytes,
+                    durable: true,
+                })
+                .collect(),
             ..Shared::default()
         }));
         let flags = Arc::new(Flags::default());
 
         let actor = Actor {
             shared: shared.clone(),
-            sink,
+            sink: sink.clone(),
             fetcher,
             device_id: device_id.to_string(),
             connector,
@@ -535,6 +592,7 @@ impl ChatClient {
 
         match ready_rx.await {
             Ok(Ok(())) => Ok(Self {
+                sink,
                 shared,
                 events,
                 shutdown: shutdown_tx,
@@ -568,6 +626,18 @@ impl ChatClient {
     /// on every reconnect — the exact wedge class chat2 replaces. The ops
     /// stay in the local doc and reach peers via the next checkpoint.
     pub fn enqueue_update(&self, bytes: Vec<u8>) {
+        self.enqueue_batch(uuid::Uuid::new_v4().to_string(), bytes);
+    }
+
+    /// Queue an already-journaled batch without changing its deduplication ID.
+    pub fn enqueue_batch(&self, batch_id: String, bytes: Vec<u8>) {
+        let durable = match self.sink.persist_update(&batch_id, &bytes) {
+            Ok(()) => true,
+            Err(err) => {
+                tracing::error!(%err, "chat2: outbox write failed; retaining batch for retry");
+                false
+            }
+        };
         if bytes.len() > MAX_PUSH_BYTES {
             use std::sync::atomic::Ordering::Relaxed;
             tracing::error!(
@@ -576,15 +646,19 @@ impl ChatClient {
                  updates are KB-scale — this is an upstream bug)"
             );
             self.flags.rejected.fetch_add(1, Relaxed);
+            let _ = self.sink.reject_update(&batch_id);
             let _ = self.events.send(ChatEvent::PushRejected);
             return;
         }
         {
             let mut shared = lock(&self.shared);
-            shared.pending.push_back(PendingPush {
-                batch_id: uuid::Uuid::new_v4().to_string(),
-                bytes,
-            });
+            if !shared.pending.iter().any(|p| p.batch_id == batch_id) {
+                shared.pending.push_back(PendingPush {
+                    batch_id,
+                    bytes,
+                    durable,
+                });
+            }
         }
         let _ = self.nudge.try_send(());
     }
@@ -1212,22 +1286,19 @@ impl Actor {
 
     /// Send only the queue's head batch — the quota-probe path.
     async fn push_head(&self, pipe: &mut BinPipe) -> bool {
-        let frame = {
-            let shared = lock(&self.shared);
-            shared.pending.front().map(|push| {
-                wire::encode(
-                    frame_type::PUSH,
-                    &wire::PushHeader {
-                        batch_id: &push.batch_id,
-                    },
-                    &push.bytes,
-                )
-            })
-        };
-        match frame {
-            Some(frame) => pipe.tx.send(frame).await.is_ok(),
-            None => true,
+        let push = lock(&self.shared).pending.front().cloned();
+        let Some(push) = push else { return true };
+        if !ensure_durable(&self.shared, self.sink.as_ref(), &push) {
+            return false;
         }
+        let frame = wire::encode(
+            frame_type::PUSH,
+            &wire::PushHeader {
+                batch_id: &push.batch_id,
+            },
+            &push.bytes,
+        );
+        pipe.tx.send(frame).await.is_ok()
     }
 
     /// One HTTPS sync cycle off the critical path: flush pending batches
@@ -1249,19 +1320,20 @@ impl Actor {
         let events = self.events.clone();
         let busy = self.sync_busy.clone();
         tokio::spawn(async move {
-            let batches: Vec<(String, Vec<u8>)> = lock(&shared)
-                .pending
-                .iter()
-                .map(|p| (p.batch_id.clone(), p.bytes.clone()))
-                .collect();
-            for (batch_id, bytes) in batches {
-                match transport.push(batch_id, bytes).await {
+            let batches: Vec<PendingPush> = lock(&shared).pending.iter().cloned().collect();
+            for push in batches {
+                if !ensure_durable(&shared, sink.as_ref(), &push) {
+                    break;
+                }
+                match transport.push(push.batch_id, push.bytes).await {
                     Ok(ack) => {
                         if let Ok(v) = serde_json::from_str::<serde_json::Value>(&ack) {
                             if let (Some(b), Some(seq)) = (v["batchId"].as_str(), v["seq"].as_u64())
                             {
                                 let mut sh = lock(&shared);
-                                sh.pending.retain(|p| p.batch_id != b);
+                                if sink.acknowledge_update(b).is_ok() {
+                                    sh.pending.retain(|p| p.batch_id != b);
+                                }
                                 // Contiguity rule (see handle_frame ACK): an
                                 // own-push ack proves the server has rows up
                                 // to `seq`, not that WE have the interleaved
@@ -1427,21 +1499,18 @@ impl Actor {
     }
 
     async fn push_pending(&self, pipe: &mut BinPipe) -> bool {
-        // Clone rather than drain: batches stay queued until their ack.
-        let frames: Vec<Vec<u8>> = lock(&self.shared)
-            .pending
-            .iter()
-            .map(|push| {
-                wire::encode(
-                    frame_type::PUSH,
-                    &wire::PushHeader {
-                        batch_id: &push.batch_id,
-                    },
-                    &push.bytes,
-                )
-            })
-            .collect();
-        for frame in frames {
+        let batches: Vec<PendingPush> = lock(&self.shared).pending.iter().cloned().collect();
+        for push in batches {
+            if !ensure_durable(&self.shared, self.sink.as_ref(), &push) {
+                return false;
+            }
+            let frame = wire::encode(
+                frame_type::PUSH,
+                &wire::PushHeader {
+                    batch_id: &push.batch_id,
+                },
+                &push.bytes,
+            );
             if pipe.tx.send(frame).await.is_err() {
                 return false;
             }
@@ -1473,7 +1542,11 @@ impl Actor {
                     return false;
                 };
                 let mut shared = lock(&self.shared);
-                shared.pending.retain(|p| p.batch_id != ack.batch_id);
+                if self.sink.acknowledge_update(&ack.batch_id).is_ok() {
+                    shared.pending.retain(|p| p.batch_id != ack.batch_id);
+                } else {
+                    shared.retry_at = Some(tokio::time::Instant::now() + QUOTA_RETRY);
+                }
                 // Same contiguity rule as ROW: our own batch landing at
                 // `seq` proves rows up to seq exist server-side, not that we
                 // HAVE the interleaved ones from other devices.
@@ -1528,6 +1601,10 @@ impl Actor {
                     // wedge class this design exists to kill. The ops stay
                     // in the local doc and travel with the next checkpoint.
                     "too_large" | "empty" | "bad_push" if !batch_id.is_empty() => {
+                        if let Err(err) = self.sink.reject_update(batch_id) {
+                            tracing::error!(%err, "chat2: cannot persist checkpoint obligation");
+                            return false;
+                        }
                         let mut shared = lock(&self.shared);
                         let before = shared.pending.len();
                         shared.pending.retain(|p| p.batch_id != batch_id);

--- a/crates/sync/src/store.rs
+++ b/crates/sync/src/store.rs
@@ -2,6 +2,7 @@
 //! processed-command ledger (ARCHITECTURE §2 command plane: entries are marked
 //! processed BEFORE execution so a crash can never double-execute a command).
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -37,6 +38,16 @@ const MIGRATIONS: &[&str] = &[
     // (M1/M3): 2 = thin chat2 rebuild; NULL/0 = pre-migration s2 doc.
     "ALTER TABLE snapshots ADD COLUMN cursor INTEGER;
      ALTER TABLE snapshots ADD COLUMN epoch INTEGER;",
+    // v3 — publication survives actor eviction and process restart.
+    "CREATE TABLE chat_outbox (
+        ordinal INTEGER PRIMARY KEY AUTOINCREMENT,
+        doc_id TEXT NOT NULL,
+        batch_id TEXT NOT NULL UNIQUE,
+        bytes BLOB NOT NULL,
+        needs_checkpoint INTEGER NOT NULL DEFAULT 0
+     ) STRICT;
+     CREATE INDEX chat_outbox_doc ON chat_outbox(doc_id,ordinal);
+     CREATE TABLE chat_outbox_initialized (doc_id TEXT PRIMARY KEY) STRICT;",
 ];
 
 /// SQLite-backed store under a data directory (`{data_dir}/docs.sqlite3`).
@@ -46,6 +57,7 @@ const MIGRATIONS: &[&str] = &[
 /// that gives command execution mark-BEFORE-execute idempotence.
 pub struct DocsStore {
     conn: Mutex<Connection>,
+    failed_publications: Mutex<HashSet<String>>,
 }
 
 impl DocsStore {
@@ -60,7 +72,102 @@ impl DocsStore {
         migrate(&mut conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
+            failed_publications: Mutex::new(HashSet::new()),
         })
+    }
+
+    /// Insert before sending. Stable IDs make crash-after-ACK replay idempotent.
+    pub fn enqueue_chat_update(
+        &self,
+        doc_id: &str,
+        batch_id: &str,
+        bytes: &[u8],
+    ) -> Result<(), StoreError> {
+        let result = self.conn().execute(
+            "INSERT OR IGNORE INTO chat_outbox(doc_id,batch_id,bytes) VALUES (?1,?2,?3)",
+            params![doc_id, batch_id, bytes],
+        );
+        if result.is_err() {
+            self.failed_publications
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .insert(doc_id.to_string());
+        }
+        result?;
+        Ok(())
+    }
+
+    pub fn pending_chat_updates(&self, doc_id: &str) -> Result<Vec<(String, Vec<u8>)>, StoreError> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare("SELECT batch_id,bytes FROM chat_outbox WHERE doc_id=?1 ORDER BY ordinal")?;
+        Ok(stmt
+            .query_map(params![doc_id], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<Result<_, _>>()?)
+    }
+
+    pub fn reject_chat_update(&self, doc_id: &str, batch_id: &str) -> Result<(), StoreError> {
+        self.conn().execute(
+            "UPDATE chat_outbox SET needs_checkpoint=1 WHERE doc_id=?1 AND batch_id=?2",
+            params![doc_id, batch_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn rejected_chat_updates(
+        &self,
+        doc_id: &str,
+    ) -> Result<Vec<(String, Vec<u8>)>, StoreError> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare("SELECT batch_id,bytes FROM chat_outbox WHERE doc_id=?1 AND needs_checkpoint=1 ORDER BY ordinal")?;
+        Ok(stmt
+            .query_map(params![doc_id], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<Result<_, _>>()?)
+    }
+
+    pub fn acknowledge_chat_update(&self, doc_id: &str, batch_id: &str) -> Result<(), StoreError> {
+        self.conn().execute(
+            "DELETE FROM chat_outbox WHERE doc_id=?1 AND batch_id=?2",
+            params![doc_id, batch_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn chat_outbox_initialized(&self, doc_id: &str) -> Result<bool, StoreError> {
+        Ok(self
+            .conn()
+            .query_row(
+                "SELECT 1 FROM chat_outbox_initialized WHERE doc_id=?1",
+                params![doc_id],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some())
+    }
+
+    /// Upgrade legacy snapshots (including orphaned local history) once. The
+    /// marker and complete replay obligation commit together; never reset cursors.
+    pub fn initialize_chat_outbox(
+        &self,
+        doc_id: &str,
+        updates: &[Vec<u8>],
+    ) -> Result<(), StoreError> {
+        let mut conn = self.conn();
+        let tx = conn.transaction()?;
+        if tx.execute(
+            "INSERT OR IGNORE INTO chat_outbox_initialized(doc_id) VALUES (?1)",
+            params![doc_id],
+        )? != 0
+        {
+            for bytes in updates {
+                tx.execute(
+                    "INSERT INTO chat_outbox(doc_id,batch_id,bytes) VALUES (?1,?2,?3)",
+                    params![doc_id, uuid::Uuid::new_v4().to_string(), bytes],
+                )?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
     }
 
     /// Latest saved snapshot for `doc_id`, if any.
@@ -78,11 +185,15 @@ impl DocsStore {
 
     /// Save (upsert) the snapshot for `doc_id`.
     pub fn save_snapshot(&self, doc_id: &str, bytes: &[u8]) -> Result<(), StoreError> {
-        self.conn().execute(
+        let mut conn = self.conn();
+        let tx = conn.transaction()?;
+        tx.execute(
             "INSERT INTO snapshots (doc_id, bytes, saved_at) VALUES (?1, ?2, ?3)
              ON CONFLICT(doc_id) DO UPDATE SET bytes = excluded.bytes, saved_at = excluded.saved_at",
             params![doc_id, bytes, now_ms()],
         )?;
+        self.invalidate_failed_publication(&tx, doc_id)?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -96,12 +207,16 @@ impl DocsStore {
         cursor: u64,
         epoch: u32,
     ) -> Result<(), StoreError> {
-        self.conn().execute(
+        let mut conn = self.conn();
+        let tx = conn.transaction()?;
+        tx.execute(
             "INSERT INTO snapshots (doc_id, bytes, saved_at, cursor, epoch) VALUES (?1, ?2, ?3, ?4, ?5)
              ON CONFLICT(doc_id) DO UPDATE SET bytes = excluded.bytes, saved_at = excluded.saved_at,
                  cursor = excluded.cursor, epoch = excluded.epoch",
             params![doc_id, bytes, now_ms(), cursor as i64, epoch as i64],
         )?;
+        self.invalidate_failed_publication(&tx, doc_id)?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -131,8 +246,15 @@ impl DocsStore {
     /// Delete the snapshot row for `doc_id` (destructive schema breaks: the
     /// legacy `workspace` row is dropped on open). Missing rows are a no-op.
     pub fn delete_snapshot(&self, doc_id: &str) -> Result<(), StoreError> {
-        self.conn()
-            .execute("DELETE FROM snapshots WHERE doc_id = ?1", params![doc_id])?;
+        let mut conn = self.conn();
+        let tx = conn.transaction()?;
+        tx.execute("DELETE FROM snapshots WHERE doc_id = ?1", params![doc_id])?;
+        tx.execute("DELETE FROM chat_outbox WHERE doc_id = ?1", params![doc_id])?;
+        tx.execute(
+            "DELETE FROM chat_outbox_initialized WHERE doc_id = ?1",
+            params![doc_id],
+        )?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -196,6 +318,28 @@ impl DocsStore {
             params![command_id, now_ms()],
         )?;
         Ok(changed > 0)
+    }
+
+    // Every snapshot path, including ACK/cursor persistence, must retain a
+    // replay obligation for operations whose outbox write failed. Invalidate
+    // the marker atomically with those operations becoming durable in a snapshot.
+    fn invalidate_failed_publication(
+        &self,
+        tx: &rusqlite::Transaction<'_>,
+        doc_id: &str,
+    ) -> Result<(), StoreError> {
+        if self
+            .failed_publications
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .contains(doc_id)
+        {
+            tx.execute(
+                "DELETE FROM chat_outbox_initialized WHERE doc_id=?1",
+                params![doc_id],
+            )?;
+        }
+        Ok(())
     }
 
     fn conn(&self) -> MutexGuard<'_, Connection> {
@@ -327,5 +471,88 @@ mod tests {
         );
         assert!(store.is_processed("cmd-1").unwrap());
         assert!(!store.mark_processed("cmd-1").unwrap());
+    }
+}
+
+#[cfg(test)]
+mod publication_tests {
+    use super::*;
+    #[test]
+    fn outbox_survives_restart_initializes_once_and_preserves_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+        let original;
+        {
+            let store = DocsStore::open(dir.path()).unwrap();
+            store
+                .save_snapshot_with_cursor("chat", b"snapshot", 40229, 2)
+                .unwrap();
+            store
+                .initialize_chat_outbox("chat", &[b"legacy-tail".to_vec()])
+                .unwrap();
+            original = store.pending_chat_updates("chat").unwrap();
+            store
+                .enqueue_chat_update("chat", "stable-id", b"new-turn")
+                .unwrap();
+            store
+                .enqueue_chat_update("chat", "stable-id", b"new-turn")
+                .unwrap();
+        }
+        let store = DocsStore::open(dir.path()).unwrap();
+        store
+            .initialize_chat_outbox("chat", &[b"must-not-reseed".to_vec()])
+            .unwrap();
+        let pending = store.pending_chat_updates("chat").unwrap();
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0], original[0]);
+        assert_eq!(pending[1], ("stable-id".into(), b"new-turn".to_vec()));
+        assert_eq!(
+            store.load_snapshot_with_cursor("chat").unwrap().unwrap(),
+            (b"snapshot".to_vec(), 40229, 2)
+        );
+        store
+            .acknowledge_chat_update("other-chat", "stable-id")
+            .unwrap();
+        assert_eq!(store.pending_chat_updates("chat").unwrap().len(), 2);
+        store.acknowledge_chat_update("chat", "stable-id").unwrap();
+        assert_eq!(store.pending_chat_updates("chat").unwrap(), original);
+        store.delete_snapshot("chat").unwrap();
+        assert!(store.pending_chat_updates("chat").unwrap().is_empty());
+        assert!(!store.chat_outbox_initialized("chat").unwrap());
+    }
+}
+
+#[cfg(test)]
+mod publication_failure_tests {
+    use super::*;
+    #[test]
+    fn cursor_save_after_failed_outbox_write_keeps_a_durable_replay_obligation() {
+        for cursor_save in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let store = DocsStore::open(dir.path()).unwrap();
+            store
+                .save_snapshot_with_cursor("chat", b"before", 42, 2)
+                .unwrap();
+            store.initialize_chat_outbox("chat", &[]).unwrap();
+            store.conn().execute_batch("CREATE TRIGGER fail_publication BEFORE INSERT ON chat_outbox BEGIN SELECT RAISE(FAIL, 'injected disk failure'); END;").unwrap();
+            assert!(
+                store
+                    .enqueue_chat_update("chat", "batch", b"cleanup")
+                    .is_err()
+            );
+            if cursor_save {
+                store
+                    .save_snapshot_with_cursor("chat", b"after", 43, 2)
+                    .unwrap();
+            } else {
+                store.save_snapshot("chat", b"after").unwrap();
+            }
+            drop(store);
+            let reopened = DocsStore::open(dir.path()).unwrap();
+            assert!(!reopened.chat_outbox_initialized("chat").unwrap());
+            assert_eq!(
+                reopened.load_snapshot_with_cursor("chat").unwrap().unwrap(),
+                (b"after".to_vec(), if cursor_save { 43 } else { 42 }, 2)
+            );
+        }
     }
 }

--- a/docs/session-publication.md
+++ b/docs/session-publication.md
@@ -1,0 +1,70 @@
+# Durable session publication
+
+A remote agent can complete a turn while every peer parks its updates on missing
+Loro dependencies. In the observed recurrence, 136 previous-writer cleanup
+operations were absent from desktop; the next writer depended on their final
+operation. Fetching the same older checkpoint could never supply that history.
+
+Two lifecycle paths could strand local operations: LRU eviction dropped the
+in-memory pending queue, and runtime shutdown disconnected the local-update
+subscription before draining agents. A nonzero download cursor suppressed
+republication when reopening. Snapshot replay proved the causal blockage;
+historical relay/drop records were insufficient to attribute the original loss
+to one specific lifecycle event.
+
+The SQLite `chat_outbox` now journals each local update before network admission.
+Stable batch IDs survive client recreation and make lost-ACK replay idempotent.
+Opening a document imports pending updates before attaching writers, including
+updates newer than its last debounced snapshot. The local subscription survives
+network disconnection through agent cleanup. Cold-open initialization completes
+before exposing the writable handle. Durably queued operations can be evicted;
+a failed disk write pins the in-memory copy and invalidates the legacy replay
+marker atomically with subsequent snapshot saves, including cursor saves.
+
+A one-time, transactional bootstrap journals the saved document's operation
+history regardless of download cursor, repairing histories stranded by older
+writers. History is divided into relay-sized operation ranges without rewriting
+IDs, commands, epochs, or download cursors. This deliberately trades a one-time
+upload for recovery without relying on an unverified relay frontier. For the
+incident input, it produced 28 rows totaling 8,102,543 bytes. Subsequent opens
+replay only outstanding batches.
+
+Indivisible oversized or permanently rejected batches remain durable checkpoint
+obligations. A periodic retry survives missed events and failed POSTs; only
+rejections covered by a successfully uploaded snapshot retire. Checkpoint
+frontiers are decoded from the actual captured bytes, preventing concurrent
+writes from advertising a newer frontier than the snapshot.
+
+No relay protocol change or session lineage migration is required. SQLite
+migration 3 adds the outbox, its index, and the bootstrap marker. Older readers
+can consume the same updates. Writers must run the fix to obtain these durability
+guarantees; downgrading to a writer that does not journal updates reintroduces
+its old failure modes. This does not claim protection from arbitrary relay
+history deletion or prove that every possible checkpoint-pruning defect is fixed.
+
+## Validation
+
+`cargo test --locked -p zeron-sync --lib` covers the sync client and storage,
+including cursor preservation, restart/deduplication, and injected outbox-write
+failure followed by ordinary or cursor-bearing snapshot persistence.
+
+`cargo test --locked -p zeron-engine --lib --test session_publication --test restart_resume --test local_profiles --test born_chat2_race --test codex_subagents --test message_queue --test transcript_salvage`
+covers actual LRU eviction, disconnected cleanup before snapshot debounce,
+engine restart/resume, command queues, and profile lifecycle. The Codex adapter
+fixture reproduces a successful-but-invisible resumed turn, then validates full
+transcript equality through real ChatClients and EngineChatSinks over a loopback
+WebSocket relay. The relay withholds ACKs to test client recreation and rejects
+the first checkpoint POST to verify retry and retirement after success.
+
+The ignored `real_codex_restart_publication` test uses an installed authenticated
+Codex executable selected by `SESSION_SYNC_CODEX`; `SESSION_SYNC_MODEL` defaults
+to `gpt-6-astra`, with medium reasoning. It passed with two successful turns and
+an assertion that both used the same native session. All engine profiles and
+conversation working directories are temporary; no existing agent is interrupted.
+
+The ignored `supplied_incident_snapshots_reconcile_via_durable_bootstrap` test
+accepts `SESSION_SYNC_DESKTOP_SNAPSHOT` and `SESSION_SYNC_REMOTE_SNAPSHOT` paths.
+It passed using actual incident inputs through the loopback relay, restoring
+168 messages and exact transcript/command equality. Private snapshots and
+transcript bodies are not checked in. CI runs the deterministic suite without
+accounts or private inputs.


### PR DESCRIPTION
A completed remote turn could become invisible on desktop because its updates depended on local cleanup operations that never reached the relay. LRU eviction discarded the in-memory push queue; runtime shutdown also disconnected the local-update subscription before draining agents. Reopening a nonzero-cursor snapshot preserved the dependencies but did not republish them, leaving peers repeatedly fetching an older checkpoint.

This change journals outgoing updates in SQLite with stable batch IDs, restores them before attaching writers, and replays them across client recreation without duplicate relay rows. The durable subscription remains attached through disconnected shutdown cleanup. Cold opens publish their handles only after subscription setup. A transactional, one-time bounded replay repairs saved history stranded by older writers without changing message IDs, commands, epochs, or download cursors.

Rejected updates remain durable checkpoint obligations, including across a failed POST or missed event. Checkpoint frontiers now come from the captured snapshot bytes. Failed outbox writes preserve an in-memory copy and invalidate the bootstrap marker atomically with subsequent snapshot persistence, including cursor saves.

### Validation

- **254 deterministic tests passed:** 34 sync/storage tests and 220 engine/unit/integration tests covering LRU eviction, shutdown cleanup before snapshot debounce, restart/resume, profile switching, command queues, Codex subagents, and transcript salvage.
- **Real authenticated Codex harness, Astra Medium:** fresh and resumed turns completed in an isolated temporary profile; both used the same native session. Withheld predecessor operations reproduced an invisible successful turn. Durable replay through loopback WebSocket ChatClients restored exact transcript equality. Lost ACKs followed by sender recreation added no duplicate relay rows.
- **Actual incident snapshots:** the new bootstrap generated 28 bounded rows (8,102,543 bytes), restoring all 168 messages and exact transcript/command equality through the loopback relay. Private snapshots and transcript bodies are not included in this PR.
- Fault injection also covers an indivisible oversized operation, first-checkpoint POST failure with successful retry, and SQLite outbox-write failure followed by snapshot persistence.
- Added a CI job for the deterministic regressions. Live/account-dependent and private-input tests remain explicit opt-ins.

### Compatibility and scope

SQLite migration 3 adds the publication journal; the relay wire protocol and session lineage are unchanged. Existing documents incur one bounded full-history upload on first open after upgrade, then only outstanding batches replay. Writers must run the fix to obtain its durability guarantees. No production service was deployed, restarted, or interrupted during validation.

The actual snapshots establish the missing-dependency chain; historical relay/drop records are insufficient to prove which lifecycle event initiated the original loss. This addresses the reproduced publication defects and does not claim to fix arbitrary relay history deletion or every checkpoint-pruning scenario. Implementation and reproduction details are in `docs/session-publication.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791680172&installation_model_id=425430&pr_number=316&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F316&signature=73c6e826feee6712496aaddf7af6227ebe9705a7c6545e80cc129274d68c9dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->