### PR TITLE
Fix native text selection and task accordion behavior

### DIFF
--- a/crates/ui/src/composer.rs
+++ b/crates/ui/src/composer.rs
@@ -222,6 +222,8 @@ fn input_scroll_offset_for_cursor(
 enum PressIntent {
     /// Take the whole field.
     SelectAll,
+    /// Select the word under the pointer.
+    SelectWord,
     /// Grow the current selection to the pressed position.
     ExtendSelection,
     /// Put the caret at the pressed position.
@@ -232,20 +234,18 @@ impl PressIntent {
     /// Whether the press starts a drag selection. A select-all must not, or
     /// the next mouse move shrinks it back to a drag from the press position.
     fn arms_drag(self) -> bool {
-        !matches!(self, Self::SelectAll)
+        !matches!(self, Self::SelectAll | Self::SelectWord)
     }
 }
 
-/// Read the intent from the press. Two clicks or more take the whole field,
-/// and every further click keeps it, so holding the button through a third
-/// click does not change what is selected.
+/// Read the intent from the press. A double click selects a word; a third
+/// click keeps the existing whole-field behavior.
 fn press_intent(click_count: usize, shift: bool) -> PressIntent {
-    if click_count >= 2 {
-        PressIntent::SelectAll
-    } else if shift {
-        PressIntent::ExtendSelection
-    } else {
-        PressIntent::PlaceCaret
+    match click_count {
+        2 => PressIntent::SelectWord,
+        3.. => PressIntent::SelectAll,
+        _ if shift => PressIntent::ExtendSelection,
+        _ => PressIntent::PlaceCaret,
     }
 }
 
@@ -2246,6 +2246,17 @@ impl ComposerInput {
             .unwrap_or(self.content.len())
     }
 
+    fn word_range_at(&self, offset: usize) -> Range<usize> {
+        let offset = self.projection.normalize_range(offset..offset).start;
+        if let Some(start) = self.projection.previous_boundary(offset) {
+            return start..offset;
+        }
+        if let Some(end) = self.projection.next_boundary(offset) {
+            return offset..end;
+        }
+        crate::markdown::selection::word_range(&self.content, offset)
+    }
+
     /// Byte range of the logical line containing `offset`.
     fn line_range_at(&self, offset: usize) -> Range<usize> {
         let start = self.content[..offset]
@@ -2706,6 +2717,11 @@ impl ComposerInput {
             PressIntent::SelectAll => {
                 self.move_to(0, cx);
                 self.select_to(self.content.len(), cx);
+            }
+            PressIntent::SelectWord => {
+                let range = self.word_range_at(self.index_for_mouse_position(event.position));
+                self.move_to(range.start, cx);
+                self.select_to(range.end, cx);
             }
             PressIntent::ExtendSelection => {
                 let index = self.index_for_mouse_position(event.position);
@@ -7525,21 +7541,31 @@ mod tests {
     /// multi-click leaves the drag disarmed is invisible until a selection
     /// collapses under the pointer.
     #[test]
-    fn a_press_of_two_or_more_clicks_takes_the_whole_field_and_leaves_the_drag_disarmed() {
+    fn multi_click_intent_matches_macos_selection_granularity() {
         assert_eq!(press_intent(1, false), PressIntent::PlaceCaret);
         assert_eq!(press_intent(1, true), PressIntent::ExtendSelection);
-        assert_eq!(press_intent(2, false), PressIntent::SelectAll);
-        // A triple click keeps the whole field, so holding the button down
-        // through a third click does not change what is selected.
+        assert_eq!(press_intent(2, false), PressIntent::SelectWord);
+        assert_eq!(press_intent(2, true), PressIntent::SelectWord);
+        // A triple click keeps the whole field.
         assert_eq!(press_intent(3, false), PressIntent::SelectAll);
-        // The whole field wins over the shift modifier: shift has nothing
-        // left to extend once everything is selected.
-        assert_eq!(press_intent(2, true), PressIntent::SelectAll);
-        // Only a caret press arms the drag. A select-all that armed it would
-        // collapse to a drag selection on the next mouse move.
+        // Multi-click selection must not arm drag, or the next mouse move
+        // would collapse it back to a drag from the press position.
         assert!(press_intent(1, false).arms_drag());
         assert!(press_intent(1, true).arms_drag());
         assert!(!press_intent(2, false).arms_drag());
+        assert!(!press_intent(3, false).arms_drag());
+    }
+
+    #[gpui::test]
+    fn double_click_selects_the_word_at_the_pointer(cx: &mut gpui::TestAppContext) {
+        let input = cx.new(|cx| ComposerInput::new("Composer", cx));
+        input.update(cx, |input, cx| input.set_text("one héllo, = world", cx));
+        input.read_with(cx, |input, _| {
+            assert_eq!(input.word_range_at(6), 4..10);
+            assert_eq!(input.word_range_at(10), 4..10);
+            assert_eq!(input.word_range_at(11), 11..11);
+            assert_eq!(input.word_range_at(12), 12..13);
+        });
     }
 
     #[test]

--- a/crates/ui/src/markdown/render.rs
+++ b/crates/ui/src/markdown/render.rs
@@ -1117,12 +1117,22 @@ pub(crate) fn paint_text_selection(
     layout: &gpui::TextLayout,
     theme: &Theme,
 ) {
+    paint_text_selection_with_wash(window, key, text, layout, selection_wash(theme));
+}
+
+fn paint_text_selection_with_wash(
+    window: &mut Window,
+    key: &std::sync::Arc<str>,
+    text: &SharedString,
+    layout: &gpui::TextLayout,
+    wash: Hsla,
+) {
     if let Some(range) = super::selection::wash_range(key) {
         for rect in range_rects(layout, &range, 0.0, 0.0) {
             window.paint_quad(quad(
                 rect,
                 px(0.0),
-                selection_wash(theme),
+                wash,
                 px(0.0),
                 gpui::transparent_black(),
                 BorderStyle::default(),
@@ -1137,6 +1147,33 @@ pub(crate) fn paint_text_selection(
         })
     });
     register_selection_listeners(window, key, text, layout);
+}
+
+fn selectable_text_element(
+    key: std::sync::Arc<str>,
+    text: SharedString,
+    runs: Vec<TextRun>,
+    wash: Hsla,
+) -> AnyElement {
+    let styled = StyledText::new(text.clone()).with_runs(runs);
+    let layout = styled.layout().clone();
+    let underlay = canvas(
+        |_, _, _| (),
+        move |_, _, window, _| {
+            paint_text_selection_with_wash(window, &key, &text, &layout, wash);
+        },
+    )
+    .absolute()
+    .size_full();
+    div()
+        .relative()
+        .child(underlay)
+        .child(styled)
+        .into_any_element()
+}
+
+fn code_line_selection_key(row_key: &str, code_ix: usize, line_ix: usize) -> std::sync::Arc<str> {
+    format!("{row_key}-code{code_ix}-line{line_ix}").into()
 }
 
 /// One painted text element, registered per frame in document order — the
@@ -1782,6 +1819,7 @@ fn render_code_block_source_with_actions(
         None => Vec::new(),
     };
     let scroll_id: SharedString = format!("{}-code{ix}", opts.row_key).into();
+    let sel_wash = selection_wash(theme);
     let code_ui = opts.code.as_ref().and_then(|code| code.get(&ix)).cloned();
     let fit_content = code_ui.as_ref().is_some_and(|ui| ui.fit_content);
 
@@ -1857,6 +1895,7 @@ fn render_code_block_source_with_actions(
             *off = start + line.len() + 1; // +1 for the '\n'
             let local = slice_spans(&veil_spans, start, start + line.len());
             let runs = apply_veil(runs.clone(), &local);
+            let key = code_line_selection_key(&opts.row_key, ix, li);
             Some(
                 div()
                     .map(|el| {
@@ -1866,7 +1905,7 @@ fn render_code_block_source_with_actions(
                             el.h(px(CODE_LINE_HEIGHT)).flex_none()
                         }
                     })
-                    .child(StyledText::new(line.clone()).with_runs(runs)),
+                    .child(selectable_text_element(key, line.clone(), runs, sel_wash)),
             )
         }));
 
@@ -2046,6 +2085,44 @@ pub fn runs_for_syntax_line_with_plain(
 mod tests {
     use super::*;
     use crate::markdown::parser::{InlineStyle, parse_full};
+    use gpui::TestAppContext;
+
+    struct CodeSelectionHarness;
+
+    impl Render for CodeSelectionHarness {
+        fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            let theme = Theme::of(cx).clone();
+            let opts = RenderOptions::settled("code-test".into());
+            div().size_full().child(render_code_block_source(
+                None, "word", 0, 0, &opts, &theme, None,
+            ))
+        }
+    }
+
+    #[gpui::test]
+    fn code_block_lines_support_native_word_selection(cx: &mut TestAppContext) {
+        cx.update(|cx| cx.set_global(Theme::dark()));
+        let (_, cx) = cx.add_window_view(|_, _| CodeSelectionHarness);
+        cx.simulate_resize(size(px(640.0), px(240.0)));
+        cx.update(|window, cx| {
+            window.refresh();
+            let _ = window.draw(cx);
+        });
+
+        let key = "code-test-code0-line0";
+        let bounds = selection_test_bounds(key);
+        cx.simulate_event(gpui::MouseDownEvent {
+            button: gpui::MouseButton::Left,
+            position: bounds.origin + point(px(5.0), px(9.0)),
+            click_count: 2,
+            ..Default::default()
+        });
+        assert_eq!(
+            super::super::selection::selected_text().as_deref(),
+            Some("word")
+        );
+        super::super::selection::clear_if_owner(key);
+    }
 
     #[test]
     fn code_block_indices_include_nested_quotes_and_lists() {

--- a/crates/ui/src/settings.rs
+++ b/crates/ui/src/settings.rs
@@ -426,6 +426,8 @@ pub struct UiSettings {
     /// Agent-sent Markdown fences: wrap long lines to the chat width instead
     /// of exposing their horizontal scroll plane.
     pub code_fences_fit_content: bool,
+    /// Automatically expand the active tool group while an agent is working.
+    pub expand_active_task: bool,
     /// Save edited workspace files automatically after the configured delay.
     pub files_autosave_enabled: bool,
     /// Idle time before an edited workspace file is saved automatically.
@@ -483,6 +485,7 @@ impl Default for UiSettings {
             diff_split: false,
             diff_wrap: false,
             code_fences_fit_content: false,
+            expand_active_task: true,
             files_autosave_enabled: false,
             files_autosave_delay_ms: FILES_AUTOSAVE_DELAY_DEFAULT_MS,
             files_word_wrap: false,
@@ -1071,6 +1074,7 @@ mod tests {
         assert_eq!(loaded.composer_send_behavior, ComposerSendBehavior::Enter);
         assert_eq!(loaded.sidebar_width, 300.0);
         assert!(!loaded.sound_enabled);
+        assert!(loaded.expand_active_task);
     }
 
     #[test]
@@ -1148,6 +1152,7 @@ mod tests {
             diff_split: true,
             diff_wrap: true,
             code_fences_fit_content: true,
+            expand_active_task: false,
             files_autosave_enabled: true,
             files_autosave_delay_ms: 1_500,
             files_word_wrap: true,
@@ -1461,6 +1466,7 @@ mod tests {
         assert_eq!(d.terminal_height, 280.0);
         assert!(!d.sidebar_collapsed && !d.right_pane_open && !d.terminal_open);
         assert!(!d.escape_stops_active_agent);
+        assert!(d.expand_active_task);
     }
 
     #[test]

--- a/crates/ui/src/settings/appearance.rs
+++ b/crates/ui/src/settings/appearance.rs
@@ -5,8 +5,8 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use gpui::{
-    AnyElement, Context, Entity, FocusHandle, Focusable, Hsla, IntoElement, KeyDownEvent, Render,
-    SharedString, Subscription, Window, div, prelude::*, px,
+    AnyElement, Context, Entity, EventEmitter, FocusHandle, Focusable, Hsla, IntoElement,
+    KeyDownEvent, Render, SharedString, Subscription, Window, div, prelude::*, px,
 };
 use zeron_theme::vscode::{ImportReport, SourceCompilation};
 use zeron_theme::{
@@ -36,6 +36,7 @@ struct ImportDialog {
 }
 
 pub struct AppearancePage {
+    expand_active_task: bool,
     selected_font: UiFontFamily,
     selected_size: UiFontSize,
     font_focus: FocusHandle,
@@ -51,9 +52,17 @@ pub struct AppearancePage {
     library_error: Option<SharedString>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum AppearanceEvent {
+    ExpandActiveTaskChanged(bool),
+}
+
+impl EventEmitter<AppearanceEvent> for AppearancePage {}
+
 impl AppearancePage {
-    pub fn new(cx: &mut Context<Self>) -> Self {
+    pub fn new(expand_active_task: bool, cx: &mut Context<Self>) -> Self {
         Self {
+            expand_active_task,
             selected_font: typography::effective(cx),
             selected_size: typography::font_size(cx),
             font_focus: cx.focus_handle(),
@@ -2058,6 +2067,41 @@ impl Render for AppearancePage {
         let modal = self
             .render_import_dialog(window.viewport_size(), &theme, window, cx)
             .or_else(|| self.render_review_dialog(window.viewport_size(), &theme, cx));
+        let expand_active_task = self.expand_active_task;
+        let chat_behavior = widgets::section_card(&theme).child(
+            widgets::card_row(&theme, false)
+                .child(widgets::row_tile(&theme, icons::EXPAND_ARROWS))
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .flex()
+                        .flex_col()
+                        .child(widgets::row_title(&theme, "Expand active task"))
+                        .child(widgets::meta_line(
+                            &theme,
+                            vec![
+                                div()
+                                    .child(SharedString::from(
+                                        "Automatically open the active task accordion while an agent is working.",
+                                    ))
+                                    .into_any_element(),
+                            ],
+                        )),
+                )
+                .child(
+                    widgets::toggle_switch(&theme, expand_active_task)
+                        .id("appearance-expand-active-task-toggle")
+                        .cursor_pointer()
+                        .on_click(cx.listener(move |this, _, _, cx| {
+                            this.expand_active_task = !this.expand_active_task;
+                            cx.emit(AppearanceEvent::ExpandActiveTaskChanged(
+                                this.expand_active_task,
+                            ));
+                            cx.notify();
+                        })),
+                ),
+        );
 
         let font_rows: Vec<AnyElement> = availability
             .choices()
@@ -2327,7 +2371,16 @@ impl Render for AppearancePage {
                                 .text_color(theme.warning)
                                 .child(warning),
                         )
-                    }),
+                    })
+                    .child(
+                        div()
+                            .mt(px(36.0))
+                            .flex()
+                            .flex_col()
+                            .gap(px(10.0))
+                            .child(widgets::field_label(&theme, "Chat behavior"))
+                            .child(chat_behavior),
+                    ),
             )
             .children(modal)
     }

--- a/crates/ui/src/shell.rs
+++ b/crates/ui/src/shell.rs
@@ -36,7 +36,7 @@ use crate::motion::{self, AnimationExt as _, MotionSpec, RESIZE, SPLASH_OUT, TAB
 use crate::popover::{self, Loadable};
 use crate::rail;
 use crate::settings::accounts::AccountsPage;
-use crate::settings::appearance::AppearancePage;
+use crate::settings::appearance::{AppearanceEvent, AppearancePage};
 use crate::settings::archived::ArchivedPage;
 use crate::settings::devices::DevicesPage;
 use crate::settings::files::{FilesSettingsEvent, FilesSettingsPage};
@@ -1172,7 +1172,7 @@ pub struct Shell {
     /// the transcript's bottom clearance, and the jump pill's anchor (the
     /// same one-frame lag every fade here rides).
     bottom_stack: std::rc::Rc<std::cell::Cell<f32>>,
-    /// The sidebar's archived accordion (t3code Sidebar): OPEN by default
+    /// The sidebar's archived accordion (t3code Sidebar): CLOSED by default
     /// (user request), session-transient. `archived_shown` pages the
     /// expanded list ("Show more" reveals another page).
     pub(super) archived_open: bool,
@@ -1250,6 +1250,7 @@ pub struct Shell {
     harnesses_page: Option<Entity<HarnessesPage>>,
     shortcuts_sub: Option<Subscription>,
     notifications_sub: Option<Subscription>,
+    appearance_sub: Option<Subscription>,
     files_settings_sub: Option<Subscription>,
     /// Session-row context menu, including the Copy submenu.
     chat_menu: popover::Popup<ChatMenuState>,
@@ -1548,7 +1549,7 @@ impl Shell {
             // Seed with the compact composer stack's rough height so the
             // first frame's clearance isn't zero (the measure corrects it).
             bottom_stack: std::rc::Rc::new(std::cell::Cell::new(120.0)),
-            archived_open: true,
+            archived_open: false,
             archived_shown: 0,
             archived_hover: None,
             sidebar_collapsed_groups: std::collections::HashSet::new(),
@@ -1591,6 +1592,7 @@ impl Shell {
             harnesses_page: None,
             shortcuts_sub: None,
             notifications_sub: None,
+            appearance_sub: None,
             files_settings_sub: None,
             chat_menu: popover::Popup::default(),
             rename_dialog: None,
@@ -3267,7 +3269,18 @@ impl Shell {
             }
             SettingsSection::Appearance => {
                 if self.appearance_page.is_none() {
-                    self.appearance_page = Some(cx.new(AppearancePage::new));
+                    let page =
+                        cx.new(|cx| AppearancePage::new(self.settings.expand_active_task, cx));
+                    self.appearance_sub = Some(cx.subscribe(
+                        &page,
+                        |this: &mut Shell, _, event: &AppearanceEvent, cx| {
+                            let AppearanceEvent::ExpandActiveTaskChanged(enabled) = *event;
+                            this.settings.expand_active_task = enabled;
+                            this.schedule_save(cx);
+                            cx.notify();
+                        },
+                    ));
+                    self.appearance_page = Some(page);
                 }
                 match &self.appearance_page {
                     Some(page) => page.clone().into_any_element(),

--- a/crates/ui/src/transcript.rs
+++ b/crates/ui/src/transcript.rs
@@ -360,6 +360,15 @@ fn tool_group_collapses(tools: &[ToolItem]) -> bool {
     tools.iter().any(|t| !is_agent_tool(t))
 }
 
+fn tool_group_open(
+    collapses: bool,
+    user_open: Option<bool>,
+    auto_open: bool,
+    expand_active_task: bool,
+) -> bool {
+    !collapses || user_open.unwrap_or(auto_open && expand_active_task)
+}
+
 /// Column budget for soft-wrapping thought text into detail lines. The
 /// detail body is preformatted (no element wrapping), so the wrap happens
 /// here — conservative enough to fit the card at typical transcript widths.
@@ -5311,7 +5320,12 @@ impl Transcript {
         // Agent/spawn chips never fold: they are their own row, always open,
         // no "Called N tools" header — a running subagent stays visible.
         let collapses = tool_group_collapses(tools);
-        let open = !collapses || fold.open.unwrap_or(auto_open);
+        let open = tool_group_open(
+            collapses,
+            fold.open,
+            auto_open,
+            crate::settings::current(cx).expand_active_task,
+        );
         // Chips render their EFFECTIVE detail: the precomputed doc-resident
         // one, upgraded in place by a fetched sidecar blob (chat2-sync A3).
         // Resolved per paint (a HashMap probe per chip) so fetched content
@@ -6926,6 +6940,17 @@ mod tests {
             selection_scroll_step(bounds, gpui::point(px(20.0), px(220.0)))
                 > selection_scroll_step(bounds, gpui::point(px(20.0), px(200.0)))
         );
+    }
+
+    #[test]
+    fn active_tool_group_auto_open_honors_setting() {
+        assert!(tool_group_open(true, None, true, true));
+        assert!(!tool_group_open(true, None, true, false));
+        // A manual choice still wins over the automatic default.
+        assert!(tool_group_open(true, Some(true), true, false));
+        assert!(!tool_group_open(true, Some(false), true, true));
+        // Agent chips that never collapse stay open regardless of the toggle.
+        assert!(tool_group_open(false, None, true, false));
     }
 
     // ---- streaming parse wiring (the transcript side, not the parser) ----


### PR DESCRIPTION
## Summary

- Restore native macOS word selection in the composer.
- Allow selecting text in syntax-highlighted code blocks.
- Move the active-task expansion setting into Appearance and remove the standalone QOL section.
- Start the Archived sidebar accordion collapsed.

## Testing

- `cargo +beta test -p zeron-ui --lib`
- 808 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/zeron/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791762660&installation_model_id=425430&pr_number=331&repository=zeronsh%2Fzeron&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fzeron%2Fpull%2F331&signature=798ef47d55708f2ea8fdf37fa1a005d77a0dcbf9d514d27349747bfefd8c9263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->