### PR TITLE
Fix sidebar filter changing when adding a project

### DIFF
--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -390,6 +390,11 @@ impl Shell {
     pub(super) fn land_in_space(&mut self, space_id: String, cx: &mut Context<Self>) {
         self.route = Route::Chat;
         self.focus_composer(cx);
+        // "All" stays as-is; an explicit project filter follows the new
+        // project so the first send lands in a visible session.
+        if self.settings.space_filter.is_some() {
+            self.settings.space_filter = Some(space_id.clone());
+        }
         self.settings.last_space_id = Some(space_id.clone());
         self.state.update(cx, |s, cx| {
             s.select_space(Some(space_id), cx);

--- a/crates/ui/src/shell/spaces.rs
+++ b/crates/ui/src/shell/spaces.rs
@@ -385,12 +385,11 @@ impl Shell {
         }
     }
 
-    /// Land in a just-added space: filter the sidebar to it and open the
-    /// new-session canvas there.
+    /// Open the new-session canvas in a just-added space, preserving the
+    /// sidebar's current project filter.
     pub(super) fn land_in_space(&mut self, space_id: String, cx: &mut Context<Self>) {
         self.route = Route::Chat;
         self.focus_composer(cx);
-        self.settings.space_filter = Some(space_id.clone());
         self.settings.last_space_id = Some(space_id.clone());
         self.state.update(cx, |s, cx| {
             s.select_space(Some(space_id), cx);


### PR DESCRIPTION
Adding a project currently switches the left sidebar to that project's chats, hiding the previously visible conversations. Preserve the existing sidebar filter when opening the new-session canvas in the added project, including when the chosen folder is already registered.

Validation: `cargo check --locked --offline -p zeron-ui` passed with existing warnings; `git diff --check` passed for the change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/zeron/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791748959&installation_model_id=425430&pr_number=328&repository=zeronsh%2Fzeron&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fzeron%2Fpull%2F328&signature=f64dd6d5d4629571db7d4b9ae05647f8c4c8827bd17bf8c0f7515b781166fada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->