### PR TITLE
preview: stop re-probing dev servers, cheap per-connection check, prompt re-pairing

### DIFF
--- a/crates/preview/src/discovery.rs
+++ b/crates/preview/src/discovery.rs
@@ -131,6 +131,50 @@ fn mark_descendants(listeners: &mut [Listener], parents: &HashMap<u32, u32>, own
     }
 }
 
+/// Process start in ms since the epoch, derived the same way for the scanner
+/// and for [`same_process`] so the two agree exactly.
+#[cfg(target_os = "linux")]
+fn linux_clock() -> (u64, u64) {
+    let boot = std::fs::read_to_string("/proc/stat")
+        .ok()
+        .and_then(|s| {
+            s.lines().find_map(|line| {
+                line.strip_prefix("btime ")
+                    .and_then(|v| v.parse::<u64>().ok())
+            })
+        })
+        .unwrap_or(0);
+    let ticks = unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.max(1) as u64;
+    (boot, ticks)
+}
+#[cfg(target_os = "linux")]
+fn linux_started_at(stat_fields: &[&str], boot: u64, ticks: u64) -> u64 {
+    boot * 1000
+        + stat_fields
+            .get(19)
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(0)
+            * 1000
+            / ticks
+}
+
+/// Whether `pid` is still the process the scanner observed with `started_at`.
+/// Cheap enough to run per proxied connection; a full [`listeners`] pass
+/// walks every process (and spawns lsof/ps on macOS), which the proxy used
+/// to do for every asset a remote page requested.
+#[cfg(target_os = "linux")]
+pub fn same_process(pid: u32, started_at: u64) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    let Some((_, tail)) = stat.rsplit_once(") ") else {
+        return false;
+    };
+    let fields: Vec<_> = tail.split_whitespace().collect();
+    let (boot, ticks) = linux_clock();
+    linux_started_at(&fields, boot, ticks) == started_at
+}
+
 #[cfg(target_os = "linux")]
 pub fn listeners() -> Vec<Listener> {
     use std::{fs, os::unix::fs::MetadataExt};
@@ -148,16 +192,7 @@ pub fn listeners() -> Vec<Listener> {
             }
         }
     }
-    let boot = fs::read_to_string("/proc/stat")
-        .ok()
-        .and_then(|s| {
-            s.lines().find_map(|line| {
-                line.strip_prefix("btime ")
-                    .and_then(|v| v.parse::<u64>().ok())
-            })
-        })
-        .unwrap_or(0);
-    let ticks = unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.max(1) as u64;
+    let (boot, ticks) = linux_clock();
     let uid = unsafe { libc::geteuid() };
     let mut result = Vec::new();
     let mut parents = HashMap::new();
@@ -186,13 +221,7 @@ pub fn listeners() -> Vec<Listener> {
         let Ok(cwd) = fs::read_link(path.join("cwd")) else {
             continue;
         };
-        let started_at = boot * 1000
-            + fields
-                .get(19)
-                .and_then(|v| v.parse::<u64>().ok())
-                .unwrap_or(0)
-                * 1000
-                / ticks;
+        let started_at = linux_started_at(&fields, boot, ticks);
         let args = fs::read(path.join("cmdline"))
             .unwrap_or_default()
             .split(|b| *b == 0)
@@ -271,9 +300,35 @@ fn proc_address(value: &str, ipv6: bool) -> Option<SocketAddr> {
     ))
 }
 
+/// `ps lstart=` tokens ("Thu Sep 11 16:14:42 2026") to ms since the epoch.
+#[cfg(target_os = "macos")]
+fn parse_lstart(parts: &[&str]) -> u64 {
+    use chrono::TimeZone;
+    chrono::NaiveDateTime::parse_from_str(&parts.join(" "), "%a %b %e %T %Y")
+        .ok()
+        .and_then(|d| chrono::Local.from_local_datetime(&d).earliest())
+        .map(|d| d.timestamp_millis().max(0) as u64)
+        .unwrap_or(0)
+}
+
+/// See the Linux variant. One `ps -p` for a single pid instead of two lsof
+/// passes and a full `ps -ax` per proxied connection.
+#[cfg(target_os = "macos")]
+pub fn same_process(pid: u32, started_at: u64) -> bool {
+    let Ok(output) = std::process::Command::new("/bin/ps")
+        .args(["-o", "lstart=", "-p", &pid.to_string()])
+        .env("LC_ALL", "C")
+        .output()
+    else {
+        return false;
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    let parts: Vec<_> = text.split_whitespace().collect();
+    parts.len() >= 5 && parse_lstart(&parts[..5]) == started_at
+}
+
 #[cfg(target_os = "macos")]
 pub fn listeners() -> Vec<Listener> {
-    use chrono::TimeZone;
     use std::process::Command;
     let uid = unsafe { libc::geteuid() }.to_string();
     let fields = |arguments: &[&str]| -> Vec<(u32, String)> {
@@ -313,12 +368,7 @@ pub fn listeners() -> Vec<Listener> {
                 continue;
             };
             parents.insert(pid, parent);
-            let started_at =
-                chrono::NaiveDateTime::parse_from_str(&parts[2..7].join(" "), "%a %b %e %T %Y")
-                    .ok()
-                    .and_then(|d| chrono::Local.from_local_datetime(&d).earliest())
-                    .map(|d| d.timestamp_millis().max(0) as u64)
-                    .unwrap_or(0);
+            let started_at = parse_lstart(&parts[2..7]);
             processes.insert(
                 pid,
                 (
@@ -373,6 +423,10 @@ pub fn listeners() -> Vec<Listener> {
 pub fn listeners() -> Vec<Listener> {
     Vec::new()
 }
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn same_process(_pid: u32, _started_at: u64) -> bool {
+    false
+}
 
 #[cfg(test)]
 mod tests {
@@ -402,6 +456,56 @@ mod tests {
         );
         assert!(proc_address("0101A8C0:1435", false).is_none());
         assert!(proc_address("malformed:00", true).is_none());
+    }
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn same_process_matches_the_scanner_start_time() {
+        let child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        struct Kill(std::process::Child);
+        impl Drop for Kill {
+            fn drop(&mut self) {
+                let _ = self.0.kill();
+                let _ = self.0.wait();
+            }
+        }
+        let _guard = Kill(child);
+        // `listeners()` only reports sockets; derive the scanner's start time
+        // through the same platform path it uses.
+        #[cfg(target_os = "linux")]
+        let started_at = {
+            let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).unwrap();
+            let (_, tail) = stat.rsplit_once(") ").unwrap();
+            let fields: Vec<_> = tail.split_whitespace().collect();
+            let (boot, ticks) = linux_clock();
+            linux_started_at(&fields, boot, ticks)
+        };
+        #[cfg(target_os = "macos")]
+        let started_at = {
+            let output = std::process::Command::new("/bin/ps")
+                .args(["-axo", "pid=,ppid=,lstart=,command="])
+                .env("LC_ALL", "C")
+                .output()
+                .unwrap();
+            let text = String::from_utf8_lossy(&output.stdout);
+            text.lines()
+                .map(|line| line.split_whitespace().collect::<Vec<_>>())
+                .find(|parts| parts.first().and_then(|p| p.parse::<u32>().ok()) == Some(pid))
+                .map(|parts| parse_lstart(&parts[2..7]))
+                .unwrap()
+        };
+        assert!(started_at > 0);
+        assert!(same_process(pid, started_at));
+        assert!(!same_process(pid, started_at + 1000));
+        assert!(!same_process(pid, 0));
+        drop(_guard);
+        assert!(
+            !same_process(pid, started_at),
+            "a reaped pid no longer matches"
+        );
     }
     #[tokio::test]
     async fn requires_an_http_response() {

--- a/crates/preview/src/peer.rs
+++ b/crates/preview/src/peer.rs
@@ -57,6 +57,7 @@ struct Inner {
     stop: CancellationToken,
     ice_servers: Vec<RTCIceServer>,
 }
+const PAIR_INTERVAL: Duration = Duration::from_secs(10);
 #[derive(Clone)]
 pub struct Peers(Arc<Inner>);
 impl Peers {
@@ -85,6 +86,20 @@ impl Peers {
             })),
             receiver,
         )
+    }
+    /// Replace STUN servers; an empty list pairs over host candidates only.
+    /// Must be called before the handle is shared.
+    pub fn set_ice_servers(&mut self, urls: Vec<String>) -> anyhow::Result<()> {
+        let inner = Arc::get_mut(&mut self.0).context("preview peers already shared")?;
+        inner.ice_servers = if urls.is_empty() {
+            Vec::new()
+        } else {
+            vec![RTCIceServer {
+                urls,
+                ..Default::default()
+            }]
+        };
+        Ok(())
     }
     async fn send(&self, to: &str, signal: Signal) -> anyhow::Result<()> {
         tokio::select! { _ = self.0.stop.cancelled() => anyhow::bail!("preview networking stopped"), result = self.0.output.send(OutgoingSignal { to: to.into(), signal }) => { result?; Ok(()) } }
@@ -163,10 +178,17 @@ impl Peers {
         );
         Ok(description)
     }
-    async fn offer(&self, device: &str, session: String) -> anyhow::Result<()> {
+    /// `requested` marks an offer made because the other device asked for one.
+    async fn offer(&self, device: &str, session: String, requested: bool) -> anyhow::Result<()> {
         let mut peers = self.0.peers.lock().await;
-        if peers.get(device).is_some_and(|p| !p.stop.is_cancelled()) {
-            return Ok(());
+        if let Some(existing) = peers.get(device) {
+            // A live peer is reused, unless the other device asked to pair
+            // under a new session: it has dropped its side, so ours is a
+            // zombie whose failure would only surface once ICE consent
+            // expires (~30s), stalling every request until then.
+            if !existing.stop.is_cancelled() && (!requested || existing.session == session) {
+                return Ok(());
+            }
         }
         anyhow::ensure!(
             peers.len() < 16 || peers.contains_key(device),
@@ -207,7 +229,7 @@ impl Peers {
                     self.0.device.as_str() < device && signal.sdp.is_none(),
                     "invalid preview initiator"
                 );
-                self.offer(device, signal.session).await?;
+                self.offer(device, signal.session, true).await?;
             }
             "offer" => {
                 anyhow::ensure!(
@@ -276,25 +298,20 @@ impl Peers {
     ) -> anyhow::Result<Stream> {
         let device = device.to_owned();
         let result = tokio::time::timeout(Duration::from_secs(30), async {
-            let existing = self.0.peers.lock().await.get(&device).cloned();
-            if existing.as_ref().is_none_or(|p| p.stop.is_cancelled() || p.ready.borrow().as_ref().is_some_and(Mux::is_closed)) {
-                if let Some(peer) = existing { peer.close().await; }
-                let session = uuid::Uuid::new_v4().to_string();
-                if self.0.device < device { self.offer(&device, session).await?; }
-                else {
-                    let should_request = {
-                        let mut requested = self.0.requested.lock().await;
-                        let now = tokio::time::Instant::now();
-                        if requested.get(&device).is_some_and(|at| now.duration_since(*at) < Duration::from_secs(10)) { false }
-                        else { requested.insert(device.clone(), now); true }
-                    };
-                    if should_request { self.send(&device, Signal { kind: "connect".into(), session, sdp: None }).await?; }
-                }
-            }
+            // A failed or transport-dead peer is closed here; the loop below
+            // pairs afresh.
+            let stale = self.0.peers.lock().await.get(&device).cloned().filter(|p| {
+                p.stop.is_cancelled() || p.ready.borrow().as_ref().is_some_and(Mux::is_closed)
+            });
+            if let Some(peer) = stale { peer.close().await; }
             loop {
                 let changed = self.0.changed.notified();
                 let mux = self.0.peers.lock().await.get(&device).and_then(|peer| peer.ready.borrow().clone());
                 if let Some(mux) = mux.filter(|m| !m.is_closed()) { return mux.open(service, websocket).await; }
+                // Pairing is re-attempted while waiting, so one lost signal or
+                // a stalled attempt costs at most the pacing interval rather
+                // than the whole timeout.
+                self.pair(&device).await?;
                 tokio::select! { _ = self.0.stop.cancelled() => anyhow::bail!("preview networking stopped"), _ = changed => {}, _ = tokio::time::sleep(Duration::from_millis(100)) => {} }
             }
         }).await;
@@ -302,6 +319,35 @@ impl Peers {
             self.remove(&device).await;
         }
         result.context("Could not connect directly to this device. Check that both devices are online and their networks allow WebRTC.")?
+    }
+    /// Starts (or asks the initiating device to start) a pairing attempt, at
+    /// most once per pacing interval per device. `remove` resets the pacing.
+    async fn pair(&self, device: &str) -> anyhow::Result<()> {
+        {
+            let mut requested = self.0.requested.lock().await;
+            let now = tokio::time::Instant::now();
+            if requested
+                .get(device)
+                .is_some_and(|at| now.duration_since(*at) < PAIR_INTERVAL)
+            {
+                return Ok(());
+            }
+            requested.insert(device.to_owned(), now);
+        }
+        let session = uuid::Uuid::new_v4().to_string();
+        if self.0.device.as_str() < device {
+            self.offer(device, session, false).await
+        } else {
+            self.send(
+                device,
+                Signal {
+                    kind: "connect".into(),
+                    session,
+                    sdp: None,
+                },
+            )
+            .await
+        }
     }
     pub async fn remove(&self, device: &str) {
         self.0.requested.lock().await.remove(device);
@@ -489,6 +535,59 @@ mod tests {
         forward_a.abort();
         forward_b.abort();
         result.expect("a failed STUN probe must not prevent peer setup");
+    }
+    async fn echo_round(peers: &Peers, device: &str) {
+        let mut stream = peers.open(device, "service", false).await.unwrap();
+        stream.write_all(b"ping").await.unwrap();
+        stream.shutdown().await.unwrap();
+        let mut bytes = Vec::new();
+        stream.read_to_end(&mut bytes).await.unwrap();
+        assert_eq!(bytes, b"ping");
+    }
+    #[tokio::test]
+    async fn a_dropped_peer_pairs_again_without_waiting_for_ice_failure() {
+        // The device that drops its peer (sleep, network roam, coordinator
+        // lease reset) must be served promptly by the other side, whose own
+        // peer object still looks healthy until ICE consent expires.
+        let stop = CancellationToken::new();
+        let (mut a, mut a_out) = Peers::new("a".into(), Arc::new(Echo), stop.clone());
+        let (mut b, mut b_out) = Peers::new("b".into(), Arc::new(Echo), stop.clone());
+        a.set_ice_servers(Vec::new()).unwrap();
+        b.set_ice_servers(Vec::new()).unwrap();
+        let peer_b = b.clone();
+        let forward_a = tokio::spawn(async move {
+            while let Some(message) = a_out.recv().await {
+                let _ = peer_b.signal("a", message.signal).await;
+            }
+        });
+        let peer_a = a.clone();
+        let forward_b = tokio::spawn(async move {
+            while let Some(message) = b_out.recv().await {
+                let _ = peer_a.signal("b", message.signal).await;
+            }
+        });
+        let result = tokio::time::timeout(Duration::from_secs(40), async {
+            echo_round(&b, "a").await;
+            // Non-initiator drops: its connect request must replace a's peer.
+            b.remove("a").await;
+            tokio::time::timeout(Duration::from_secs(8), echo_round(&b, "a"))
+                .await
+                .expect("re-pair after the requester dropped its peer stalled");
+            // Initiator drops: it offers again and b replaces its peer.
+            a.remove("b").await;
+            tokio::time::timeout(Duration::from_secs(8), echo_round(&a, "b"))
+                .await
+                .expect("re-pair after the initiator dropped its peer stalled");
+            // Both directions still work over the final pair.
+            echo_round(&b, "a").await;
+        })
+        .await;
+        stop.cancel();
+        a.clear().await;
+        b.clear().await;
+        forward_a.abort();
+        forward_b.abort();
+        result.expect("re-pairing test stalled");
     }
     #[tokio::test]
     async fn actual_webrtc_pair_streams_in_both_directions() {

--- a/crates/preview/src/service.rs
+++ b/crates/preview/src/service.rs
@@ -8,14 +8,84 @@ use crate::{
 };
 use futures::{StreamExt, stream};
 use std::{
+    collections::HashMap,
+    net::SocketAddr,
     path::PathBuf,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tokio_util::sync::CancellationToken;
+
+/// Discovery must not turn into HTTP traffic against the user's dev servers.
+/// A listening socket is probed until it answers HTTP once; that verdict then
+/// holds for the socket's lifetime, because the process enumeration each
+/// cycle already proves the same process still owns the same port. Sockets
+/// that did not answer HTTP (a server bound but not yet serving) are retried
+/// with a capped exponential backoff instead of on every cycle.
+#[derive(Default)]
+pub(crate) struct ProbeMemory {
+    verdicts: HashMap<(u32, u64, SocketAddr), Verdict>,
+}
+enum Verdict {
+    Http,
+    NotHttp {
+        retry_at: Instant,
+        backoff: Duration,
+    },
+}
+const NOT_HTTP_INITIAL_BACKOFF: Duration = Duration::from_secs(4);
+const NOT_HTTP_MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+/// (servers already confirmed HTTP, listeners to probe this cycle)
+type Planned<T> = (Vec<(T, discovery::Listener)>, Vec<(T, discovery::Listener)>);
+
+fn probe_key(listener: &discovery::Listener) -> (u32, u64, SocketAddr) {
+    (listener.pid, listener.started_at, listener.address)
+}
+
+impl ProbeMemory {
+    /// Splits this cycle's candidates into servers already known to speak
+    /// HTTP and listeners that need a probe now. Verdicts for sockets that
+    /// are no longer listed are forgotten so a reused port is probed afresh.
+    pub(crate) fn plan<T>(
+        &mut self,
+        candidates: Vec<(T, discovery::Listener)>,
+        now: Instant,
+    ) -> Planned<T> {
+        let present: std::collections::HashSet<_> =
+            candidates.iter().map(|(_, l)| probe_key(l)).collect();
+        self.verdicts.retain(|key, _| present.contains(key));
+        let mut known = Vec::new();
+        let mut probe = Vec::new();
+        for candidate in candidates {
+            match self.verdicts.get(&probe_key(&candidate.1)) {
+                Some(Verdict::Http) => known.push(candidate),
+                Some(Verdict::NotHttp { retry_at, .. }) if *retry_at > now => {}
+                _ => probe.push(candidate),
+            }
+        }
+        (known, probe)
+    }
+    pub(crate) fn record(&mut self, listener: &discovery::Listener, http: bool, now: Instant) {
+        let key = probe_key(listener);
+        let verdict = if http {
+            Verdict::Http
+        } else {
+            let backoff = match self.verdicts.get(&key) {
+                Some(Verdict::NotHttp { backoff, .. }) => (*backoff * 2).min(NOT_HTTP_MAX_BACKOFF),
+                _ => NOT_HTTP_INITIAL_BACKOFF,
+            };
+            Verdict::NotHttp {
+                retry_at: now + backoff,
+                backoff,
+            }
+        };
+        self.verdicts.insert(key, verdict);
+    }
+}
 #[derive(Clone)]
 pub struct PreviewService(Arc<Inner>);
 struct Inner {
@@ -83,7 +153,9 @@ impl PreviewService {
         let catalog = self.0.catalog.clone();
         let stop = self.0.stop.clone();
         let scanner = tokio::spawn(async move {
+            let mut memory = ProbeMemory::default();
             loop {
+                let memory = &mut memory;
                 let scan = async {
                     let projects = projects.clone();
                     let candidates = tokio::task::spawn_blocking(move || {
@@ -116,16 +188,22 @@ impl PreviewService {
                     })
                     .await
                     .unwrap_or_default();
-                    let servers = stream::iter(candidates)
+                    let (mut servers, probe) = memory.plan(candidates, Instant::now());
+                    let probed: Vec<_> = stream::iter(probe)
                         .map(|(root, listener)| async move {
-                            discovery::is_http(listener.address)
-                                .await
-                                .then_some((root, listener))
+                            let http = discovery::is_http(listener.address).await;
+                            (root, listener, http)
                         })
                         .buffer_unordered(12)
-                        .filter_map(|item| async { item })
                         .collect()
                         .await;
+                    let now = Instant::now();
+                    for (root, listener, http) in probed {
+                        memory.record(&listener, http, now);
+                        if http {
+                            servers.push((root, listener));
+                        }
+                    }
                     if let Err(error) = catalog.replace_local(servers) {
                         tracing::warn!(%error, "could not update preview services");
                     }
@@ -182,5 +260,70 @@ impl Connector for LocalConnector {
         Ok(Box::new(
             tokio::net::TcpStream::connect(route.listener.address).await?,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn listener(pid: u32, port: u16) -> discovery::Listener {
+        discovery::Listener {
+            pid,
+            parent: 1,
+            cwd: "/work/app".into(),
+            args: vec!["node".into()],
+            started_at: 1_000,
+            address: ([127, 0, 0, 1], port).into(),
+            zeron_owned: false,
+        }
+    }
+    #[test]
+    fn a_confirmed_http_server_is_never_probed_again() {
+        let mut memory = ProbeMemory::default();
+        let t0 = Instant::now();
+        let (known, probe) = memory.plan(vec![((), listener(7, 8081))], t0);
+        assert!(known.is_empty());
+        assert_eq!(probe.len(), 1);
+        memory.record(&probe[0].1, true, t0);
+        for cycle in 1..1_000u64 {
+            let now = t0 + Duration::from_secs(2 * cycle);
+            let (known, probe) = memory.plan(vec![((), listener(7, 8081))], now);
+            assert_eq!(known.len(), 1, "cycle {cycle} must reuse the verdict");
+            assert!(probe.is_empty(), "cycle {cycle} must not send a request");
+        }
+    }
+    #[test]
+    fn non_http_listeners_back_off_and_reused_ports_are_probed_afresh() {
+        let mut memory = ProbeMemory::default();
+        let t0 = Instant::now();
+        let (_, probe) = memory.plan(vec![((), listener(7, 8081))], t0);
+        memory.record(&probe[0].1, false, t0);
+        let (_, probe) = memory.plan(vec![((), listener(7, 8081))], t0 + Duration::from_secs(2));
+        assert!(probe.is_empty(), "the very next cycle is skipped");
+        let (_, probe) = memory.plan(vec![((), listener(7, 8081))], t0 + Duration::from_secs(5));
+        assert_eq!(probe.len(), 1, "retried after the initial backoff");
+        memory.record(&probe[0].1, false, t0 + Duration::from_secs(5));
+        let (_, probe) = memory.plan(vec![((), listener(7, 8081))], t0 + Duration::from_secs(10));
+        assert!(probe.is_empty(), "backoff doubled");
+        // A different process on the same port carries no verdict over.
+        let (_, probe) = memory.plan(vec![((), listener(8, 8081))], t0 + Duration::from_secs(10));
+        assert_eq!(probe.len(), 1);
+        // The original socket, once absent, is forgotten and re-probed on return.
+        memory.record(&probe[0].1, true, t0);
+        let (known, probe) =
+            memory.plan(vec![((), listener(7, 8081))], t0 + Duration::from_secs(11));
+        assert!(known.is_empty());
+        assert_eq!(probe.len(), 1);
+    }
+    #[test]
+    fn backoff_is_capped() {
+        let mut memory = ProbeMemory::default();
+        let mut now = Instant::now();
+        for _ in 0..20 {
+            memory.record(&listener(7, 8081), false, now);
+            now += NOT_HTTP_MAX_BACKOFF;
+        }
+        let (_, probe) = memory.plan(vec![((), listener(7, 8081))], now);
+        assert_eq!(probe.len(), 1, "still retried once per max backoff");
     }
 }

--- a/crates/preview/src/service.rs
+++ b/crates/preview/src/service.rs
@@ -244,18 +244,14 @@ impl Connector for LocalConnector {
             .0
             .local_route(id)
             .ok_or_else(|| anyhow::anyhow!("preview service stopped"))?;
-        // Recheck process ownership before dialing: a stopped dev server's port
-        // may have been reused by an unrelated process since the last scan.
-        let expected = route.listener.clone();
-        let valid = tokio::task::spawn_blocking(move || {
-            discovery::listeners().iter().any(|actual| {
-                actual.pid == expected.pid
-                    && actual.started_at == expected.started_at
-                    && actual.cwd == expected.cwd
-                    && actual.address == expected.address
-            })
-        })
-        .await?;
+        // Recheck process identity before dialing: a stopped dev server's port
+        // may have been reused since the last scan. Checking the one pid is
+        // cheap; enumerating every listener here spawned lsof and ps for each
+        // asset a remote page requested, which showed up as memory and CPU
+        // churn on the hosting Mac.
+        let (pid, started_at) = (route.listener.pid, route.listener.started_at);
+        let valid =
+            tokio::task::spawn_blocking(move || discovery::same_process(pid, started_at)).await?;
         anyhow::ensure!(valid, "preview process changed; waiting for rediscovery");
         Ok(Box::new(
             tokio::net::TcpStream::connect(route.listener.address).await?,

--- a/crates/preview/tests/discovery.rs
+++ b/crates/preview/tests/discovery.rs
@@ -98,3 +98,56 @@ async fn only_current_project_http_processes_are_exposed_and_removals_are_live()
         );
     }
 }
+
+/// A discovered dev server receives exactly one probe for its lifetime. The
+/// scanner used to send `HEAD /` every cycle to every project listener, which
+/// showed up as request spam (and growing memory) in dev servers like Expo.
+#[tokio::test]
+async fn a_discovered_server_is_probed_once_not_every_cycle() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = temp.path().join("app");
+    std::fs::create_dir(&app).unwrap();
+    let log = temp.path().join("requests.log");
+    let script = format!(
+        "import http.server,socketserver\n\
+         class H(http.server.SimpleHTTPRequestHandler):\n\
+         \x20   def do_HEAD(self):\n\
+         \x20       open({log:?},'a').write(self.command+' '+self.path+'\\n')\n\
+         \x20       super().do_HEAD()\n\
+         \x20   def log_message(self,*a): pass\n\
+         socketserver.TCPServer(('127.0.0.1',0),H).serve_forever()\n",
+        log = log.display().to_string()
+    );
+    let server = Child(
+        std::process::Command::new("python3")
+            .args(["-c", &script])
+            .current_dir(&app)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .unwrap(),
+    );
+    let service = PreviewService::new(
+        temp.path().join("names.json"),
+        "local".into(),
+        "Laptop".into(),
+    )
+    .unwrap();
+    let roots = vec![app.clone()];
+    service.start(Arc::new(move || roots.clone()), None).await;
+    wait(&service, Some(server.0.id())).await;
+    // Several scan cycles (2s cadence) pass while the server stays discovered.
+    tokio::time::sleep(Duration::from_secs(7)).await;
+    assert_eq!(
+        service.catalog().snapshot().services.len(),
+        1,
+        "the server stays listed without being re-probed"
+    );
+    let requests = std::fs::read_to_string(&log).unwrap_or_default();
+    assert_eq!(
+        requests.lines().count(),
+        1,
+        "expected a single discovery probe, got:\n{requests}"
+    );
+    service.shutdown().await;
+}

--- a/crates/preview/tests/discovery.rs
+++ b/crates/preview/tests/discovery.rs
@@ -4,6 +4,10 @@ use std::{
     time::Duration,
 };
 use zeron_preview::PreviewService;
+/// Every service binds the fixed proxy port, so tests in this binary must
+/// not run concurrently: one test freeing 7331 for its own proxy to reclaim
+/// would otherwise race another test's service for it.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 struct Child(std::process::Child);
 impl Drop for Child {
     fn drop(&mut self) {
@@ -48,6 +52,7 @@ async fn wait(service: &PreviewService, expected_pid: Option<u32>) {
 }
 #[tokio::test]
 async fn only_current_project_http_processes_are_exposed_and_removals_are_live() {
+    let _serial = SERIAL.lock().await;
     let temp = tempfile::tempdir().unwrap();
     let a = temp.path().join("app");
     let b = temp.path().join("unrelated");
@@ -104,6 +109,7 @@ async fn only_current_project_http_processes_are_exposed_and_removals_are_live()
 /// showed up as request spam (and growing memory) in dev servers like Expo.
 #[tokio::test]
 async fn a_discovered_server_is_probed_once_not_every_cycle() {
+    let _serial = SERIAL.lock().await;
     let temp = tempfile::tempdir().unwrap();
     let app = temp.path().join("app");
     std::fs::create_dir(&app).unwrap();

--- a/crates/preview/tests/leak.rs
+++ b/crates/preview/tests/leak.rs
@@ -1,0 +1,349 @@
+//! Remote-preview churn must not accumulate tasks, streams, or memory. This
+//! drives many mixed requests (small, echo, partially consumed then dropped,
+//! WebSocket) through the proxy on the viewing device over a real WebRTC pair
+//! to a backend on the hosting device and compares live tasks and RSS
+//! against the warmed-up baseline.
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use http_body_util::{BodyExt, Full, StreamBody, combinators::UnsyncBoxBody};
+use hyper::{
+    Request, Response,
+    body::{Frame, Incoming},
+};
+use hyper_util::rt::TokioIo;
+use std::{
+    convert::Infallible,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{
+    WebSocketStream,
+    tungstenite::{Message, client::IntoClientRequest, protocol::Role},
+};
+use tokio_util::sync::CancellationToken;
+use zeron_preview::{
+    catalog::Catalog,
+    discovery::Listener,
+    mux::{self, BoxIo, Connector},
+    peer::Peers,
+    proxy::{self, Router},
+};
+type Body = UnsyncBoxBody<Bytes, hyper::Error>;
+fn full(value: impl Into<Bytes>) -> Body {
+    Full::new(value.into())
+        .map_err(|never: Infallible| match never {})
+        .boxed_unsync()
+}
+struct Count(Arc<AtomicUsize>);
+impl Drop for Count {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+async fn server(stop: CancellationToken, active: Arc<AtomicUsize>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            let socket = tokio::select! { _ = stop.cancelled() => break, value = listener.accept() => value.unwrap().0 };
+            active.fetch_add(1, Ordering::SeqCst);
+            let guard = Count(active.clone());
+            let stop = stop.clone();
+            tokio::spawn(async move {
+                let _guard = guard;
+                let service =
+                    hyper::service::service_fn(move |mut request: Request<Incoming>| async move {
+                        let response = match request.uri().path() {
+                            "/echo" => Response::new(request.into_body().boxed_unsync()),
+                            "/infinite" => {
+                                let body = futures::stream::unfold(0u64, move |index| async move {
+                                    tokio::time::sleep(Duration::from_millis(5)).await;
+                                    Some((
+                                        Ok::<_, hyper::Error>(Frame::data(Bytes::from(vec![
+                                            42;
+                                            8192
+                                        ]))),
+                                        index + 1,
+                                    ))
+                                });
+                                Response::new(StreamBody::new(body).boxed_unsync())
+                            }
+                            "/ws" => {
+                                let accept =
+                                    tokio_tungstenite::tungstenite::handshake::derive_accept_key(
+                                        request.headers()["sec-websocket-key"].as_bytes(),
+                                    );
+                                let upgrade = hyper::upgrade::on(&mut request);
+                                tokio::spawn(async move {
+                                    let Ok(upgraded) = upgrade.await else { return };
+                                    let mut socket = WebSocketStream::from_raw_socket(
+                                        TokioIo::new(upgraded),
+                                        Role::Server,
+                                        None,
+                                    )
+                                    .await;
+                                    while let Some(Ok(message)) = socket.next().await {
+                                        if message.is_close() {
+                                            let _ = socket.flush().await;
+                                            break;
+                                        }
+                                        if (message.is_text() || message.is_binary())
+                                            && socket.send(message).await.is_err()
+                                        {
+                                            break;
+                                        }
+                                    }
+                                });
+                                Response::builder()
+                                    .status(101)
+                                    .header("connection", "upgrade")
+                                    .header("upgrade", "websocket")
+                                    .header("sec-websocket-accept", accept)
+                                    .body(full(""))
+                                    .unwrap()
+                            }
+                            _ => Response::new(full(format!("server:{port}"))),
+                        };
+                        Ok::<_, Infallible>(response)
+                    });
+                tokio::select! { _ = stop.cancelled() => {}, _ = hyper::server::conn::http1::Builder::new().serve_connection(TokioIo::new(socket), service).with_upgrades() => {} }
+            });
+        }
+    });
+    port
+}
+struct Backend(Catalog);
+#[async_trait::async_trait]
+impl Connector for Backend {
+    async fn connect(&self, id: &str) -> anyhow::Result<BoxIo> {
+        let route = self
+            .0
+            .local_route(id)
+            .ok_or_else(|| anyhow::anyhow!("unknown service"))?;
+        Ok(Box::new(TcpStream::connect(route.listener.address).await?))
+    }
+}
+struct NoLocal;
+#[async_trait::async_trait]
+impl Connector for NoLocal {
+    async fn connect(&self, _: &str) -> anyhow::Result<BoxIo> {
+        anyhow::bail!("viewer has no local services")
+    }
+}
+fn rss_kb() -> u64 {
+    let statm = std::fs::read_to_string("/proc/self/statm").unwrap_or_default();
+    let pages: u64 = statm
+        .split_whitespace()
+        .nth(1)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    pages * 4
+}
+fn alive_tasks() -> usize {
+    tokio::runtime::Handle::current()
+        .metrics()
+        .num_alive_tasks()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_preview_churn_does_not_accumulate_tasks_or_memory() {
+    let iterations: usize = std::env::var("PREVIEW_LEAK_ITERATIONS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(60);
+    let temp = tempfile::tempdir().unwrap();
+    let stop = CancellationToken::new();
+    let active = Arc::new(AtomicUsize::new(0));
+    let backend_port = server(stop.child_token(), active.clone()).await;
+
+    // Hosting device "a" advertises the backend; viewing device "b" proxies.
+    let host_catalog =
+        Catalog::open(temp.path().join("a.json"), "a".into(), "Desk".into()).unwrap();
+    host_catalog
+        .replace_local(vec![(
+            "/work/app".into(),
+            Listener {
+                pid: 1,
+                parent: 1,
+                cwd: "/work/app".into(),
+                args: vec!["node".into(), "vite".into()],
+                started_at: 1,
+                address: ([127, 0, 0, 1], backend_port).into(),
+                zeron_owned: true,
+            },
+        )])
+        .unwrap();
+    let (mut a, mut a_out) = Peers::new(
+        "a".into(),
+        Arc::new(Backend(host_catalog.clone())),
+        stop.clone(),
+    );
+    a.set_ice_servers(Vec::new()).unwrap();
+    let viewer_catalog =
+        Catalog::open(temp.path().join("b.json"), "b".into(), "Laptop".into()).unwrap();
+    viewer_catalog
+        .set_remote("a", host_catalog.local_services())
+        .unwrap();
+    let (mut b, mut b_out) = Peers::new("b".into(), Arc::new(NoLocal), stop.clone());
+    b.set_ice_servers(Vec::new()).unwrap();
+    let peer_b = b.clone();
+    tokio::spawn(async move {
+        while let Some(message) = a_out.recv().await {
+            let _ = peer_b.signal("a", message.signal).await;
+        }
+    });
+    let peer_a = a.clone();
+    tokio::spawn(async move {
+        while let Some(message) = b_out.recv().await {
+            let _ = peer_a.signal("b", message.signal).await;
+        }
+    });
+    let local = mux::local(Arc::new(NoLocal), stop.clone());
+    let (port, _listeners) = proxy::serve(
+        Router {
+            catalog: viewer_catalog.clone(),
+            local,
+            peers: b.clone(),
+        },
+        0,
+        stop.clone(),
+    )
+    .await
+    .unwrap();
+    viewer_catalog.set_proxy_status(port, None);
+    let service = viewer_catalog.snapshot().services[0].clone();
+    assert_eq!(service.device_id, "a");
+    let url = service.url(port);
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .resolve(&service.hostname, ([127, 0, 0, 1], port).into())
+        .build()
+        .unwrap();
+
+    let round = |client: reqwest::Client, url: String, hostname: String| async move {
+        let text = client.get(&url).send().await.unwrap().text().await.unwrap();
+        assert!(text.starts_with("server:"), "{text}");
+        let body = vec![9u8; 64 * 1024 + 3];
+        let echoed = client
+            .post(format!("{url}/echo"))
+            .body(body.clone())
+            .send()
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(echoed.len(), body.len());
+        // A page navigated away mid-download: body dropped after one chunk.
+        let mut infinite = client
+            .get(format!("{url}/infinite"))
+            .send()
+            .await
+            .unwrap()
+            .bytes_stream();
+        infinite.next().await.unwrap().unwrap();
+        drop(infinite);
+        // A fresh connection abandoned before its response headers arrive.
+        let mut early = TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port))
+            .await
+            .unwrap();
+        tokio::io::AsyncWriteExt::write_all(
+            &mut early,
+            format!("GET /infinite HTTP/1.1\r\nHost: {hostname}:{port}\r\n\r\n").as_bytes(),
+        )
+        .await
+        .unwrap();
+        drop(early);
+        let request = format!("ws://{hostname}:{port}/ws")
+            .into_client_request()
+            .unwrap();
+        let tcp = TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port))
+            .await
+            .unwrap();
+        let (mut ws, _) = tokio_tungstenite::client_async(request, tcp).await.unwrap();
+        ws.send(Message::Text("hmr".into())).await.unwrap();
+        assert!(ws.next().await.unwrap().unwrap().is_text());
+        ws.close(None).await.unwrap();
+        let _ = ws.next().await;
+    };
+    let hostname = service.hostname.clone();
+    let quiesce = |active: Arc<AtomicUsize>| async move {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while active.load(Ordering::SeqCst) > 0 {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("backend connections never drained");
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    };
+
+    // Warm up: pairs the WebRTC peer and fills connection pools.
+    for _ in 0..3 {
+        round(client.clone(), url.clone(), hostname.clone()).await;
+    }
+    quiesce(active.clone()).await;
+    let tasks_before = alive_tasks();
+    let rss_before = rss_kb();
+    for i in 0..iterations {
+        round(client.clone(), url.clone(), hostname.clone()).await;
+        if (i + 1) % 50 == 0 {
+            quiesce(active.clone()).await;
+            eprintln!(
+                "iteration {}: alive tasks {} (baseline {}), rss {} KiB (baseline {})",
+                i + 1,
+                alive_tasks(),
+                tasks_before,
+                rss_kb(),
+                rss_before
+            );
+        }
+    }
+    quiesce(active.clone()).await;
+    let tasks_after = alive_tasks();
+    let rss_after = rss_kb();
+    eprintln!("tasks {tasks_before} -> {tasks_after}; rss {rss_before} -> {rss_after} KiB");
+    assert!(
+        tasks_after <= tasks_before + 4,
+        "tasks leaked across {iterations} rounds: {tasks_before} -> {tasks_after}"
+    );
+    // Re-pairing churn: a laptop that sleeps, roams networks, or loses the
+    // coordinator lease tears the peer down and pairs again. Closed peers
+    // must release their WebRTC state.
+    let churn: usize = std::env::var("PREVIEW_LEAK_CHURN")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6);
+    for i in 0..churn {
+        b.remove("a").await;
+        round(client.clone(), url.clone(), hostname.clone()).await;
+        if (i + 1) % 4 == 0 {
+            quiesce(active.clone()).await;
+            eprintln!(
+                "re-pair {}: alive tasks {} (baseline {}), rss {} KiB (baseline {})",
+                i + 1,
+                alive_tasks(),
+                tasks_before,
+                rss_kb(),
+                rss_before
+            );
+        }
+    }
+    quiesce(active.clone()).await;
+    let tasks_churned = alive_tasks();
+    eprintln!(
+        "after {churn} re-pairs: tasks {tasks_before} -> {tasks_churned}; rss {} KiB",
+        rss_kb()
+    );
+    assert!(
+        tasks_churned <= tasks_before + 4,
+        "tasks leaked across {churn} re-pairs: {tasks_before} -> {tasks_churned}"
+    );
+    stop.cancel();
+    a.clear().await;
+    b.clear().await;
+}


### PR DESCRIPTION
## Summary
Three fixes in the localhost preview feature, prompted by two user reports: an Expo dev server being spammed (memory growing), and a memory leak with the in-app browser on remote localhost.

### 1. Scanner no longer re-probes discovered dev servers every 2 s
The cross-device preview scanner re-enumerated listeners every 2 s and sent a fresh `HEAD /` to **every** listener under any chat's cwd, forever (twice per cycle on macOS for wildcard-bound servers). The scanner now remembers a verdict per `(pid, started_at, address)`: a socket that answered HTTP once is accepted on later cycles with no request; non-HTTP sockets back off 4 s → 60 s; verdicts are dropped when the socket disappears.

### 2. Host no longer enumerates every process per proxied connection
Before dialing a dev server for a remote peer, the hosting device re-ran the **full** listener enumeration to confirm the port had not been reused. On macOS that is two `lsof` passes and a `ps -ax` for every asset a remote page requests, i.e. hundreds of subprocess spawns and a large allocation burst per page load. This is the most likely source of the "memory leak on remote localhost" report on the hosting Mac. Replaced with a pid + start-time check (`discovery::same_process`): one `/proc/<pid>/stat` read on Linux, one `ps -o lstart= -p <pid>` on macOS, derived exactly as the scanner derives start times.

### 3. Dropped peers re-pair promptly instead of stalling 30 s
When the viewing device dropped its peer (sleep, network roam, coordinator lease reset) and sent a new `connect`, the host ignored it because its own peer still looked healthy until ICE consent expired (~30 s). Every request stalled for the full open timeout. A `connect` under a new session now replaces the host's peer, and the requester re-pairs on a 10 s pace while waiting.

## Verification
- `a_discovered_server_is_probed_once_not_every_cycle`: real request-counting HTTP server; old scanner sends 4 probes in 9 s, new sends exactly 1.
- `same_process_matches_the_scanner_start_time`: live child pid matches, wrong start time / reaped pid do not.
- `a_dropped_peer_pairs_again_without_waiting_for_ice_failure`: real WebRTC pair; after `remove` on either side the next open completes within 8 s (stalled 30 s before).
- `remote_preview_churn_does_not_accumulate_tasks_or_memory` (new `tests/leak.rs`): proxy on the viewer → real WebRTC pair → backend on the host; 300 rounds × {GET, 64 KiB echo, body dropped mid-stream, connection dropped pre-headers, WebSocket} plus 24 re-pairs left live tokio tasks flat at 16 and RSS within ~1 MiB. Defaults are smaller for CI (`PREVIEW_LEAK_ITERATIONS`, `PREVIEW_LEAK_CHURN` to scale).
- Full `zeron-preview` suite (18 tests) and `zeron-engine` preview tests pass; clippy clean on touched files.

Not verified here: the macOS WebKit host itself (no macOS box). The engine-side path shows no leak under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)