### PR TITLE
Allow editing staged review comments across diffs and files

### DIFF
--- a/crates/ui/src/changes.rs
+++ b/crates/ui/src/changes.rs
@@ -965,7 +965,10 @@ fn comment_state_key(
     comments: &[ReviewComment],
     draft: Option<&(String, CommentSide, u32)>,
 ) -> u64 {
-    let mut parts: Vec<String> = comments.iter().map(|comment| comment.id.clone()).collect();
+    let mut parts: Vec<String> = comments
+        .iter()
+        .flat_map(|comment| [comment.id.clone(), comment.body.clone()])
+        .collect();
     if let Some((path, side, line)) = draft {
         parts.push(format!("draft:{path}:{}:{line}", side.tag()));
     }
@@ -1530,6 +1533,7 @@ struct HoverRow {
 }
 
 struct CommentDraft {
+    editing_id: Option<String>,
     /// Composer the note will stage onto, captured when the card opened. A
     /// draft belongs to the checkout it was written over, so it must not
     /// follow the user onto whatever chat is selected by commit time.
@@ -2573,7 +2577,17 @@ impl Changes {
     /// Cloned because rendering borrows `self` mutably a moment later.
     fn staged_comments(&self, cx: &App) -> Vec<ReviewComment> {
         let state = self.state.read(cx);
-        state.review_comments(&state.composer_key()).to_vec()
+        state
+            .review_comments(&state.composer_key())
+            .iter()
+            .filter(|comment| {
+                self.draft
+                    .as_ref()
+                    .and_then(|draft| draft.editing_id.as_ref())
+                    != Some(&comment.id)
+            })
+            .cloned()
+            .collect()
     }
 
     fn comments_for(&self, path: &str, cx: &App) -> Vec<ReviewComment> {
@@ -2717,6 +2731,7 @@ impl Changes {
         let key = self.state.read(cx).composer_key();
         let old_path = self.old_path_of(&path);
         self.draft = Some(CommentDraft {
+            editing_id: None,
             key,
             path,
             old_path,
@@ -2726,6 +2741,32 @@ impl Changes {
             _events: events,
         });
         window.focus(&handle, cx);
+        self.sync_comment_rows(cx);
+        cx.notify();
+    }
+
+    fn edit_comment(&mut self, id: &str, window: &mut Window, cx: &mut Context<Self>) {
+        let state = self.state.read(cx);
+        let Some(comment) = state
+            .review_comments(&state.composer_key())
+            .iter()
+            .find(|comment| comment.id == id && !comment.is_file())
+            .cloned()
+        else {
+            return;
+        };
+        let Some((side, line)) = comment.diff_anchor() else {
+            return;
+        };
+        self.open_draft(comment.path.clone(), side, line, window, cx);
+        let draft = self.draft.as_mut().unwrap();
+        draft.editing_id = Some(comment.id);
+        if let comments::CommentSource::Diff { old_path, .. } = comment.source {
+            draft.old_path = old_path;
+        }
+        draft
+            .input
+            .update(cx, |input, cx| input.set_text(comment.body, cx));
         self.sync_comment_rows(cx);
         cx.notify();
     }
@@ -2746,13 +2787,18 @@ impl Changes {
             cx.notify();
             return;
         }
-        let comment = ReviewComment::new(draft.path, draft.side, draft.line, body)
-            .renamed_from(draft.old_path);
+
         // `draft.key`, not the live one: the note stages onto the composer it
         // was written against even if the selection moved under it.
         let key = draft.key;
         self.state.update(cx, |state, cx| {
-            state.add_review_comment(&key, comment);
+            if let Some(id) = draft.editing_id {
+                state.update_review_comment_body(&key, &id, body);
+            } else {
+                let comment = ReviewComment::new(draft.path, draft.side, draft.line, body)
+                    .renamed_from(draft.old_path);
+                state.add_review_comment(&key, comment);
+            }
             cx.notify();
         });
         self.sync_comment_rows(cx);
@@ -3222,6 +3268,7 @@ impl Changes {
                         comment,
                         &theme,
                         cx,
+                        Self::edit_comment,
                         Self::remove_comment,
                     ),
                     None => gpui::Empty.into_any_element(),
@@ -3242,6 +3289,7 @@ impl Changes {
                         draft_cite_path(draft),
                         draft.line,
                         draft.input.clone(),
+                        draft.editing_id.is_some(),
                         &theme,
                         cx,
                         Self::cancel_draft,
@@ -4866,6 +4914,74 @@ impl Render for Changes {
 mod tests {
     use super::*;
     use chrono::Utc;
+
+    #[gpui::test]
+    fn editing_staged_diff_comments_preserves_identity_and_cancellation(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            gpui_base::init(cx);
+            cx.set_global(Theme::dark());
+        });
+        let window = cx.add_window(|_, cx| {
+            let state = cx.new(|_| AppState::new());
+            Changes::new(state, cx)
+        });
+        window
+            .update(cx, |changes, window, cx| {
+                for side in [CommentSide::Old, CommentSide::New] {
+                    let original =
+                        ReviewComment::new("new.rs", side, 7, "Original 🦀\nSecond line")
+                            .renamed_from(Some("old.rs"));
+                    changes.state.update(cx, |state, _| {
+                        state.add_review_comment("", original.clone())
+                    });
+                    changes.edit_comment(&original.id, window, cx);
+                    let draft = changes.draft.as_ref().unwrap();
+                    assert_eq!(draft.input.read(cx).text(), original.body);
+                    assert_eq!(draft_cite_path(draft), original.cite_path());
+                    assert!(draft.input.read(cx).focus_handle(cx).is_focused(window));
+                    let input = draft.input.clone();
+                    input.update(cx, |input, cx| input.set_text("Cancelled", cx));
+                    assert_eq!(changes.state.read(cx).review_comments("")[0], original);
+                    changes.cancel_draft(cx);
+                    assert_eq!(
+                        changes.state.read(cx).review_comments(""),
+                        &[original.clone()]
+                    );
+
+                    changes.edit_comment(&original.id, window, cx);
+                    changes
+                        .draft
+                        .as_ref()
+                        .unwrap()
+                        .input
+                        .clone()
+                        .update(cx, |input, cx| {
+                            input.set_text("  Revised\nMore detail  ", cx)
+                        });
+                    changes.commit_draft(cx);
+                    let mut expected = original.clone();
+                    expected.body = "Revised\nMore detail".into();
+                    assert_eq!(
+                        changes.state.read(cx).review_comments(""),
+                        &[expected.clone()]
+                    );
+                    assert_ne!(
+                        comment_state_key(&[original], None),
+                        comment_state_key(&[expected.clone()], None)
+                    );
+                    changes.edit_comment(&expected.id, window, cx);
+                    let sent = changes
+                        .state
+                        .update(cx, |state, _| state.take_review_comments(""));
+                    assert!(comments::with_comments("", &sent).contains("Revised\n  More detail"));
+                    changes.commit_draft(cx);
+                    assert!(changes.state.read(cx).review_comments("").is_empty());
+                }
+            })
+            .unwrap();
+    }
 
     const PATCH: &str = "\
 diff --git a/src/main.rs b/src/main.rs

--- a/crates/ui/src/comment_ui.rs
+++ b/crates/ui/src/comment_ui.rs
@@ -42,6 +42,7 @@ pub(crate) fn render_comment_card<T: 'static>(
     comment: &ReviewComment,
     theme: &Theme,
     cx: &Context<T>,
+    edit: fn(&mut T, &str, &mut gpui::Window, &mut Context<T>),
     remove: fn(&mut T, &str, &mut Context<T>),
 ) -> AnyElement {
     let group: SharedString = format!("cmt-card-{}", comment.id).into();
@@ -88,6 +89,7 @@ pub(crate) fn render_comment_card<T: 'static>(
                                 .text_color(theme.text_faint)
                                 .child(SharedString::from(comment.location())),
                         )
+                        .child(render_comment_edit(comment, group.clone(), theme, cx, edit))
                         .child(
                             div()
                                 .id(SharedString::from(format!("cmt-remove-{}", comment.id)))
@@ -124,6 +126,40 @@ pub(crate) fn render_comment_card<T: 'static>(
         .into_any_element()
 }
 
+pub(crate) fn render_comment_edit<T: 'static>(
+    comment: &ReviewComment,
+    group: SharedString,
+    theme: &Theme,
+    cx: &Context<T>,
+    edit: fn(&mut T, &str, &mut gpui::Window, &mut Context<T>),
+) -> AnyElement {
+    let id = comment.id.clone();
+    div()
+        .id(SharedString::from(format!("cmt-edit-{id}")))
+        .flex_none()
+        .size(px(16.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(4.0))
+        .cursor_pointer()
+        .role(gpui::Role::Button)
+        .aria_label("Edit comment")
+        .opacity(0.0)
+        .group_hover(group, |style| style.opacity(1.0))
+        .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| cx.stop_propagation())
+        .on_click(cx.listener(move |this, _, window, cx| {
+            cx.stop_propagation();
+            edit(this, &id, window, cx);
+        }))
+        .child(
+            crate::icons::icon(crate::icons::PEN)
+                .size(px(12.0))
+                .text_color(theme.text_muted),
+        )
+        .into_any_element()
+}
+
 fn comment_accent_bar(color: gpui::Hsla) -> gpui::Div {
     div().w(px(ACCENT_BAR_WIDTH)).h_full().flex_none().bg(color)
 }
@@ -133,6 +169,7 @@ pub(crate) fn render_comment_draft<T: 'static>(
     path: &str,
     line: u32,
     input: Entity<ComposerInput>,
+    editing: bool,
     theme: &Theme,
     cx: &Context<T>,
     cancel: fn(&mut T, &mut Context<T>),
@@ -207,8 +244,13 @@ pub(crate) fn render_comment_draft<T: 'static>(
                                 .on_click(cx.listener(move |this, _, _, cx| cancel(this, cx))),
                         )
                         .child(
-                            comment_action("cmt-commit", "Comment", true, theme)
-                                .on_click(cx.listener(move |this, _, _, cx| commit(this, cx))),
+                            comment_action(
+                                "cmt-commit",
+                                if editing { "Save" } else { "Comment" },
+                                true,
+                                theme,
+                            )
+                            .on_click(cx.listener(move |this, _, _, cx| commit(this, cx))),
                         ),
                 ),
         )

--- a/crates/ui/src/files/markdown_preview.rs
+++ b/crates/ui/src/files/markdown_preview.rs
@@ -121,7 +121,7 @@ pub(super) struct MarkdownPreview {
     block_lines: Vec<u32>,
     comment_owner: Option<gpui::WeakEntity<super::FilesSurface>>,
     comments: Vec<crate::comments::ReviewComment>,
-    comment_draft: Option<(u32, gpui::Entity<crate::composer::ComposerInput>)>,
+    comment_draft: Option<(u32, gpui::Entity<crate::composer::ComposerInput>, bool)>,
     pub editor: Option<gpui::WeakEntity<super::editor::FileEditorState>>,
     list: ListState,
     cache: Rc<RefCell<RenderCache>>,
@@ -232,7 +232,7 @@ impl MarkdownPreview {
         &mut self,
         owner: gpui::WeakEntity<super::FilesSurface>,
         comments: Vec<crate::comments::ReviewComment>,
-        draft: Option<(u32, gpui::Entity<crate::composer::ComposerInput>)>,
+        draft: Option<(u32, gpui::Entity<crate::composer::ComposerInput>, bool)>,
         cx: &mut Context<Self>,
     ) {
         self.comment_owner = Some(owner);
@@ -273,6 +273,12 @@ impl MarkdownPreview {
         }
     }
 
+    fn edit_comment(&mut self, id: &str, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(owner) = &self.comment_owner {
+            let _ = owner.update(cx, |owner, cx| owner.edit_editor_comment(id, window, cx));
+        }
+    }
+
     fn remove_comment(&mut self, id: &str, cx: &mut Context<Self>) {
         if let Some(owner) = &self.comment_owner {
             let _ = owner.update(cx, |owner, cx| owner.remove_editor_comment(id, cx));
@@ -285,15 +291,22 @@ impl MarkdownPreview {
             .iter()
             .filter(|comment| comment_block(&self.block_lines, comment.line) == Some(ix))
             .map(|comment| {
-                crate::comment_ui::render_comment_card(comment, theme, cx, Self::remove_comment)
+                crate::comment_ui::render_comment_card(
+                    comment,
+                    theme,
+                    cx,
+                    Self::edit_comment,
+                    Self::remove_comment,
+                )
             })
             .collect();
-        if let Some((line, input)) = &self.comment_draft {
+        if let Some((line, input, editing)) = &self.comment_draft {
             if comment_block(&self.block_lines, *line) == Some(ix) {
                 elements.push(crate::comment_ui::render_comment_draft(
                     &self.path,
                     *line,
                     input.clone(),
+                    *editing,
                     theme,
                     cx,
                     Self::cancel_comment,

--- a/crates/ui/src/files/preview.rs
+++ b/crates/ui/src/files/preview.rs
@@ -61,6 +61,7 @@ struct EditorCommentAnchor {
 }
 
 struct EditorCommentDraft {
+    editing_id: Option<String>,
     key: String,
     path: String,
     line: u32,
@@ -802,6 +803,14 @@ impl FilesSurface {
             }
             self.sync_editor_comment_anchors(path, editor, cx);
         }
+        if let Some(draft) = self.preview.comment_draft.as_mut()
+            && draft.path == path
+            && let Some((_, line)) = updates
+                .iter()
+                .find(|(id, _)| draft.editing_id.as_ref() == Some(id))
+        {
+            draft.line = *line;
+        }
         if !updates.is_empty() {
             let key = self.chat_id.clone();
             self.state.update(cx, |state, cx| {
@@ -841,6 +850,7 @@ impl FilesSurface {
         });
         let focus = input.read(cx).focus_handle(cx);
         self.preview.comment_draft = Some(EditorCommentDraft {
+            editing_id: None,
             key: self.chat_id.clone(),
             path,
             line,
@@ -852,8 +862,35 @@ impl FilesSurface {
         cx.notify();
     }
 
+    pub(super) fn edit_editor_comment(
+        &mut self,
+        id: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(comment) = self
+            .state
+            .read(cx)
+            .review_comments(&self.chat_id)
+            .iter()
+            .find(|comment| comment.id == id && comment.is_file())
+            .cloned()
+        else {
+            return;
+        };
+        self.open_editor_comment_draft(comment.path, comment.line, window, cx);
+        let draft = self.preview.comment_draft.as_mut().unwrap();
+        draft.editing_id = Some(comment.id);
+        draft
+            .input
+            .update(cx, |input, cx| input.set_text(comment.body, cx));
+        cx.notify();
+    }
+
     pub(super) fn cancel_editor_comment(&mut self, cx: &mut Context<Self>) {
-        self.preview.comment_draft = None;
+        if let Some(draft) = self.preview.comment_draft.take() {
+            self.preview.active_comment = draft.editing_id;
+        }
         self.trim_document_cache(cx);
         cx.notify();
     }
@@ -864,6 +901,17 @@ impl FilesSurface {
         };
         let body = draft.input.read(cx).text().trim().to_string();
         if body.is_empty() {
+            self.preview.active_comment = draft.editing_id;
+            cx.notify();
+            return;
+        }
+        if let Some(id) = draft.editing_id {
+            self.state.update(cx, |state, cx| {
+                state.update_review_comment_body(&draft.key, &id, body);
+                cx.notify();
+            });
+            self.preview.active_comment = Some(id);
+            self.trim_document_cache(cx);
             cx.notify();
             return;
         }
@@ -2389,7 +2437,16 @@ impl FilesSurface {
             .comment_draft
             .as_ref()
             .filter(|draft| draft.path == path && draft.key == self.chat_id)
-            .map(|draft| (draft.line, draft.input.clone()));
+            .map(|draft| (draft.line, draft.input.clone(), draft.editing_id.is_some()));
+        let editing_id = self
+            .preview
+            .comment_draft
+            .as_ref()
+            .and_then(|draft| draft.editing_id.as_ref());
+        let comments = comments
+            .into_iter()
+            .filter(|comment| Some(&comment.id) != editing_id)
+            .collect();
         let owner = cx.weak_entity();
         view.update(cx, |view, cx| view.set_comments(owner, comments, draft, cx));
     }
@@ -2671,6 +2728,13 @@ impl FilesSurface {
                             .text_color(theme.text_faint)
                             .child(SharedString::from(comment.location())),
                     )
+                    .child(crate::comment_ui::render_comment_edit(
+                        &comment,
+                        group.clone(),
+                        theme,
+                        cx,
+                        Self::edit_editor_comment,
+                    ))
                     .child(
                         div()
                             .id(SharedString::from(format!(
@@ -2720,6 +2784,12 @@ impl FilesSurface {
         cx: &Context<Self>,
     ) -> AnyElement {
         let card = crate::popover::popover_card_flush(theme)
+            .on_key_down(cx.listener(|this, event: &gpui::KeyDownEvent, _, cx| {
+                if event.keystroke.key == "escape" {
+                    cx.stop_propagation();
+                    this.cancel_editor_comment(cx);
+                }
+            }))
             .absolute()
             .left(px(left))
             .top(px(top))
@@ -2757,8 +2827,22 @@ impl FilesSurface {
                             .on_click(cx.listener(|this, _, _, cx| this.cancel_editor_comment(cx))),
                     )
                     .child(
-                        editor_comment_action("file-comment-commit", "Comment", true, theme)
-                            .on_click(cx.listener(|this, _, _, cx| this.commit_editor_comment(cx))),
+                        editor_comment_action(
+                            "file-comment-commit",
+                            if self
+                                .preview
+                                .comment_draft
+                                .as_ref()
+                                .is_some_and(|draft| draft.editing_id.is_some())
+                            {
+                                "Save"
+                            } else {
+                                "Comment"
+                            },
+                            true,
+                            theme,
+                        )
+                        .on_click(cx.listener(|this, _, _, cx| this.commit_editor_comment(cx))),
                     ),
             );
         crate::frost::frosted(crate::popover::CARD_RADIUS, crate::frost::MENU_BLUR, card)
@@ -3708,6 +3792,68 @@ mod markdown_buffer_tests {
                     assert_eq!(staged[0].line, 3);
                     assert_eq!(staged[0].body, "Clarify this paragraph");
                     assert!(staged[0].is_file());
+                    for save in [false, true] {
+                        cx.update_window(window.into(), |_, window, cx| {
+                            window.refresh();
+                            let _ = window.draw(cx);
+                            let bounds = view.read(cx).test_block_bounds(1);
+                            let gutter = ((bounds.size.width - px(900.0)) / 2.0).max(px(24.0));
+                            click(
+                                window,
+                                gpui::point(
+                                    bounds.right() - gutter - px(46.0),
+                                    bounds.bottom()
+                                        - px(12.0)
+                                        - px(comments::card_height(&staged[0].body))
+                                        + px(21.0),
+                                ),
+                                cx,
+                            );
+                            let input = owner
+                                .read(cx)
+                                .preview
+                                .comment_draft
+                                .as_ref()
+                                .expect("Edit reopens the comment input")
+                                .input
+                                .clone();
+                            assert_eq!(input.read(cx).text(), staged[0].body);
+                            assert!(input.read(cx).focus_handle(cx).is_focused(window));
+                            input.update(cx, |input, cx| input.set_text("Revised paragraph", cx));
+                            window.refresh();
+                            let _ = window.draw(cx);
+                            if save {
+                                let bounds = view.read(cx).test_block_bounds(1);
+                                click(
+                                    window,
+                                    gpui::point(
+                                        bounds.right() - gutter - px(45.0),
+                                        bounds.bottom() - px(36.0),
+                                    ),
+                                    cx,
+                                );
+                            } else {
+                                window.dispatch_event(
+                                    gpui::PlatformInput::KeyDown(gpui::KeyDownEvent {
+                                        keystroke: gpui::Keystroke::parse("escape").unwrap(),
+                                        is_held: false,
+                                        prefer_character_input: false,
+                                    }),
+                                    cx,
+                                );
+                            }
+                        })
+                        .unwrap();
+                        assert!(owner.read(cx).preview.comment_draft.is_none());
+                        let mut expected = staged[0].clone();
+                        if save {
+                            expected.body = "Revised paragraph".into();
+                        }
+                        assert_eq!(
+                            owner.read(cx).staged_file_comments("README.md", cx),
+                            vec![expected]
+                        );
+                    }
                     let editor = owner.read(cx).preview.documents["README.md"]
                         .editor
                         .clone()
@@ -3772,6 +3918,112 @@ mod markdown_buffer_tests {
             })
             .detach();
         });
+    }
+
+    #[gpui::test]
+    fn editing_file_comments_keeps_the_live_anchor(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            gpui_base::init(cx);
+            cx.set_global(Theme::dark());
+        });
+        let window = cx.add_window(|_, cx| {
+            let state = cx.new(|_| crate::state::AppState::new());
+            FilesSurface::new(state, "chat".into(), false, 1000, 13.0, false, false, cx)
+        });
+        window
+            .update(cx, |surface, window, cx| {
+                let theme = Theme::of(cx).clone();
+                let editor = super::super::editor::new_file_editor(
+                    "first\nsecond\nthird\n",
+                    "a.rs",
+                    false,
+                    &theme,
+                    window,
+                    cx,
+                );
+                let mut document = FileDocument::loading(DocumentKey {
+                    chat_id: "chat".into(),
+                    checkout_id: None,
+                    path: "a.rs".into(),
+                });
+                document.editor = Some(editor.clone());
+                surface.preview.documents.insert("a.rs".into(), document);
+                let original = ReviewComment::file("a.rs", 2, "Original 🦀\nSecond line");
+                surface.state.update(cx, |state, _| {
+                    state.add_review_comment("chat", original.clone())
+                });
+                surface.sync_editor_comment_anchors("a.rs", &editor, cx);
+                let anchor = surface.preview.comment_anchors["a.rs"][&original.id]
+                    .range
+                    .clone();
+
+                surface.edit_editor_comment(&original.id, window, cx);
+                let input = surface
+                    .preview
+                    .comment_draft
+                    .as_ref()
+                    .unwrap()
+                    .input
+                    .clone();
+                assert_eq!(input.read(cx).text(), original.body);
+                assert!(input.read(cx).focus_handle(cx).is_focused(window));
+                input.update(cx, |input, cx| input.set_text("Cancelled", cx));
+                assert_eq!(
+                    surface.staged_file_comments("a.rs", cx),
+                    vec![original.clone()]
+                );
+                surface.cancel_editor_comment(cx);
+                assert_eq!(
+                    surface.staged_file_comments("a.rs", cx),
+                    vec![original.clone()]
+                );
+                assert_eq!(
+                    surface.preview.active_comment.as_deref(),
+                    Some(original.id.as_str())
+                );
+
+                surface.edit_editor_comment(&original.id, window, cx);
+                // Move the existing editor decoration while the body is being edited.
+                let (range, _) = comment_anchor_range(editor.read(cx).text(), 3).unwrap();
+                anchor.set(
+                    vec![TextDecoration::new(range, HighlightStyle::default())],
+                    cx,
+                );
+                surface.sync_editor_comment_lines("a.rs", &editor, cx);
+                assert_eq!(surface.preview.comment_draft.as_ref().unwrap().line, 3);
+                surface
+                    .preview
+                    .comment_draft
+                    .as_ref()
+                    .unwrap()
+                    .input
+                    .clone()
+                    .update(cx, |input, cx| {
+                        input.set_text("  Revised\nMore detail  ", cx)
+                    });
+                surface.commit_editor_comment(cx);
+                let mut expected = original.clone();
+                expected.line = 3;
+                expected.body = "Revised\nMore detail".into();
+                assert_eq!(surface.staged_file_comments("a.rs", cx), vec![expected]);
+                // The original decoration handle still controls the stored anchor.
+                let (range, _) = comment_anchor_range(editor.read(cx).text(), 1).unwrap();
+                anchor.set(
+                    vec![TextDecoration::new(range, HighlightStyle::default())],
+                    cx,
+                );
+                surface.sync_editor_comment_lines("a.rs", &editor, cx);
+                assert_eq!(surface.staged_file_comments("a.rs", cx)[0].line, 1);
+
+                surface.edit_editor_comment(&original.id, window, cx);
+                let sent = surface
+                    .state
+                    .update(cx, |state, _| state.take_review_comments("chat"));
+                assert!(comments::with_comments("", &sent).contains("Revised\n  More detail"));
+                surface.commit_editor_comment(cx);
+                assert!(surface.staged_file_comments("a.rs", cx).is_empty());
+            })
+            .unwrap();
     }
 
     #[gpui::test]

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -784,6 +784,18 @@ impl AppState {
         }
     }
 
+    /// Update only a staged comment's body. A stale editor must never recreate
+    /// a comment that has already been removed or sent to the agent.
+    pub fn update_review_comment_body(&mut self, key: &str, id: &str, body: String) {
+        if let Some(comment) = self
+            .review_comments
+            .get_mut(key)
+            .and_then(|comments| comments.iter_mut().find(|comment| comment.id == id))
+        {
+            comment.body = body;
+        }
+    }
+
     pub fn update_review_comment_line(&mut self, key: &str, id: &str, line: u32) {
         if let Some(comment) = self
             .review_comments
@@ -3950,6 +3962,30 @@ mod tests {
             1
         );
         assert!(parse_orgs(&serde_json::json!("nope")).is_empty());
+    }
+
+    #[test]
+    fn review_comment_body_updates_are_scoped_and_keep_current_metadata() {
+        let mut state = AppState::new();
+        let original = ReviewComment::file("a.rs", 2, "Original");
+        state.add_review_comment("chat-1", original.clone());
+        state.add_review_comment("chat-2", original.clone());
+        state.begin_review_comment_flush("chat-1", 1);
+        state.update_review_comment_line("chat-1", &original.id, 9);
+        state.rename_review_comment_path("chat-1", "a.rs", "renamed.rs");
+        state.update_review_comment_body("chat-1", &original.id, "Revised".into());
+        let mut expected = original.clone();
+        expected.path = "renamed.rs".into();
+        expected.line = 9;
+        expected.body = "Revised".into();
+        assert_eq!(state.review_comments("chat-1"), &[expected]);
+        assert_eq!(state.review_comments("chat-2"), &[original.clone()]);
+        assert!(state.review_comment_flush_pending("chat-1"));
+        state.remove_review_comment("chat-1", &original.id);
+        state.update_review_comment_body("chat-1", &original.id, "Stale".into());
+        state.update_review_comment_body("missing-chat", &original.id, "Stale".into());
+        assert!(state.review_comments("chat-1").is_empty());
+        assert!(state.review_comments("missing-chat").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Staged review comments previously had to be deleted and recreated to correct their text. Add an Edit action to comment cards in Changes diffs, the text editor, and Markdown previews. Editing reopens the existing input with the current body and a Save action; cancelling leaves the original comment unchanged.

Saving updates only the body by ID, preserving the path, line, diff side, rename metadata, and editor anchor. The next prompt includes the updated text. Stale edits cannot recreate comments that have already been removed or sent, and diff layout caches now account for body changes so card heights stay current across open views.

Closes #310.

Validation:
- `cargo test --locked -p zeron-ui --lib -- --test-threads=1` — 838 passed.
- Regression coverage for edit/save/cancel, both diff sides, live editor anchors, chat scoping, stale edits after sending, and Markdown Edit/Save/Escape interactions.
- `rustfmt --check --edition 2024` on all five changed Rust files and `git diff --check` passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/zeron/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791730306&installation_model_id=425430&pr_number=323&repository=zeronsh%2Fzeron&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fzeron%2Fpull%2F323&signature=dec14fc0a117a41bbb16825ebfdb7283e95e39f1ef62a54a5cd7574959c0bad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->