### PR TITLE
fix(ui): balance queue vertical spacing

### DIFF
--- a/crates/ui/src/queue.rs
+++ b/crates/ui/src/queue.rs
@@ -80,7 +80,10 @@ const ROW_PAD_X: f32 = 8.0;
 const ROW_RADIUS: f32 = 8.0;
 const PANEL_PAD_X: f32 = 8.0;
 const PANEL_RADIUS: f32 = ROW_RADIUS + PANEL_PAD_X;
-const PANEL_PAD_TOP: f32 = PANEL_PAD_X;
+const PANEL_PAD_Y: f32 = 8.0;
+// The font's visible glyphs sit 1px above the row's geometric center.
+const PANEL_PAD_TOP: f32 = PANEL_PAD_Y + 1.0;
+const PANEL_PAD_BOTTOM: f32 = PANEL_PAD_Y - 1.0;
 /// The custom 24px queue glyphs have quieter geometry than the legacy set, so
 /// render them slightly larger to preserve the previous optical weight.
 const QUEUE_ICON_SIZE: f32 = 13.0;
@@ -206,7 +209,8 @@ fn queue_panel_surface(theme: &Theme) -> gpui::Div {
         .when(!theme.is_frost(), |el| el.shadow_lg())
         .px(px(PANEL_PAD_X))
         .pt(px(PANEL_PAD_TOP))
-        .pb(px(QUEUE_COMPOSER_OVERLAP))
+        // Preserve the visible bottom padding above the overlapping composer.
+        .pb(px(PANEL_PAD_BOTTOM + QUEUE_COMPOSER_OVERLAP))
         .flex()
         .flex_col()
 }


### PR DESCRIPTION
The queue's vertical padding did not account for the area covered by the composer, leaving uneven visible space around its content. Preserve bottom padding above the overlap and apply a 1 px optical correction to center the visible glyphs.

<img width="848" height="142" alt="image" src="https://github.com/user-attachments/assets/126c4122-7145-459c-82e6-cb7522d05076" />

Validation: the updated app screenshot shows 22 clear pixels above and below the queue text. `rustfmt --check --edition 2024 crates/ui/src/queue.rs` and `git diff --check` pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/zeron/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791728173&installation_model_id=425430&pr_number=321&repository=zeronsh%2Fzeron&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fzeron%2Fpull%2F321&signature=c2890b8c6ea7992062b66029618ffe2e78ac4dd5916a371ea142960d6c8d628a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->