### PR TITLE
Self-host the edge with AUTH_MODE=none

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ zeron daemon start
 
 On macOS: use the desktop release, or build `zeron` from source and run `zeron daemon install` to install the launchd service.
 
+Prefer to keep sync off other people's servers? The edge can run on your own machine with `docker compose`, no Cloudflare or WorkOS account needed — see [docs/SELFHOST.md](docs/SELFHOST.md).
+
 ---
 
 Developing or curious how it works? [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/zeronsh/comet) or check out [ARCHITECTURE.md](ARCHITECTURE.md).

--- a/crates/engine/src/auth.rs
+++ b/crates/engine/src/auth.rs
@@ -7,7 +7,11 @@
 //!
 //! Two modes:
 //! - **Dev** (no WorkOS client id configured, or the edge reports `auth: "dev"`): always
-//!   signed in; the bearer IS the configured user id (current M2/M3 behavior).
+//!   signed in; the bearer IS the configured user id (current M2/M3 behavior). A
+//!   self-hosted edge in `AUTH_MODE=none` is the same mode from the engine's side,
+//!   except the identity comes from the edge: [`Auth::detect`] reads `userId`/`orgId`
+//!   off `/health` and uses `user@org` as the dev bearer, so every device pointed at
+//!   that edge lands in the same workspace without coordinating env vars.
 //! - **WorkOS**: authorization-code flow. Headed devices use a loopback callback server
 //!   on an ephemeral port; headless devices use the paste-code flow (the redirect is the
 //!   edge's hosted `/auth/cli/callback` page, which shows `state.code` to paste back via
@@ -136,6 +140,10 @@ pub struct AuthConfig {
     pub dev_user_id: String,
     /// Loopback callback port; `None` = ephemeral.
     pub callback_port: Option<u16>,
+    /// Set by [`Auth::detect`] when the edge answered `auth: "none"`: a self-hosted
+    /// open edge whose identity this config adopted. Sync is on for such an edge even
+    /// though no bearer was configured — the edge does not want one.
+    pub open_edge: bool,
 }
 
 impl AuthConfig {
@@ -147,6 +155,7 @@ impl AuthConfig {
             workos_api_base: "https://api.workos.com".into(),
             dev_user_id: "dev-user".into(),
             callback_port: None,
+            open_edge: false,
         }
     }
 }
@@ -289,39 +298,67 @@ impl Auth {
         }
     }
 
-    /// Like [`Auth::new`], but additionally probes `{edge}/health`: an edge running in
-    /// dev auth mode forces dev mode even when a client id is configured (matching the
-    /// edge's "bearer = user id" verification).
+    /// Like [`Auth::new`], but additionally probes `{edge}/health`:
+    /// - `auth: "dev"` forces dev mode even when a client id is configured (matching
+    ///   the edge's "bearer = user id" verification).
+    /// - `auth: "none"` (self-hosted open edge) forces dev mode and adopts the edge's
+    ///   fixed `userId`/`orgId` as the `user@org` dev bearer, so the engine's
+    ///   development profile lands in the workspace the edge actually serves.
+    ///
+    /// An unreachable edge leaves the config untouched; this never blocks boot on
+    /// the network for longer than the probe timeout.
     pub async fn detect(mut config: AuthConfig) -> Self {
-        if config.workos_client_id.is_some() {
-            #[derive(Deserialize)]
-            struct Health {
-                auth: Option<String>,
+        #[derive(Deserialize)]
+        struct Health {
+            auth: Option<String>,
+            #[serde(default, rename = "userId")]
+            user_id: Option<String>,
+            #[serde(default, rename = "orgId")]
+            org_id: Option<String>,
+        }
+        let url = format!("{}/health", config.edge_url.trim_end_matches('/'));
+        let probe = async {
+            let response = reqwest::Client::new()
+                .get(&url)
+                .timeout(Duration::from_secs(3))
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            response.json::<Health>().await.map_err(|e| e.to_string())
+        };
+        match probe.await {
+            Err(error) => {
+                tracing::debug!(%url, %error, "auth: edge health probe failed; keeping configured mode");
             }
-            let url = format!("{}/health", config.edge_url.trim_end_matches('/'));
-            let probe = async {
-                reqwest::Client::new()
-                    .get(&url)
-                    .timeout(Duration::from_secs(3))
-                    .send()
-                    .await
-                    .ok()?
-                    .json::<Health>()
-                    .await
-                    .ok()
-            };
-            if let Some(health) = probe.await
-                && health.auth.as_deref() == Some("dev")
-            {
-                tracing::info!("auth: edge is in dev mode — using dev bearer");
-                config.workos_client_id = None;
-            }
+            Ok(health) => match health.auth.as_deref() {
+                Some("none") => {
+                    let non_empty = |s: Option<String>| s.filter(|s| !s.trim().is_empty());
+                    let user = non_empty(health.user_id).unwrap_or_else(|| "local".into());
+                    let org = non_empty(health.org_id).unwrap_or_else(|| "local".into());
+                    tracing::info!(%user, %org, "auth: edge is open (AUTH_MODE=none) — skipping WorkOS");
+                    config.workos_client_id = None;
+                    config.dev_user_id = format!("{user}@{org}");
+                    config.open_edge = true;
+                }
+                Some("dev") if config.workos_client_id.is_some() => {
+                    tracing::info!("auth: edge is in dev mode — using dev bearer");
+                    config.workos_client_id = None;
+                }
+                _ => {}
+            },
         }
         Self::new(config)
     }
 
     pub fn workos_enabled(&self) -> bool {
         self.inner.workos.is_some()
+    }
+
+    /// True when [`Auth::detect`] found a self-hosted edge in `AUTH_MODE=none` and
+    /// adopted its identity. Such an edge is meant to be synced against even though the
+    /// runtime is in dev mode with no configured bearer.
+    pub fn open_edge(&self) -> bool {
+        self.inner.config.open_edge
     }
 
     /// True when construction loaded a parseable persisted WorkOS session.
@@ -349,6 +386,21 @@ impl Auth {
             return Some(dev.split('@').next().unwrap_or(dev).to_string());
         }
         self.state().user().map(|u| u.id.clone())
+    }
+
+    /// The org half of a `user@org` dev bearer — set by [`Auth::detect`] when a
+    /// self-hosted edge advertises its identity. `None` in WorkOS mode or for a bare
+    /// dev user id.
+    pub fn dev_org_id(&self) -> Option<String> {
+        if self.inner.workos.is_some() {
+            return None;
+        }
+        self.inner
+            .config
+            .dev_user_id
+            .split_once('@')
+            .map(|(_, org)| org.to_string())
+            .filter(|org| !org.is_empty())
     }
 
     /// Current bearer for edge rooms / the device relay — `None` when signed out.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -592,6 +592,14 @@ impl Engine {
     /// Resolve the shared dev/WorkOS auth configuration for headed and headless
     /// modes. A clean WorkOS boot deliberately avoids probing Edge: signed-out
     /// installations must be able to start locally without network access.
+    ///
+    /// A dev-mode boot (no WorkOS client id) that was pointed at an edge
+    /// explicitly (`ZERON_EDGE_URL` set) does probe: that is the self-host path
+    /// (`ZERON_EDGE_URL=… ZERON_WORKOS_CLIENT_ID=`), and an edge answering
+    /// `auth: "none"` dictates the identity every device must use — its
+    /// `userId`/`orgId` override any `ZERON_EDGE_TOKEN`, because the edge will
+    /// only ever authorize rooms under its own fixed org. A dev boot with no
+    /// edge named stays offline and makes no requests at all.
     pub async fn build_auth(config: &EngineConfig) -> Auth {
         let mut auth_config = AuthConfig::new(config.edge_url.clone(), config.data_dir.clone());
         auth_config.workos_client_id = config.workos_client_id.clone();
@@ -608,6 +616,10 @@ impl Engine {
         );
         if let Some(token) = &config.edge_token {
             auth_config.dev_user_id = token.clone();
+        }
+        let edge_named = std::env::var("ZERON_EDGE_URL").is_ok_and(|url| !url.trim().is_empty());
+        if auth_config.workos_client_id.is_none() && edge_named {
+            return Auth::detect(auth_config).await;
         }
         Auth::new(auth_config)
     }
@@ -640,7 +652,11 @@ impl Engine {
                     .and_then(|token| token.split_once('@'))
                     .map(|(_, org)| org.to_string())
                     .filter(|org| !org.is_empty());
-                let org_id = dev_token_org
+                // The auth service's org wins: a self-hosted `AUTH_MODE=none` edge
+                // advertises the org it serves and `build_auth` adopted it there.
+                let org_id = auth
+                    .dev_org_id()
+                    .or(dev_token_org)
                     .or(config.org_id.clone())
                     .unwrap_or_else(|| env_or("ZERON_ORG_ID", DEFAULT_ORG_ID));
                 let user_id = auth
@@ -731,11 +747,15 @@ impl Engine {
             // Dev Auth always exposes `dev_user_id` as its synthetic access
             // token, including when WorkOS was merely disabled with
             // ZERON_WORKOS_CLIENT_ID="". Only an explicitly configured,
-            // non-empty bearer opts this runtime into Edge rooms and relays.
-            WorkspaceScope::Development => config
-                .edge_token
-                .as_deref()
-                .is_some_and(|token| !token.trim().is_empty()),
+            // non-empty bearer — or a self-hosted edge that announced itself
+            // as open on `/health` — opts this runtime into Edge rooms and relays.
+            WorkspaceScope::Development => {
+                auth.open_edge()
+                    || config
+                        .edge_token
+                        .as_deref()
+                        .is_some_and(|token| !token.trim().is_empty())
+            }
         };
         if edge_enabled {
             // OS network-path events (macOS NWPathMonitor): the instant the

--- a/crates/engine/tests/auth.rs
+++ b/crates/engine/tests/auth.rs
@@ -569,3 +569,52 @@ async fn detect_probes_edge_dev_mode() {
     assert_eq!(auth.access_token().await.as_deref(), Some("dev-w"));
     task.abort();
 }
+
+#[tokio::test]
+async fn detect_probes_edge_none_mode_adopts_identity() {
+    // A self-hosted open edge advertises its fixed identity; the engine adopts it as the
+    // `user@org` dev bearer even over an explicitly configured one.
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let task = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            if read_request(&mut stream).await.is_some() {
+                respond(
+                    &mut stream,
+                    "200 OK",
+                    r#"{"ok":true,"auth":"none","userId":"home","orgId":"lab"}"#,
+                )
+                .await;
+            }
+        }
+    });
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = workos_config(&format!("http://127.0.0.1:{port}"), dir.path());
+    config.dev_user_id = "someone@else".into();
+    let auth = Auth::detect(config).await;
+    assert!(!auth.workos_enabled(), "open edge skips WorkOS");
+    assert_eq!(auth.access_token().await.as_deref(), Some("home@lab"));
+    assert_eq!(auth.user_id().as_deref(), Some("home"));
+    assert_eq!(auth.dev_org_id().as_deref(), Some("lab"));
+    assert!(auth.open_edge(), "an open edge is one we sync against");
+    task.abort();
+}
+
+#[tokio::test]
+async fn detect_leaves_dev_config_alone_when_edge_is_unreachable() {
+    // Nothing listening: the probe times out and the configured dev identity stands.
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    drop(listener);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = AuthConfig::new(format!("http://127.0.0.1:{port}"), dir.path());
+    config.dev_user_id = "alice@acme".into();
+    let auth = Auth::detect(config).await;
+    assert!(!auth.workos_enabled());
+    assert_eq!(auth.user_id().as_deref(), Some("alice"));
+    assert_eq!(auth.dev_org_id().as_deref(), Some("acme"));
+    assert!(!auth.open_edge());
+}

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -1,0 +1,31 @@
+# Self-hosted Zeron edge: rooms + blobs on a Docker volume, no Cloudflare,
+# no WorkOS. See docs/SELFHOST.md.
+#
+#   docker compose -f docker-compose.selfhost.yml up --build
+#
+# Point a client at it:
+#   ZERON_EDGE_URL=http://localhost:8787 ZERON_WORKOS_CLIENT_ID= zeron headless
+services:
+  edge:
+    build:
+      context: ./edge
+      dockerfile: Dockerfile
+    ports:
+      - "8787:8787"
+    environment:
+      AUTH_MODE: ${AUTH_MODE:-none}
+      SELFHOST_USER_ID: ${SELFHOST_USER_ID:-local}
+      SELFHOST_ORG_ID: ${SELFHOST_ORG_ID:-local}
+    volumes:
+      # Durable Object SQLite + R2 object store (attachments, backups).
+      - zeron-edge-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8787/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+volumes:
+  zeron-edge-data:

--- a/docs/SELFHOST.md
+++ b/docs/SELFHOST.md
@@ -1,0 +1,93 @@
+# Self-hosting the edge
+
+Run the same `edge/` Worker that backs `edge.zeron.sh` on your own machine:
+local workerd via `wrangler dev`, Durable Object and R2 state on disk, no
+Cloudflare account, no WorkOS. Every device you point at it lands in one
+shared workspace, so you get multi-device sync without an account.
+
+## Quick start
+
+```bash
+docker compose -f docker-compose.selfhost.yml up --build
+curl -s localhost:8787/health
+# {"ok":true,"auth":"none","userId":"local","orgId":"local"}
+```
+
+Point an engine at it. Setting `ZERON_WORKOS_CLIENT_ID` to the empty string
+turns the built-in production login off; because `ZERON_EDGE_URL` names an
+edge explicitly, the engine probes its `/health`, sees `auth: "none"`, adopts
+the edge's identity and enables sync. No `zeron login`. (A dev-mode engine
+with no `ZERON_EDGE_URL` never touches the network — that behaviour is
+unchanged.)
+
+```bash
+ZERON_EDGE_URL=http://localhost:8787 ZERON_WORKOS_CLIENT_ID= zeron headless
+```
+
+To make it stick across reboots, install the daemon with those variables in
+the environment — `zeron daemon install` bakes `ZERON_EDGE_URL` and
+`ZERON_WORKOS_CLIENT_ID` into the service unit:
+
+```bash
+ZERON_EDGE_URL=https://zeron.example.net ZERON_WORKOS_CLIENT_ID= zeron daemon install
+```
+
+The desktop app reads the same two variables.
+
+## What `AUTH_MODE=none` means
+
+There is no bearer check. Every request is treated as the single fixed user
+and org configured on the edge (`SELFHOST_USER_ID` / `SELFHOST_ORG_ID`,
+default `local` / `local`), which is Zeron's one-user-many-devices model with
+the identity supplied by the server instead of a login.
+
+That also means **anyone who can reach the port is that user**. Put the edge
+on a private network — a LAN, Tailscale, or behind a reverse proxy that does
+its own authentication. Do not expose port 8787 to the public internet.
+
+Compared with `AUTH_MODE=dev` (which already existed for local development),
+`none` moves the identity to the edge: devices no longer need a matching
+`ZERON_EDGE_TOKEN=user@org`, they just need the URL. An explicit
+`ZERON_EDGE_TOKEN` is ignored against a `none` edge, because the edge will
+only authorize rooms under its own org anyway.
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTH_MODE` | `none` | Leave as `none` for self-host. `dev` and `workos` behave as in `wrangler.jsonc`. |
+| `SELFHOST_USER_ID` | `local` | The user every caller becomes. |
+| `SELFHOST_ORG_ID` | `local` | The org every caller becomes. Changing it after first use starts a fresh workspace. |
+
+State lives in the `zeron-edge-data` Docker volume (`/data` in the
+container): Durable Object SQLite for rooms and registries, and the R2-backed
+object store for attachments and backups. Back it up like any other volume.
+
+### Without Docker
+
+```bash
+cd edge
+npm ci
+npm run dev:selfhost          # wrangler dev, persisted to ./data, on 0.0.0.0:8787
+```
+
+### Updates
+
+Clients look for release artifacts on the edge they are pointed at
+(`/releases/manifest.json`). A self-hosted edge has none, so `zeron update`
+and the in-app auto-update log a warning and do nothing; update the binary
+the way you installed it. Publishing your own builds into the `RELEASES`
+bucket makes the normal flow work again.
+
+### TLS
+
+workerd serves plain HTTP. For anything beyond one machine, terminate TLS
+in front of it (Caddy, nginx, Tailscale Serve) and give clients the `https://`
+URL. WebSocket upgrades must be passed through.
+
+## Keeping `wrangler.selfhost.jsonc` current
+
+The self-host config is a copy of `wrangler.jsonc` minus the Cloudflare
+account, routes and production vars. When a new Durable Object class or
+migration is added to `wrangler.jsonc`, add it here too — a class missing
+from the self-host bindings is a room the Worker cannot route to.

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -1,0 +1,33 @@
+# Zeron edge — self-host image.
+# The same Worker + Durable Object + R2 code as production, run under local
+# workerd (via wrangler) with rooms and blobs persisted to /data.
+#
+#   docker build -t zeron-edge .
+#   docker run --rm -p 8787:8787 -v zeron-edge-data:/data zeron-edge
+#
+# See docs/SELFHOST.md.
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json wrangler.selfhost.jsonc docker-entrypoint.sh ./
+COPY src ./src
+
+RUN chmod +x docker-entrypoint.sh
+
+ENV AUTH_MODE=none \
+    SELFHOST_USER_ID=local \
+    SELFHOST_ORG_ID=local \
+    npm_config_update_notifier=false
+
+EXPOSE 8787
+VOLUME ["/data"]
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/edge/docker-entrypoint.sh
+++ b/edge/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Docker entrypoint: the production Worker under local workerd, state on /data.
+set -eu
+exec npx wrangler dev \
+  --config wrangler.selfhost.jsonc \
+  --ip 0.0.0.0 \
+  --port 8787 \
+  --local \
+  --persist-to /data \
+  --var "AUTH_MODE:${AUTH_MODE:-none}" \
+  --var "SELFHOST_USER_ID:${SELFHOST_USER_ID:-local}" \
+  --var "SELFHOST_ORG_ID:${SELFHOST_ORG_ID:-local}"

--- a/edge/package.json
+++ b/edge/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev --port 27640 --var AUTH_MODE:dev",
+    "dev:selfhost": "wrangler dev --config wrangler.selfhost.jsonc --port 8787 --ip 0.0.0.0 --local --persist-to ./data",
     "deploy": "wrangler deploy",
     "build": "wrangler deploy --dry-run --outdir dist",
     "typecheck": "tsc --noEmit",

--- a/edge/src/auth.test.ts
+++ b/edge/src/auth.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { authMode, authenticate, selfhostIdentity, verifyToken } from "./auth";
+import type { Env } from "./env";
+
+const env = (vars: Partial<Env>): Env => ({ WORKOS_CLIENT_ID: "", AUTH_MODE: "workos", ...vars }) as Env;
+
+describe("authMode", () => {
+  it("normalizes case and whitespace", () => {
+    expect(authMode(env({ AUTH_MODE: " None " }))).toBe("none");
+    expect(authMode(env({ AUTH_MODE: "DEV" }))).toBe("dev");
+  });
+
+  it("treats anything unrecognized as workos", () => {
+    expect(authMode(env({ AUTH_MODE: "" }))).toBe("workos");
+    expect(authMode(env({ AUTH_MODE: "pair" }))).toBe("workos");
+    expect(authMode(env({ AUTH_MODE: undefined as unknown as string }))).toBe("workos");
+  });
+});
+
+describe("AUTH_MODE=none", () => {
+  const open = env({ AUTH_MODE: "none" });
+
+  it("defaults the identity to local/local", () => {
+    expect(selfhostIdentity(open)).toEqual({ userId: "local", orgId: "local" });
+  });
+
+  it("honours SELFHOST_* overrides and ignores blanks", () => {
+    expect(selfhostIdentity(env({ AUTH_MODE: "none", SELFHOST_USER_ID: " dan ", SELFHOST_ORG_ID: "home" }))).toEqual({
+      userId: "dan",
+      orgId: "home"
+    });
+    expect(selfhostIdentity(env({ AUTH_MODE: "none", SELFHOST_USER_ID: "  " }))).toEqual({
+      userId: "local",
+      orgId: "local"
+    });
+  });
+
+  it("authenticates a request with no bearer at all", async () => {
+    const request = new Request("https://edge.local/session/abc/ws");
+    expect(await authenticate(open, request)).toEqual({ userId: "local", orgId: "local" });
+  });
+
+  it("ignores whatever bearer is presented", async () => {
+    expect(await verifyToken(open, "someone@else")).toEqual({ userId: "local", orgId: "local" });
+    const request = new Request("https://edge.local/tail/abc", {
+      headers: { authorization: "Bearer not-a-jwt" }
+    });
+    expect(await authenticate(open, request)).toEqual({ userId: "local", orgId: "local" });
+  });
+});
+
+describe("AUTH_MODE=dev", () => {
+  const dev = env({ AUTH_MODE: "dev" });
+
+  it("still requires a bearer", async () => {
+    expect(await authenticate(dev, new Request("https://edge.local/tail/abc"))).toBeUndefined();
+  });
+
+  it("parses user@org", async () => {
+    expect(await verifyToken(dev, "alice@acme")).toEqual({ userId: "alice", orgId: "acme" });
+    expect(await verifyToken(dev, "alice")).toEqual({ userId: "alice" });
+  });
+});

--- a/edge/src/auth.ts
+++ b/edge/src/auth.ts
@@ -7,6 +7,11 @@
  * Workspace rooms (`ws/{orgId}`) authorize on the token's WorkOS organization
  * claim (`org_id`, present when the session was refreshed scoped to an org):
  * membership = claim equals the room's orgId.
+ *
+ * AUTH_MODE=none (self-host): no bearer required. The edge is a single-tenant
+ * trust boundary — every caller is the fixed user+org from `SELFHOST_USER_ID`
+ * / `SELFHOST_ORG_ID` (default `local`/`local`). Anyone who can reach the
+ * port is that user, so this mode belongs on a private network.
  */
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import type { Env } from "./env";
@@ -17,6 +22,21 @@ export interface Verified {
   /** WorkOS `org_id` claim — the org the caller's session is scoped to. */
   readonly orgId?: string;
 }
+
+export type AuthMode = "workos" | "dev" | "none";
+
+/** Normalized `AUTH_MODE`; anything unrecognized is treated as `workos`. */
+export const authMode = (env: Env): AuthMode => {
+  const mode = (env.AUTH_MODE ?? "workos").trim().toLowerCase();
+  return mode === "dev" || mode === "none" ? mode : "workos";
+};
+
+/** The single identity every caller gets under AUTH_MODE=none. */
+export const selfhostIdentity = (env: Env): Verified => {
+  const userId = (env.SELFHOST_USER_ID ?? "local").trim() || "local";
+  const orgId = (env.SELFHOST_ORG_ID ?? "local").trim() || "local";
+  return { userId, orgId };
+};
 
 const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
@@ -37,7 +57,12 @@ export const bearerFromRequest = (request: Request): string | undefined => {
 };
 
 export const verifyToken = async (env: Env, token: string): Promise<Verified | undefined> => {
-  if (env.AUTH_MODE === "dev") {
+  const mode = authMode(env);
+  if (mode === "none") {
+    // The bearer is ignored: self-host is open to whoever can reach the process.
+    return selfhostIdentity(env);
+  }
+  if (mode === "dev") {
     // Dev mode mirrors the old apps/server: the bearer string IS the user id.
     // `userId@orgId` additionally carries a fake org claim so workspace-room
     // membership is exercisable locally (smoke tests).
@@ -63,6 +88,7 @@ export const verifyToken = async (env: Env, token: string): Promise<Verified | u
 };
 
 export const authenticate = async (env: Env, request: Request): Promise<Verified | undefined> => {
+  if (authMode(env) === "none") return selfhostIdentity(env);
   const token = bearerFromRequest(request);
   if (!token) return undefined;
   return verifyToken(env, token);

--- a/edge/src/env.ts
+++ b/edge/src/env.ts
@@ -13,8 +13,14 @@ export interface Env {
    * /releases/* for the curl-install flow. */
   RELEASES: R2Bucket;
   WORKOS_CLIENT_ID: string;
-  /** "workos" (verify AuthKit JWTs) or "dev" (bearer == userId, never prod). */
+  /** "workos" (verify AuthKit JWTs), "dev" (bearer == userId, never prod), or
+   * "none" (self-host: no bearer, every caller is the fixed SELFHOST_* identity;
+   * docs/SELFHOST.md). */
   AUTH_MODE: string;
+  /** AUTH_MODE=none identity (default `local` / `local`). Single-tenant
+   * self-host: every device shares this user+org. */
+  SELFHOST_USER_ID?: string;
+  SELFHOST_ORG_ID?: string;
   /** Optional overrides for the WorkOS trust anchor. */
   WORKOS_ISSUER?: string;
   WORKOS_JWKS_URL?: string;

--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -36,7 +36,7 @@
  *   GET  /chat2/:chatId/stats
  *   POST /chat2/:chatId/reset
  */
-import { authenticate } from "./auth";
+import { authMode, authenticate, selfhostIdentity } from "./auth";
 import { handleAuthRoute } from "./auth-routes";
 import { AUTH_USER_HEADER, ROOM_KIND_HEADER, type Env } from "./env";
 import { SessionRoom } from "./session-room";
@@ -116,7 +116,14 @@ export default {
     const parts = url.pathname.split("/").filter(Boolean);
 
     if (url.pathname === "/health") {
-      return json({ ok: true, auth: env.AUTH_MODE === "dev" ? "dev" : "workos" });
+      const mode = authMode(env);
+      if (mode === "none") {
+        // Self-host: advertise the fixed identity so engines adopt it without
+        // any out-of-band `user@org` configuration.
+        const id = selfhostIdentity(env);
+        return json({ ok: true, auth: mode, userId: id.userId, orgId: id.orgId });
+      }
+      return json({ ok: true, auth: mode });
     }
 
     // ── public install surface (also routed from zeron.sh): the

--- a/edge/wrangler.selfhost.jsonc
+++ b/edge/wrangler.selfhost.jsonc
@@ -1,0 +1,55 @@
+{
+  // Self-host config: the same Worker, Durable Objects and R2 bindings as
+  // wrangler.jsonc, but run under local workerd with disk persistence —
+  // no Cloudflare account, no routes, no WorkOS (AUTH_MODE=none).
+  //
+  //   wrangler dev --config wrangler.selfhost.jsonc --local --persist-to ./data
+  //   docker compose -f ../docker-compose.selfhost.yml up   (see docs/SELFHOST.md)
+  //
+  // Keep the bindings and migrations in lockstep with wrangler.jsonc: DO
+  // storage is keyed by class name, so a class missing here is a room the
+  // Worker will fail to route to.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "zeron-edge-selfhost",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-01",
+  "workers_dev": false,
+  "rules": [{ "type": "Text", "globs": ["**/*.sh"], "fallthrough": true }],
+  "alias": {
+    "loro-crdt": "loro-crdt/base64"
+  },
+  "durable_objects": {
+    "bindings": [
+      { "name": "SESSION_ROOMS", "class_name": "SessionRoom" },
+      { "name": "DEVICE_ROOMS", "class_name": "DeviceRoom" },
+      { "name": "PREVIEW_ROOMS", "class_name": "PreviewRoom" },
+      { "name": "REGISTRY_ROOMS", "class_name": "RegistryRoom" },
+      { "name": "CHAT_ROOMS", "class_name": "ChatRoom" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["SessionRoom", "DeviceRoom"] },
+    { "tag": "v2", "new_sqlite_classes": ["RegistryRoom"] },
+    { "tag": "v3", "new_sqlite_classes": ["ChatRoom"] },
+    { "tag": "v4", "new_sqlite_classes": ["PreviewRoom"] }
+  ],
+  "r2_buckets": [
+    {
+      // Attachments + backups — disk-backed under --persist-to.
+      "binding": "BLOBS",
+      "bucket_name": "zeron-selfhost-blobs"
+    },
+    {
+      // Release mirror for /releases/*; unused unless you publish builds
+      // through your own edge, but the Worker binds it unconditionally.
+      "binding": "RELEASES",
+      "bucket_name": "zeron-selfhost-releases"
+    }
+  ],
+  "vars": {
+    "WORKOS_CLIENT_ID": "",
+    "AUTH_MODE": "none",
+    "SELFHOST_USER_ID": "local",
+    "SELFHOST_ORG_ID": "local"
+  }
+}


### PR DESCRIPTION
## Summary

Run the production edge Worker on your own machine — local workerd via `wrangler dev`, Durable Object and R2 state on a Docker volume, no Cloudflare account, no WorkOS — and have every device pointed at it share one workspace.

```bash
docker compose -f docker-compose.selfhost.yml up --build
ZERON_EDGE_URL=http://localhost:8787 ZERON_WORKOS_CLIENT_ID= zeron headless
```

`ZERON_EDGE_URL` already existed "for local dev / self-hosting"; this fills in the rest so it is actually a self-host story rather than a dev-mode one.

## Edge

- A third `AUTH_MODE`, `none`: no bearer is checked, every caller is the fixed identity from `SELFHOST_USER_ID` / `SELFHOST_ORG_ID` (default `local`/`local`). `/health` advertises `userId`/`orgId` so clients adopt it without any out-of-band `user@org` coordination.
- `none` is open to whoever can reach the port. `docs/SELFHOST.md` says so plainly and tells people to keep it on a private network or behind their own auth.
- Packaging: `edge/Dockerfile`, `docker-compose.selfhost.yml` (volume-backed, healthcheck), `edge/wrangler.selfhost.jsonc` (bindings and migrations mirror `wrangler.jsonc`, with a note to keep them in lockstep), `npm run dev:selfhost`.
- `edge/src/auth.test.ts` covers mode normalisation, identity defaults/overrides, and that `none` authenticates with or without a bearer while `dev` still requires one.

## Engine

- `Auth::detect` (previously only used by tests) now understands `auth: "none"`: drops WorkOS, takes the edge's `userId`/`orgId` as the `user@org` dev bearer, and flags the config as an open edge.
- `resolve_profile` prefers that org for the development profile, and `assemble_runtime` enables Edge rooms/relays for an open edge even with no `ZERON_EDGE_TOKEN`.
- `build_auth` probes only when WorkOS is off **and** `ZERON_EDGE_URL` is set. A dev boot that names no edge still makes zero network requests — `local_first::development_without_an_explicit_bearer_stays_offline` is unchanged and passing. A clean WorkOS boot is untouched.
- Two new tests in `engine/tests/auth.rs`: identity adoption from a `none` edge (overriding a configured dev bearer), and an unreachable edge leaving the configured dev identity alone.

## Verification

- `npm test` in `edge/` (unit + workerd), `cargo test -p zeron-engine` all green.
- End to end against both `npm run dev:selfhost` and the compose image: engine logs `auth: edge is open (AUTH_MODE=none)`, registry room joins under `org=local`, device-room host connects, profile lands in `orgs/local/local`. Compose healthcheck goes healthy.

## Not in this PR

A locked-down self-host mode (device tokens + QR pairing for phones) is a separate feature and will follow once this lands. Release mirroring for `zeron update` against a self-hosted edge is documented as unsupported for now.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791682628&installation_model_id=425430&pr_number=317&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F317&signature=870871c2b90e6c9a8fa3190c2fd716cf3e74a3a7d5be7278e24f016d4df48784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
