### PR TITLE
Update DeepWiki links for renamed repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ On macOS: use the desktop release, or build `zeron` from source and run `zeron d
 
 ---
 
-Developing or curious how it works? [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/zeronsh/comet) or check out [ARCHITECTURE.md](ARCHITECTURE.md).
+Developing or curious how it works? [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/zeronsh/zeron) or check out [ARCHITECTURE.md](ARCHITECTURE.md).
 
 Licensed under the [MIT License](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,6 +51,6 @@ macOS 上用桌面版发行包，或者从源码构建 `zeron`，再运行 `zero
 
 ---
 
-想参与开发，或者好奇它怎么跑起来的？[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/zeronsh/comet)，也可以看 [ARCHITECTURE.md](ARCHITECTURE.md)。
+想参与开发，或者好奇它怎么跑起来的？[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/zeronsh/zeron)，也可以看 [ARCHITECTURE.md](ARCHITECTURE.md)。
 
 采用 [MIT License](LICENSE)。


### PR DESCRIPTION
Update the DeepWiki badge target to zeronsh/zeron in the English and Chinese READMEs following the repository rename. Verified both links and ran git diff --check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/zeron/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791684716&installation_model_id=425430&pr_number=318&repository=zeronsh%2Fzeron&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fzeron%2Fpull%2F318&signature=efeddb803c817db4c05147208b32e98fced8523028b336a6e2994e0c5246c2e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->